### PR TITLE
Harden email threading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.next
+node_modules
+frontend/.next
+frontend/node_modules
+backend/__pycache__
+backend/**/__pycache__
+backend/.pytest_cache
+.pytest_cache
+.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,7 @@ backend/__pycache__
 backend/**/__pycache__
 backend/.pytest_cache
 .pytest_cache
-.env
+.env*
+**/.env*
+!.env.example
+!**/.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Local development defaults. Copy to .env and edit as needed.
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/ai_email
+DEBUG=false
+ENCRYPTION_KEY=
+
+# AI features. Leave blank to disable LLM/embedding-backed flows locally.
+OPENAI_API_KEY=
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+OPENAI_MODEL=gpt-4o
+
+# Frontend talks to the backend through this URL.
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Sending is configured per user in tenant_configs. Without real credentials,
+# the backend send service returns an explicit simulated result.
+SMTP_MODE=simulated

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Local development defaults. Copy to .env and edit as needed.
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/ai_email
+POSTGRES_DB=ai_email
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=change-me-local-only
+DATABASE_URL=postgresql+asyncpg://postgres:change-me-local-only@localhost:5432/ai_email
 DEBUG=false
 ENCRYPTION_KEY=
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,29 @@
+# Architecture
+
+## System shape
+
+```mermaid
+flowchart LR
+  UI[Next.js frontend] --> API[FastAPI backend]
+  API --> DB[(Postgres + pgvector)]
+  API --> LLM[OpenAI APIs when configured]
+  API --> SMTP[SMTP when configured]
+```
+
+The backend owns persistence, threading, search, AI summaries, and outbound send orchestration. The frontend consumes the backend contracts and renders inbox, detail, thread history, reply composer, and network graph surfaces.
+
+## Threading boundary
+
+`backend/services/threading_service.py` is the canonical domain service for assigning persisted `thread_id` values. Parsers extract raw email headers, and import/API paths persist the service-assigned value. The detailed behavior is documented in `docs/threading-contract.md`.
+
+## Data and tenancy boundary
+
+The current `emails` table does not have an owner/mailbox key. Email and search behavior should therefore be treated as single-user local-development behavior. Multi-user production safety requires a schema migration that adds mailbox ownership and applies that filter to every email/search query.
+
+## Local deployment boundary
+
+`docker-compose.yml` provides the blessed local stack: Postgres with pgvector, FastAPI backend, and Next.js frontend. The backend bootstrap script creates the `vector` extension, metadata-defined tables for fresh local databases, and idempotent threading-column backfills for existing local databases. There is no Alembic migration history in this repo yet.
+
+## Send boundary
+
+Outbound replies preserve `In-Reply-To` and `References` headers in the built message payload. Local/dev behavior is explicit: missing SMTP config returns a 400, and simulated send results are marked with `simulated: true` rather than described as real delivery.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Prefer `docker compose up -d --build` for full-stack local work.
+3. For manual backend work, run commands from `backend/`.
+4. For frontend work, run `npm install` before lint/build/test.
+
+## Verification before opening a PR
+
+```bash
+./scripts/verify_threading.sh
+```
+
+For backend-only changes, run `cd backend && python3 -m pytest -q`. For frontend changes, run `cd frontend && npm test && npm run lint && npm run build`.
+
+## Threading changes
+
+- Add or update tests before production code changes.
+- Keep `backend/services/threading_service.py` as the only canonical thread assignment owner.
+- Keep fixtures in `backend/tests/fixtures` small and synthetic; do not commit real email data.
+- Preserve honest send semantics: simulated local send is not delivery proof.
+- Do not claim multi-user email isolation until the email owner/mailbox migration exists and queries are scoped.
+
+## Secrets and data
+
+Never commit `.env`, real mailbox exports, SMTP credentials, OAuth secrets, OpenAI keys, or user email content. Use synthetic `.eml` fixtures only.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Full-stack email client with a FastAPI backend, Next.js frontend, vector search,
 
 ```bash
 cp .env.example .env
-docker compose up -d --build
+POSTGRES_PASSWORD=change-me-local-only docker compose up -d --build
 docker compose exec backend python import_fixtures.py
 curl -s http://localhost:8000/api/emails
-open http://localhost:3000
+python3 -m webbrowser http://localhost:3000
 ```
 
 What you should see: the fixture import loads a three-message `Quarterly plan` conversation. `/api/emails` returns one threaded inbox item with `reply_count` greater than 1, and the frontend shows conversation history oldest to newest.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# AI Email Client
+
+Full-stack email client with a FastAPI backend, Next.js frontend, vector search, AI summaries, and hardened email threading.
+
+## Five-minute local path
+
+```bash
+cp .env.example .env
+docker compose up -d --build
+docker compose exec backend python import_fixtures.py
+curl -s http://localhost:8000/api/emails
+open http://localhost:3000
+```
+
+What you should see: the fixture import loads a three-message `Quarterly plan` conversation. `/api/emails` returns one threaded inbox item with `reply_count` greater than 1, and the frontend shows conversation history oldest to newest.
+
+The fixture importer uses real OpenAI embeddings only when `OPENAI_API_KEY` is set. With the default empty key it writes local zero-vector embeddings so the threading proof path works offline.
+
+## Manual development path
+
+Backend:
+
+```bash
+cd backend
+python3 -m pip install -r requirements.txt
+python3 scripts/bootstrap_db.py
+python3 -m pytest -q
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm install
+npm test
+npm run lint
+npm run build
+npm run dev
+```
+
+## Threading proof points
+
+- Canonical thread IDs are assigned in `backend/services/threading_service.py`.
+- Parser output preserves raw `Message-ID`, `In-Reply-To`, `References`, and `Reply-To` headers.
+- Importers persist the canonical service-assigned `thread_id`; they do not recompute their own thread IDs.
+- Replies include `In-Reply-To` and `References` headers in the send payload.
+- Development sends are explicit simulations unless a real SMTP path is wired.
+
+## API smoke examples
+
+```bash
+curl -s http://localhost:8000/api/emails | jq '.emails[] | {subject, thread_id, reply_count}'
+curl -s http://localhost:8000/api/emails/thread/thread-root@example.com | jq '.thread[] | {message_id, in_reply_to, references}'
+
+# Requires a tenant OpenAI key because search generates a query embedding.
+curl -s -X POST http://localhost:8000/api/search -H 'content-type: application/json' -d '{"query":"Quarterly plan"}'
+
+# Send remains honest in local/dev mode: if SMTP is not configured, the API returns 400.
+curl -s -X POST http://localhost:8000/api/emails/send \
+  -H 'content-type: application/json' \
+  -d '{"to":"alice@example.com","subject":"Re: Quarterly plan","body":"Thanks","in_reply_to":"<thread-reply-2@example.com>","references":"<thread-root@example.com> <thread-reply-1@example.com> <thread-reply-2@example.com>"}'
+```
+
+## Error-message contract
+
+Errors should tell a contributor what failed and avoid leaking internals:
+
+| Flow | Expected signal | Fix |
+|---|---|---|
+| SMTP not configured | `400 {"detail":"SMTP is not configured"}` | Create a tenant config with SMTP host, port, and username before testing real send. |
+| Local simulated send | `{"status":"simulated","simulated":true}` | Treat as payload/header verification only, not delivery proof. |
+| Search without OpenAI key | `400 {"detail":"OpenAI API key not configured"}` | Add a tenant OpenAI key or skip search smoke locally. |
+| Search backend failure | `500 {"detail":"Search failed"}` | Check backend logs; raw exceptions are intentionally not returned to clients. |
+| Missing thread | `404 {"detail":"Thread not found"}` | Re-import fixtures or verify the URL uses the normalized thread id. |
+
+## Current scope contract
+
+This repo still uses dummy header auth and does not persist an owner/mailbox key on email rows. Treat local data as single-user development data until a mailbox ownership migration is added.
+
+## Verification used for this hardening pass
+
+```bash
+./scripts/verify_threading.sh
+
+# Equivalent manual checks:
+cd backend && python3 -m pytest -q
+cd frontend && npm test && npm run lint && npm run build
+```
+
+Known local warnings: backend tests emit dependency/toolchain deprecation warnings from Starlette multipart and compiled SWIG metadata. They are not caused by threading code.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+# Backend
+
+FastAPI service for email ingestion, search, AI summaries, calendar sync, and threaded email APIs.
+
+## Setup
+
+```bash
+python3 -m pip install -r requirements.txt
+python3 scripts/bootstrap_db.py
+python3 -m pytest -q
+uvicorn main:app --reload
+```
+
+Set `DATABASE_URL` in `.env` or use the default `postgresql+asyncpg://postgres:postgres@localhost:5432/ai_email`.
+
+For local fixture imports, `OPENAI_API_KEY` is optional. When absent, `import_fixtures.py` uses zero-vector embeddings so the local threading proof path does not need network access.
+
+## Threading endpoints
+
+- `GET /api/emails` returns inbox items grouped by `thread_id` with `reply_count`.
+- `GET /api/emails/{id}` returns message details including `thread_id`, `message_id`, `in_reply_to`, `references`, and `reply_to`.
+- `GET /api/emails/thread/{thread_id}` returns the conversation oldest to newest.
+- `POST /api/emails/send` accepts `in_reply_to` and `references` and returns either real send status or explicit simulation status.
+
+## Schema bootstrap and backfill
+
+`python3 scripts/bootstrap_db.py` creates the `vector` extension, runs `Base.metadata.create_all` for fresh local databases, and applies idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements for the threading columns (`thread_id`, `in_reply_to`, `references`, `reply_to`) plus the thread index. Existing email rows that predate threading should then be backfilled by reprocessing imported `.eml` files or by assigning `thread_id` with `services.threading_service.assign_thread_id` in chronological order.
+
+Before claiming multi-user safety, add an owner/mailbox column to `emails`, backfill it, and scope every email/search query by that key.
+
+## Warning classification
+
+Current backend test warnings are known dependency/toolchain warnings:
+
+- `starlette.formparsers` imports `multipart`, which emits a pending deprecation warning.
+- Compiled SWIG metadata emits `__module__` deprecation warnings during import.
+
+Threading code should not add new warnings. Treat any new warning from application modules as a regression.

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from db.session import get_db
 from db.models import Email, TenantConfig
 from pydantic import BaseModel, EmailStr
 import datetime
 from services.email_client import send_email
+from services.threading_service import normalize_message_id
 import logging
 from api.auth import get_current_user
 
@@ -14,11 +15,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/emails")
 
 
+def canonical_thread_key(email: Email) -> str:
+    return (
+        normalize_message_id(email.thread_id)
+        or normalize_message_id(email.message_id)
+        or email.message_id
+    )
+
+
+def thread_lookup_values(thread_id: str) -> list[str]:
+    normalized = normalize_message_id(thread_id) or thread_id
+    return list({thread_id, normalized, f"<{normalized}>"})
+
+
 class EmailListItem(BaseModel):
     id: int
     thread_id: str | None = None
     subject: str | None
     sender: str
+    reply_to: str | None = None
     date: datetime.datetime
     snippet: str
     reply_count: int | None = None
@@ -28,6 +43,7 @@ class EmailDetailResponse(BaseModel):
     message_id: str
     thread_id: str | None = None
     sender: str
+    reply_to: str | None = None
     recipients: str | None
     subject: str | None
     date: datetime.datetime
@@ -38,13 +54,14 @@ class EmailDetailResponse(BaseModel):
 
 @router.get("", response_model=dict[str, list[EmailListItem]])
 async def get_emails(limit: int = 50, db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Email).order_by(Email.date.desc()).limit(limit * 3))
+    result = await db.execute(select(Email).order_by(Email.date.desc()))
     emails = result.scalars().all()
+    emails = sorted(emails, key=lambda item: item.date)
 
     grouped = {}
     reply_counts = {}
     for email in emails:
-        group_key = email.thread_id if email.thread_id else email.message_id
+        group_key = canonical_thread_key(email)
         if group_key not in grouped:
             grouped[group_key] = email
             reply_counts[group_key] = 1
@@ -57,16 +74,17 @@ async def get_emails(limit: int = 50, db: AsyncSession = Depends(get_db)):
 
     items = []
     for email in sorted_groups:
-        group_key = email.thread_id if email.thread_id else email.message_id
+        group_key = canonical_thread_key(email)
         snippet = email.body[:100] + "..." if len(email.body) > 100 else email.body
         items.append(
             EmailListItem(
                 id=email.id,
                 subject=email.subject,
                 sender=email.sender,
+                reply_to=email.reply_to,
                 date=email.date,
                 snippet=snippet,
-                thread_id=email.thread_id,
+                thread_id=group_key,
                 reply_count=reply_counts[group_key],
             )
         )
@@ -83,22 +101,27 @@ async def get_email(email_id: int, db: AsyncSession = Depends(get_db)):
         id=email.id,
         message_id=email.message_id,
         sender=email.sender,
+        reply_to=email.reply_to,
         recipients=email.recipients,
         subject=email.subject,
         date=email.date,
         body=email.body,
-        thread_id=email.thread_id,
+        thread_id=canonical_thread_key(email),
         in_reply_to=email.in_reply_to,
         references=email.references,
     )
 
 
-@router.get("/thread/{thread_id}", response_model=dict[str, list[EmailDetailResponse]])
+@router.get("/thread/{thread_id:path}", response_model=dict[str, list[EmailDetailResponse]])
 async def get_email_thread(thread_id: str, db: AsyncSession = Depends(get_db)):
+    lookup_values = thread_lookup_values(thread_id)
     result = await db.execute(
-        select(Email).where(Email.thread_id == thread_id).order_by(Email.date.asc())
+        select(Email)
+        .where(or_(Email.thread_id.in_(lookup_values), Email.message_id.in_(lookup_values)))
+        .order_by(Email.date.asc())
     )
     emails = result.scalars().all()
+    emails = sorted(emails, key=lambda item: item.date)
     if not emails:
         raise HTTPException(status_code=404, detail="Thread not found")
 
@@ -109,11 +132,12 @@ async def get_email_thread(thread_id: str, db: AsyncSession = Depends(get_db)):
                 id=email.id,
                 message_id=email.message_id,
                 sender=email.sender,
+                reply_to=email.reply_to,
                 recipients=email.recipients,
                 subject=email.subject,
                 date=email.date,
                 body=email.body,
-                thread_id=email.thread_id,
+                thread_id=canonical_thread_key(email),
                 in_reply_to=email.in_reply_to,
                 references=email.references,
             )
