### PR TITLE
docs: document robot review merge gate

### DIFF
--- a/.agents/skills/fix-development-mistakes/SKILL.md
+++ b/.agents/skills/fix-development-mistakes/SKILL.md
@@ -1,39 +1,63 @@
-<skill_content name="fix-development-mistakes">
-# Skill: fix-development-mistakes
+---
+name: fix-development-mistakes
+description: >-
+  Use when linter errors, dependency downgrades, security vulnerabilities, file
+  overwrites, merge conflicts, or merge-gate misdiagnoses occur during
+  development and need root-cause repair.
+---
 
 # Fix Development Mistakes
 
 ## Overview
 
-A skill to fix linter errors, dependency downgrades, security vulnerabilities, file overwrites, and other mistakes that occur during development. This ensures root causes are traced and fixed properly without human intervention.
+Fix linter errors, dependency downgrades, security vulnerabilities, file
+overwrites, and other mistakes that occur during development. The goal is to
+trace the root cause and fix it properly without waiting for human intervention.
 
 ## When to use
 
 Use this skill when:
+
 - Dependabot or code scanning alerts report a vulnerability.
-- A subagent overwrites a file instead of appending to it (e.g. `exceptions.py` or `requirements.txt`).
-- A linter or static analyzer throws an error (e.g., `mypy`, `flake8`, `ruff`).
-- Merge conflicts result in accidental loss of code or unintended dependency downgrades.
+- A subagent overwrites a file instead of appending to it, such as
+  `exceptions.py` or `requirements.txt`.
+- A linter or static analyzer throws an error, such as `mypy`, `flake8`, or
+  `ruff`.
+- Merge conflicts result in accidental loss of code or unintended dependency
+  downgrades.
+- Merge gates, CodeRabbit/robot review, GitHub approval, or stale required
+  status contexts are misdiagnosed; use `github-robot-review-gate`.
 
 ## Workflow
 
-### 1. Root Cause Analysis
-- **Identify the error:** Read the error message, warning, or security alert.
-- **Trace back:** Check git logs or `git diff` to see what introduced the error.
-- **Understand why:** Did a subagent misunderstand a prompt? Did a package conflict force a downgrade? Was a security patch reverted?
+### 1. Root cause analysis
 
-### 2. Formulate the Fix
-- **File overwrites:** Use `git checkout origin/master -- <file>` to restore the original content, then append the new changes safely using the `edit` or `write` tool.
-- **Dependency issues:** Pin dependencies to secure versions. Resolve conflicts by upgrading the conflicting package rather than downgrading the patched package.
-- **Linter errors:** Add missing type hints, fix indentation, add docstrings, or suppress the warning ONLY if the rule is intentionally violated and commented.
+- Identify the exact error, warning, or security alert.
+- Trace back through git history or `git diff` to see what introduced it.
+- Understand whether the source is a prompt misunderstanding, package conflict,
+  reverted security patch, stale ruleset, or environment mismatch.
 
-### 3. Execution & Verification
-- Execute the fix using appropriate tools (`edit`, `write`, `bash`).
-- Run the test suite and the linter locally.
-- Confirm the warning, error, or vulnerability is resolved.
+### 2. Formulate the fix
 
-### 4. Commit and Push
-- Commit the change with a descriptive message starting with `fix: `.
-- Example: `fix: restore exceptions.py overwritten by subagent` or `fix: upgrade pytest to 9.0.3 to resolve CVE-2025-71176`.
-- Push directly if on a feature branch, or create a PR if on master.
-</skill_content>
+- File overwrites: restore the original content from the correct base, then add
+  the intended changes narrowly.
+- Dependency issues: pin secure versions and resolve conflicts by upgrading the
+  conflicting package rather than downgrading a patched package.
+- Linter errors: add missing type hints, fix indentation, add docstrings, or use
+  a narrow documented suppression only when the rule is intentionally violated.
+- Merge-gate issues: collect ruleset/check/review evidence before changing code
+  or repository settings.
+
+### 3. Execute and verify
+
+- Apply the smallest targeted fix.
+- Run the relevant test suite and linter locally.
+- Confirm the warning, error, vulnerability, or gate blocker is resolved.
+
+### 4. Commit and push
+
+- Commit with a descriptive message starting with the `fix:` prefix.
+- Example: `fix: restore exceptions.py overwritten by subagent`.
+- Example: `fix: upgrade pytest to resolve CVE-2025-71176`.
+- Push to the feature branch only after verification and PR-continuity checks,
+  or create a PR if on `master`.

