### PR TITLE
feat: implement LLM-based email summarization and drafting (O3)

### DIFF
--- a/backend/api/llm.py
+++ b/backend/api/llm.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from services.llm_service import extract_todos_and_summary, draft_reply, ExtractionResult
+
+router = APIRouter(prefix="/api/llm")
+
+class SummarizeRequest(BaseModel):
+    email_body: str
+
+class DraftRequest(BaseModel):
+    email_body: str
+    instruction: str
+
+@router.post("/summarize", response_model=ExtractionResult)
+async def summarize_endpoint(request: SummarizeRequest):
+    return await extract_todos_and_summary(request.email_body)
+
+@router.post("/draft")
+async def draft_endpoint(request: DraftRequest):
+    reply = await draft_reply(request.email_body, request.instruction)
+    return {"draft": reply}

--- a/backend/api/llm.py
+++ b/backend/api/llm.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from services.llm_service import extract_todos_and_summary, draft_reply, ExtractionResult
 
@@ -13,9 +13,15 @@ class DraftRequest(BaseModel):
 
 @router.post("/summarize", response_model=ExtractionResult)
 async def summarize_endpoint(request: SummarizeRequest):
-    return await extract_todos_and_summary(request.email_body)
+    try:
+        return await extract_todos_and_summary(request.email_body)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/draft")
 async def draft_endpoint(request: DraftRequest):
-    reply = await draft_reply(request.email_body, request.instruction)
-    return {"draft": reply}
+    try:
+        reply = await draft_reply(request.email_body, request.instruction)
+        return {"draft": reply}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/llm.py
+++ b/backend/api/llm.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from services.llm_service import extract_todos_and_summary, draft_reply, ExtractionResult
+from core.exceptions import LLMServiceError
 
 router = APIRouter(prefix="/api/llm")
 
@@ -15,13 +16,17 @@ class DraftRequest(BaseModel):
 async def summarize_endpoint(request: SummarizeRequest):
     try:
         return await extract_todos_and_summary(request.email_body)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except LLMServiceError:
+        raise HTTPException(status_code=500, detail="An internal server error occurred while processing the request.")
+    except Exception:
+        raise HTTPException(status_code=500, detail="An internal server error occurred while processing the request.")
 
 @router.post("/draft")
 async def draft_endpoint(request: DraftRequest):
     try:
         reply = await draft_reply(request.email_body, request.instruction)
         return {"draft": reply}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except LLMServiceError:
+        raise HTTPException(status_code=500, detail="An internal server error occurred while processing the request.")
+    except Exception:
+        raise HTTPException(status_code=500, detail="An internal server error occurred while processing the request.")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     # OpenAI Settings
     OPENAI_API_KEY: SecretStr | None = None
     OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-small"
+    OPENAI_MODEL: str = "gpt-4o"
     
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -1,0 +1,3 @@
+class LLMServiceError(Exception):
+    """Exception raised for errors in the LLM service."""
+    pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api.search import router as search_router
+from api.llm import router as llm_router
 
 app = FastAPI(title="AI Email Client API")
 
 app.include_router(search_router)
+app.include_router(llm_router)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -1,0 +1,38 @@
+from openai import AsyncOpenAI
+from core.config import settings
+from pydantic import BaseModel
+
+class ExtractionResult(BaseModel):
+    summary: str
+    todos: list[str]
+
+async def _get_client() -> AsyncOpenAI:
+    if not settings.OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY is not set")
+    return AsyncOpenAI(api_key=settings.OPENAI_API_KEY.get_secret_value())
+
+async def extract_todos_and_summary(email_body: str) -> ExtractionResult:
+    client = await _get_client()
+    response = await client.beta.chat.completions.parse(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant. Summarize the email and extract action items."},
+            {"role": "user", "content": email_body}
+        ],
+        response_format=ExtractionResult
+    )
+    if not response.choices[0].message.parsed:
+        raise RuntimeError("Failed to parse LLM response")
+    return response.choices[0].message.parsed
+
+async def draft_reply(email_body: str, instruction: str) -> str:
+    client = await _get_client()
+    response = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": f"You are drafting a professional reply. Instruction: {instruction}"},
+            {"role": "user", "content": email_body}
+        ]
+    )
+    content = response.choices[0].message.content
+    return content if content is not None else ""

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -1,38 +1,57 @@
+import logging
 from openai import AsyncOpenAI
 from core.config import settings
+from core.exceptions import LLMServiceError
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 class ExtractionResult(BaseModel):
     summary: str
     todos: list[str]
 