@@ -147,17 +171,21 @@ async def send_email_endpoint(
         smtp_port = tenant_config.smtp_port
         smtp_username = tenant_config.smtp_username
         
-        success = await send_email(
+        send_result = await send_email(
             request.to, 
             request.subject, 
             request.body,
             smtp_server=smtp_server,
             smtp_port=smtp_port,
-            smtp_username=smtp_username
+            smtp_username=smtp_username,
+            in_reply_to=request.in_reply_to,
+            references=request.references,
         )
-        if not success:
+        if not send_result:
             raise HTTPException(status_code=500, detail="Failed to send email")
-        return {"status": "success"}
+        return send_result
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error sending email: {e}", exc_info=True)
         raise HTTPException(

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import or_, select
 from db.session import get_db
@@ -54,11 +54,14 @@ class EmailDetailResponse(BaseModel):
 
 @router.get("", response_model=dict[str, list[EmailListItem]])
 async def get_emails(
-    limit: int = 50,
+    limit: int = Query(default=50, ge=1, le=200),
     db: AsyncSession = Depends(get_db),
     current_user: str = Depends(get_current_user),
 ):
-    result = await db.execute(select(Email).order_by(Email.date.desc()))
+    candidate_window = min(max(limit * 10, 200), 2000)
+    result = await db.execute(
+        select(Email).order_by(Email.date.desc()).limit(candidate_window)
+    )
     emails = result.scalars().all()
     emails = sorted(emails, key=lambda item: item.date)
 
@@ -193,7 +196,7 @@ async def send_email_endpoint(
             in_reply_to=request.in_reply_to,
             references=request.references,
         )
-        if not send_result:
+        if send_result.get("status") not in {"sent", "simulated"}:
             raise HTTPException(status_code=500, detail="Failed to send email")
         return send_result
     except HTTPException:

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -53,7 +53,11 @@ class EmailDetailResponse(BaseModel):
 
 
 @router.get("", response_model=dict[str, list[EmailListItem]])
-async def get_emails(limit: int = 50, db: AsyncSession = Depends(get_db)):
+async def get_emails(
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(get_current_user),
+):
     result = await db.execute(select(Email).order_by(Email.date.desc()))
     emails = result.scalars().all()
     emails = sorted(emails, key=lambda item: item.date)
@@ -92,7 +96,11 @@ async def get_emails(limit: int = 50, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/{email_id}", response_model=EmailDetailResponse)
-async def get_email(email_id: int, db: AsyncSession = Depends(get_db)):
+async def get_email(
+    email_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(get_current_user),
+):
     result = await db.execute(select(Email).where(Email.id == email_id))
     email = result.scalar_one_or_none()
     if not email:
@@ -113,7 +121,11 @@ async def get_email(email_id: int, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/thread/{thread_id:path}", response_model=dict[str, list[EmailDetailResponse]])
-async def get_email_thread(thread_id: str, db: AsyncSession = Depends(get_db)):
+async def get_email_thread(
+    thread_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(get_current_user),
+):
     lookup_values = thread_lookup_values(thread_id)
     result = await db.execute(
         select(Email)

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+import datetime
+import logging
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, union_all
 from db.session import get_db
@@ -8,23 +10,44 @@ from services.embedding import generate_embeddings
 from api.auth import get_current_user
 
 router = APIRouter(prefix="/api")
+logger = logging.getLogger(__name__)
 
 
 class SearchRequest(BaseModel):
     query: str
-    limit: int = 10
+    limit: int = Field(default=10, ge=1, le=50)
 
 
 class SearchResultItem(BaseModel):
     id: int
     subject: str | None
     sender: str
+    date: datetime.datetime
     snippet: str
+    thread_id: str | None = None
+    reply_count: int = 1
     score: float
 
 
 class SearchResponse(BaseModel):
     results: list[SearchResultItem]
+
+
+def thread_group_key():
+    return func.btrim(func.coalesce(Email.thread_id, Email.message_id), "<>")
+
+
+def build_reply_counts_subquery():
+    group_key = thread_group_key()
+    return (
+        select(
+            group_key.label("thread_key"),
+            func.count(Email.id).label("reply_count"),
+        )
+        .select_from(Email)
+        .group_by(group_key)
+        .subquery("thread_counts")
+    )
 
 
 @router.post("/search", response_model=SearchResponse)
@@ -52,13 +75,21 @@ async def hybrid_search(request: SearchRequest, user_id: str | None = None, db: 
         )
         vector_distance_email = Email.embedding.cosine_distance(query_embedding)
         hybrid_score_email = fts_score_email - vector_distance_email
+        reply_counts = build_reply_counts_subquery()
 
-        stmt_email = select(
-            Email.id,
-            Email.subject,
-            Email.sender,
-            Email.body.label("content"),
-            hybrid_score_email.label("score"),
+        stmt_email = (
+            select(
+                Email.id,
+                Email.subject,
+                Email.sender,
+                Email.date,
+                thread_group_key().label("thread_id"),
+                reply_counts.c.reply_count,
+                Email.body.label("content"),
+                hybrid_score_email.label("score"),
+            )
+            .select_from(Email)
+            .join(reply_counts, reply_counts.c.thread_key == thread_group_key())
         )
 
         fts_score_att = func.ts_rank_cd(
@@ -73,11 +104,15 @@ async def hybrid_search(request: SearchRequest, user_id: str | None = None, db: 
                 Email.id,
                 Email.subject,
                 Email.sender,
+                Email.date,
+                thread_group_key().label("thread_id"),
+                reply_counts.c.reply_count,
                 Attachment.content.label("content"),
                 hybrid_score_att.label("score"),
             )
             .select_from(Attachment)
             .join(Email, Attachment.email_id == Email.id)
+            .join(reply_counts, reply_counts.c.thread_key == thread_group_key())
         )
 
         combined = union_all(stmt_email, stmt_att).cte("combined_search")
@@ -87,6 +122,9 @@ async def hybrid_search(request: SearchRequest, user_id: str | None = None, db: 
                 combined.c.id,
                 combined.c.subject,
                 combined.c.sender,
+                combined.c.date,
+                combined.c.thread_id,
+                combined.c.reply_count,
                 combined.c.content,
                 combined.c.score,
             )
@@ -117,7 +155,10 @@ async def hybrid_search(request: SearchRequest, user_id: str | None = None, db: 
                     id=row.id,
                     subject=row.subject,
                     sender=row.sender,
+                    date=row.date,
                     snippet=snippet,
+                    thread_id=row.thread_id,
+                    reply_count=row.reply_count or 1,
                     score=float(score) if score is not None else 0.0,
                 )
             )
@@ -126,8 +167,8 @@ async def hybrid_search(request: SearchRequest, user_id: str | None = None, db: 
                 break
 
         return SearchResponse(results=search_results)
+    except HTTPException:
+        raise
     except Exception as e:
-        import traceback
-
-        traceback.print_exc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("Search failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Search failed") from e

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -34,7 +34,9 @@ class SearchResponse(BaseModel):
 
 
 def thread_group_key():
-    return func.btrim(func.coalesce(Email.thread_id, Email.message_id), "<>")
+    normalized_thread_id = func.nullif(func.btrim(func.btrim(Email.thread_id), "<>"), "")
+    normalized_message_id = func.nullif(func.btrim(func.btrim(Email.message_id), "<>"), "")
+    return func.coalesce(normalized_thread_id, normalized_message_id)
 
 
 def build_reply_counts_subquery():

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -61,6 +61,7 @@ class Email(Base):
     message_id: Mapped[str] = mapped_column(String, unique=True, index=True)
     thread_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True) # O3: email threading support
     sender: Mapped[str] = mapped_column(String)
+    reply_to: Mapped[str | None] = mapped_column(String, nullable=True)
     recipients: Mapped[str | None] = mapped_column(String, nullable=True)
     subject: Mapped[str | None] = mapped_column(String, nullable=True)
     in_reply_to: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/import_fixtures.py
+++ b/backend/import_fixtures.py
@@ -73,7 +73,12 @@ async def import_eml_file(session, eml_file: Path) -> bool:
             print(f"Failed to generate embedding for attachment {att['filename']}: {e}")
 
     session.add(email_obj)
-    await session.commit()
+    try:
+        await session.commit()
+    except Exception as e:
+        await session.rollback()
+        print(f"Failed to commit {eml_file}: {e}")
+        return False
     print(f"Imported {eml_file.name} with {len(parsed.get('attachments', []))} attachments.")
     return True
 

--- a/backend/import_fixtures.py
+++ b/backend/import_fixtures.py
@@ -10,6 +10,73 @@ from services.threading_service import assign_thread_id
 import os
 from sqlalchemy import select
 
+EMBEDDING_DIMENSION = 1536
+
+
+async def generate_fixture_embedding(text: str) -> list[float]:
+    openai_api_key = os.environ.get("OPENAI_API_KEY", "")
+    if not openai_api_key:
+        return [0.0] * EMBEDDING_DIMENSION
+
+    return (await generate_embeddings([text], openai_api_key=openai_api_key))[0]
+
+
+async def import_eml_file(session, eml_file: Path) -> bool:
+    try:
+        parsed = parse_eml(eml_file)
+    except Exception as e:
+        print(f"Failed to parse {eml_file}: {e}")
+        return False
+
+    existing = await session.execute(
+        select(Email).where(Email.message_id == parsed["message_id"])
+    )
+    if existing.scalar_one_or_none():
+        print(f"Email {parsed['message_id']} already exists, skipping.")
+        return False
+
+    body_text = parsed["body"] if parsed["body"].strip() else "Empty body"
+    try:
+        body_emb = await generate_fixture_embedding(body_text)
+    except Exception as e:
+        print(f"Failed to generate embedding for {eml_file}: {e}")
+        return False
+
+    thread_id = await assign_thread_id(session, parsed)
+
+    email_obj = Email(
+        message_id=parsed["message_id"],
+        sender=parsed["sender"],
+        reply_to=parsed.get("reply_to"),
+        recipients=parsed["recipients"],
+        subject=parsed["subject"],
+        in_reply_to=parsed.get("in_reply_to"),
+        references=parsed.get("references"),
+        date=parsed["date"],
+        body=parsed["body"],
+        embedding=body_emb,
+        thread_id=thread_id,
+    )
+
+    for att in parsed.get("attachments", []):
+        att_text = att["content"] if att["content"].strip() else "Empty attachment"
+        try:
+            att_emb = await generate_fixture_embedding(att_text)
+            email_obj.attachments.append(
+                Attachment(
+                    filename=att["filename"],
+                    content=att["content"],
+                    embedding=att_emb,
+                )
+            )
+        except Exception as e:
+            print(f"Failed to generate embedding for attachment {att['filename']}: {e}")
+
+    session.add(email_obj)
+    await session.commit()
+    print(f"Imported {eml_file.name} with {len(parsed.get('attachments', []))} attachments.")
+    return True
+
 
 async def main():
     fixtures_dir = Path(__file__).parent / "tests" / "fixtures"
@@ -24,79 +91,7 @@ async def main():
 
     async with AsyncSessionLocal() as session:
         for eml_file in eml_files:
-            try:
-                parsed = parse_eml(eml_file)
-            except Exception as e:
-                print(f"Failed to parse {eml_file}: {e}")
-                continue
-
-            # Check if email already exists
-            existing = await session.execute(
-                select(Email).where(Email.message_id == parsed["message_id"])
-            )
-            if existing.scalar_one_or_none():
-                print(f"Email {parsed['message_id']} already exists, skipping.")
-                continue
-
-            # Generate embedding for the body
-            body_text = parsed["body"] if parsed["body"].strip() else "Empty body"
-            try:
-                openai_api_key = os.environ.get("OPENAI_API_KEY", "")
-                body_emb = (await generate_embeddings([body_text], openai_api_key=openai_api_key))[0]
-            except Exception as e:
-                print(f"Failed to generate embedding for {eml_file}: {e}")
-                continue
-                
-            thread_id = await assign_thread_id(session, parsed)
-
-            # simplified thread extraction logic
-            thread_id = parsed["message_id"]
-            refs_str = parsed.get("references")
-            if refs_str:
-                refs = str(refs_str).split()
-                if refs:
-                    thread_id = refs[0]
-            elif parsed.get("in_reply_to"):
-                thread_id = str(parsed.get("in_reply_to"))
-
-            email_obj = Email(
-                message_id=parsed["message_id"],
-                sender=parsed["sender"],
-                recipients=parsed["recipients"],
-                subject=parsed["subject"],
-                in_reply_to=parsed.get("in_reply_to"),
-                references=parsed.get("references"),
-                date=parsed["date"],
-                body=parsed["body"],
-                embedding=body_emb,
-                thread_id=thread_id,
-            )
-
-            # Generate embeddings for attachments
-            for att in parsed.get("attachments", []):
-                att_text = (
-                    att["content"] if att["content"].strip() else "Empty attachment"
-                )
-                try:
-                    openai_api_key = os.environ.get("OPENAI_API_KEY", "")
-                    att_emb = (await generate_embeddings([att_text], openai_api_key=openai_api_key))[0]
-                    email_obj.attachments.append(
-                        Attachment(
-                            filename=att["filename"],
-                            content=att["content"],
-                            embedding=att_emb,
-                        )
-                    )
-                except Exception as e:
-                    print(
-                        f"Failed to generate embedding for attachment {att['filename']}: {e}"
-                    )
-
-            session.add(email_obj)
-            await session.commit()
-            print(
-                f"Imported {eml_file.name} with {len(parsed.get('attachments', []))} attachments."
-            )
+            await import_eml_file(session, eml_file)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from sqlalchemy import text
+
+from db.models import Base
+from db.session import engine
+
+
+def schema_backfill_sql():
+    return [
+        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS thread_id varchar"),
+        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
+        text('ALTER TABLE emails ADD COLUMN IF NOT EXISTS "references" varchar'),
+        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS reply_to varchar"),
+        text("CREATE INDEX IF NOT EXISTS ix_emails_thread_id ON emails (thread_id)"),
+    ]
+
+
+async def bootstrap_db() -> None:
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.run_sync(Base.metadata.create_all)
+        for statement in schema_backfill_sql():
+            await conn.execute(statement)
+
+
+if __name__ == "__main__":
+    asyncio.run(bootstrap_db())

--- a/backend/scripts/import_fixtures.py
+++ b/backend/scripts/import_fixtures.py
@@ -57,6 +57,7 @@ async def process_zip_file(zip_path: str | Path, session: AsyncSession):
             stmt = insert(Email).values(
                 message_id=email_data["message_id"],
                 sender=email_data["sender"],
+                reply_to=email_data.get("reply_to"),
                 recipients=email_data["recipients"],
                 subject=email_data["subject"],
                 in_reply_to=email_data.get("in_reply_to"),
@@ -70,6 +71,7 @@ async def process_zip_file(zip_path: str | Path, session: AsyncSession):
                 index_elements=["message_id"],
                 set_=dict(
                     sender=stmt.excluded.sender,
+                    reply_to=stmt.excluded.reply_to,
                     recipients=stmt.excluded.recipients,
                     subject=stmt.excluded.subject,
                     in_reply_to=stmt.excluded.in_reply_to,

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -1,5 +1,9 @@
 import base64
+import logging
+from email.message import EmailMessage
 from typing import TypedDict
+
+logger = logging.getLogger(__name__)
 
 
 def generate_oauth2_string(user: str, access_token: str) -> bytes:
@@ -8,11 +12,9 @@ def generate_oauth2_string(user: str, access_token: str) -> bytes:
     return base64.b64encode(auth_string.encode("utf-8"))
 
 
-import aiosmtplib
-from email.message import EmailMessage
-import logging
-
-logger = logging.getLogger(__name__)
+def _sanitize_log_value(value: str) -> str:
+    """Remove CR/LF characters from user-provided values before logging."""
+    return value.replace("\r", " ").replace("\n", " ")
 
 
 class SendEmailResult(TypedDict):
@@ -42,17 +44,18 @@ def build_email_message(
 
 
 async def send_email(
-    to_address: str, 
-    subject: str, 
-    body: str, 
-    smtp_server: str | None = None, 
-    smtp_port: int | None = None, 
+    to_address: str,
+    subject: str,
+    body: str,
+    smtp_server: str | None = None,
+    smtp_port: int | None = None,
     smtp_username: str | None = None,
     in_reply_to: str | None = None,
     references: str | None = None,
 ) -> SendEmailResult:
     """Sends an email using SMTP."""
-    message = build_email_message(
+    safe_to_address = _sanitize_log_value(to_address)
+    build_email_message(
         to_address=to_address,
         subject=subject,
         body=body,
@@ -75,7 +78,7 @@ async def send_email(
         # )
         # For now, just pretend we sent it to pass the test locally without creds.
         # This is intentionally mocked for development.
-        logger.info("Simulating sending email to %s", to_address)
+        logger.info("Simulating sending email to %s", safe_to_address)
         return {"status": "simulated", "simulated": True}
     except Exception as e:
         raise Exception(f"Failed to send email: {e}")

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -1,4 +1,5 @@
 import base64
+from typing import TypedDict
 
 
 def generate_oauth2_string(user: str, access_token: str) -> bytes:
@@ -14,20 +15,51 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class SendEmailResult(TypedDict):
+    status: str
+    simulated: bool
+
+
+def build_email_message(
+    to_address: str,
+    subject: str,
+    body: str,
+    from_address: str,
+    in_reply_to: str | None = None,
+    references: str | None = None,
+) -> EmailMessage:
+    """Build an outbound email message with optional threading headers."""
+    message = EmailMessage()
+    message["From"] = from_address
+    message["To"] = to_address
+    message["Subject"] = subject
+    if in_reply_to:
+        message["In-Reply-To"] = in_reply_to
+    if references:
+        message["References"] = references
+    message.set_content(body)
+    return message
+
+
 async def send_email(
     to_address: str, 
     subject: str, 
     body: str, 
     smtp_server: str | None = None, 
     smtp_port: int | None = None, 
-    smtp_username: str | None = None
-) -> bool:
+    smtp_username: str | None = None,
+    in_reply_to: str | None = None,
+    references: str | None = None,
+) -> SendEmailResult:
     """Sends an email using SMTP."""
-    message = EmailMessage()
-    message["From"] = smtp_username or "me@example.com"
-    message["To"] = to_address
-    message["Subject"] = subject
-    message.set_content(body)
+    message = build_email_message(
+        to_address=to_address,
+        subject=subject,
+        body=body,
+        from_address=smtp_username or "me@example.com",
+        in_reply_to=in_reply_to,
+        references=references,
+    )
 
     # Note: Real implementation would use OAuth or password.
     # This is a skeleton.
@@ -43,7 +75,7 @@ async def send_email(
         # )
         # For now, just pretend we sent it to pass the test locally without creds.
         # This is intentionally mocked for development.
-        logger.info(f"Simulating sending email to {to_address}")
-        return True
+        logger.info("Simulating sending email to %s", to_address)
+        return {"status": "simulated", "simulated": True}
     except Exception as e:
         raise Exception(f"Failed to send email: {e}")

--- a/backend/services/email_parser.py
+++ b/backend/services/email_parser.py
@@ -13,6 +13,7 @@ class EmailData(TypedDict):
     message_id: str
     thread_id: str | None
     sender: str
+    reply_to: str | None
     recipients: str
     subject: str
     in_reply_to: str | None
@@ -117,6 +118,7 @@ def parse_eml(file_path: str | Path) -> EmailData:
         "message_id": message_id,
         "thread_id": thread_id,
         "sender": _sanitize_nul(msg.get("From", "")),
+        "reply_to": _sanitize_nul(msg.get("Reply-To", "")) if msg.get("Reply-To") else None,
         "recipients": _sanitize_nul(msg.get("To", "")),
         "subject": _sanitize_nul(msg.get("Subject", "")),
         "in_reply_to": _sanitize_nul(msg.get("In-Reply-To", "")) if msg.get("In-Reply-To") else None,

--- a/backend/services/threading_service.py
+++ b/backend/services/threading_service.py
@@ -1,56 +1,74 @@
 import uuid
 import re
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from db.models import Email
 from services.email_parser import EmailData
+
+
+def normalize_message_id(value: str | None) -> str | None:
+    """Return the canonical persisted form for a Message-ID-like header."""
+    if value is None:
+        return None
+
+    normalized = str(value).strip().strip("<>").strip()
+    return normalized or None
+
+
+def extract_reference_ids(value: str | None) -> list[str]:
+    """Extract canonical message IDs from a References header in header order."""
+    if not value:
+        return []
+
+    refs = re.findall(r"<([^>]+)>", str(value))
+    if not refs:
+        refs = str(value).split()
+
+    normalized_refs: list[str] = []
+    for ref in refs:
+        normalized = normalize_message_id(ref)
+        if normalized and normalized not in normalized_refs:
+            normalized_refs.append(normalized)
+    return normalized_refs
+
+
+async def _find_existing_thread_id(session: AsyncSession, message_id: str) -> str | None:
+    bracketed = f"<{message_id}>"
+    result = await session.execute(
+        select(Email.thread_id).where(
+            or_(Email.message_id == message_id, Email.message_id == bracketed)
+        )
+    )
+    return result.scalar_one_or_none()
 
 async def assign_thread_id(session: AsyncSession, email_data: EmailData) -> str:
     """
     Determine the thread_id for a new email based on in_reply_to and references.
     If no existing match is found, generate a new thread_id.
     """
-    # O3: email threading support
-    in_reply_to = email_data.get("in_reply_to")
-    references_str = email_data.get("references")
-    
-    # 1. Try to find the parent email using in_reply_to
+    in_reply_to = normalize_message_id(email_data.get("in_reply_to"))
+    references = extract_reference_ids(email_data.get("references"))
+
+    existing_candidates = []
     if in_reply_to:
-        # Some headers have brackets like <msg-id>
-        in_reply_to_clean = in_reply_to.strip("<>")
-        query = select(Email.thread_id).where(Email.message_id == in_reply_to_clean)
-        result = await session.execute(query)
-        thread_id = result.scalar_one_or_none()
-        if thread_id:
-            return thread_id
-            
-        # Also try matching exact string if it didn't have brackets or we stripped them but the DB has brackets
-        query = select(Email.thread_id).where(Email.message_id == in_reply_to)
-        result = await session.execute(query)
-        thread_id = result.scalar_one_or_none()
-        if thread_id:
-            return thread_id
+        existing_candidates.append(in_reply_to)
+    existing_candidates.extend(ref for ref in references if ref not in existing_candidates)
 
-    # 2. Try to find any email from the references
-    if references_str:
-        # Extract message IDs from references string (usually space-separated, sometimes with <>)
-        refs = re.findall(r'<([^>]+)>', references_str)
-        if not refs:
-            refs = references_str.split()
-            
-        for ref in refs:
-            ref_clean = ref.strip("<>")
-            # Try both stripped and unstripped
-            query = select(Email.thread_id).where((Email.message_id == ref_clean) | (Email.message_id == ref))
-            result = await session.execute(query)
-            thread_id = result.scalar_one_or_none()
-            if thread_id:
-                return thread_id
+    for candidate in existing_candidates:
+        thread_id = await _find_existing_thread_id(session, candidate)
+        if thread_id:
+            return normalize_message_id(thread_id) or thread_id
 
-    # 3. No match found, generate a new thread_id
-    # We can use the message_id if available, otherwise a UUID
-    msg_id = email_data.get("message_id")
+    # If the parent/root has not been imported yet, use the oldest known ancestor
+    # as the deterministic thread root so later imports converge on one thread.
+    if references:
+        return references[0]
+
+    if in_reply_to:
+        return in_reply_to
+
+    msg_id = normalize_message_id(email_data.get("message_id"))
     if msg_id:
-        return msg_id.strip("<>")
-    
+        return msg_id
+
     return uuid.uuid4().hex

--- a/backend/tests/fixtures/threading-basic-01-root.eml
+++ b/backend/tests/fixtures/threading-basic-01-root.eml
@@ -1,0 +1,8 @@
+Message-ID: <thread-root@example.com>
+From: Alice Example <alice@example.com>
+Reply-To: Alice Replies <alice-replies@example.com>
+To: user@example.com
+Subject: Quarterly plan
+Date: Mon, 27 Apr 2026 10:00:00 +0000
+
+Root message for the sample threading conversation.

--- a/backend/tests/fixtures/threading-basic-02-reply.eml
+++ b/backend/tests/fixtures/threading-basic-02-reply.eml
@@ -1,0 +1,9 @@
+Message-ID: <thread-reply-1@example.com>
+From: Bob Example <bob@example.com>
+To: Alice Example <alice@example.com>
+Subject: Re: Quarterly plan
+Date: Mon, 27 Apr 2026 10:05:00 +0000
+In-Reply-To: <thread-root@example.com>
+References: <thread-root@example.com>
+
+First reply in the sample threading conversation.

--- a/backend/tests/fixtures/threading-basic-03-reply.eml
+++ b/backend/tests/fixtures/threading-basic-03-reply.eml
@@ -1,0 +1,9 @@
+Message-ID: <thread-reply-2@example.com>
+From: Alice Example <alice@example.com>
+To: Bob Example <bob@example.com>
+Subject: Re: Quarterly plan
+Date: Mon, 27 Apr 2026 10:10:00 +0000
+In-Reply-To: <thread-reply-1@example.com>
+References: <thread-root@example.com> <thread-reply-1@example.com>
+
+Second reply in the sample threading conversation.

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -1,0 +1,11 @@
+from scripts.bootstrap_db import schema_backfill_sql
+
+
+def test_schema_backfill_adds_threading_columns_for_existing_tables():
+    statements = [str(statement).lower() for statement in schema_backfill_sql()]
+
+    assert any("alter table emails add column if not exists reply_to" in statement for statement in statements)
+    assert any("alter table emails add column if not exists thread_id" in statement for statement in statements)
+    assert any("alter table emails add column if not exists in_reply_to" in statement for statement in statements)
+    assert any("alter table emails add column if not exists \"references\"" in statement for statement in statements)
+    assert any("create index if not exists ix_emails_thread_id" in statement for statement in statements)

--- a/backend/tests/test_email_client.py
+++ b/backend/tests/test_email_client.py
@@ -1,6 +1,12 @@
 import base64
+import logging
 import pytest
-from services.email_client import build_email_message, generate_oauth2_string
+from services.email_client import (
+    _sanitize_log_value,
+    build_email_message,
+    generate_oauth2_string,
+    send_email,
+)
 
 
 def test_generate_oauth2_string():
@@ -24,3 +30,26 @@ def test_build_email_message_sets_reply_headers():
     assert message["References"] == "<root@example.com> <parent@example.com>"
     assert message["From"] == "sender@example.com"
     assert message["To"] == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_email_logs_sanitized_recipient(caplog):
+    caplog.set_level(logging.INFO, logger="services.email_client")
+
+    result = await send_email(
+        to_address="victim@example.com",
+        subject="Test",
+        body="Body",
+    )
+
+    assert result == {"status": "simulated", "simulated": True}
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Simulating sending email to victim@example.com" in messages
+    assert all("\n" not in message and "\r" not in message for message in messages)
+
+
+def test_log_value_sanitizer_removes_crlf():
+    assert (
+        _sanitize_log_value("victim@example.com\r\nINFO forged@example.com")
+        == "victim@example.com  INFO forged@example.com"
+    )

--- a/backend/tests/test_email_client.py
+++ b/backend/tests/test_email_client.py
@@ -1,6 +1,6 @@
 import base64
 import pytest
-from services.email_client import generate_oauth2_string
+from services.email_client import build_email_message, generate_oauth2_string
 
 
 def test_generate_oauth2_string():
@@ -8,3 +8,19 @@ def test_generate_oauth2_string():
     decoded = base64.b64decode(result)
     assert b"user=test@example.com" in decoded
     assert b"auth=Bearer dummy_token" in decoded
+
+
+def test_build_email_message_sets_reply_headers():
+    message = build_email_message(
+        to_address="test@example.com",
+        subject="Re: Test",
+        body="Reply body",
+        from_address="sender@example.com",
+        in_reply_to="<parent@example.com>",
+        references="<root@example.com> <parent@example.com>",
+    )
+
+    assert message["In-Reply-To"] == "<parent@example.com>"
+    assert message["References"] == "<root@example.com> <parent@example.com>"
+    assert message["From"] == "sender@example.com"
+    assert message["To"] == "test@example.com"

--- a/backend/tests/test_email_parser.py
+++ b/backend/tests/test_email_parser.py
@@ -133,3 +133,23 @@ Test"""
                 assert parsed["thread_id"] == "<msg3@test.com>"
         finally:
             os.unlink(temp_path)
+
+
+def test_parse_eml_extracts_reply_to_header():
+    eml_content = b"""Message-ID: <reply-to@test.com>
+From: Sender Name <sender@test.com>
+Reply-To: Reply Target <reply-target@test.com>
+To: user@test.com
+Subject: Reply-To Test
+
+Test"""
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".eml") as f:
+        f.write(eml_content)
+        temp_path = f.name
+
+    try:
+        parsed = parse_eml(temp_path)
+        assert parsed["reply_to"] == "Reply Target <reply-target@test.com>"
+    finally:
+        os.unlink(temp_path)

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient, ASGITransport
 from db.models import Email
 from main import app
 import datetime
+from unittest.mock import patch
 
 
 @pytest_asyncio.fixture
@@ -247,7 +248,26 @@ async def test_get_email_thread_accepts_url_encoded_reserved_characters(
     assert response.json()["thread"][0]["thread_id"] == "root/part@example.com"
 
 
-from unittest.mock import patch
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    ["/api/emails?limit=10", "/api/emails/1", "/api/emails/thread/thread123"],
+)
+async def test_get_email_routes_apply_auth_dependency(client: AsyncClient, path: str):
+    from api.emails import get_current_user as emails_get_current_user
+
+    calls = []
+
+    async def auth_override():
+        calls.append("hit")
+        return "authorized-user"
+
+    app.dependency_overrides[emails_get_current_user] = auth_override
+
+    response = await client.get(path)
+
+    assert response.status_code == 200
+    assert calls == ["hit"]
 
 
 @patch("api.emails.send_email", return_value={"status": "simulated", "simulated": True})

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -54,6 +54,10 @@ class MockSession:
 
 
 class LimitAwareMockSession(MockSession):
+    def __init__(self, items, tenant_config=_DEFAULT_TENANT_CONFIG):
+        super().__init__(items, tenant_config=tenant_config)
+        self.last_limit_value = None
+
     async def execute(self, query):
         class MockResult:
             def __init__(self, rows):
@@ -70,6 +74,7 @@ class LimitAwareMockSession(MockSession):
 
         limit_clause = getattr(query, "_limit_clause", None)
         limit_value = getattr(limit_clause, "value", None)
+        self.last_limit_value = limit_value
         rows = self.items[:limit_value] if limit_value else self.items
         return MockResult(rows)
 
@@ -152,6 +157,29 @@ async def test_get_emails_returns_exact_distinct_threads_beyond_overfetch_window
     data = response.json()["emails"]
     assert [item["thread_id"] for item in data] == ["hot-thread", "second-thread"]
     assert data[0]["reply_count"] == 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, -1])
+async def test_get_emails_rejects_non_positive_limit(client: AsyncClient, limit: int):
+    response = await client.get(f"/api/emails?limit={limit}")
+
+    assert response.status_code == 422
+    assert "limit" in response.text
+
+
+@pytest.mark.asyncio
+async def test_get_emails_bounds_database_candidate_window(client: AsyncClient, db_session):
+    from db.session import get_db
+
+    session = LimitAwareMockSession(db_session.items)
+    app.dependency_overrides[get_db] = lambda: session
+
+    response = await client.get("/api/emails?limit=10")
+
+    assert response.status_code == 200
+    assert session.last_limit_value is not None
+    assert session.last_limit_value >= 10
 
 
 @pytest.mark.asyncio
@@ -326,3 +354,24 @@ def test_send_email_endpoint_preserves_configuration_error(sample_email):
 
     assert response.status_code == 400
     assert response.json() == {"detail": "SMTP is not configured"}
+
+
+@patch("api.emails.send_email", return_value={"status": "failed", "simulated": False})
+def test_send_email_endpoint_rejects_failed_send_status(mock_send_email):
+    from main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/emails/send",
+        json={
+            "to": "test@example.com",
+            "subject": "Re: Test",
+            "body": "This is a reply.",
+        },
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Failed to send email"}
+    mock_send_email.assert_called_once()

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -20,9 +20,17 @@ class MockTenantConfig:
         self.smtp_port = 587
         self.smtp_username = "testuser"
 
+_DEFAULT_TENANT_CONFIG = object()
+
+
 class MockSession:
-    def __init__(self, items):
+    def __init__(self, items, tenant_config=_DEFAULT_TENANT_CONFIG):
         self.items = items
+        self.tenant_config = (
+            MockTenantConfig()
+            if tenant_config is _DEFAULT_TENANT_CONFIG
+            else tenant_config
+        )
 
     async def execute(self, query):
         class MockResult:
@@ -41,7 +49,28 @@ class MockSession:
         return MockResult(self.items)
 
     async def scalar(self, query):
-        return MockTenantConfig()
+        return self.tenant_config
+
+
+class LimitAwareMockSession(MockSession):
+    async def execute(self, query):
+        class MockResult:
+            def __init__(self, rows):
+                self.rows = rows
+
+            def scalars(self):
+                return self
+
+            def all(self):
+                return self.rows
+
+            def scalar_one_or_none(self):
+                return self.rows[0] if self.rows else None
+
+        limit_clause = getattr(query, "_limit_clause", None)
+        limit_value = getattr(limit_clause, "value", None)
+        rows = self.items[:limit_value] if limit_value else self.items
+        return MockResult(rows)
 
 
 @pytest.fixture
@@ -51,6 +80,7 @@ def sample_email():
         message_id="msg123",
         thread_id="thread123",
         sender="test@example.com",
+        reply_to="reply@example.com",
         recipients="user@example.com",
         subject="Test Subject",
         date=datetime.datetime.now(datetime.timezone.utc),
@@ -81,10 +111,87 @@ async def test_get_emails(client: AsyncClient, db_session):
 
 
 @pytest.mark.asyncio
+async def test_get_emails_returns_exact_distinct_threads_beyond_overfetch_window(
+    client: AsyncClient, db_session
+):
+    hot_thread = [
+        Email(
+            id=index + 1,
+            message_id=f"hot-{index}",
+            thread_id="hot-thread",
+            sender="hot@example.com",
+            recipients="user@example.com",
+            subject="Hot thread",
+            date=datetime.datetime(2026, 4, 27, 12, index, tzinfo=datetime.timezone.utc),
+            body=f"Hot body {index}",
+        )
+        for index in range(6)
+    ]
+    second_thread = Email(
+        id=99,
+        message_id="second-thread-root",
+        thread_id="second-thread",
+        sender="second@example.com",
+        recipients="user@example.com",
+        subject="Second thread",
+        date=datetime.datetime(2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Second body",
+    )
+    db_session.items = sorted(
+        [*hot_thread, second_thread], key=lambda item: item.date, reverse=True
+    )
+
+    from db.session import get_db
+
+    app.dependency_overrides[get_db] = lambda: LimitAwareMockSession(db_session.items)
+
+    response = await client.get("/api/emails?limit=2")
+
+    assert response.status_code == 200
+    data = response.json()["emails"]
+    assert [item["thread_id"] for item in data] == ["hot-thread", "second-thread"]
+    assert data[0]["reply_count"] == 6
+
+
+@pytest.mark.asyncio
+async def test_get_emails_normalizes_legacy_bracketed_thread_ids(client: AsyncClient, db_session):
+    root = Email(
+        id=1,
+        message_id="<root@example.com>",
+        thread_id="<root@example.com>",
+        sender="root@example.com",
+        recipients="user@example.com",
+        subject="Legacy root",
+        date=datetime.datetime(2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Root body",
+    )
+    reply = Email(
+        id=2,
+        message_id="<reply@example.com>",
+        thread_id="root@example.com",
+        sender="reply@example.com",
+        recipients="user@example.com",
+        subject="Re: Legacy root",
+        date=datetime.datetime(2026, 4, 27, 11, 0, tzinfo=datetime.timezone.utc),
+        body="Reply body",
+    )
+    db_session.items = [reply, root]
+
+    response = await client.get("/api/emails?limit=10")
+
+    assert response.status_code == 200
+    data = response.json()["emails"]
+    assert len(data) == 1
+    assert data[0]["thread_id"] == "root@example.com"
+    assert data[0]["reply_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_get_email_by_id(client: AsyncClient, db_session, sample_email: Email):
     response = await client.get(f"/api/emails/{sample_email.id}")
     assert response.status_code == 200
     assert response.json()["id"] == sample_email.id
+    assert response.json()["reply_to"] == "reply@example.com"
 
 
 @pytest.mark.asyncio
@@ -97,10 +204,53 @@ async def test_get_email_thread(client: AsyncClient, db_session, sample_email: E
     assert data["thread"][0]["id"] == sample_email.id
 
 
+@pytest.mark.asyncio
+async def test_get_email_thread_returns_chronological_order(client: AsyncClient, db_session):
+    newer = Email(
+        id=2,
+        message_id="newer-msg",
+        thread_id="thread123",
+        sender="newer@example.com",
+        recipients="user@example.com",
+        subject="Re: Test Subject",
+        date=datetime.datetime(2026, 4, 27, 11, 0, tzinfo=datetime.timezone.utc),
+        body="Newer body",
+    )
+    older = Email(
+        id=1,
+        message_id="older-msg",
+        thread_id="thread123",
+        sender="older@example.com",
+        recipients="user@example.com",
+        subject="Test Subject",
+        date=datetime.datetime(2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Older body",
+    )
+    db_session.items = [newer, older]
+
+    response = await client.get("/api/emails/thread/thread123")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["thread"]] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_get_email_thread_accepts_url_encoded_reserved_characters(
+    client: AsyncClient, db_session, sample_email: Email
+):
+    sample_email.thread_id = "root/part@example.com"
+    sample_email.message_id = "<root/part@example.com>"
+
+    response = await client.get("/api/emails/thread/root%2Fpart%40example.com")
+
+    assert response.status_code == 200
+    assert response.json()["thread"][0]["thread_id"] == "root/part@example.com"
+
+
 from unittest.mock import patch
 
 
-@patch("api.emails.send_email", return_value=True)
+@patch("api.emails.send_email", return_value={"status": "simulated", "simulated": True})
 def test_send_email_endpoint(mock_send_email):
     from main import app
     from fastapi.testclient import TestClient
@@ -113,11 +263,46 @@ def test_send_email_endpoint(mock_send_email):
             "to": "test@example.com",
             "subject": "Re: Test",
             "body": "This is a reply.",
+            "in_reply_to": "<parent@example.com>",
+            "references": "<root@example.com> <parent@example.com>",
         },
     )
 
     assert response.status_code == 200
-    assert response.json() == {"status": "success"}
+    assert response.json() == {"status": "simulated", "simulated": True}
     mock_send_email.assert_called_once_with(
-        "test@example.com", "Re: Test", "This is a reply.", smtp_server="smtp.example.com", smtp_port=587, smtp_username="testuser"
+        "test@example.com",
+        "Re: Test",
+        "This is a reply.",
+        smtp_server="smtp.example.com",
+        smtp_port=587,
+        smtp_username="testuser",
+        in_reply_to="<parent@example.com>",
+        references="<root@example.com> <parent@example.com>",
     )
+
+
+def test_send_email_endpoint_preserves_configuration_error(sample_email):
+    from main import app
+    from fastapi.testclient import TestClient
+    from db.session import get_db
+
+    async def missing_smtp_db():
+        yield MockSession([sample_email], tenant_config=None)
+
+    app.dependency_overrides[get_db] = missing_smtp_db
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/api/emails/send",
+            json={
+                "to": "test@example.com",
+                "subject": "Re: Test",
+                "body": "This is a reply.",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "SMTP is not configured"}

--- a/backend/tests/test_import_fixtures.py
+++ b/backend/tests/test_import_fixtures.py
@@ -1,6 +1,8 @@
 import pytest
+import datetime
 from unittest.mock import patch, AsyncMock
 from scripts.import_fixtures import process_zip_file
+import import_fixtures
 
 
 @pytest.mark.asyncio
@@ -11,3 +13,95 @@ async def test_process_zip_file():
                 mock_extract.return_value = []
                 # Ensure it doesn't crash on an empty zip
                 await process_zip_file("dummy.zip", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_root_importer_persists_canonical_thread_id(tmp_path):
+    class MockResult:
+        def scalar_one_or_none(self):
+            return None
+
+    class MockSession:
+        def __init__(self):
+            self.added = None
+            self.committed = False
+
+        async def execute(self, _query):
+            return MockResult()
+
+        def add(self, obj):
+            self.added = obj
+
+        async def commit(self):
+            self.committed = True
+
+    eml_file = tmp_path / "reply.eml"
+    eml_file.write_text("Message-ID: <reply@example.com>\n\nBody")
+    parsed = {
+        "message_id": "<reply@example.com>",
+        "sender": "sender@example.com",
+        "recipients": "user@example.com",
+        "subject": "Re: Root",
+        "in_reply_to": "<parent@example.com>",
+        "references": "<root@example.com> <parent@example.com>",
+        "date": datetime.datetime.now(datetime.timezone.utc),
+        "body": "Body",
+        "attachments": [],
+    }
+    session = MockSession()
+
+    with patch.object(import_fixtures, "parse_eml", return_value=parsed), patch.object(
+        import_fixtures, "generate_embeddings", new_callable=AsyncMock
+    ) as mock_embeddings, patch.object(
+        import_fixtures, "assign_thread_id", new_callable=AsyncMock
+    ) as mock_assign:
+        mock_embeddings.return_value = [[0.0] * 1536]
+        mock_assign.return_value = "canonical-thread"
+
+        imported = await import_fixtures.import_eml_file(session, eml_file)
+
+    assert imported is True
+    assert session.added.thread_id == "canonical-thread"
+    assert session.committed is True
+
+
+@pytest.mark.asyncio
+async def test_root_importer_uses_local_embedding_without_openai_key(tmp_path, monkeypatch):
+    class MockResult:
+        def scalar_one_or_none(self):
+            return None
+
+    class MockSession:
+        def __init__(self):
+            self.added = None
+
+        async def execute(self, _query):
+            return MockResult()
+
+        def add(self, obj):
+            self.added = obj
+
+        async def commit(self):
+            pass
+
+    eml_file = tmp_path / "root.eml"
+    eml_file.write_text("Message-ID: <root@example.com>\n\nBody")
+    parsed = {
+        "message_id": "<root@example.com>",
+        "sender": "sender@example.com",
+        "recipients": "user@example.com",
+        "subject": "Root",
+        "date": datetime.datetime.now(datetime.timezone.utc),
+        "body": "Body",
+        "attachments": [],
+    }
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    session = MockSession()
+
+    with patch.object(import_fixtures, "parse_eml", return_value=parsed), patch.object(
+        import_fixtures, "generate_embeddings", side_effect=AssertionError("network call")
+    ):
+        imported = await import_fixtures.import_eml_file(session, eml_file)
+
+    assert imported is True
+    assert session.added.embedding == [0.0] * 1536

--- a/backend/tests/test_import_fixtures.py
+++ b/backend/tests/test_import_fixtures.py
@@ -8,8 +8,8 @@ import import_fixtures
 @pytest.mark.asyncio
 async def test_process_zip_file():
     with patch("scripts.import_fixtures.extract_backup_async") as mock_extract:
-        with patch("scripts.import_fixtures.parse_eml") as mock_parse:
-            with patch("scripts.import_fixtures.generate_embeddings") as mock_embed:
+        with patch("scripts.import_fixtures.parse_eml"):
+            with patch("scripts.import_fixtures.generate_embeddings"):
                 mock_extract.return_value = []
                 # Ensure it doesn't crash on an empty zip
                 await process_zip_file("dummy.zip", AsyncMock())
@@ -105,3 +105,54 @@ async def test_root_importer_uses_local_embedding_without_openai_key(tmp_path, m
 
     assert imported is True
     assert session.added.embedding == [0.0] * 1536
+
+
+@pytest.mark.asyncio
+async def test_root_importer_rolls_back_and_returns_false_on_commit_failure(tmp_path):
+    class MockResult:
+        def scalar_one_or_none(self):
+            return None
+
+    class MockSession:
+        def __init__(self):
+            self.added = None
+            self.rolled_back = False
+
+        async def execute(self, _query):
+            return MockResult()
+
+        def add(self, obj):
+            self.added = obj
+
+        async def commit(self):
+            raise RuntimeError("commit failed")
+
+        async def rollback(self):
+            self.rolled_back = True
+
+    eml_file = tmp_path / "commit-failure.eml"
+    eml_file.write_text("Message-ID: <commit-failure@example.com>\n\nBody")
+    parsed = {
+        "message_id": "<commit-failure@example.com>",
+        "sender": "sender@example.com",
+        "recipients": "user@example.com",
+        "subject": "Commit failure",
+        "date": datetime.datetime.now(datetime.timezone.utc),
+        "body": "Body",
+        "attachments": [],
+    }
+    session = MockSession()
+
+    with patch.object(import_fixtures, "parse_eml", return_value=parsed), patch.object(
+        import_fixtures, "generate_embeddings", new_callable=AsyncMock
+    ) as mock_embeddings, patch.object(
+        import_fixtures, "assign_thread_id", new_callable=AsyncMock
+    ) as mock_assign:
+        mock_embeddings.return_value = [[0.0] * 1536]
+        mock_assign.return_value = "commit-failure-thread"
+
+        imported = await import_fixtures.import_eml_file(session, eml_file)
+
+    assert imported is False
+    assert session.added is not None
+    assert session.rolled_back is True

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -35,4 +35,7 @@ def test_readme_uses_cross_platform_browser_command():
     readme = (REPO_ROOT / "README.md").read_text()
 
     assert "open http://localhost:3000" not in readme
-    assert "python3 -m webbrowser http://localhost:3000" in readme
+    assert (
+        "python -m webbrowser http://localhost:3000" in readme
+        or "python3 -m webbrowser http://localhost:3000" in readme
+    )

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_dockerignore_excludes_nested_environment_files_but_keeps_examples():
+    dockerignore = (REPO_ROOT / ".dockerignore").read_text()
+
+    assert ".env*" in dockerignore
+    assert "**/.env*" in dockerignore
+    assert "!.env.example" in dockerignore
+    assert "!**/.env.example" in dockerignore
+
+
+def test_compose_externalizes_postgres_credentials():
+    compose = (REPO_ROOT / "docker-compose.yml").read_text()
+
+    assert "POSTGRES_PASSWORD: postgres" not in compose
+    assert "postgres:postgres@" not in compose
+    assert "${POSTGRES_DB" in compose
+    assert "${POSTGRES_USER" in compose
+    assert "${POSTGRES_PASSWORD" in compose
+
+
+def test_env_example_documents_required_postgres_password():
+    env_example = (REPO_ROOT / ".env.example").read_text()
+
+    assert "POSTGRES_PASSWORD=change-me-local-only" in env_example
+    assert "postgres:postgres@" not in env_example
+    assert "postgres:change-me-local-only@" in env_example
+
+
+def test_readme_uses_cross_platform_browser_command():
+    readme = (REPO_ROOT / "README.md").read_text()
+
+    assert "open http://localhost:3000" not in readme
+    assert "python3 -m webbrowser http://localhost:3000" in readme

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -75,6 +75,8 @@ def test_search_reply_counts_group_by_coalesced_thread_key():
     subquery = build_reply_counts_subquery()
     sql = str(subquery.select()).lower()
 
-    assert "btrim(coalesce(emails.thread_id, emails.message_id)" in sql
+    assert "coalesce(nullif(btrim(btrim(emails.thread_id)" in sql
+    assert "nullif(btrim(btrim(emails.message_id)" in sql
+    assert "coalesce(emails.thread_id, emails.message_id)" not in sql
     assert "count(emails.id)" in sql
-    assert "group by btrim(coalesce(emails.thread_id, emails.message_id)" in sql
+    assert "group by coalesce(nullif(btrim(btrim(emails.thread_id)" in sql

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
@@ -12,6 +13,9 @@ class MockRow:
         self.sender = sender
         self.content = content
         self.score = score
+        self.date = datetime.datetime(2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc)
+        self.thread_id = "thread-123"
+        self.reply_count = 2
 
 
 class MockResult:
@@ -60,3 +64,17 @@ def test_search_endpoint_success(mock_generate_embeddings, client):
     assert len(data["results"]) == 1
     assert data["results"][0]["id"] == 1
     assert data["results"][0]["subject"] == "Test Subject"
+    assert data["results"][0]["date"] == "2026-04-27T10:00:00Z"
+    assert data["results"][0]["thread_id"] == "thread-123"
+    assert data["results"][0]["reply_count"] == 2
+
+
+def test_search_reply_counts_group_by_coalesced_thread_key():
+    from api.search import build_reply_counts_subquery
+
+    subquery = build_reply_counts_subquery()
+    sql = str(subquery.select()).lower()
+
+    assert "btrim(coalesce(emails.thread_id, emails.message_id)" in sql
+    assert "count(emails.id)" in sql
+    assert "group by btrim(coalesce(emails.thread_id, emails.message_id)" in sql

--- a/backend/tests/test_threading_service.py
+++ b/backend/tests/test_threading_service.py
@@ -1,0 +1,86 @@
+import pytest
+
+from services.threading_service import assign_thread_id
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _SequentialSession:
+    def __init__(self, values):
+        self._values = list(values)
+        self.execute_count = 0
+
+    async def execute(self, _query):
+        self.execute_count += 1
+        value = self._values.pop(0) if self._values else None
+        return _ScalarResult(value)
+
+
+@pytest.mark.asyncio
+async def test_reply_before_root_uses_first_reference_as_deterministic_thread_id():
+    session = _SequentialSession([None, None, None])
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<reply@example.com>",
+            "in_reply_to": "<parent@example.com>",
+            "references": "<root@example.com> <parent@example.com>",
+        },
+    )
+
+    assert thread_id == "root@example.com"
+
+
+@pytest.mark.asyncio
+async def test_reply_without_references_uses_in_reply_to_as_deterministic_thread_id():
+    session = _SequentialSession([None, None])
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<reply@example.com>",
+            "in_reply_to": "<parent@example.com>",
+            "references": None,
+        },
+    )
+
+    assert thread_id == "parent@example.com"
+
+
+@pytest.mark.asyncio
+async def test_existing_parent_thread_id_wins_over_deterministic_fallback():
+    session = _SequentialSession(["thread-123"])
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<reply@example.com>",
+            "in_reply_to": "<parent@example.com>",
+            "references": "<root@example.com> <parent@example.com>",
+        },
+    )
+
+    assert thread_id == "thread-123"
+
+
+@pytest.mark.asyncio
+async def test_existing_legacy_bracketed_thread_id_is_normalized():
+    session = _SequentialSession(["<root@example.com>"])
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<reply@example.com>",
+            "in_reply_to": "<root@example.com>",
+            "references": "<root@example.com>",
+        },
+    )
+
+    assert thread_id == "root@example.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ services:
   db:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_DB: ai_email
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ${POSTGRES_DB:-ai_email}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d ai_email"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/ai_email
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}@db:5432/${POSTGRES_DB:-ai_email}
       DEBUG: "false"
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
     environment:
+      # NEXT_PUBLIC_API_URL is baked into browser-side client code. Keep this
+      # host-reachable URL for local Compose; http://backend:8000 is only
+      # resolvable inside the Docker network, not from the user's browser.
       NEXT_PUBLIC_API_URL: http://localhost:8000
     depends_on:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: ai_email
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d ai_email"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/ai_email
+      DEBUG: "false"
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    command: ["sh", "-c", "python scripts/bootstrap_db.py && uvicorn main:app --host 0.0.0.0 --port 8000"]
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:

--- a/docs/development/fixtures.md
+++ b/docs/development/fixtures.md
@@ -1,0 +1,30 @@
+# Fixture Import Workflow
+
+The blessed local fixture path is `backend/import_fixtures.py`. It imports `.eml` files from `backend/tests/fixtures` and persists the canonical `thread_id` returned by `assign_thread_id`.
+
+## Local command
+
+```bash
+cd backend
+python3 import_fixtures.py
+```
+
+Inside Docker Compose:
+
+```bash
+docker compose exec backend python import_fixtures.py
+```
+
+## Included threading fixture
+
+The `threading-basic-*` fixtures model one three-message conversation:
+
+1. `threading-basic-01-root.eml`, root message with `Reply-To`.
+2. `threading-basic-02-reply.eml`, reply with `In-Reply-To` and `References`.
+3. `threading-basic-03-reply.eml`, second reply with full reference chain.
+
+Use this fixture to verify inbox grouping, thread detail ordering, reply metadata, and search contract shape.
+
+## Embeddings and offline mode
+
+When `OPENAI_API_KEY` is set, the importer stores real embeddings. When it is blank, the root fixture importer stores zero-vector embeddings so local threading can be proven without external network access. Semantic search still requires a configured tenant OpenAI key because query-time embeddings are generated at request time.

--- a/docs/threading-contract.md
+++ b/docs/threading-contract.md
@@ -1,0 +1,31 @@
+# Email Threading Contract
+
+## Canonical owner
+
+`backend/services/threading_service.py` owns persisted `thread_id` assignment. Parsers extract headers. Importers and API code must not recompute a competing thread ID.
+
+## Header normalization
+
+- Persisted `thread_id` strips surrounding angle brackets and whitespace.
+- `Message-ID`, `In-Reply-To`, and `References` are retained on the email row for outbound replies and debugging.
+- `Reply-To` is captured separately and used before the display `From` value when drafting replies.
+
+## Assignment order
+
+1. If `In-Reply-To` matches an imported parent, reuse that parent thread.
+2. If any `References` ancestor matches an imported message, reuse that thread.
+3. If no parent exists yet, use the oldest `References` value as the deterministic root.
+4. If there are no references but `In-Reply-To` exists, use it as the deterministic parent root.
+5. If there are no threading headers, use the message ID.
+6. If the message ID is missing, generate a surrogate UUID.
+
+## API behavior
+
+- Inbox list returns one item per thread and exact `reply_count` across persisted rows available to the endpoint.
+- Thread detail returns messages oldest to newest.
+- Search returns message-level results with list-compatible `date`, `thread_id`, and `reply_count` fields.
+- Send returns honest status. A simulated local send is not presented as real delivery.
+
+## Current ownership boundary
+
+Email rows are single-user development data today. Multi-user production safety requires an owner/mailbox key on `emails` and matching filters in email and search endpoints.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend ./
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_API_URL=http://localhost:8000
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,28 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AI Email Client Frontend
 
-## Getting Started
+Next.js app for the threaded inbox, email detail pane, AI summary, action items, reply composer, and network graph.
 
-First, run the development server:
+## Setup
 
 ```bash
+npm install
+npm test
+npm run lint
+npm run build
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open <http://localhost:3000>. The app expects the backend at `NEXT_PUBLIC_API_URL`, defaulting to <http://localhost:8000>.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Threading UI contract
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- Inbox rows show selected state and thread message counts.
+- Search results use the same date/thread metadata shape as inbox results.
+- Detail view clears stale conversation state when switching emails.
+- Conversation history shows oldest-to-newest order and marks the selected message.
+- Thread fetch failures are visible and retryable.
+- Reply sends include `In-Reply-To` and `References` metadata.
 
-## Learn More
+## Local docs note
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+This project uses Next.js 16. The local guidance lives under `node_modules/next/dist/docs/` after `npm install`.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: process.cwd(),
+  },
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1966,6 +1967,299 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1990,6 +2284,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2356,6 +2657,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2999,6 +3318,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3303,6 +3735,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -3567,6 +4009,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4330,6 +4782,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4826,6 +5285,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4890,6 +5359,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5232,6 +5711,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7423,6 +7917,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7675,6 +8180,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8103,6 +8615,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -8595,6 +9141,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8638,6 +9191,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8646,6 +9206,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -8979,6 +9546,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -9025,6 +9609,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9536,6 +10130,200 @@
         "component-emitter": "^1.3.0 || ^2.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -9647,6 +10435,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
+        "jsdom": "^29.1.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.5"
@@ -47,6 +48,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -522,6 +574,159 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.63.0",
       "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.63.0.tgz",
@@ -908,6 +1113,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3829,6 +4052,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -4311,6 +4544,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4344,6 +4591,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4416,6 +4677,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -4647,6 +4915,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6108,6 +6389,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -6609,6 +6903,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6877,6 +7178,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7403,6 +7755,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -8135,6 +8494,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8772,6 +9144,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -9497,6 +9882,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -9670,6 +10062,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9911,6 +10316,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -10324,6 +10739,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -10331,6 +10759,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -10543,6 +11006,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -32,7 +33,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   },
   "overrides": {
     "postcss": "^8.5.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "jsdom": "^29.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
     <DashboardLayout>
       <ResizablePanelGroup orientation="horizontal" className="h-full items-stretch">
         <ResizablePanel defaultSize={25} minSize={20}>
-          <EmailList onSelectEmail={setSelectedEmail} />
+          <EmailList onSelectEmail={setSelectedEmail} selectedEmailId={selectedEmail} />
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={50} minSize={30}>

--- a/frontend/src/components/EmailDetail.test.tsx
+++ b/frontend/src/components/EmailDetail.test.tsx
@@ -58,7 +58,7 @@ type Deferred<T> = {
 type TestEmail = {
   id: number;
   message_id: string;
-  thread_id: string;
+  thread_id: string | null;
   sender: string;
   recipients: string;
   subject: string;
@@ -216,5 +216,82 @@ describe("EmailDetail", () => {
     expect(container.textContent).toContain("Thread B sibling body");
     expect(container.textContent).toContain("2 msgs");
     expect(container.textContent).not.toContain("Thread A stale sibling body");
+  });
+
+  it("clears conversation loading when the latest email has no thread", async () => {
+    const threadedEmail: TestEmail = {
+      id: 1,
+      message_id: "<threaded@example.com>",
+      thread_id: "thread-a",
+      sender: "threaded@example.com",
+      recipients: "user@example.com",
+      subject: "Threaded",
+      date: "2026-04-27T10:00:00Z",
+      body: "Threaded body",
+    };
+    const standaloneEmail: TestEmail = {
+      id: 3,
+      message_id: "<standalone@example.com>",
+      thread_id: null,
+      sender: "standalone@example.com",
+      recipients: "user@example.com",
+      subject: "Standalone",
+      date: "2026-04-27T12:00:00Z",
+      body: "Standalone body",
+    };
+
+    const threadedEmailResponse = deferred<ReturnType<typeof jsonResponse>>();
+    const threadResponse = deferred<ReturnType<typeof jsonResponse>>();
+    const standaloneEmailResponse = deferred<ReturnType<typeof jsonResponse>>();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/emails/1")) return threadedEmailResponse.promise;
+      if (url.endsWith("/api/emails/3")) return standaloneEmailResponse.promise;
+      if (url.endsWith("/api/emails/thread/thread-a")) return threadResponse.promise;
+      if (url.endsWith("/api/llm/summarize")) {
+        return Promise.resolve(jsonResponse({ summary: "Summary", todos: [] }));
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<EmailDetail emailId={1} />);
+    });
+
+    await act(async () => {
+      threadedEmailResponse.resolve(jsonResponse(threadedEmail));
+      await threadedEmailResponse.promise;
+      await Promise.resolve();
+    });
+
+    await waitForCondition(() =>
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).endsWith("/api/emails/thread/thread-a"),
+      ),
+    );
+
+    await act(async () => {
+      root?.render(<EmailDetail emailId={3} />);
+    });
+
+    await act(async () => {
+      standaloneEmailResponse.resolve(jsonResponse(standaloneEmail));
+      await standaloneEmailResponse.promise;
+      await Promise.resolve();
+    });
+
+    await waitForCondition(() =>
+      container?.textContent?.includes("Standalone body") ?? false,
+    );
+
+    expect(container.textContent).toContain("Standalone body");
+    expect(container.textContent).toContain("1 msgs");
+    expect(container.textContent).not.toContain("Loading conversation...");
   });
 });

--- a/frontend/src/components/EmailDetail.test.tsx
+++ b/frontend/src/components/EmailDetail.test.tsx
@@ -1,0 +1,220 @@
+/* @vitest-environment jsdom */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+vi.mock("@/components/ui/avatar", () => ({
+  Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input type="checkbox" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("lucide-react", () => ({
+  MessagesSquare: () => <svg aria-hidden="true" />,
+}));
+
+import { EmailDetail } from "./EmailDetail";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+type TestEmail = {
+  id: number;
+  message_id: string;
+  thread_id: string;
+  sender: string;
+  recipients: string;
+  subject: string;
+  date: string;
+  body: string;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  };
+}
+
+async function flushAsyncWork() {
+  for (let index = 0; index < 5; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+async function waitForCondition(condition: () => boolean) {
+  for (let index = 0; index < 20; index += 1) {
+    if (condition()) return;
+    await flushAsyncWork();
+  }
+}
+
+describe("EmailDetail", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the latest conversation when an older thread request resolves late", async () => {
+    const emailA: TestEmail = {
+      id: 1,
+      message_id: "<a@example.com>",
+      thread_id: "thread-a",
+      sender: "a@example.com",
+      recipients: "user@example.com",
+      subject: "Thread A",
+      date: "2026-04-27T10:00:00Z",
+      body: "Selected A body",
+    };
+    const emailB: TestEmail = {
+      id: 2,
+      message_id: "<b@example.com>",
+      thread_id: "thread-b",
+      sender: "b@example.com",
+      recipients: "user@example.com",
+      subject: "Thread B",
+      date: "2026-04-27T11:00:00Z",
+      body: "Selected B body",
+    };
+    const siblingB: TestEmail = {
+      ...emailB,
+      id: 3,
+      message_id: "<b-sibling@example.com>",
+      body: "Thread B sibling body",
+    };
+    const siblingA: TestEmail = {
+      ...emailA,
+      id: 4,
+      message_id: "<a-sibling@example.com>",
+      body: "Thread A stale sibling body",
+    };
+
+    const emailAResponse = deferred<ReturnType<typeof jsonResponse>>();
+    const threadAResponse = deferred<ReturnType<typeof jsonResponse>>();
+    const emailBResponse = deferred<ReturnType<typeof jsonResponse>>();
+    const threadBResponse = deferred<ReturnType<typeof jsonResponse>>();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/emails/1")) return emailAResponse.promise;
+        if (url.endsWith("/api/emails/2")) return emailBResponse.promise;
+        if (url.endsWith("/api/emails/thread/thread-a")) return threadAResponse.promise;
+        if (url.endsWith("/api/emails/thread/thread-b")) return threadBResponse.promise;
+        if (url.endsWith("/api/llm/summarize")) {
+          return Promise.resolve(jsonResponse({ summary: "Summary", todos: [] }));
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<EmailDetail emailId={1} />);
+    });
+
+    await act(async () => {
+      emailAResponse.resolve(jsonResponse(emailA));
+      await emailAResponse.promise;
+    });
+
+    await act(async () => {
+      root?.render(<EmailDetail emailId={2} />);
+    });
+
+    await act(async () => {
+      emailBResponse.resolve(jsonResponse(emailB));
+      await emailBResponse.promise;
+      await Promise.resolve();
+    });
+
+    await waitForCondition(() =>
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).endsWith("/api/emails/thread/thread-b"),
+      ),
+    );
+
+    await act(async () => {
+      threadBResponse.resolve(jsonResponse({ thread: [emailB, siblingB] }));
+      await threadBResponse.promise;
+    });
+
+    await waitForCondition(() =>
+      container?.textContent?.includes("Thread B sibling body") ?? false,
+    );
+
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toContain(
+      "http://localhost:8000/api/emails/thread/thread-b",
+    );
+    expect(container.textContent).toContain("Thread B sibling body");
+    expect(container.textContent).toContain("2 msgs");
+
+    await act(async () => {
+      threadAResponse.resolve(jsonResponse({ thread: [emailA, siblingA] }));
+      await threadAResponse.promise;
+    });
+    await flushAsyncWork();
+
+    expect(container.textContent).toContain("Thread B sibling body");
+    expect(container.textContent).toContain("2 msgs");
+    expect(container.textContent).not.toContain("Thread A stale sibling body");
+  });
+});

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -45,12 +45,17 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
 
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState<{type: 'success' | 'error', message: string} | null>(null);
+  const threadRequestIdRef = useRef(0);
 
   const fetchThread = useCallback(async (currentEmail: EmailData) => {
+    const requestId = threadRequestIdRef.current + 1;
+    threadRequestIdRef.current = requestId;
+    const isLatestThreadRequest = () => requestId === threadRequestIdRef.current;
+
     setThreadError(null);
 
     if (!currentEmail.thread_id) {
-      setThreadEmails([currentEmail]);
+      if (isLatestThreadRequest()) setThreadEmails([currentEmail]);
       return;
     }
 
@@ -59,13 +64,15 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
       const threadRes = await fetch(buildThreadUrl(API_URL, currentEmail.thread_id));
       if (!threadRes.ok) throw new Error("Failed to fetch thread");
       const threadJson = await threadRes.json();
+      if (!isLatestThreadRequest()) return;
       setThreadEmails(threadJson.thread || []);
     } catch (err) {
+      if (!isLatestThreadRequest()) return;
       console.error("Error fetching thread:", err);
       setThreadError("Conversation could not load.");
       setThreadEmails([currentEmail]);
     } finally {
-      setThreadLoading(false);
+      if (isLatestThreadRequest()) setThreadLoading(false);
     }
   }, []);
 
@@ -75,6 +82,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
     let isMounted = true;
 
     const fetchData = async () => {
+      threadRequestIdRef.current += 1;
       setLoading(true);
       setEmail(null);
       setThreadEmails([]);

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -8,18 +8,15 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { MessagesSquare } from "lucide-react";
+import {
+  buildThreadUrl,
+  buildReplyPayload,
+  formatEmailDate,
+  getConversationMessages,
+  type ThreadEmailData,
+} from "@/lib/email-threading";
 
-interface EmailData {
-  id: number;
-  subject: string | null;
-  sender: string;
-  body: string;
-  date: string;
-  thread_id?: string; // O3: email threading support
-  message_id?: string;
-  in_reply_to?: string;
-  references?: string;
-}
+type EmailData = ThreadEmailData;
 
 interface LlmData {
   summary: string;
@@ -34,6 +31,9 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
   const [llmData, setLlmData] = useState<LlmData | null>(null);
   const [llmError, setLlmError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [threadLoading, setThreadLoading] = useState(false);
+  const [threadError, setThreadError] = useState<string | null>(null);
 
   const [draft, setDraft] = useState<string>('');
   const [isDrafting, setIsDrafting] = useState(false);
@@ -46,6 +46,29 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
   const [isSyncing, setIsSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState<{type: 'success' | 'error', message: string} | null>(null);
 
+  const fetchThread = useCallback(async (currentEmail: EmailData) => {
+    setThreadError(null);
+
+    if (!currentEmail.thread_id) {
+      setThreadEmails([currentEmail]);
+      return;
+    }
+
+    setThreadLoading(true);
+    try {
+      const threadRes = await fetch(buildThreadUrl(API_URL, currentEmail.thread_id));
+      if (!threadRes.ok) throw new Error("Failed to fetch thread");
+      const threadJson = await threadRes.json();
+      setThreadEmails(threadJson.thread || []);
+    } catch (err) {
+      console.error("Error fetching thread:", err);
+      setThreadError("Conversation could not load.");
+      setThreadEmails([currentEmail]);
+    } finally {
+      setThreadLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!emailId) return;
     
@@ -54,6 +77,9 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
     const fetchData = async () => {
       setLoading(true);
       setEmail(null);
+      setThreadEmails([]);
+      setThreadError(null);
+      setDetailError(null);
       setLlmData(null);
       setLlmError(null);
       setDraft('');
@@ -68,19 +94,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
         if (!isMounted) return;
         setEmail(emailJson);
 
-        if (emailJson.thread_id) {
-          try {
-            const threadRes = await fetch(`${API_URL}/api/emails/thread/${emailJson.thread_id}`);
-            if (threadRes.ok) {
-              const threadJson = await threadRes.json();
-              if (isMounted) setThreadEmails(threadJson.thread || []);
-            }
-          } catch (err) {
-            console.error("Error fetching thread:", err);
-          }
-        } else {
-          if (isMounted) setThreadEmails([emailJson]);
-        }
+        await fetchThread(emailJson);
 
         try {
           const llmRes = await fetch(`${API_URL}/api/llm/summarize`, {
@@ -98,6 +112,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
         }
       } catch (err) {
         console.error("Error fetching email details:", err);
+        if (isMounted) setDetailError("Error loading email");
       } finally {
         if (isMounted) setLoading(false);
       }
@@ -106,7 +121,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
     fetchData();
 
     return () => { isMounted = false; };
-  }, [emailId]);
+  }, [emailId, fetchThread]);
 
   const handleDraftReply = async () => {
     if (!email) return;
@@ -138,17 +153,18 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
       const res = await fetch(`${API_URL}/api/emails/send`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          to: email.sender,
-          subject: email.subject?.startsWith('Re:') ? email.subject : `Re: ${email.subject || ''}`,
-          body: draft,
-          in_reply_to: email.message_id,
-          references: email.references ? `${email.references} ${email.message_id}` : email.message_id
-        })
+        body: JSON.stringify(buildReplyPayload(email, draft))
       });
       if (!res.ok) throw new Error("Failed to send email");
-      setSendStatus({ type: 'success', message: 'Reply sent successfully!' });
+      const result = await res.json();
+      setSendStatus({
+        type: 'success',
+        message: result.simulated
+          ? 'Reply simulated in development mode. No email was delivered.'
+          : 'Reply sent successfully!',
+      });
       setDraft('');
+      await fetchThread(email);
     } catch (err) {
       console.error("Error sending email:", err);
       setSendStatus({ type: 'error', message: 'Error sending reply.' });
@@ -173,7 +189,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
       if (!res.ok) throw new Error("Failed to sync");
       const data = await res.json();
       setSyncStatus({ type: 'success', message: `Synced ${data.synced} events!` });
-    } catch (err) {
+    } catch {
       setSyncStatus({ type: 'error', message: 'Error syncing to calendar.' });
     } finally {
       setIsSyncing(false);
@@ -192,12 +208,14 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
   }
 
   if (loading) {
-    return <div className="flex items-center justify-center h-full text-muted-foreground">Loading details...</div>;
+    return <div role="status" aria-live="polite" className="flex items-center justify-center h-full text-muted-foreground">Loading details...</div>;
   }
 
-  if (!email) {
-    return <div className="flex items-center justify-center h-full text-muted-foreground text-red-500">Error loading email</div>;
+  if (!email || detailError) {
+    return <div role="alert" className="flex items-center justify-center h-full text-muted-foreground text-red-500">{detailError || 'Error loading email'}</div>;
   }
+
+  const conversationMessages = getConversationMessages(email, threadEmails);
 
   return (
     <div className="flex h-full flex-col">
@@ -212,11 +230,11 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
               <span className="text-muted-foreground">{email.sender}</span>
             </div>
             <div className="line-clamp-1 text-xs text-muted-foreground">
-              Reply-To: {email.sender}
+              Reply-To: {email.reply_to || email.sender}
             </div>
           </div>
           <div className="text-xs text-muted-foreground whitespace-nowrap">
-            {new Date(email.date).toLocaleString()}
+            {formatEmailDate(email.date)}
           </div>
         </div>
       </div>
@@ -250,8 +268,8 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
                 <ul className="list-none space-y-2 text-sm">
                   {llmData.todos.map((todo, idx) => (
                     <li key={idx} className="flex items-start gap-2 rounded-md border p-3">
-                      <Checkbox className="mt-1" />
-                      <span className="font-medium">{todo}</span>
+                      <Checkbox id={`todo-${idx}`} className="mt-1" />
+                      <label htmlFor={`todo-${idx}`} className="font-medium">{todo}</label>
                     </li>
                   ))}
                 </ul>
@@ -289,16 +307,25 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
               <h3 className="text-sm font-semibold uppercase text-muted-foreground tracking-wider">Conversation History</h3>
               <Badge variant="secondary" className="text-[10px] flex items-center gap-1">
                 <MessagesSquare className="w-3 h-3" />
-                {threadEmails.length > 0 ? threadEmails.length : 1} msgs
+                {conversationMessages.length} msgs
               </Badge>
             </div>
+            <p className="text-xs text-muted-foreground">Oldest to newest. Replies target the selected message.</p>
+            {threadLoading && <p role="status" aria-live="polite" className="text-sm text-muted-foreground">Loading conversation...</p>}
+            {threadError && (
+              <div role="alert" className="flex items-center gap-3 text-sm text-red-500">
+                <span>{threadError}</span>
+                <Button size="sm" variant="outline" onClick={() => fetchThread(email)}>Retry</Button>
+              </div>
+            )}
             <div className="space-y-4">
-              {(threadEmails.length > 0 ? threadEmails : [email]).map((msg) => (
-                <div key={msg.id} className="rounded-lg border p-4 bg-card text-card-foreground">
+              {conversationMessages.map((msg) => (
+                <div key={msg.id} className={`rounded-lg border p-4 bg-card text-card-foreground ${msg.id === email.id ? 'border-primary' : ''}`} aria-current={msg.id === email.id ? "true" : undefined}>
                   <div className="flex items-center justify-between mb-2">
                     <span className="font-medium text-sm">{msg.sender}</span>
-                    <span className="text-xs text-muted-foreground">{new Date(msg.date).toLocaleString()}</span>
+                    <span className="text-xs text-muted-foreground">{formatEmailDate(msg.date)}</span>
                   </div>
+                  {msg.id === email.id && <Badge variant="outline" className="mb-2 text-[10px]">Selected message</Badge>}
                   <div className="text-sm whitespace-pre-wrap">{msg.body}</div>
                 </div>
               ))}
@@ -311,7 +338,10 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
             <div className="flex flex-col sm:flex-row sm:items-end gap-2 justify-between">
               <div className="space-y-1.5 flex-1 max-w-sm">
                 <h3 className="text-sm font-semibold text-primary uppercase tracking-wider">Reply</h3>
+                <label htmlFor="reply-instruction" className="sr-only">AI reply instruction</label>
                 <Input
+                  id="reply-instruction"
+                  aria-label="AI reply instruction"
                   value={instruction}
                   onChange={(e) => setInstruction(e.target.value)}
                   placeholder="e.g. reply politely"
@@ -328,9 +358,12 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
               </Button>
             </div>
             
-            {draftError && <p className="text-sm text-red-500">{draftError}</p>}
+            {draftError && <p role="alert" className="text-sm text-red-500">{draftError}</p>}
 
+            <label htmlFor="reply-draft" className="sr-only">Reply draft</label>
             <Textarea 
+              id="reply-draft"
+              aria-label="Reply draft"
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               placeholder="Your reply..."
@@ -340,7 +373,7 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
             <div className="flex items-center justify-between">
               <div>
                 {sendStatus && (
-                  <p className={`text-sm ${sendStatus.type === 'success' ? 'text-green-600' : 'text-red-500'}`}>
+                  <p role={sendStatus.type === 'error' ? 'alert' : 'status'} aria-live="polite" className={`text-sm ${sendStatus.type === 'success' ? 'text-green-600' : 'text-red-500'}`}>
                     {sendStatus.message}
                   </p>
                 )}

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -55,7 +55,10 @@ export function EmailDetail({ emailId }: { emailId: number | null }) {
     setThreadError(null);
 
     if (!currentEmail.thread_id) {
-      if (isLatestThreadRequest()) setThreadEmails([currentEmail]);
+      if (isLatestThreadRequest()) {
+        setThreadLoading(false);
+        setThreadEmails([currentEmail]);
+      }
       return;
     }
 

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -1,24 +1,30 @@
 import React, { useEffect, useState } from 'react';
-import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { MessagesSquare } from "lucide-react";
+import { formatEmailDate } from "@/lib/email-threading";
 
 interface EmailItem {
   id: number;
   subject: string | null;
   sender: string;
-  date: string;
+  date?: string;
   snippet: string;
   unread?: boolean;
   thread_id?: string; // O3: email threading support
   reply_count?: number;
 }
 
-export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => void }) {
+export function EmailList({
+  onSelectEmail,
+  selectedEmailId,
+}: {
+  onSelectEmail: (id: number) => void;
+  selectedEmailId?: number | null;
+}) {
   const [emails, setEmails] = useState<EmailItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,6 +62,7 @@ export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => vo
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Initial inbox fetch synchronizes client state with the backend.
     fetchEmails();
   }, []);
 
@@ -70,7 +77,10 @@ export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => vo
           }}
           className="flex gap-2"
         >
+          <label htmlFor="email-search" className="sr-only">Search emails</label>
           <Input 
+            id="email-search"
+            aria-label="Search emails"
             placeholder="Search emails..." 
             value={searchQuery}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
@@ -83,17 +93,21 @@ export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => vo
       <ScrollArea className="flex-1 w-full">
         <div className="flex flex-col gap-2 p-4">
           {loading ? (
-            <div className="text-sm text-muted-foreground">Loading emails...</div>
+            <div role="status" aria-live="polite" className="text-sm text-muted-foreground">Loading emails...</div>
           ) : error ? (
-            <div className="text-sm text-red-500">{error}</div>
+            <div role="alert" className="text-sm text-red-500">{error}</div>
           ) : emails.length === 0 ? (
             <div className="text-sm text-muted-foreground">No emails found.</div>
           ) : (
-            emails.map((email: EmailItem) => (
+            emails.map((email: EmailItem) => {
+              const selected = selectedEmailId === email.id;
+
+              return (
               <button 
                 key={email.id} 
                 onClick={() => onSelectEmail(email.id)}
-                className="flex flex-col items-start gap-2 rounded-lg border p-3 text-left text-sm transition-all hover:bg-accent"
+                aria-current={selected ? "true" : undefined}
+                className={`flex flex-col items-start gap-2 rounded-lg border p-3 text-left text-sm transition-all hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${selected ? 'border-primary bg-accent' : ''}`}
               >
                 <div className="flex w-full flex-col gap-1">
                   <div className="flex items-center">
@@ -104,7 +118,7 @@ export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => vo
                       <div className="font-semibold truncate max-w-[120px]">{email.sender}</div>
                     </div>
                     <div className="ml-auto text-xs text-muted-foreground whitespace-nowrap">
-                      {new Date(email.date).toLocaleDateString()}
+                      {formatEmailDate(email.date)}
                     </div>
                   </div>
                   <div className="flex items-center gap-2 w-full">
@@ -126,7 +140,8 @@ export function EmailList({ onSelectEmail }: { onSelectEmail: (id: number) => vo
                   </div>
                 )}
               </button>
-            ))
+              );
+            })
           )}
         </div>
       </ScrollArea>

--- a/frontend/src/lib/email-threading.test.ts
+++ b/frontend/src/lib/email-threading.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildThreadUrl,
+  buildReplyPayload,
+  formatEmailDate,
+  getConversationMessages,
+} from "./email-threading";
+
+const baseEmail = {
+  id: 1,
+  subject: "Quarterly plan",
+  sender: "Alice Example <alice@example.com>",
+  reply_to: "reply@example.com",
+  body: "Root body",
+  date: "2026-04-27T10:00:00Z",
+  thread_id: "root@example.com",
+  message_id: "<root@example.com>",
+  references: "<root@example.com>",
+};
+
+describe("email threading UI helpers", () => {
+  it("builds a reply payload with safe recipient and threading headers", () => {
+    expect(buildReplyPayload(baseEmail, "Thanks")).toEqual({
+      to: "reply@example.com",
+      subject: "Re: Quarterly plan",
+      body: "Thanks",
+      in_reply_to: "<root@example.com>",
+      references: "<root@example.com>",
+    });
+  });
+
+  it("extracts the mailbox from display-name Reply-To headers", () => {
+    const emailWithDisplayReplyTo = {
+      ...baseEmail,
+      reply_to: "Alice Replies <alice-replies@example.com>",
+    };
+
+    expect(buildReplyPayload(emailWithDisplayReplyTo, "Thanks").to).toBe(
+      "alice-replies@example.com",
+    );
+  });
+
+  it("appends the selected message id to existing references", () => {
+    const replyEmail = {
+      ...baseEmail,
+      message_id: "<reply@example.com>",
+      references: "<root@example.com>",
+    };
+
+    expect(buildReplyPayload(replyEmail, "Thanks").references).toBe(
+      "<root@example.com> <reply@example.com>",
+    );
+  });
+
+  it("uses exact reference tokens when deciding whether to append the selected message id", () => {
+    const replyEmail = {
+      ...baseEmail,
+      message_id: "reply@example.com",
+      references: "<parent-reply@example.com>",
+    };
+
+    expect(buildReplyPayload(replyEmail, "Thanks").references).toBe(
+      "<parent-reply@example.com> reply@example.com",
+    );
+  });
+
+  it("falls back to sender mailbox when Reply-To is absent", () => {
+    const emailWithoutReplyTo = { ...baseEmail, reply_to: undefined };
+
+    expect(buildReplyPayload(emailWithoutReplyTo, "Thanks").to).toBe(
+      "alice@example.com",
+    );
+  });
+
+  it("falls back to the selected email when the thread response is empty", () => {
+    expect(getConversationMessages(baseEmail, [])).toEqual([baseEmail]);
+  });
+
+  it("falls back to the selected email when a stale thread response is for another message", () => {
+    const staleThread = [{ ...baseEmail, id: 2, message_id: "<other@example.com>" }];
+
+    expect(getConversationMessages(baseEmail, staleThread)).toEqual([baseEmail]);
+  });
+
+  it("returns a stable label for invalid or missing dates", () => {
+    expect(formatEmailDate(undefined)).toBe("Unknown date");
+    expect(formatEmailDate("not-a-date")).toBe("Unknown date");
+  });
+
+  it("encodes reserved characters in thread URLs", () => {
+    expect(buildThreadUrl("http://localhost:8000", "root/part?x@example.com")).toBe(
+      "http://localhost:8000/api/emails/thread/root%2Fpart%3Fx%40example.com",
+    );
+  });
+});

--- a/frontend/src/lib/email-threading.ts
+++ b/frontend/src/lib/email-threading.ts
@@ -1,0 +1,89 @@
+export interface ThreadEmailData {
+  id: number;
+  subject: string | null;
+  sender: string;
+  reply_to?: string | null;
+  body: string;
+  date?: string | null;
+  thread_id?: string | null;
+  message_id?: string | null;
+  in_reply_to?: string | null;
+  references?: string | null;
+}
+
+export interface ReplyPayload {
+  to: string;
+  subject: string;
+  body: string;
+  in_reply_to?: string;
+  references?: string;
+}
+
+function extractMailbox(value: string): string {
+  const angleMatch = value.match(/<([^>]+)>/);
+  return (angleMatch?.[1] ?? value).trim();
+}
+
+function buildReferences(email: ThreadEmailData): string | undefined {
+  const references = email.references?.trim();
+  const messageId = email.message_id?.trim();
+
+  if (!references) return messageId || undefined;
+  if (!messageId) return references;
+
+  const normalizedMessageId = messageId.replace(/^<|>$/g, "");
+  const referenceTokens =
+    references.match(/<[^>]+>/g)?.map((token) => token.replace(/^<|>$/g, "")) ??
+    references.split(/\s+/).map((token) => token.replace(/^<|>$/g, ""));
+
+  if (referenceTokens.includes(normalizedMessageId)) return references;
+
+  return `${references} ${messageId}`;
+}
+
+export function formatEmailDate(value?: string | null): string {
+  if (!value) return "Unknown date";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown date";
+
+  return date.toLocaleString();
+}
+
+export function buildThreadUrl(apiUrl: string, threadId: string): string {
+  return `${apiUrl}/api/emails/thread/${encodeURIComponent(threadId)}`;
+}
+
+export function getConversationMessages<T extends ThreadEmailData>(
+  selectedEmail: T,
+  threadEmails: T[],
+): T[] {
+  const hasSelectedEmail = threadEmails.some(
+    (threadEmail) =>
+      threadEmail.id === selectedEmail.id ||
+      (!!selectedEmail.message_id && threadEmail.message_id === selectedEmail.message_id),
+  );
+
+  return hasSelectedEmail ? threadEmails : [selectedEmail];
+}
+
+export function buildReplyPayload(
+  email: ThreadEmailData,
+  draft: string,
+): ReplyPayload {
+  const to = email.reply_to?.trim()
+    ? extractMailbox(email.reply_to)
+    : extractMailbox(email.sender);
+  const subject = email.subject?.startsWith("Re:")
+    ? email.subject
+    : `Re: ${email.subject || ""}`;
+  const references = buildReferences(email);
+
+  return {
+    to,
+    subject,
+    body: draft,
+    in_reply_to: email.message_id || undefined,
+    references,
+  };
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});

--- a/scripts/ci/strix_model_utils.sh
+++ b/scripts/ci/strix_model_utils.sh
@@ -75,15 +75,18 @@ normalize_model() {
 		return 0
 	fi
 
+	if is_vertex_resource_path "$model"; then
+		local provider
+		provider="$(sanitize_provider_name "vertex_ai")" || return $?
+		printf '%s/%s\n' "$provider" "$(extract_vertex_model_id "$model")"
+		return 0
+	fi
+
 	local provider="${DEFAULT_PROVIDER:-}"
 	if [ -z "$provider" ]; then
 		provider="vertex_ai"
 	fi
-
-	if is_vertex_resource_path "$model"; then
-		printf '%s/%s\n' "$provider" "$(extract_vertex_model_id "$model")"
-		return 0
-	fi
+	provider="$(sanitize_provider_name "$provider")" || return $?
 
 	case "$model" in
 	projects/* | models/* | publishers/*)

--- a/scripts/ci/strix_model_utils.sh
+++ b/scripts/ci/strix_model_utils.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Helper functions shared by the Strix CI gate and its self-test harness.
+
+trim_whitespace() {
+	local value="${1-}"
+	# Collapse only the leading/trailing shell whitespace that can be introduced by
+	# secret files or workflow inputs. Internal spacing remains meaningful for the
+	# few callers that parse lists after trimming each token.
+	value="${value#"${value%%[!$' \t\r\n']*}"}"
+	value="${value%"${value##*[!$' \t\r\n']}"}"
+	printf '%s\n' "$value"
+}
+
+sanitize_provider_name() {
+	local provider
+	provider="$(trim_whitespace "${1-}")"
+	if [ -z "$provider" ]; then
+		return 1
+	fi
+	if [[ ! "$provider" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]]; then
+		echo "ERROR: STRIX_LLM_DEFAULT_PROVIDER contains unsupported characters: '$provider'." >&2
+		return 2
+	fi
+	printf '%s\n' "$provider"
+}
+
+is_vertex_resource_path() {
+	local path
+	path="$(trim_whitespace "${1-}")"
+	if [ -z "$path" ] || [[ "$path" =~ [[:space:][:cntrl:]] ]]; then
+		return 1
+	fi
+
+	IFS='/' read -r -a parts <<<"$path"
+	local part
+	for part in "${parts[@]}"; do
+		if [ -z "$part" ]; then
+			return 1
+		fi
+	done
+
+	case "${#parts[@]}" in
+	2)
+		[ "${parts[0]}" = "models" ]
+		;;
+	4)
+		[ "${parts[0]}" = "publishers" ] && [ "${parts[2]}" = "models" ]
+		;;
+	6)
+		[ "${parts[0]}" = "projects" ] && [ "${parts[2]}" = "locations" ] && [ "${parts[4]}" = "models" ]
+		;;
+	8)
+		[ "${parts[0]}" = "projects" ] && [ "${parts[2]}" = "locations" ] && [ "${parts[4]}" = "publishers" ] && [ "${parts[6]}" = "models" ]
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+extract_vertex_model_id() {
+	local model
+	model="$(trim_whitespace "${1-}")"
+	if is_vertex_resource_path "$model"; then
+		printf '%s\n' "${model##*/}"
+	else
+		printf '%s\n' "$model"
+	fi
+}
+
+normalize_model() {
+	local model
+	model="$(trim_whitespace "${1-}")"
+	if [ -z "$model" ]; then
+		return 0
+	fi
+
+	local provider="${DEFAULT_PROVIDER:-}"
+	if [ -z "$provider" ]; then
+		provider="vertex_ai"
+	fi
+
+	if is_vertex_resource_path "$model"; then
+		printf '%s/%s\n' "$provider" "$(extract_vertex_model_id "$model")"
+		return 0
+	fi
+
+	case "$model" in
+	projects/* | models/* | publishers/*)
+		printf '%s\n' "$model"
+		return 0
+		;;
+	*/*)
+		printf '%s\n' "$model"
+		return 0
+		;;
+	*)
+		printf '%s/%s\n' "$provider" "$model"
+		return 0
+		;;
+	esac
+}

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1358,11 +1358,22 @@ is_llm_api_connection_error() {
 	return 1
 }
 
+is_llm_service_unavailable_error() {
+	if grep -Eiq 'litellm(\.exceptions)?\.ServiceUnavailableError' "$STRIX_LOG" &&
+		grep -Eiq '(GeminiException|VertexAI|Vertex_ai|vertex\.ai|openai|anthropic|LLM CONNECTION FAILED|Could not establish connection to the language model)' "$STRIX_LOG" &&
+		grep -Eiq '("status"[[:space:]]*:[[:space:]]*"UNAVAILABLE"|(^|[^0-9])503([^0-9]|$)|high demand|Service Unavailable)' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
 ## Determines whether the last strix failure is a transient error eligible
 ## for same-model retry (up to STRIX_TRANSIENT_RETRY_PER_MODEL times).
-## Three error families qualify:
+## Four error families qualify:
 ##   - RateLimit / RESOURCE_EXHAUSTED / HTTP 429
 ##   - litellm API connection failures with LLM-provider evidence
+##   - litellm service-unavailable / high-demand provider failures
 ##   - MidStreamFallbackError (litellm mid-stream provider switch)
 ## Timeouts remain infrastructure errors for guard logic, but the caller should
 ## move directly to fallback model evaluation instead of spending the remaining
@@ -1372,6 +1383,9 @@ is_transient_same_model_retry_error() {
 		return 1
 	fi
 	if is_llm_api_connection_error; then
+		return 0
+	fi
+	if is_llm_service_unavailable_error; then
 		return 0
 	fi
 	if is_rate_limit_error; then
@@ -1411,6 +1425,8 @@ run_strix_with_transient_retry() {
 			retry_reason="rate limit"
 		elif is_llm_api_connection_error; then
 			retry_reason="LLM API connection"
+		elif is_llm_service_unavailable_error; then
+			retry_reason="LLM service unavailable"
 		elif is_midstream_fallback_error; then
 			retry_reason="midstream fallback"
 		fi
@@ -1558,6 +1574,10 @@ has_detected_infrastructure_error() {
 	fi
 
 	if is_llm_api_connection_error; then
+		return 0
+	fi
+
+	if is_llm_service_unavailable_error; then
 		return 0
 	fi
 
@@ -1884,6 +1904,10 @@ is_vertex_retryable_error() {
 	fi
 
 	if is_llm_api_connection_error; then
+		return 0
+	fi
+
+	if is_llm_service_unavailable_error; then
 		return 0
 	fi
 

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1349,10 +1349,20 @@ PY
 	return 1
 }
 
+is_llm_api_connection_error() {
+	if grep -Eiq 'litellm(\.exceptions)?\.APIConnectionError' "$STRIX_LOG" &&
+		grep -Eiq '(GeminiException|Server disconnected without sending a response|LLM CONNECTION FAILED|Could not establish connection to the language model)' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
 ## Determines whether the last strix failure is a transient error eligible
 ## for same-model retry (up to STRIX_TRANSIENT_RETRY_PER_MODEL times).
-## Two error families qualify:
+## Three error families qualify:
 ##   - RateLimit / RESOURCE_EXHAUSTED / HTTP 429
+##   - litellm API connection failures with LLM-provider evidence
 ##   - MidStreamFallbackError (litellm mid-stream provider switch)
 ## Timeouts remain infrastructure errors for guard logic, but the caller should
 ## move directly to fallback model evaluation instead of spending the remaining
@@ -1360,6 +1370,9 @@ PY
 is_transient_same_model_retry_error() {
 	if is_timeout_error; then
 		return 1
+	fi
+	if is_llm_api_connection_error; then
+		return 0
 	fi
 	if is_rate_limit_error; then
 		return 0
@@ -1396,6 +1409,8 @@ run_strix_with_transient_retry() {
 		local retry_reason="transient error"
 		if is_rate_limit_error; then
 			retry_reason="rate limit"
+		elif is_llm_api_connection_error; then
+			retry_reason="LLM API connection"
 		elif is_midstream_fallback_error; then
 			retry_reason="midstream fallback"
 		fi
@@ -1539,6 +1554,10 @@ has_detected_infrastructure_error() {
 	fi
 
 	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	if is_llm_api_connection_error; then
 		return 0
 	fi
 
@@ -1861,6 +1880,10 @@ is_vertex_retryable_error() {
 	fi
 
 	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	if is_llm_api_connection_error; then
 		return 0
 	fi
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -451,6 +451,34 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
+	gemini-high-demand-retry-same-model-success)
+		case "${STRIX_LLM:-}" in
+		gemini/retry-high-demand-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "LLM CONNECTION FAILED"
+				echo 'litellm.ServiceUnavailableError: GeminiException - {"error":{"code":503,"message":"This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.","status":"UNAVAILABLE"}}'
+				exit 1
+			fi
+			echo "scan ok after same-model high-demand retry"
+			exit 0
+			;;
+		*)
+			echo "Error: high-demand retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 37
+			;;
+		esac
+		;;
+	service-unavailable-no-llm-marker-nonrecoverable)
+		echo 'ServiceUnavailableError: {"error":{"code":503,"status":"UNAVAILABLE"}}'
+		echo 'target application high demand response'
+		exit 1
+		;;
 	server-disconnect-no-llm-marker-nonrecoverable)
 		echo "ConnectionError: Server disconnected without sending a response."
 		exit 1
@@ -2081,6 +2109,32 @@ run_gate_case "vertex-primary-api-connection-retry-same-model-success" \
 	"gemini/retry-api-connection-primary|gemini/retry-api-connection-primary" \
 	"https://example.invalid|https://example.invalid" \
 	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "gemini-high-demand-retry-same-model-success" \
+	"gemini/retry-high-demand-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model high-demand retry" \
+	"2" \
+	"gemini/retry-high-demand-primary|gemini/retry-high-demand-primary" \
+	"https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "service-unavailable-no-llm-marker-nonrecoverable" \
+	"custom/service-unavailable-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"custom/service-unavailable-primary" \
+	"https://example.invalid" \
+	"custom" \
 	"__DEFAULT__" \
 	"" \
 	"1"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -3315,6 +3315,36 @@ assert_vertex_extract() {
 	fi
 }
 
+assert_normalized_model() {
+	local label="$1" model="$2" default_provider="$3" expected="$4"
+	local actual rc old_default_provider="${DEFAULT_PROVIDER-__UNSET__}"
+	if [ "$old_default_provider" = "__UNSET__" ]; then
+		unset DEFAULT_PROVIDER
+	else
+		DEFAULT_PROVIDER="$old_default_provider"
+	fi
+
+	DEFAULT_PROVIDER="$default_provider"
+	set +e
+	actual="$(normalize_model "$model")"
+	rc=$?
+	set -e
+
+	if [ "$old_default_provider" = "__UNSET__" ]; then
+		unset DEFAULT_PROVIDER
+	else
+		DEFAULT_PROVIDER="$old_default_provider"
+	fi
+
+	if [ "$rc" -ne 0 ]; then
+		record_failure "normalize_model($label) rc=$rc model='$model'"
+		return
+	fi
+	if [ "$actual" != "$expected" ]; then
+		record_failure "normalize_model($label): got '$actual' want '$expected'"
+	fi
+}
+
 # Valid paths — should return 0
 assert_vertex_path "models/<id>" "models/gemini-2.5-pro" 0
 assert_vertex_path "publishers/<p>/models/<id>" "publishers/google/models/gemini-2.5-pro" 0
@@ -3341,6 +3371,14 @@ assert_vertex_extract "projects/…/publishers/…/models/<id>" "projects/my-pro
 # extract_vertex_model_id — non-vertex paths return as-is
 assert_vertex_extract "non-vertex-passthrough" "deepseek/models/deepseek-r1" "deepseek/models/deepseek-r1"
 assert_vertex_extract "plain-model-passthrough" "gemini-2.5-pro" "gemini-2.5-pro"
+
+# Explicit Vertex resource paths must remain Vertex models even when the default
+# provider points at a non-Vertex provider.
+assert_normalized_model \
+	"vertex-resource-ignores-nonvertex-default-provider" \
+	"projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro" \
+	"anthropic" \
+	"vertex_ai/gemini-2.5-pro"
 
 # Whitespace in paths — must be rejected (SAST word-splitting guard)
 assert_vertex_path "space-in-project" "projects/my proj/locations/us/models/foo" 1

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -424,6 +424,37 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
+	vertex-primary-api-connection-retry-same-model-success)
+		case "${STRIX_LLM:-}" in
+		gemini/retry-api-connection-primary|vertex_ai/retry-api-connection-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "LLM CONNECTION FAILED"
+				echo "litellm.APIConnectionError: GeminiException - Server disconnected without sending a response."
+				exit 1
+			fi
+			echo "scan ok after same-model api connection retry"
+			exit 0
+			;;
+		vertex_ai/fallback-one)
+			echo "Error: fallback should not be needed for API connection retry scenario" >&2
+			exit 36
+			;;
+		*)
+			echo "Error: API connection retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 36
+			;;
+		esac
+		;;
+	server-disconnect-no-llm-marker-nonrecoverable)
+		echo "ConnectionError: Server disconnected without sending a response."
+		exit 1
+		;;
 	vertex-all-ratelimited)
 		echo "Penetration test failed: LLM request failed: RateLimitError"
 		exit 1
@@ -2040,6 +2071,28 @@ run_gate_case "vertex-primary-ratelimit-retry-same-model-success" \
 	"__DEFAULT__" \
 	"" \
 	"1"
+
+run_gate_case "vertex-primary-api-connection-retry-same-model-success" \
+	"gemini/retry-api-connection-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model api connection retry" \
+	"2" \
+	"gemini/retry-api-connection-primary|gemini/retry-api-connection-primary" \
+	"https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "server-disconnect-no-llm-marker-nonrecoverable" \
+	"vertex_ai/app-server-disconnect-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/app-server-disconnect-primary" \
+	"<unset>"
 
 # Bug 11: Timeout should move directly to fallback instead of retrying the same model.
 run_gate_case "vertex-primary-timeout-retry-same-model-success" \

--- a/scripts/verify_threading.sh
+++ b/scripts/verify_threading.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+log() {
+  printf '[verify-threading] %s\n' "$*" >&2
+}
+
+run_backend_checks() {
+  log "running backend threading checks"
+  (
+    cd "${REPO_ROOT}/backend"
+    python3 -m pytest \
+      tests/test_threading_service.py \
+      tests/test_import_fixtures.py \
+      tests/test_email_parser.py \
+      tests/test_emails_api.py \
+      tests/test_email_client.py \
+      tests/test_search.py \
+      -q
+  )
+}
+
+ensure_frontend_dependencies() {
+  if [[ ! -d "${REPO_ROOT}/frontend/node_modules" ]]; then
+    log "frontend dependencies missing; running npm install"
+    (
+      cd "${REPO_ROOT}/frontend"
+      npm install
+    )
+  fi
+}
+
+run_frontend_checks() {
+  log "running frontend threading checks"
+  ensure_frontend_dependencies
+  (
+    cd "${REPO_ROOT}/frontend"
+    npm test
+    npm run lint
+    npm run build
+  )
+}
+
+run_backend_checks
+run_frontend_checks
+log "threading verification complete"


### PR DESCRIPTION
## Summary
- Canonicalizes thread IDs across parsing, import, inbox grouping, thread detail, search, and legacy bracketed data.
- Preserves reply headers and safer reply targets, with honest simulated-send semantics and frontend thread trust states.
- Adds fixture import, schema bootstrap/backfill, Docker Compose setup, contributor docs, and a threading verification script.

## Test Plan
- `cd backend && python3 -m pytest -q` → 61 passed, 3 known dependency/toolchain warnings
- `cd frontend && npm test && npm run lint && npm run build` → passed
- `./scripts/verify_threading.sh` → 26 backend threading checks passed, frontend tests/lint/build passed

## Review Evidence
- Subagent final blocker check: PASS, no blockers.