--- a/.agents/skills/github-robot-review-gate/SKILL.md
+++ b/.agents/skills/github-robot-review-gate/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: github-robot-review-gate
+description: >-
+  Use when GitHub PR merge gates, CodeRabbit robot-review policy, required
+  review settings, stale status contexts, or temporary required-check rollbacks
+  are blocking or being misdiagnosed.
+---
+
+# GitHub Robot Review Gate
+
+## Core rule
+
+Diagnose the exact merge blocker before changing code or repository settings.
+CodeRabbit/check-run success can satisfy this repo's robot-review policy only
+when current-head CodeRabbit blocking findings, warnings, and failures are fixed,
+rebutted with evidence, or superseded. It is not a GitHub `APPROVED` review. If
+GitHub rulesets require human approval, fix the ruleset contract rather than
+waiting for humans or disabling security.
+
+## Root-cause-first workflow
+
+1. Capture the PR head SHA, mergeability, review decision, required checks, and
+   rule evaluation before proposing a fix.
+2. Separate four signals: GitHub review state, CodeRabbit robot-review evidence,
+   required status contexts, and ruleset settings.
+3. Identify the narrow blocker: missing current-head robot evidence, unresolved
+   robot findings, human-review ruleset count, unresolved threads, stale status
+   context, or failing check.
+4. Apply only the minimal reversible fix, then re-capture the same evidence.
+
+## Evidence commands
+
+```bash
+gh pr view <pr> \
+  --json number,headRefOid,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,latestReviews
+gh pr checks <pr> --required
+gh api repos/<owner>/<repo>/pulls/<pr>/reviews
+gh api repos/<owner>/<repo>/commits/<sha>/status
+gh api repos/<owner>/<repo>/commits/<sha>/check-runs
+gh api repos/<owner>/<repo>/rulesets \
+  --jq '.[] | {name, enforcement, conditions, rules}'
+```
+
+Record the current head SHA with every screenshot, review, and check summary so
+stale evidence is not mistaken for current-head approval.
+
+## Guardrails
+
+- Do not bypass branch protection, add bypass actors, use admin merge, force
+  push, dismiss reviews, or disable security checks unless explicitly requested.
+- Do not treat `Review skipped`, CodeRabbit walkthroughs, or check-run success as
+  a GitHub `APPROVED` review object. They are robot-review gate evidence only.
+- Do not wait for human review by default in this repo when robot-review policy
+  applies; instead verify `required_approving_review_count=0`.
+- Do not remove required review thread resolution; keep
+  `required_review_thread_resolution=true`.
+
+## Stale required status contexts
+
+If a PR that hardens or restores a workflow is blocked by a stale required
+context (for example `strix` while fixing Strix), document the stale context and
+use a temporary, reversible ruleset adjustment only when necessary. Capture
+equivalent temporary evidence before merge, such as a trusted-base rerun,
+scanner artifact, SARIF output, or manual security review evidence tied to the
+current head SHA. The rollback requirement is part of the fix: restore the
+`strix` required context immediately after the hardened workflow emits that
+context successfully on the protected branch.
+
+## Safe temporary handling
+
+- Prefer rerunning or updating the branch before touching rulesets.
+- If temporary removal is unavoidable, capture before/after ruleset JSON, owner,
+  expiry, current head SHA, equivalent temporary evidence, and a dated rollback
+  note in the PR.
+- Restore required contexts and confirm `gh pr checks --required` shows the
+  hardened context before declaring the gate resolved.
+
+## Common mistakes
+
+- Equating CodeRabbit status with GitHub `APPROVED`: treat it as repo
+  robot-review evidence, then check ruleset review count.
+- Waiting for human review despite policy: verify ruleset count is zero and
+  robot evidence is current-head.
+- Removing `strix` permanently to unblock Strix fixes: temporarily remove only
+  with evidence, then restore once Strix emits.
+- Disabling scanners to merge faster: keep security gates on; fix the gate
+  contract or the failing scanner.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,3 +56,5 @@ The gate fails closed when a changed PR-head blob cannot be validated or copied;
 it must never fall back to scanning trusted-base content for a modified PR path.
 Strix remains a required Medium-or-higher gate, while third-party LLM/provider
 warnings are tracked separately unless they make the scan incomplete.
+Merge-gate governance for Strix, CodeRabbit, and required review evidence is
+documented in `docs/development/merge-gate-policy.md`.