-async def _get_client() -> AsyncOpenAI:
-    if not settings.OPENAI_API_KEY:
-        raise ValueError("OPENAI_API_KEY is not set")
-    return AsyncOpenAI(api_key=settings.OPENAI_API_KEY.get_secret_value())
+_client: AsyncOpenAI | None = None
+
+def _get_client() -> AsyncOpenAI:
+    global _client
+    if _client is None:
+        if not settings.OPENAI_API_KEY:
+            raise ValueError("OPENAI_API_KEY is not set")
+        _client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY.get_secret_value())
+    return _client
 
 async def extract_todos_and_summary(email_body: str) -> ExtractionResult:
-    client = await _get_client()
-    response = await client.beta.chat.completions.parse(
-        model="gpt-4o",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant. Summarize the email and extract action items."},
-            {"role": "user", "content": email_body}
-        ],
-        response_format=ExtractionResult
-    )
+    client = _get_client()
+    try:
+        response = await client.beta.chat.completions.parse(
+            model=settings.OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant. Summarize the email and extract action items."},
+                {"role": "user", "content": email_body}
+            ],
+            response_format=ExtractionResult
+        )
+    except Exception as e:
+        logger.error(f"Error calling OpenAI API for extraction: {e}")
+        raise LLMServiceError(f"OpenAI API error during extraction: {e}") from e
+
     if not response.choices[0].message.parsed:
         raise RuntimeError("Failed to parse LLM response")
     return response.choices[0].message.parsed
 
 async def draft_reply(email_body: str, instruction: str) -> str:
-    client = await _get_client()
-    response = await client.chat.completions.create(
-        model="gpt-4o",
-        messages=[
-            {"role": "system", "content": f"You are drafting a professional reply. Instruction: {instruction}"},
-            {"role": "user", "content": email_body}
-        ]
-    )
+    client = _get_client()
+    try:
+        response = await client.chat.completions.create(
+            model=settings.OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": f"You are drafting a professional reply. Instruction: {instruction}"},
+                {"role": "user", "content": email_body}
+            ]
+        )
+    except Exception as e:
+        logger.error(f"Error calling OpenAI API for drafting: {e}")
+        raise LLMServiceError(f"OpenAI API error during drafting: {e}") from e
+
     content = response.choices[0].message.content
     return content if content is not None else ""

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -1,35 +1,10 @@
-from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 from main import app
 
 client = TestClient(app)
 
-@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
-@patch("api.llm.draft_reply", new_callable=AsyncMock)
-def test_llm_endpoints_exist(mock_draft, mock_extract):
-    from services.llm_service import ExtractionResult
-    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
-    mock_draft.return_value = "This is a draft reply."
-
+def test_llm_endpoints_exist():
     resp1 = client.post("/api/llm/summarize", json={"email_body": "test"})
     resp2 = client.post("/api/llm/draft", json={"email_body": "test", "instruction": "reply yes"})
-    
     assert resp1.status_code in [200, 400, 422, 500]
     assert resp2.status_code in [200, 400, 422, 500]
-
-@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
-def test_summarize_endpoint(mock_extract):
-    from services.llm_service import ExtractionResult
-    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
-    
-    resp = client.post("/api/llm/summarize", json={"email_body": "test email"})
-    assert resp.status_code == 200
-    assert resp.json() == {"summary": "Test summary", "todos": ["Task 1"]}
-
-@patch("api.llm.draft_reply", new_callable=AsyncMock)
-def test_draft_endpoint(mock_draft):
-    mock_draft.return_value = "This is a draft reply."
-    
-    resp = client.post("/api/llm/draft", json={"email_body": "test email", "instruction": "reply nicely"})
-    assert resp.status_code == 200
-    assert resp.json() == {"draft": "This is a draft reply."}

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -1,10 +1,35 @@
+from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 from main import app
 
 client = TestClient(app)
 
-def test_llm_endpoints_exist():
+@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
+@patch("api.llm.draft_reply", new_callable=AsyncMock)
+def test_llm_endpoints_exist(mock_draft, mock_extract):
+    from services.llm_service import ExtractionResult
+    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    mock_draft.return_value = "This is a draft reply."
+
     resp1 = client.post("/api/llm/summarize", json={"email_body": "test"})
     resp2 = client.post("/api/llm/draft", json={"email_body": "test", "instruction": "reply yes"})
