### PR TITLE
Harden Strix privileged PR scanning

### DIFF
--- a/.agents/skills/github-actions-privileged-pr-scan/SKILL.md
+++ b/.agents/skills/github-actions-privileged-pr-scan/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: github-actions-privileged-pr-scan
+description: >-
+  Use when a GitHub Actions pull request workflow needs repository secrets,
+  cloud credentials, security scanners, SCA/SAST tools, or other privileged
+  inputs while inspecting PR-authored code.
+---
+
+# GitHub Actions Privileged PR Scan
+
+## Core rule
+
+Treat PR code as untrusted whenever repository secrets are reachable. Run
+trusted base workflow code, fetch PR head as data, and fail closed on
+metadata/blob read errors.
+
+## Checklist
+
+- Use `pull_request_target` only when secrets are required; otherwise prefer
+  `pull_request` with no secrets.
+- Checkout the trusted base commit for scripts, dependencies, and scanner wrappers.
+- Never checkout or execute the PR branch in the privileged job.
+- Fetch PR head by immutable ref/SHA and verify the fetched commit matches `github.event.pull_request.head.sha`.
+- Copy changed PR-head blobs into a temporary scope and scan that scope as data.
+- Reject path traversal, pathspec-shaped, absolute, symlink, and non-regular
+  file inputs.
+- If PR-head lookup/read/copy/chmod fails, fail closed; do not substitute base
+  content.
+- Keep workflow permissions least-privilege and pin third-party actions.
+- Add regression tests for trigger choice, base checkout, PR-head blob copy,
+  lookup failure, and severity threshold behavior.
+
+## Common mistake
+
+Unsafe pattern:
+
+```yaml
+on: pull_request
+steps:
+  - uses: actions/checkout@...
+  - run: ./scripts/security-scan.sh
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+```
+
+Safer privileged pattern:
+
+```yaml
+on: pull_request_target
+steps:
+  - uses: actions/checkout@...
+    with:
+      ref: ${{ github.event.pull_request.base.sha }}
+      persist-credentials: false
+  - run: git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+  - run: ./scripts/security-scan-pr-head-as-data.sh
+```

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -2,15 +2,15 @@ name: Strix Security Scan
 
 on:
   push:
-    branches: [main]
-  pull_request:
+    branches: [master]
+  pull_request_target:
   schedule:
     # Weekly scan on protected branches (Mondays at 03:00 UTC).
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
 concurrency:
-  group: strix-${{ github.workflow }}-${{ github.ref }}
+  group: strix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # cancel-in-progress deliberately disabled: an attacker could force-push
   # a benign commit to cancel an in-progress scan of a malicious commit.
   cancel-in-progress: false
@@ -32,8 +32,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # For pull_request_target, keep the working tree on trusted base code.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Fetch pull request head for trusted scan
+        if: github.event_name == 'pull_request_target'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+          git cat-file -e "$PR_HEAD_SHA^{commit}"
+          fetched_head_sha="$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head")"
+          test "$fetched_head_sha" = "$PR_HEAD_SHA"
 
       - name: Self-test Strix gate script
         run: bash ./scripts/ci/test_strix_quick_gate.sh
@@ -95,7 +108,7 @@ jobs:
               exit 1
             fi
             echo 'can_run=false' >> "$GITHUB_OUTPUT"
-            echo 'Skipping Strix on pull_request because the configured model requires GCP_SA_KEY.'
+            echo 'Skipping Strix on pull_request_target because the configured model requires GCP_SA_KEY.'
           else
             echo 'can_run=true' >> "$GITHUB_OUTPUT"
           fi
@@ -218,14 +231,15 @@ jobs:
           STRIX_MEMORY_COMPRESSOR_TIMEOUT: 10
           STRIX_TRANSIENT_RETRY_PER_MODEL: 2
           STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
-          STRIX_PROCESS_TIMEOUT_SECONDS: ${{ github.event_name == 'pull_request' && '1200' || '2400' }}
+          STRIX_PROCESS_TIMEOUT_SECONDS: ${{ github.event_name == 'pull_request_target' && '1200' || '2400' }}
           STRIX_TOTAL_TIMEOUT_SECONDS: 3000
           STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 20