--- a/docs/development/merge-gate-policy.md
+++ b/docs/development/merge-gate-policy.md
@@ -1,0 +1,81 @@
+# Merge Gate Policy
+
+This repository's merge gate is evidence-based: required checks must pass,
+review threads must be resolved, and the current PR head must have current-head
+CodeRabbit/robot-review evidence. Human review is not awaited by default.
+
+## Required gate contract
+
+- Required status checks must pass on the current head SHA.
+- The CodeRabbit robot-review gate is satisfied by current-head CodeRabbit
+  evidence only when current-head blocking findings, warnings, and failures are
+  fixed, rebutted with evidence, or superseded. Authoritative current-head
+  `Review skipped` evidence satisfies the robot-review gate when applicable.
+- GitHub rulesets should use `required_approving_review_count=0` so GitHub does
+  not require a human `APPROVED` review when robot-review policy applies.
+- GitHub rulesets should keep `required_review_thread_resolution=true`.
+- No bypass actors should be configured for routine delivery.
+- Security workflows and scanners are required gates, not optional paths.
+
+## Evidence commands
+
+Use the same head SHA across all checks:
+
+```bash
+gh pr view <pr> \
+  --json number,headRefOid,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+gh pr checks <pr> --required
+gh api repos/<owner>/<repo>/pulls/<pr>/reviews
+gh api repos/<owner>/<repo>/commits/<sha>/check-runs
+gh api repos/<owner>/<repo>/rulesets --jq '.[] | {name, enforcement, rules}'
+```
+
+## Robot review versus GitHub approval
+
+CodeRabbit review/check evidence satisfies this repo's robot-review policy only
+after current-head CodeRabbit blocking comments, pre-merge warnings, and failure
+findings are resolved or superseded. It is not the same object as a GitHub
+`APPROVED` review. If GitHub reports a missing approving review, inspect the
+ruleset before waiting for a human review. The expected setting is
+`required_approving_review_count=0`.
+
+## Stale required contexts
+
+A required context can become stale when the PR is fixing the workflow that
+emits it. For example, PRs that fix Strix may be blocked by a required `strix`
+context before the hardened Strix workflow can emit a valid result.
+
+Handling policy:
+
+1. Prefer branch update or rerun first.
+2. If the required context cannot be emitted until the PR lands, document the
+   stale context and use only a temporary, reversible ruleset adjustment.
+   Capture equivalent temporary evidence before merge, such as a trusted-base
+   rerun, scanner artifact, SARIF output, or manual security review evidence
+   tied to the current head SHA.
+3. Restore the `strix` required context after the hardened workflow emits it
+   successfully on the protected branch.
+4. Re-run required-check evidence after restore.
+
+## PR #108/#109 evidence summary
+
+- PR #108 exposed the merge-gate ambiguity: CodeRabbit/robot-review evidence was
+  conflated with a GitHub `APPROVED` review, while ruleset configuration could
+  still require human approval despite repo policy.
+- Issue #109 documents the durable fix: distinguish robot-review evidence from
+  GitHub approval objects, keep human approval count at zero, preserve review
+  thread resolution, and handle stale `strix` required contexts with explicit
+  rollback.
+- The root cause was policy/evidence mismatch, not lack of human review.
+
+## Rollback and recovery
+
+- Do not add bypass actors, disable security checks, dismiss reviews, or use admin
+  merge for normal delivery.
+- Any temporary ruleset change must have captured before/after JSON, owner,
+  expiry, head SHA, equivalent temporary evidence, and a named restore
+  condition.
+- Restore required contexts immediately after the repaired workflow emits them.
+- If the platform still rejects merge after policy-aligned settings and passing
+  checks, record the rejection as an external blocker with the exact command
+  output and head SHA.

--- a/docs/development/merge-gate-policy.md
+++ b/docs/development/merge-gate-policy.md
@@ -11,10 +11,10 @@ CodeRabbit/robot-review evidence. Human review is not awaited by default.
   evidence only when current-head blocking findings, warnings, and failures are
   fixed, rebutted with evidence, or superseded. Authoritative current-head
   `Review skipped` evidence satisfies the robot-review gate when applicable.
-- GitHub rulesets should use `required_approving_review_count=0` so GitHub does
+- GitHub rulesets must use `required_approving_review_count=0` so GitHub does
   not require a human `APPROVED` review when robot-review policy applies.
-- GitHub rulesets should keep `required_review_thread_resolution=true`.
-- No bypass actors should be configured for routine delivery.
+- GitHub rulesets must keep `required_review_thread_resolution=true`.
+- Bypass actors must not be configured for routine delivery.
 - Security workflows and scanners are required gates, not optional paths.
 
 ## Evidence commands


### PR DESCRIPTION
## Summary
- Document the evidence-based merge gate contract for CodeRabbit/robot-review, Strix, and required review settings.
- Add a repo-local skill for diagnosing GitHub robot-review gate blockers and stale required contexts.
- Cross-link the merge-gate policy from the architecture CI security boundary.

## Verification
- `git diff --check`
- `markdownlint-cli2 ".agents/skills/fix-development-mistakes/SKILL.md" ".agents/skills/github-robot-review-gate/SKILL.md" "docs/development/merge-gate-policy.md" "ARCHITECTURE.md"`

Closes #109