-    assert resp1.status_code in [200, 400, 422, 500]
-    assert resp2.status_code in [200, 400, 422, 500]
+    
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+
+@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
+def test_summarize_endpoint(mock_extract):
+    from services.llm_service import ExtractionResult
+    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    
+    resp = client.post("/api/llm/summarize", json={"email_body": "test email"})
+    assert resp.status_code == 200
+    assert resp.json() == {"summary": "Test summary", "todos": ["Task 1"]}
+
+@patch("api.llm.draft_reply", new_callable=AsyncMock)
+def test_draft_endpoint(mock_draft):
+    mock_draft.return_value = "This is a draft reply."
+    
+    resp = client.post("/api/llm/draft", json={"email_body": "test email", "instruction": "reply nicely"})
+    assert resp.status_code == 200
+    assert resp.json() == {"draft": "This is a draft reply."}

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
+@patch("api.llm.draft_reply", new_callable=AsyncMock)
+def test_llm_endpoints_exist(mock_draft, mock_extract):
+    from services.llm_service import ExtractionResult
+    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    mock_draft.return_value = "This is a draft reply."
+
+    resp1 = client.post("/api/llm/summarize", json={"email_body": "test"})
+    resp2 = client.post("/api/llm/draft", json={"email_body": "test", "instruction": "reply yes"})
+    
+    assert resp1.status_code in [200, 400, 422, 500]
+    assert resp2.status_code in [200, 400, 422, 500]
+
+@patch("api.llm.extract_todos_and_summary", new_callable=AsyncMock)
+def test_summarize_endpoint(mock_extract):
+    from services.llm_service import ExtractionResult
+    mock_extract.return_value = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    
+    resp = client.post("/api/llm/summarize", json={"email_body": "test email"})
+    assert resp.status_code == 200
+    assert resp.json() == {"summary": "Test summary", "todos": ["Task 1"]}
+
+@patch("api.llm.draft_reply", new_callable=AsyncMock)
+def test_draft_endpoint(mock_draft):
+    mock_draft.return_value = "This is a draft reply."
+    
+    resp = client.post("/api/llm/draft", json={"email_body": "test email", "instruction": "reply nicely"})
+    assert resp.status_code == 200
+    assert resp.json() == {"draft": "This is a draft reply."}

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,11 +1,74 @@
 import pytest
-from services.llm_service import extract_todos_and_summary, draft_reply
+from unittest.mock import AsyncMock, MagicMock, patch
+from services.llm_service import extract_todos_and_summary, draft_reply, ExtractionResult
+from core.exceptions import LLMServiceError
+
+@pytest.fixture
+def mock_openai():
+    with patch("services.llm_service._get_client") as mock_get_client:
+        # Mock the AsyncOpenAI client instance
+        mock_client_instance = MagicMock()
+        mock_get_client.return_value = mock_client_instance
+        yield mock_client_instance
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    # Reset the global client in llm_service before each test
+    import services.llm_service
+    services.llm_service._client = None
+    yield
 
 @pytest.mark.asyncio
-async def test_extract_todos_and_summary_unauthorized():
-    # Will fail if API key is not valid, but we just check if it's importable and callable
-    try:
+async def test_extract_todos_and_summary_success(mock_openai):
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_message = MagicMock()
+    mock_message.parsed = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    mock_openai.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
+
+    # Call the service
+    result = await extract_todos_and_summary("Test email")
+
+    # Verify results
+    assert result.summary == "Test summary"
+    assert result.todos == ["Task 1"]
+    mock_openai.beta.chat.completions.parse.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_extract_todos_and_summary_api_error(mock_openai):
+    # Setup mock to raise an exception
+    mock_openai.beta.chat.completions.parse = AsyncMock(side_effect=Exception("API Error"))
+
+    with pytest.raises(LLMServiceError, match="OpenAI API error during extraction"):
         await extract_todos_and_summary("Test email")
-    except Exception as e:
-        pass
-    assert extract_todos_and_summary is not None
+
+@pytest.mark.asyncio
+async def test_draft_reply_success(mock_openai):
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_message = MagicMock()
+    mock_message.content = "Drafted reply text"
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    mock_openai.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    # Call the service
+    result = await draft_reply("Test email", "Draft a positive reply")
+
+    # Verify results
+    assert result == "Drafted reply text"
+    mock_openai.chat.completions.create.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_draft_reply_api_error(mock_openai):
+    # Setup mock to raise an exception
+    mock_openai.chat.completions.create = AsyncMock(side_effect=Exception("API Error"))
+
+    with pytest.raises(LLMServiceError, match="OpenAI API error during drafting"):
+        await draft_reply("Test email", "Draft a positive reply")

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,0 +1,11 @@
+import pytest
+from services.llm_service import extract_todos_and_summary, draft_reply
+
+@pytest.mark.asyncio
+async def test_extract_todos_and_summary_unauthorized():
+    # Will fail if API key is not valid, but we just check if it's importable and callable
+    try:
+        await extract_todos_and_summary("Test email")
+    except Exception as e:
+        pass
+    assert extract_todos_and_summary is not None


### PR DESCRIPTION
## Summary
- Closes #6
- Implement `llm_service.py` to extract TODOs and summary from emails, and draft replies using `AsyncOpenAI`.
- Implement FastAPI endpoints for `/api/llm/summarize` and `/api/llm/draft`.
- Add appropriate mock tests and error handling to ensure production readiness.

## Test Plan
- [x] Mocked tests verify `summarize` and `draft` service functions.
- [x] API endpoint tests verify routing and payload serialization.
- [x] Exceptions caught and properly converted to 500 status codes without leaking sensitive data.