-          STRIX_DISABLE_PR_SCOPING: ${{ github.event_name == 'pull_request' && '0' || '1' }}
-          GH_TOKEN: ${{ github.event_name == 'pull_request' && github.token || '' }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-          PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
-          PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+          STRIX_FAIL_ON_MIN_SEVERITY: MEDIUM
+          STRIX_DISABLE_PR_SCOPING: ${{ github.event_name == 'pull_request_target' && '0' || '1' }}
+          GH_TOKEN: ${{ github.event_name == 'pull_request_target' && github.token || '' }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
+          PR_BASE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
         run: bash ./scripts/ci/strix_quick_gate.sh
 
       - name: Upload Strix reports artifact

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -29,11 +29,19 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout
+      - name: Checkout trusted pull request base
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # For pull_request_target, keep the working tree on trusted base code.
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Checkout current trusted ref
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,20 +10,49 @@ flowchart LR
   API --> SMTP[SMTP when configured]
 ```
 
-The backend owns persistence, threading, search, AI summaries, and outbound send orchestration. The frontend consumes the backend contracts and renders inbox, detail, thread history, reply composer, and network graph surfaces.
+The backend owns persistence, threading, search, AI summaries, and outbound
+send orchestration. The frontend consumes the backend contracts and renders
+inbox, detail, thread history, reply composer, and network graph surfaces.
 
 ## Threading boundary
 
-`backend/services/threading_service.py` is the canonical domain service for assigning persisted `thread_id` values. Parsers extract raw email headers, and import/API paths persist the service-assigned value. The detailed behavior is documented in `docs/threading-contract.md`.
+`backend/services/threading_service.py` is the canonical domain service for
+assigning persisted `thread_id` values. Parsers extract raw email headers, and
+import/API paths persist the service-assigned value. The detailed behavior is
+documented in `docs/threading-contract.md`.
 
 ## Data and tenancy boundary
 
-The current `emails` table does not have an owner/mailbox key. Email and search behavior should therefore be treated as single-user local-development behavior. Multi-user production safety requires a schema migration that adds mailbox ownership and applies that filter to every email/search query.
+The current `emails` table does not have an owner/mailbox key. Email and
+search behavior should therefore be treated as single-user local-development
+behavior. Multi-user production safety requires a schema migration that adds
+mailbox ownership and applies that filter to every email/search query.
 
 ## Local deployment boundary
 
-`docker-compose.yml` provides the blessed local stack: Postgres with pgvector, FastAPI backend, and Next.js frontend. The backend bootstrap script creates the `vector` extension, metadata-defined tables for fresh local databases, and idempotent threading-column backfills for existing local databases. There is no Alembic migration history in this repo yet.
+`docker-compose.yml` provides the blessed local stack: Postgres with pgvector,
+FastAPI backend, and Next.js frontend. The backend bootstrap script creates the
+`vector` extension, metadata-defined tables for fresh local databases, and
+idempotent threading-column backfills for existing local databases. There is no
+Alembic migration history in this repo yet.
 
 ## Send boundary
 
-Outbound replies preserve `In-Reply-To` and `References` headers in the built message payload. Local/dev behavior is explicit: missing SMTP config returns a 400, and simulated send results are marked with `simulated: true` rather than described as real delivery.
+Outbound replies preserve `In-Reply-To` and `References` headers in the built
+message payload. Local/dev behavior is explicit: missing SMTP config returns a
+400, and simulated send results are marked with `simulated: true` rather than
+described as real delivery.
+
+## CI security boundary
+
+The Strix workflow treats pull request code as untrusted whenever repository
+secrets are available. Privileged PR scans run from `pull_request_target`,
+checkout only the trusted base commit for workflow scripts and dependencies,
+fetch the pull request head as Git objects, and copy changed PR-head blobs into
+temporary scan scopes before invoking Strix. Do not checkout or execute pull
+request branch scripts in the privileged Strix job.
+
+The gate fails closed when a changed PR-head blob cannot be validated or copied;
+it must never fall back to scanning trusted-base content for a modified PR path.
+Strix remains a required Medium-or-higher gate, while third-party LLM/provider
+warnings are tracked separately unless they make the scan incomplete.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,33 @@
 # Security Policy
 
 ## Code Quality
+
 - **Standard findings:** 0건
 - **AI Findings:** 0건
 
 ## Dependabot
+
 - **Malware:** 0건
 - **Vulnerabilities:** 0건
 
 ## Code Scanning
+
 - **Code scanning:** 0건
 
 ## Secret Scanning
+
 - **Secret scanning:** 잠정적으로 0건으로 만들 것
 
 ## Strix Security Scan
+
 - **Strix Security Scan:** Medium 이상 모두 수정 (Medium 까지는 한국 법령이 요구하는 강제 사항이 포함되어 있음)
+- Pull request scans that need repository secrets must use trusted-base
+  `pull_request_target` execution: workflow scripts and dependencies come from
+  the base commit, while pull request head files are fetched and scanned only as
+  copied data.
+- If a changed pull request file cannot be read from the PR head, the Strix gate
+  fails closed and must not substitute trusted-base file contents.
 
 ## CI/CD Enforcement
+
 - Checks가 통과되어야 Merge 가능하도록 Branch Protection Rule에 의해 강제됩니다.

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -31,11 +31,12 @@ DEFAULT_PROVIDER=""
 LLM_API_BASE_FILE="${LLM_API_BASE_FILE:-}"
 STRIX_TRANSIENT_RETRY_PER_MODEL="${STRIX_TRANSIENT_RETRY_PER_MODEL:-0}"
 STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS="${STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS:-3}"
-STRIX_FAIL_ON_MIN_SEVERITY="${STRIX_FAIL_ON_MIN_SEVERITY:-HIGH}"
+STRIX_FAIL_ON_MIN_SEVERITY="${STRIX_FAIL_ON_MIN_SEVERITY:-MEDIUM}"
 RUN_START_EPOCH="$(date +%s)"
 PREEXISTING_REPORT_DIRS=()
 REPO_NAME="${REPO_ROOT##*/}"
 # shellcheck source=scripts/ci/strix_model_utils.sh
+# shellcheck disable=SC1091  # source path is repo-local; local lint may omit -x
 . "$SCRIPT_DIR/strix_model_utils.sh"
 # Sticky flag: once ANY attempt encounters an infrastructure error (rate limit,
 # LLM connection failure, mid-stream fallback, etc.), this flag stays 1 for
@@ -156,23 +157,143 @@ normalize_changed_file_path() {
 	local changed_file="$1"
 	python3 - "$REPO_ROOT" "$changed_file" <<'PY'
 from pathlib import Path
+import posixpath
+import re
 import sys
 
 repo_root = Path(sys.argv[1]).resolve(strict=True)
-relative_path = Path(sys.argv[2].strip())
 relative_path_str = sys.argv[2].strip()
 if "\n" in relative_path_str or "\r" in relative_path_str:
     raise SystemExit(1)
+if not relative_path_str:
+    raise SystemExit(1)
+if "\x00" in relative_path_str:
+    raise SystemExit(1)
+if "\\" in relative_path_str:
+    raise SystemExit(1)
+normalized = posixpath.normpath(relative_path_str)
+if normalized in (".", "") or normalized.startswith("../") or normalized == "..":
+    raise SystemExit(1)
+if not re.fullmatch(r"[A-Za-z0-9_./-]+", normalized):
+    raise SystemExit(1)
+relative_path = Path(normalized)
 if relative_path.is_absolute():
     raise SystemExit(1)
 if any(part in ('', '.', '..') for part in relative_path.parts):
     raise SystemExit(1)
-src_path = (repo_root / relative_path).resolve(strict=False)
-if not src_path.exists():
-    raise SystemExit(1)
-relative = src_path.relative_to(repo_root)
-print(relative.as_posix())
+candidate = (repo_root / relative_path).resolve(strict=False)
+candidate.relative_to(repo_root)
+print(relative_path.as_posix())
 PY
+}
+
+pull_request_head_blob_required() {
+	[ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]
+}
+
+pr_head_regular_file_mode() {
+	local relative_path="$1"
+	local head_sha tree_output line_count metadata tree_path mode object_type _object_hash
+	head_sha="$(trim_whitespace "${PR_HEAD_SHA:-}")"
+	if [ -z "$head_sha" ]; then
+		return 2
+	fi
+	if ! git cat-file -e "$head_sha^{commit}" 2>/dev/null; then
+		return 2
+	fi
+	if ! tree_output="$(git ls-tree "$head_sha" -- "$relative_path")"; then
+		return 2
+	fi
+	if [ -z "$tree_output" ]; then
+		return 1
+	fi
+	line_count="$(printf '%s\n' "$tree_output" | wc -l | tr -d ' ')"
+	if [ "$line_count" != "1" ]; then
+		return 2
+	fi
+	IFS=$'\t' read -r metadata tree_path <<<"$tree_output"
+	# shellcheck disable=SC2086 # metadata is exactly git ls-tree's mode/type/object tuple.
+	read -r mode object_type _object_hash <<<"$metadata"
+	if [ "$tree_path" != "$relative_path" ]; then
+		return 2
+	fi
+	if [ "$object_type" != "blob" ]; then
+		return 1
+	fi
+	case "$mode" in
+	100644 | 100755)
+		printf '%s\n' "$mode"
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+changed_file_exists_for_scan() {
+	local relative_path="$1"
+	if pull_request_head_blob_required; then
+		local mode_rc=0
+		pr_head_regular_file_mode "$relative_path" >/dev/null || mode_rc=$?
+		case "$mode_rc" in
+		0)
+			return 0
+			;;
+		1)
+			return 1
+			;;
+		*)
+			echo "ERROR: pull request changed file could not be read from PR head; failing closed: $relative_path" >&2
+			return 2
+			;;
+		esac
+	fi
+	if [ -f "$REPO_ROOT/$relative_path" ] && [ ! -L "$REPO_ROOT/$relative_path" ]; then
+		return 0
+	fi
+	if [ -z "$(trim_whitespace "${PR_HEAD_SHA:-}")" ]; then
+		return 1
+	fi
+	local mode_rc=0
+	pr_head_regular_file_mode "$relative_path" >/dev/null || mode_rc=$?
+	case "$mode_rc" in
+	0)
+		return 0
+		;;
+	2)
+		return 2
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+copy_pr_head_blob_to_file() {
+	local relative_path="$1"
+	local dst_path="$2"
+	local head_sha mode mode_rc tmp_dst
+	head_sha="$(trim_whitespace "${PR_HEAD_SHA:-}")"
+	mode_rc=0
+	mode="$(pr_head_regular_file_mode "$relative_path")" || mode_rc=$?
+	if [ "$mode_rc" -ne 0 ]; then
+		return 2
+	fi
+	tmp_dst="$(mktemp "$(dirname -- "$dst_path")/.pr-head.XXXXXX")" || return 2
+	if ! git show "$head_sha:$relative_path" >"$tmp_dst"; then
+		rm -f -- "$tmp_dst"
+		return 2
+	fi
+	if ! mv -- "$tmp_dst" "$dst_path"; then
+		rm -f -- "$tmp_dst"
+		return 2
+	fi
+	if [ "$mode" = "100755" ]; then
+		chmod 755 "$dst_path" || return 2
+	else
+		chmod 644 "$dst_path" || return 2
+	fi
 }
 
 is_supported_source_file() {
@@ -441,12 +562,33 @@ PY
 		head_sha="$(printf '%s' "$pr_shas" | sed -n '2p')"
 	fi
 	if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+		if pull_request_head_blob_required; then
+			echo "ERROR: pull request base/head metadata is unavailable; failing closed." >&2
+			return 2
+		fi
 		return 1
 	fi
 	if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
+		if pull_request_head_blob_required; then
+			echo "ERROR: pull request base commit could not be read; failing closed: $base_sha" >&2
+			return 2
+		fi
 		return 1
 	fi
 	if ! git cat-file -e "$head_sha^{commit}" 2>/dev/null; then
+		if pull_request_head_blob_required; then
+			echo "ERROR: pull request head commit could not be read; failing closed: $head_sha" >&2
+			return 2
+		fi
+		return 1
+	fi
+
+	local changed_files_output
+	if ! changed_files_output="$(git diff --name-only "$base_sha...$head_sha")"; then
+		if pull_request_head_blob_required; then
+			echo "ERROR: pull request changed file list could not be read; failing closed." >&2
+			return 2
+		fi
 		return 1
 	fi
 
@@ -455,9 +597,9 @@ PY
 		if [ -n "$changed_file" ]; then
 			CHANGED_FILES+=("$changed_file")
 		fi
-	done < <(git diff --name-only "$base_sha...$head_sha")
+	done <<<"$changed_files_output"
 
-	[ "${#CHANGED_FILES[@]}" -gt 0 ]
+	return 0
 }
 
 load_pull_request_head_sha() {
@@ -663,13 +805,22 @@ is_scannable_changed_file() {
 	if ! normalized_changed_file="$(normalize_changed_file_path "$changed_file")"; then
 		return 1
 	fi
-	if ! is_supported_source_file "$changed_file"; then
+	if ! is_supported_source_file "$normalized_changed_file"; then
 		return 1
 	fi
-	if [ ! -f "$REPO_ROOT/$normalized_changed_file" ] || [ -L "$REPO_ROOT/$normalized_changed_file" ]; then
+	local exists_rc=0
+	changed_file_exists_for_scan "$normalized_changed_file" || exists_rc=$?
+	case "$exists_rc" in
+	0)
+		return 0
+		;;
+	2)
+		return 2
+		;;
+	*)
 		return 1
-	fi
-	return 0
+		;;
+	esac
 }
 
 build_pull_request_scope_dir() {
@@ -685,26 +836,38 @@ build_pull_request_scope_dir() {
 			echo "ERROR: pull request changed file path is unsafe: $changed_file" >&2
 			return 2
 		}
-		mapfile -t _paths < <(
-			python3 - "$REPO_ROOT" "$scope_dir" "$relative_path" <<'PY'
+		local dst_path
+		dst_path="$(
+			python3 - "$scope_dir" "$relative_path" <<'PY'
 from pathlib import Path
 import sys
 
-repo_root = Path(sys.argv[1]).resolve(strict=True)
-scope_root = Path(sys.argv[2]).resolve(strict=True)
-relative_path = Path(sys.argv[3])
-src_path = (repo_root / relative_path).resolve(strict=False)
-if not src_path.exists():
-    raise SystemExit(1)
-src_path.relative_to(repo_root)
+scope_root = Path(sys.argv[1]).resolve(strict=True)
+relative_path = Path(sys.argv[2])
 dst_path = scope_root / relative_path
-print(src_path)
 print(dst_path)
 PY
-		)
-		local src_path="${_paths[0]}"
-		local dst_path="${_paths[1]}"
+		)"
 		mkdir -p -- "$(dirname -- "$dst_path")"
+		local copy_rc=1
+		local head_sha_for_copy
+		head_sha_for_copy="$(trim_whitespace "${PR_HEAD_SHA:-}")"
+		if pull_request_head_blob_required || { [ -n "$head_sha_for_copy" ] && git cat-file -e "$head_sha_for_copy^{commit}" 2>/dev/null; }; then
+			copy_rc=0
+			copy_pr_head_blob_to_file "$relative_path" "$dst_path" || copy_rc=$?
+		fi
+		if [ "$copy_rc" -eq 0 ]; then
+			return 0
+		fi
+		if pull_request_head_blob_required || [ "$copy_rc" -eq 2 ]; then
+			echo "ERROR: pull request changed file could not be read from PR head; failing closed: $changed_file" >&2
+			return 2
+		fi
+		local src_path="$REPO_ROOT/$relative_path"
+		if [ ! -f "$src_path" ] || [ -L "$src_path" ]; then
+			echo "ERROR: pull request changed file is unavailable in both PR head and checkout: $changed_file" >&2
+			return 2
+		fi
 		cp -- "$src_path" "$dst_path"
 	}
 
@@ -720,15 +883,28 @@ prepare_pull_request_scan_scope() {
 		return 0
 	fi
 
-	if ! load_pull_request_changed_files; then
+	local load_changed_files_rc=0
+	load_pull_request_changed_files || load_changed_files_rc=$?
+	case "$load_changed_files_rc" in
+	0)
+		;;
+	2)
+		return 2
+		;;
+	*)
 		return 0
-	fi
+		;;
+	esac
 
 	local scoped_changed_files=()
 	local changed_file
 	for changed_file in "${CHANGED_FILES[@]}"; do
-		if is_scannable_changed_file "$changed_file"; then
+		local scannable_rc=0
+		is_scannable_changed_file "$changed_file" || scannable_rc=$?
+		if [ "$scannable_rc" -eq 0 ]; then
 			scoped_changed_files+=("$changed_file")
+		elif [ "$scannable_rc" -eq 2 ]; then
+			return 2
 		fi
 	done
 
@@ -2018,7 +2194,10 @@ run_pull_request_batch_files() {
 
 	local previous_batch_file_count="$CURRENT_PULL_REQUEST_BATCH_FILE_COUNT"
 	CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="${#batch_files[@]}"
-	build_pull_request_scope_dir "${batch_files[@]}"
+	if ! build_pull_request_scope_dir "${batch_files[@]}"; then
+		CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="$previous_batch_file_count"
+		return 1
+	fi
 	TARGET_PATH="$LAST_PULL_REQUEST_SCOPE_DIR"
 	echo "Running pull request Strix batch ${batch_label}/${total_batches}." >&2
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -40,6 +40,30 @@ assert_file_contains() {
 	fi
 }
 
+assert_file_not_contains() {
+	local file_path="$1"
+	local needle="$2"
+	local message="$3"
+
+	if grep -Fq -- "$needle" "$file_path"; then
+		record_failure "$message (unexpected '$needle')"
+	fi
+}
+
+assert_strix_workflow_pr_trigger_hardened() {
+	local workflow_file="$REPO_ROOT/.github/workflows/strix.yml"
+
+	assert_file_contains "$workflow_file" "branches: [master]" "strix workflow scans the protected default branch"
+	assert_file_contains "$workflow_file" "pull_request_target:" "strix workflow uses trusted PR trigger"
+	assert_file_contains "$workflow_file" "Fetch pull request head for trusted scan" "strix workflow fetches PR head without checkout"
+	assert_file_contains "$workflow_file" "refs/remotes/pull" "strix workflow verifies fetched PR head ref"
+	assert_file_contains "$workflow_file" "github.event_name == 'pull_request_target'" "strix workflow gates PR context on pull_request_target"
+	if grep -Eq '^[[:space:]]+pull_request:[[:space:]]*$' "$workflow_file"; then
+		record_failure "strix workflow must not expose secrets on pull_request events"
+	fi
+	assert_file_not_contains "$workflow_file" "github.event_name == 'pull_request'" "strix workflow should not retain pull_request-only expressions"
+}
+
 run_gate_case() {
 	local scenario="$1"
 	local initial_model="$2"
@@ -578,6 +602,14 @@ EOS
 		echo "╰──────────────────────────────────────────────────────────────────────────────╯"
 		echo "Penetration test failed: simulated inline medium finding"
 		exit 2
+		;;
+	medium-vuln-default-threshold)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-medium-default/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-medium-default/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: MEDIUM
+EOS
+		echo "Penetration test failed: simulated medium finding"
+		exit 1
 		;;
 	critical-vuln-at-threshold)
 		mkdir -p "$STRIX_REPORTS_DIR/fake-critical/vulnerabilities"
@@ -1399,6 +1431,19 @@ EOF
 			UNRELATED_SECRET="should-not-forward"
 		)
 	fi
+	if [ "$min_fail_severity" = "__UNSET__" ]; then
+		local next_env_cmd=()
+		local env_pair
+		for env_pair in "${env_cmd[@]}"; do
+			case "$env_pair" in
+			STRIX_FAIL_ON_MIN_SEVERITY=*)
+				continue
+				;;
+			esac
+			next_env_cmd+=("$env_pair")
+		done
+		env_cmd=("${next_env_cmd[@]}")
+	fi
 	printf '%s' "$initial_model" >"$strix_llm_file"
 	env_cmd+=(STRIX_LLM_FILE="$strix_llm_file")
 	printf '%s' 'dummy' >"$llm_api_key_file"
@@ -1509,6 +1554,235 @@ EOF
 			"LLM_TIMEOUT=90;STRIX_MEMORY_COMPRESSOR_TIMEOUT=10;STRIX_REASONING_EFFORT=minimal;STRIX_LLM_MAX_RETRIES=1;GEMINI_LOCATION=GLOBAL;UNRELATED_SECRET=<unset>" \
 			"scenario=$scenario runtime env forwarding"
 	fi
+
+	rm -rf "$tmp_dir"
+}
+
+run_pull_request_target_head_scope_case() {
+	local case_name="$1"
+	local changed_file="$2"
+	local base_content="$3"
+	local head_content="$4"
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local fake_strix="$bin_dir/strix"
+	local output_log="$tmp_dir/output.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path=""
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-t" ] && [ "$#" -ge 2 ]; then
+		target_path="$2"
+		break
+	fi
+	shift
+done
+
+scoped_file="$target_path/${FAKE_STRIX_EXPECTED_CHANGED_FILE:?}"
+if [ ! -f "$scoped_file" ]; then
+	echo "Error: PR head scoped file missing ($scoped_file)" >&2
+	exit 61
+fi
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_HEAD_CONTENT:?}" "$scoped_file"; then
+	echo "Error: PR head scoped file did not contain head content" >&2
+	cat -- "$scoped_file" >&2
+	exit 62
+fi
+if [ -n "${FAKE_STRIX_UNEXPECTED_BASE_CONTENT:-}" ] && grep -Fq -- "$FAKE_STRIX_UNEXPECTED_BASE_CONTENT" "$scoped_file"; then
+	echo "Error: PR head scoped file leaked base checkout content" >&2
+	cat -- "$scoped_file" >&2
+	exit 63
+fi
+echo "scan ok with PR head content"
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		echo 'seed' >README.md
+		if [ "$base_content" != "__ABSENT__" ]; then
+			mkdir -p "$(dirname -- "$changed_file")"
+			printf '%s\n' "$base_content" >"$changed_file"
+		fi
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		mkdir -p "$(dirname -- "$changed_file")"
+		printf '%s\n' "$head_content" >"$changed_file"
+		git add .
+		git commit -qm 'head commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	local unexpected_base_content=""
+	if [ "$base_content" != "__ABSENT__" ]; then
+		unexpected_base_content="$base_content"
+	fi
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+			PATH="$bin_dir:$PATH" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			FAKE_STRIX_EXPECTED_CHANGED_FILE="$changed_file" \
+			FAKE_STRIX_EXPECTED_HEAD_CONTENT="$head_content" \
+			FAKE_STRIX_UNEXPECTED_BASE_CONTENT="$unexpected_base_content" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=$case_name exit code"
+	assert_file_contains "$output_log" "scan ok with PR head content" "case=$case_name output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_pull_request_target_aborts_on_pr_head_blob_failure_case() {
+	local case_name="$1"
+	local changed_file="$2"
+	local base_content="$3"
+	local head_content="$4"
+	local fake_git_fail_command="$5"
+	local expected_exit="1"
+	if [ "$fake_git_fail_command" = "ls-tree" ] || [ "$fake_git_fail_command" = "diff" ]; then
+		expected_exit="2"
+	fi
+	local expected_message="pull request changed file could not be read from PR head; failing closed"
+	if [ "$fake_git_fail_command" = "diff" ]; then
+		expected_message="pull request changed file list could not be read; failing closed"
+	fi
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local real_git
+	real_git="$(command -v git)"
+	local fake_git="$bin_dir/git"
+	cat >"$fake_git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "show" ]; then
+	printf 'PARTIAL_PR_HEAD_BLOB_SHOULD_BE_DISCARDED'
+	exit 1
+fi
+if [ "${1:-}" = "${FAKE_GIT_FAIL_COMMAND:-}" ]; then
+	printf 'FAILED_PR_HEAD_LOOKUP_SHOULD_FAIL_CLOSED'
+	exit 1
+fi
+exec "${REAL_GIT_PATH:?}" "$@"
+EOF
+	chmod +x "$fake_git"
+
+	local fake_strix="$bin_dir/strix"
+	local call_log="$tmp_dir/calls.log"
+	local output_log="$tmp_dir/output.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'called\n' >> "${FAKE_STRIX_CALL_LOG:?}"
+echo "Error: Strix should not run after a PR-head blob failure" >&2
+exit 64
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		echo 'seed' >README.md
+		if [ "$base_content" != "__ABSENT__" ]; then
+			mkdir -p "$(dirname -- "$changed_file")"
+			printf '%s\n' "$base_content" >"$changed_file"
+		fi
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		mkdir -p "$(dirname -- "$changed_file")"
+		printf '%s\n' "$head_content" >"$changed_file"
+		git add .
+		git commit -qm 'head commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+			PATH="$bin_dir:$PATH" \
+			REAL_GIT_PATH="$real_git" \
+			FAKE_GIT_FAIL_COMMAND="$fake_git_fail_command" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			FAKE_STRIX_CALL_LOG="$call_log" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "$expected_exit" "$rc" "case=$case_name PR-head blob failure exits closed"
+	assert_file_contains "$output_log" "$expected_message" "case=$case_name PR-head failure output"
+	local call_count="0"
+	if [ -f "$call_log" ]; then
+		call_count="$(wc -l <"$call_log" | tr -d ' ')"
+	fi
+	assert_equals "0" "$call_count" "case=$case_name PR-head blob failure must not invoke Strix"
 
 	rm -rf "$tmp_dir"
 }
@@ -1926,6 +2200,48 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+assert_strix_workflow_pr_trigger_hardened
+
+run_pull_request_target_head_scope_case \
+	"pull-request-target-modified-file-uses-head-blob" \
+	"src/app.py" \
+	"BASE_CONTENT_SHOULD_NOT_BE_SCANNED" \
+	"HEAD_CONTENT_SHOULD_BE_SCANNED"
+
+run_pull_request_target_head_scope_case \
+	"pull-request-target-added-file-uses-head-blob" \
+	"src/new_module.py" \
+	"__ABSENT__" \
+	"HEAD_ONLY_NEW_FILE_SHOULD_BE_SCANNED"
+
+run_pull_request_target_aborts_on_pr_head_blob_failure_case \
+	"pull-request-target-added-file-pr-head-blob-read-failure" \
+	"src/new_module.py" \
+	"__ABSENT__" \
+	"HEAD_CONTENT_SHOULD_NOT_BECOME_PARTIAL_SCAN_INPUT" \
+	"show"
+
+run_pull_request_target_aborts_on_pr_head_blob_failure_case \
+	"pull-request-target-modified-file-pr-head-blob-read-failure" \
+	"src/existing.py" \
+	"BASE_CONTENT_MUST_NOT_BE_USED_AFTER_HEAD_READ_FAILURE" \
+	"HEAD_CONTENT_SHOULD_NOT_BECOME_PARTIAL_SCAN_INPUT" \
+	"show"
+
+run_pull_request_target_aborts_on_pr_head_blob_failure_case \
+	"pull-request-target-modified-file-pr-head-tree-lookup-failure" \
+	"src/existing.py" \
+	"BASE_CONTENT_MUST_NOT_BE_USED_AFTER_HEAD_LOOKUP_FAILURE" \
+	"HEAD_CONTENT_SHOULD_NOT_BECOME_PARTIAL_SCAN_INPUT" \
+	"ls-tree"
+
+run_pull_request_target_aborts_on_pr_head_blob_failure_case \
+	"pull-request-target-changed-file-list-diff-failure" \
+	"src/existing.py" \
+	"BASE_CONTENT_MUST_NOT_BE_USED_AFTER_DIFF_FAILURE" \
+	"HEAD_CONTENT_SHOULD_NOT_BECOME_PARTIAL_SCAN_INPUT" \
+	"diff"
+
 run_gate_case "success" \
 	"vertex_ai/ready-primary" \
 	"vertex_ai/fallback-one vertex_ai/fallback-two" \
@@ -2342,6 +2658,20 @@ run_gate_case "inline-medium-below-threshold" \
 	"1" \
 	"vertex_ai/inline-medium-primary" \
 	"<unset>"
+
+run_gate_case "medium-vuln-default-threshold" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"0" \
+	"__UNSET__"
 
 # Infrastructure error guard: below-threshold findings must NOT pass when the
 # strix log contains evidence of infrastructure-level errors (timeout,
@@ -3428,6 +3758,7 @@ run_missing_config_case "whitespace-only-llm-api-key" "vertex_ai/ready-primary" 
 # The gate script cannot be sourced directly (it has top-level side effects),
 # so the shared helper script exposes the pure model/path functions directly.
 # shellcheck source=scripts/ci/strix_model_utils.sh
+# shellcheck disable=SC1091  # source path is repo-local; local lint may omit -x
 . "$REPO_ROOT/scripts/ci/strix_model_utils.sh"
 
 assert_vertex_path() {

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -55,6 +55,8 @@ assert_strix_workflow_pr_trigger_hardened() {
 
 	assert_file_contains "$workflow_file" "branches: [master]" "strix workflow scans the protected default branch"
 	assert_file_contains "$workflow_file" "pull_request_target:" "strix workflow uses trusted PR trigger"
+	assert_file_contains "$workflow_file" "Checkout trusted pull request base" "strix workflow names trusted PR checkout"
+	assert_file_contains "$workflow_file" "ref: \${{ github.event.pull_request.base.sha }}" "strix workflow pins PR checkout to base SHA"
 	assert_file_contains "$workflow_file" "Fetch pull request head for trusted scan" "strix workflow fetches PR head without checkout"
 	assert_file_contains "$workflow_file" "refs/remotes/pull" "strix workflow verifies fetched PR head ref"
 	assert_file_contains "$workflow_file" "github.event_name == 'pull_request_target'" "strix workflow gates PR context on pull_request_target"


### PR DESCRIPTION
## Summary
- Run Strix PR scans through `pull_request_target` while keeping checkout/scripts on the trusted base commit.
- Fetch and verify PR head commits, copy changed PR-head blobs into bounded scan scopes, and fail closed on diff/tree/blob/copy/chmod failures.
- Set the Strix severity gate to Medium, add regressions for privileged PR invariants, document the CI security boundary, and add a reusable skill for this class of workflow mistake.

## Verification
- `bash -n ./scripts/ci/strix_quick_gate.sh && bash -n ./scripts/ci/test_strix_quick_gate.sh`
- `shellcheck scripts/ci/strix_quick_gate.sh scripts/ci/test_strix_quick_gate.sh`
- `markdownlint-cli2 ARCHITECTURE.md SECURITY.md .agents/skills/github-actions-privileged-pr-scan/SKILL.md`
- `actionlint .github/workflows/strix.yml`
- `git diff --check`
- `bash ./scripts/ci/test_strix_quick_gate.sh`
- Security subagent re-review: Critical/Important/Minor none, safe to commit/push.

Closes #101.
Closes #102.
Closes #103.
Closes #105.
Part of #100. Warning ownership follow-up remains tracked in #104.