### PR TITLE
chore: fix bandit action and upload SARIF

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -20,7 +23,14 @@ jobs:
       - name: Install Bandit
         run: |
           python -m pip install --upgrade pip
-          pip install bandit
+          pip install bandit[sarif]
 
       - name: Run Bandit Scan
-        run: bandit -r backend/
+        run: bandit -r backend/ -x backend/tests/ -f sarif -o bandit-results.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: bandit-results.sarif
+          category: bandit


### PR DESCRIPTION
## Summary
- Update Bandit GitHub action to use `bandit[sarif]`.
- Exclude `backend/tests/` to prevent false positive alerts (`B101` and `B105`).
- Upload results in SARIF format to GitHub Code Scanning.