### PR TITLE
ci: improve Strix PR scan fallbacks

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -245,7 +245,8 @@ jobs:
           GEMINI_LOCATION: GLOBAL
           LLM_API_KEY_FILE: ${{ env.LLM_API_KEY_FILE }}
           LLM_API_BASE_FILE: ${{ env.LLM_API_BASE_FILE }}
-          STRIX_VERTEX_FALLBACK_MODELS: "gemini/gemini-pro-3.1-preview"
+          STRIX_GEMINI_FALLBACK_MODELS: "gemini/gemini-2.5-flash gemini/gemini-2.5-pro"
+          STRIX_VERTEX_FALLBACK_MODELS: "vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
           STRIX_TARGET_PATH: ./
           STRIX_SOURCE_DIRS: .
           STRIX_REASONING_EFFORT: ${{ github.event_name == 'push' && 'low' || 'minimal' }}

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1556,11 +1556,35 @@ fallback_models_raw_for_model() {
 	fi
 
 	if is_gemini_model "$model"; then
-		printf '%s\n' "${STRIX_GEMINI_FALLBACK_MODELS:-}"
+		if [ -n "${STRIX_GEMINI_FALLBACK_MODELS+x}" ]; then
+			printf '%s\n' "$STRIX_GEMINI_FALLBACK_MODELS"
+		else
+			printf '%s\n' "${STRIX_FALLBACK_MODELS:-}"
+		fi
 		return 0
 	fi
 
 	printf '%s\n' "${STRIX_FALLBACK_MODELS:-}"
+}
+
+fallback_models_config_name_for_model() {
+	local model="$1"
+
+	if is_vertex_model "$model"; then
+		printf '%s\n' "STRIX_VERTEX_FALLBACK_MODELS"
+		return 0
+	fi
+
+	if is_gemini_model "$model"; then
+		if [ -n "${STRIX_GEMINI_FALLBACK_MODELS+x}" ]; then
+			printf '%s\n' "STRIX_GEMINI_FALLBACK_MODELS"
+		else
+			printf '%s\n' "STRIX_GEMINI_FALLBACK_MODELS or STRIX_FALLBACK_MODELS"
+		fi
+		return 0
+	fi
+
+	printf '%s\n' "STRIX_FALLBACK_MODELS"
 }
 
 resolved_llm_api_base_for_model() {
@@ -2435,10 +2459,12 @@ run_current_target_scan() {
 	fi
 
 	if [ "$fallback_tried" -eq 0 ]; then
+		local fallback_config_name
+		fallback_config_name="$(fallback_models_config_name_for_model "$PRIMARY_MODEL")"
 		if [ "${#FALLBACK_MODELS[@]}" -eq 0 ]; then
-			echo "ERROR: No fallback models configured (STRIX_VERTEX_FALLBACK_MODELS is empty). Configure distinct models." >&2
+			echo "ERROR: No fallback models configured ($fallback_config_name is empty). Configure distinct models." >&2
 		else
-			echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in STRIX_VERTEX_FALLBACK_MODELS." >&2
+			echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in $fallback_config_name." >&2
 		fi
 	fi
 

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -901,6 +901,40 @@ is_scannable_changed_file() {
 	esac
 }
 
+pull_request_scope_context_files() {
+	local needs_backend_python=0
+	local changed_file normalized_changed_file
+	for changed_file in "$@"; do
+		normalized_changed_file="$(normalize_changed_file_path "$changed_file")" || return 2
+		case "$normalized_changed_file" in
+		backend/*.py | backend/*/*.py | backend/*/*/*.py | backend/*/*/*/*.py)
+			needs_backend_python=1
+			;;
+		esac
+	done
+
+	if [ "$needs_backend_python" -eq 1 ]; then
+		cat <<'EOF'
+backend/requirements.txt
+backend/api/__init__.py
+backend/api/auth.py
+backend/core/__init__.py
+backend/core/config.py
+backend/core/exceptions.py
+backend/db/__init__.py
+backend/db/models.py
+backend/db/session.py
+backend/services/__init__.py
+backend/services/archive.py
+backend/services/email_client.py
+backend/services/email_parser.py
+backend/services/embedding.py
+backend/services/exceptions.py
+backend/services/threading_service.py
+EOF
+	fi
+}
+
 build_pull_request_scope_dir() {
 	local scope_dir
 	scope_dir="$(mktemp -d "${TMPDIR:-/tmp}/strix-pr-scope.XXXXXX")"
@@ -946,6 +980,40 @@ PY
 			echo "ERROR: pull request changed file is unavailable in both PR head and checkout: $changed_file" >&2
 			return 2
 		fi
+		cp -- "$src_path" "$dst_path"
+	}
+
+	copy_trusted_context_file_into_scope() {
+		local context_file="$1"
+		local relative_path
+		relative_path="$(normalize_changed_file_path "$context_file")" || {
+			echo "ERROR: pull request context file path is unsafe: $context_file" >&2
+			return 2
+		}
+		local dst_path
+		dst_path="$(
+			python3 - "$scope_dir" "$relative_path" <<'PY'
+from pathlib import Path
+import sys
+
+scope_root = Path(sys.argv[1]).resolve(strict=True)
+relative_path = Path(sys.argv[2])
+dst_path = scope_root / relative_path
+print(dst_path)
+PY
+		)"
+		if [ -e "$dst_path" ]; then
+			return 0
+		fi
+		local src_path="$REPO_ROOT/$relative_path"
+		if [ ! -e "$src_path" ]; then
+			return 0
+		fi
+		if [ ! -f "$src_path" ] || [ -L "$src_path" ]; then
+			echo "ERROR: pull request trusted context file is not a regular checkout file: $context_file" >&2
+			return 2
+		fi
+		mkdir -p -- "$(dirname -- "$dst_path")"
 		cp -- "$src_path" "$dst_path"
 	}
 
@@ -996,6 +1064,15 @@ PY
 	for changed_file in "$@"; do
 		copy_changed_file_into_scope "$changed_file" || return 2
 	done
+	local context_files_text=""
+	context_files_text="$(pull_request_scope_context_files "$@")" || return 2
+	if [ -n "$context_files_text" ]; then
+		local context_file
+		while IFS= read -r context_file; do
+			[ -n "$context_file" ] || continue
+			copy_trusted_context_file_into_scope "$context_file" || return 2
+		done <<<"$context_files_text"
+	fi
 	copy_required_scope_support_files "$@" || return 2
 	LAST_PULL_REQUEST_SCOPE_DIR="$scope_dir"
 }
@@ -1455,6 +1532,37 @@ is_vertex_model() {
 	esac
 }
 
+is_gemini_model() {
+	case "$1" in
+	gemini/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+fallback_models_raw_for_model() {
+	local model="$1"
+
+	if is_vertex_model "$model"; then
+		if [ -z "${STRIX_VERTEX_FALLBACK_MODELS+x}" ]; then
+			printf '%s\n' "vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
+		else
+			printf '%s\n' "$STRIX_VERTEX_FALLBACK_MODELS"
+		fi
+		return 0
+	fi
+
+	if is_gemini_model "$model"; then
+		printf '%s\n' "${STRIX_GEMINI_FALLBACK_MODELS:-}"
+		return 0
+	fi
+
+	printf '%s\n' "${STRIX_FALLBACK_MODELS:-}"
+}
+
 resolved_llm_api_base_for_model() {
 	local model="$1"
 
@@ -1693,11 +1801,17 @@ is_llm_service_unavailable_error() {
 ##   - litellm API connection failures with LLM-provider evidence
 ##   - litellm service-unavailable / high-demand provider failures
 ##   - MidStreamFallbackError (litellm mid-stream provider switch)
-## Timeouts remain infrastructure errors for guard logic, but the caller should
-## move directly to fallback model evaluation instead of spending the remaining
-## budget retrying the same slow model.
+## Vertex timeouts remain infrastructure errors for guard logic, but the caller
+## should move directly to fallback model evaluation instead of spending the
+## remaining budget retrying the same slow model. Non-Vertex models have no
+## provider-specific fallback path in this gate, so LLM timeouts are retried on
+## the same model before being treated as non-recoverable.
 is_transient_same_model_retry_error() {
+	local model="${1-}"
 	if is_timeout_error; then
+		if [ -n "$model" ] && ! is_vertex_model "$model"; then
+			return 0
+		fi
 		return 1
 	fi
 	if is_llm_api_connection_error; then
@@ -1734,7 +1848,7 @@ run_strix_with_transient_retry() {
 			return 1
 		fi
 
-		if ! is_transient_same_model_retry_error; then
+		if ! is_transient_same_model_retry_error "$model"; then
 			return 1
 		fi
 
@@ -1745,6 +1859,8 @@ run_strix_with_transient_retry() {
 			retry_reason="LLM API connection"
 		elif is_llm_service_unavailable_error; then
 			retry_reason="LLM service unavailable"
+		elif is_timeout_error; then
+			retry_reason="LLM timeout"
 		elif is_midstream_fallback_error; then
 			retry_reason="midstream fallback"
 		fi
@@ -2204,8 +2320,10 @@ is_hallucinated_endpoint_finding() {
 	return 0
 }
 
-is_vertex_retryable_error() {
-	if is_vertex_not_found_error; then
+is_model_retryable_error() {
+	local model="$1"
+
+	if is_vertex_model "$model" && is_vertex_not_found_error; then
 		return 0
 	fi
 
@@ -2261,21 +2379,12 @@ run_current_target_scan() {
 		;;
 	esac
 
-	if ! is_vertex_model "$PRIMARY_MODEL"; then
+	if ! is_model_retryable_error "$PRIMARY_MODEL"; then
 		echo "Strix quick scan failed with a non-recoverable error." >&2
 		return 1
 	fi
 
-	if ! is_vertex_retryable_error; then
-		echo "Strix quick scan failed with a non-recoverable error." >&2
-		return 1
-	fi
-
-	if [ -z "${STRIX_VERTEX_FALLBACK_MODELS+x}" ]; then
-		FALLBACK_MODELS_RAW="vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
-	else
-		FALLBACK_MODELS_RAW="$STRIX_VERTEX_FALLBACK_MODELS"
-	fi
+	FALLBACK_MODELS_RAW="$(fallback_models_raw_for_model "$PRIMARY_MODEL")"
 	FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\r'/ }"
 	FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\n'/ }"
 	read -r -a FALLBACK_MODELS <<<"$FALLBACK_MODELS_RAW"
@@ -2291,7 +2400,11 @@ run_current_target_scan() {
 		fi
 
 		fallback_tried=1
-		echo "Primary Vertex model unavailable; retrying with fallback '$candidate'."
+		if is_vertex_model "$PRIMARY_MODEL"; then
+			echo "Primary Vertex model unavailable; retrying with fallback '$candidate'."
+		else
+			echo "Primary model unavailable; retrying with fallback '$candidate'."
+		fi
 		if run_strix_with_transient_retry "$candidate"; then
 			echo "Strix quick scan succeeded with fallback model '$candidate'."
 			return 0
@@ -2311,13 +2424,13 @@ run_current_target_scan() {
 			;;
 		esac
 
-		if ! is_vertex_retryable_error; then
+		if ! is_model_retryable_error "$candidate"; then
 			echo "Strix quick scan failed with a non-recoverable error." >&2
 			return 1
 		fi
 		done
 
-	if should_allow_pull_request_infra_zero_finding_bypass; then
+	if is_vertex_model "$PRIMARY_MODEL" && should_allow_pull_request_infra_zero_finding_bypass; then
 		return 0
 	fi
 
@@ -2329,7 +2442,11 @@ run_current_target_scan() {
 		fi
 	fi
 
-	echo "Configured Vertex model and fallback models were unavailable." >&2
+	if is_vertex_model "$PRIMARY_MODEL"; then
+		echo "Configured Vertex model and fallback models were unavailable." >&2
+	else
+		echo "Configured model and fallback models were unavailable." >&2
+	fi
 	return 1
 }
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -147,6 +147,8 @@ run_gate_case() {
 	local test_pr_sca_status_override="${24-}"
 	local current_pr_number="${25-}"
 	local authoritative_sca_runs_json="${26-}"
+	local gemini_fallback_models="${27-__SAME_AS_FALLBACK_MODELS__}"
+	local generic_fallback_models="${28-}"
 
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
@@ -582,7 +584,7 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
-	gemini-timeout-fallback-success)
+	gemini-timeout-fallback-success|gemini-generic-fallback-success)
 		case "${STRIX_LLM:-}" in
 		gemini/timeout-fallback-primary)
 			echo "LLM CONNECTION FAILED"
@@ -1646,7 +1648,23 @@ EOF
 	# "set to empty → disable fallbacks".
 	if [ -n "$fallback_models" ]; then
 		env_cmd+=(STRIX_VERTEX_FALLBACK_MODELS="$fallback_models")
-		env_cmd+=(STRIX_GEMINI_FALLBACK_MODELS="$fallback_models")
+	fi
+	case "$gemini_fallback_models" in
+	__SAME_AS_FALLBACK_MODELS__)
+		if [ -n "$fallback_models" ]; then
+			env_cmd+=(STRIX_GEMINI_FALLBACK_MODELS="$fallback_models")
+		fi
+		;;
+	__UNSET__)
+		;;
+	*)
+		if [ -n "$gemini_fallback_models" ]; then
+			env_cmd+=(STRIX_GEMINI_FALLBACK_MODELS="$gemini_fallback_models")
+		fi
+		;;
+	esac
+	if [ -n "$generic_fallback_models" ]; then
+		env_cmd+=(STRIX_FALLBACK_MODELS="$generic_fallback_models")
 	fi
 	if [ -n "$custom_source_dirs" ]; then
 		env_cmd+=(STRIX_SOURCE_DIRS="$custom_source_dirs")
@@ -1683,7 +1701,14 @@ EOF
 	fi
 	(
 		cd "$repo_root_dir"
-		env -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE "${env_cmd[@]}" \
+		env \
+			-u GITHUB_EVENT_NAME \
+			-u GITHUB_EVENT_PATH \
+			-u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+			-u STRIX_VERTEX_FALLBACK_MODELS \
+			-u STRIX_GEMINI_FALLBACK_MODELS \
+			-u STRIX_FALLBACK_MODELS \
+			"${env_cmd[@]}" \
 			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
 	)
 	local rc=$?
@@ -3064,6 +3089,35 @@ run_gate_case "gemini-timeout-fallback-success" \
 	"__DEFAULT__" \
 	"" \
 	"1"
+
+run_gate_case "gemini-generic-fallback-success" \
+	"gemini/timeout-fallback-primary" \
+	"" \
+	"0" \
+	"scan ok after gemini fallback" \
+	"3" \
+	"gemini/timeout-fallback-primary|gemini/timeout-fallback-primary|gemini/fallback-one" \
+	"https://example.invalid|https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1" \
+	"CRITICAL" \
+	"0" \
+	"" \
+	"" \
+	"1200" \
+	"0" \
+	"" \
+	"" \
+	"" \
+	"" \
+	"0" \
+	"" \
+	"" \
+	"" \
+	"__UNSET__" \
+	"gemini/fallback-one gemini/fallback-two"
 
 run_gate_case "gemini-zero-findings-timeout-fallback-fails" \
 	"gemini/zero-timeout-primary" \

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -559,6 +559,60 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
+	gemini-timeout-retry-same-model-success)
+		case "${STRIX_LLM:-}" in
+		gemini/retry-timeout-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" >"${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "LLM CONNECTION FAILED"
+				echo "Error: litellm.Timeout: Connection timed out after None seconds."
+				exit 1
+			fi
+			echo "scan ok after same-model timeout retry"
+			exit 0
+			;;
+		*)
+			echo "Error: gemini timeout retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 38
+			;;
+		esac
+		;;
+	gemini-timeout-fallback-success)
+		case "${STRIX_LLM:-}" in
+		gemini/timeout-fallback-primary)
+			echo "LLM CONNECTION FAILED"
+			echo "Error: litellm.Timeout: Connection timed out after None seconds."
+			exit 1
+			;;
+		gemini/fallback-one)
+			echo "scan ok after gemini fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: gemini timeout fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 39
+			;;
+		esac
+		;;
+	gemini-zero-findings-timeout-fallback-fails)
+		case "${STRIX_LLM:-}" in
+		gemini/zero-timeout-primary|gemini/fallback-one)
+			echo "Vulnerabilities 0"
+			echo "LLM CONNECTION FAILED"
+			echo "Error: litellm.Timeout: Connection timed out after None seconds."
+			exit 1
+			;;
+		*)
+			echo "Error: gemini zero-finding fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 40
+			;;
+		esac
+		;;
 	service-unavailable-no-llm-marker-nonrecoverable)
 		echo 'ServiceUnavailableError: {"error":{"code":503,"status":"UNAVAILABLE"}}'
 		echo 'target application high demand response'
@@ -1314,6 +1368,26 @@ EOS
 		echo "scan ok with bounded changed-file scope"
 		exit 0
 		;;
+	pr-python-scope-context)
+		if [ ! -f "$target_path/backend/api/emails.py" ]; then
+			echo "Error: changed backend file missing from scoped target ($target_path)" >&2
+			exit 57
+		fi
+		if [ ! -f "$target_path/backend/core/config.py" ]; then
+			echo "Error: backend core config context missing from scoped target ($target_path)" >&2
+			exit 58
+		fi
+		if [ ! -f "$target_path/backend/db/session.py" ]; then
+			echo "Error: backend db session context missing from scoped target ($target_path)" >&2
+			exit 59
+		fi
+		if [ ! -f "$target_path/backend/services/exceptions.py" ]; then
+			echo "Error: backend service exceptions context missing from scoped target ($target_path)" >&2
+			exit 60
+		fi
+		echo "scan ok with python dependency scope"
+		exit 0
+		;;
 	pr-changed-scope-batched)
 		attempt="0"
 		if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
@@ -1491,6 +1565,24 @@ EOF
 		echo 'GET /api/hidden-secret' >"$repo_root_dir/node_modules/fake-pkg/index.js"
 	elif [ "$scenario" = "pr-changed-scope-bounded" ]; then
 		echo 'class Unrelated {}' >"$repo_root_dir/sync-module-system/smart-crawling-common/src/main/java/org/empasy/sync/common/system/util/JwtUtil.java"
+	elif [ "$scenario" = "pr-python-scope-context" ]; then
+		mkdir -p "$repo_root_dir/backend/api" "$repo_root_dir/backend/core" "$repo_root_dir/backend/db" "$repo_root_dir/backend/services"
+		touch "$repo_root_dir/backend/api/__init__.py"
+		touch "$repo_root_dir/backend/core/__init__.py"
+		touch "$repo_root_dir/backend/db/__init__.py"
+		touch "$repo_root_dir/backend/services/__init__.py"
+		echo 'from db.session import get_db' >"$repo_root_dir/backend/api/emails.py"
+		echo 'TRUSTED_CONFIG = True' >"$repo_root_dir/backend/core/config.py"
+		echo 'class LocalError(Exception): pass' >"$repo_root_dir/backend/core/exceptions.py"
+		echo 'engine = object()' >"$repo_root_dir/backend/db/session.py"
+		echo 'class Email: pass' >"$repo_root_dir/backend/db/models.py"
+		echo 'class ServiceError(Exception): pass' >"$repo_root_dir/backend/services/exceptions.py"
+		echo 'async def extract_backup_async(*args): return []' >"$repo_root_dir/backend/services/archive.py"
+		echo 'def parse_eml(*args): return {}' >"$repo_root_dir/backend/services/email_parser.py"
+		echo 'async def generate_embeddings(*args): return []' >"$repo_root_dir/backend/services/embedding.py"
+		echo 'async def assign_thread_id(*args, **kwargs): return "thread"' >"$repo_root_dir/backend/services/threading_service.py"
+		echo 'async def send_email(*args, **kwargs): return None' >"$repo_root_dir/backend/services/email_client.py"
+		echo 'pytest==0' >"$repo_root_dir/backend/requirements.txt"
 	fi
 
 	set +e
@@ -1549,12 +1641,12 @@ EOF
 		printf '%s' "$llm_api_base_source" >"$llm_api_base_file"
 		env_cmd+=(LLM_API_BASE_FILE="$llm_api_base_file")
 	fi
-	# Only export STRIX_VERTEX_FALLBACK_MODELS when a non-empty value is
-	# provided so that the gate's ${STRIX_VERTEX_FALLBACK_MODELS+x} check
-	# correctly distinguishes "unset → use defaults" from "set to empty →
-	# disable fallbacks".
+	# Only export fallback variables when a non-empty value is provided so the
+	# gate's ${VAR+x} checks correctly distinguish "unset → use defaults" from
+	# "set to empty → disable fallbacks".
 	if [ -n "$fallback_models" ]; then
 		env_cmd+=(STRIX_VERTEX_FALLBACK_MODELS="$fallback_models")
+		env_cmd+=(STRIX_GEMINI_FALLBACK_MODELS="$fallback_models")
 	fi
 	if [ -n "$custom_source_dirs" ]; then
 		env_cmd+=(STRIX_SOURCE_DIRS="$custom_source_dirs")
@@ -1763,6 +1855,113 @@ EOF
 
 	assert_equals "0" "$rc" "case=$case_name exit code"
 	assert_file_contains "$output_log" "scan ok with PR head content" "case=$case_name output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_pull_request_target_trusted_context_scope_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local fake_strix="$bin_dir/strix"
+	local output_log="$tmp_dir/output.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+	local changed_file="backend/api/emails.py"
+	local context_file="backend/core/config.py"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path=""
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-t" ] && [ "$#" -ge 2 ]; then
+		target_path="$2"
+		break
+	fi
+	shift
+done
+
+changed_file="$target_path/${FAKE_STRIX_EXPECTED_CHANGED_FILE:?}"
+context_file="$target_path/${FAKE_STRIX_EXPECTED_CONTEXT_FILE:?}"
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_HEAD_CONTENT:?}" "$changed_file"; then
+	echo "Error: PR head changed file content was not scanned" >&2
+	cat -- "$changed_file" >&2
+	exit 65
+fi
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_TRUSTED_CONTEXT:?}" "$context_file"; then
+	echo "Error: trusted backend context content missing" >&2
+	cat -- "$context_file" >&2
+	exit 66
+fi
+if grep -Fq -- "${FAKE_STRIX_UNTRUSTED_CONTEXT:?}" "$context_file"; then
+	echo "Error: PR head context leaked into trusted context scope" >&2
+	cat -- "$context_file" >&2
+	exit 67
+fi
+echo "scan ok with trusted backend context"
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		mkdir -p "$(dirname -- "$changed_file")" "$(dirname -- "$context_file")"
+		printf '%s\n' 'BASE_CHANGED_CONTENT_SHOULD_NOT_BE_SCANNED' >"$changed_file"
+		printf '%s\n' 'TRUSTED_BASE_CONTEXT_SHOULD_BE_SCANNED' >"$context_file"
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		printf '%s\n' 'HEAD_CHANGED_CONTENT_SHOULD_BE_SCANNED' >"$changed_file"
+		printf '%s\n' 'UNTRUSTED_HEAD_CONTEXT_SHOULD_NOT_BE_SCANNED' >"$context_file"
+		git add .
+		git commit -qm 'head commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH \
+			PATH="$bin_dir:$PATH" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			STRIX_TEST_CHANGED_FILES_OVERRIDE="$changed_file" \
+			FAKE_STRIX_EXPECTED_CHANGED_FILE="$changed_file" \
+			FAKE_STRIX_EXPECTED_CONTEXT_FILE="$context_file" \
+			FAKE_STRIX_EXPECTED_HEAD_CONTENT="HEAD_CHANGED_CONTENT_SHOULD_BE_SCANNED" \
+			FAKE_STRIX_EXPECTED_TRUSTED_CONTEXT="TRUSTED_BASE_CONTEXT_SHOULD_BE_SCANNED" \
+			FAKE_STRIX_UNTRUSTED_CONTEXT="UNTRUSTED_HEAD_CONTEXT_SHOULD_NOT_BE_SCANNED" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=pull-request-target-backend-context-uses-trusted-checkout exit code"
+	assert_file_contains "$output_log" "scan ok with trusted backend context" "case=pull-request-target-backend-context-uses-trusted-checkout output"
 
 	rm -rf "$tmp_dir"
 }
@@ -2547,6 +2746,8 @@ run_pull_request_target_head_scope_case \
 	"HEAD_NESTED_CONTENT_SHOULD_BE_SCANNED" \
 	"1"
 
+run_pull_request_target_trusted_context_scope_case
+
 run_pull_request_target_aborts_on_pr_head_blob_failure_case \
 	"pull-request-target-added-file-pr-head-blob-read-failure" \
 	"src/new_module.py" \
@@ -2837,6 +3038,53 @@ run_gate_case "gemini-high-demand-retry-same-model-success" \
 	"__DEFAULT__" \
 	"" \
 	"1"
+
+run_gate_case "gemini-timeout-retry-same-model-success" \
+	"gemini/retry-timeout-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model timeout retry" \
+	"2" \
+	"gemini/retry-timeout-primary|gemini/retry-timeout-primary" \
+	"https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "gemini-timeout-fallback-success" \
+	"gemini/timeout-fallback-primary" \
+	"gemini/fallback-one gemini/fallback-two" \
+	"0" \
+	"scan ok after gemini fallback" \
+	"3" \
+	"gemini/timeout-fallback-primary|gemini/timeout-fallback-primary|gemini/fallback-one" \
+	"https://example.invalid|https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "gemini-zero-findings-timeout-fallback-fails" \
+	"gemini/zero-timeout-primary" \
+	"gemini/fallback-one" \
+	"1" \
+	"Configured model and fallback models were unavailable." \
+	"2" \
+	"gemini/zero-timeout-primary|gemini/fallback-one" \
+	"https://example.invalid|https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"0" \
+	"CRITICAL" \
+	"0" \
+	"" \
+	"" \
+	"1200" \
+	"0" \
+	"pull_request" \
+	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
 
 run_gate_case "service-unavailable-no-llm-marker-nonrecoverable" \
 	"custom/service-unavailable-primary" \
@@ -3466,6 +3714,27 @@ run_gate_case "pr-changed-scope-bounded" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
+
+run_gate_case "pr-python-scope-context" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"0" \
+	"scan ok with python dependency scope" \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"0" \
+	"CRITICAL" \
+	"0" \
+	"" \
+	"" \
+	"1200" \
+	"0" \
+	"pull_request" \
+	"backend/api/emails.py"
 
 run_gate_case "pr-changed-scope-batched" \
 	"openai/gpt-4o-mini" \


### PR DESCRIPTION
## Summary
- Adds Gemini-specific fallback models while preserving Vertex fallback behavior.
- Retries non-Vertex timeout failures on the same model before model fallback, while keeping Vertex timeout behavior failover-oriented.
- Expands scoped PR scans for backend Python changes with trusted base context files so Strix has dependency context without executing PR-head code.

## Verification
- `bash scripts/ci/test_strix_quick_gate.sh`
- `git diff --check HEAD~1..HEAD`