### PR TITLE
fix: scan PR-head Strix context files

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -2521,10 +2521,15 @@ run_pull_request_batch_files() {
 
 	local previous_batch_file_count="$CURRENT_PULL_REQUEST_BATCH_FILE_COUNT"
 	CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="${#batch_files[@]}"
-	if ! build_pull_request_scope_dir "${batch_files[@]}"; then
+	local build_scope_rc=0
+	build_pull_request_scope_dir "${batch_files[@]}" || build_scope_rc=$?
+	if [ "$build_scope_rc" -ne 0 ]; then
 		CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="$previous_batch_file_count"
 		TARGET_PATH="$previous_target_path"
 		TARGET_PATH_IS_INTERNAL_PR_SCOPE="$previous_target_is_internal"
+		if [ "$build_scope_rc" -eq 2 ]; then
+			return 2
+		fi
 		return 1
 	fi
 	TARGET_PATH="$LAST_PULL_REQUEST_SCOPE_DIR"
@@ -2550,16 +2555,26 @@ run_pull_request_batch_files() {
 		local first_half second_half
 		first_half="$(printf '%s\n' "${batch_files[@]:0:midpoint}")"
 		second_half="$(printf '%s\n' "${batch_files[@]:midpoint}")"
-		if ! run_pull_request_batch_files "${batch_label}.1" "$total_batches" "$first_half"; then
+		local first_batch_rc=0
+		run_pull_request_batch_files "${batch_label}.1" "$total_batches" "$first_half" || first_batch_rc=$?
+		if [ "$first_batch_rc" -ne 0 ]; then
 			CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="$previous_batch_file_count"
 			TARGET_PATH="$previous_target_path"
 			TARGET_PATH_IS_INTERNAL_PR_SCOPE="$previous_target_is_internal"
+			if [ "$first_batch_rc" -eq 2 ]; then
+				return 2
+			fi
 			return 1
 		fi
-		if ! run_pull_request_batch_files "${batch_label}.2" "$total_batches" "$second_half"; then
+		local second_batch_rc=0
+		run_pull_request_batch_files "${batch_label}.2" "$total_batches" "$second_half" || second_batch_rc=$?
+		if [ "$second_batch_rc" -ne 0 ]; then
 			CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="$previous_batch_file_count"
 			TARGET_PATH="$previous_target_path"
 			TARGET_PATH_IS_INTERNAL_PR_SCOPE="$previous_target_is_internal"
+			if [ "$second_batch_rc" -eq 2 ]; then
+				return 2
+			fi
 			return 1
 		fi
 		CURRENT_PULL_REQUEST_BATCH_FILE_COUNT="$previous_batch_file_count"
@@ -2579,8 +2594,10 @@ if [ "${#PULL_REQUEST_SCOPE_FILE_BATCHES[@]}" -gt 0 ]; then
 	batch_number=0
 	for batch_files_text in "${PULL_REQUEST_SCOPE_FILE_BATCHES[@]}"; do
 		batch_number=$((batch_number + 1))
-		if ! run_pull_request_batch_files "$batch_number" "$total_batches" "$batch_files_text"; then
-			exit 1
+		batch_rc=0
+		run_pull_request_batch_files "$batch_number" "$total_batches" "$batch_files_text" || batch_rc=$?
+		if [ "$batch_rc" -ne 0 ]; then
+			exit "$batch_rc"
 		fi
 	done
 	exit 0

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1005,6 +1005,34 @@ PY
 		if [ -e "$dst_path" ]; then
 			return 0
 		fi
+		# In privileged PR scans, backend context must reflect the PR head state so
+		# stale vulnerable base files do not create false findings. These files are
+		# scanned as data only; executable CI support stays under trusted-ci-context/.
+		if pull_request_head_blob_required; then
+			local mode_rc=0
+			pr_head_regular_file_mode "$relative_path" >/dev/null || mode_rc=$?
+			case "$mode_rc" in
+			0)
+				mkdir -p -- "$(dirname -- "$dst_path")"
+				copy_pr_head_blob_to_file "$relative_path" "$dst_path" || {
+					echo "ERROR: pull request context file could not be read from PR head; failing closed: $context_file" >&2
+					return 2
+				}
+				return 0
+				;;
+			1)
+				return 0
+				;;
+			3)
+				echo "ERROR: pull request context file is not a regular PR-head file; failing closed: $context_file" >&2
+				return 2
+				;;
+			*)
+				echo "ERROR: pull request context file could not be read from PR head; failing closed: $context_file" >&2
+				return 2
+				;;
+			esac
+		fi
 		local src_path="$REPO_ROOT/$relative_path"
 		if [ ! -e "$src_path" ]; then
 			return 0

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1884,7 +1884,7 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
-run_pull_request_target_trusted_context_scope_case() {
+run_pull_request_target_backend_context_uses_pr_head_case() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
 	local bin_dir="$tmp_dir/bin"
@@ -1921,17 +1921,17 @@ if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_HEAD_CONTENT:?}" "$changed_file"; then
 	cat -- "$changed_file" >&2
 	exit 65
 fi
-if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_TRUSTED_CONTEXT:?}" "$context_file"; then
-	echo "Error: trusted backend context content missing" >&2
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_HEAD_CONTEXT:?}" "$context_file"; then
+	echo "Error: PR head backend context content missing" >&2
 	cat -- "$context_file" >&2
 	exit 66
 fi
-if grep -Fq -- "${FAKE_STRIX_UNTRUSTED_CONTEXT:?}" "$context_file"; then
-	echo "Error: PR head context leaked into trusted context scope" >&2
+if grep -Fq -- "${FAKE_STRIX_UNEXPECTED_BASE_CONTEXT:?}" "$context_file"; then
+	echo "Error: stale base backend context leaked into PR scan scope" >&2
 	cat -- "$context_file" >&2
 	exit 67
 fi
-echo "scan ok with trusted backend context"
+echo "scan ok with PR head backend context"
 EOF
 	chmod +x "$fake_strix"
 	printf '%s' 'gemini/test-model' >"$strix_llm_file"
@@ -1973,8 +1973,8 @@ EOF
 			FAKE_STRIX_EXPECTED_CHANGED_FILE="$changed_file" \
 			FAKE_STRIX_EXPECTED_CONTEXT_FILE="$context_file" \
 			FAKE_STRIX_EXPECTED_HEAD_CONTENT="HEAD_CHANGED_CONTENT_SHOULD_BE_SCANNED" \
-			FAKE_STRIX_EXPECTED_TRUSTED_CONTEXT="TRUSTED_BASE_CONTEXT_SHOULD_BE_SCANNED" \
-			FAKE_STRIX_UNTRUSTED_CONTEXT="UNTRUSTED_HEAD_CONTEXT_SHOULD_NOT_BE_SCANNED" \
+			FAKE_STRIX_EXPECTED_HEAD_CONTEXT="UNTRUSTED_HEAD_CONTEXT_SHOULD_NOT_BE_SCANNED" \
+			FAKE_STRIX_UNEXPECTED_BASE_CONTEXT="TRUSTED_BASE_CONTEXT_SHOULD_BE_SCANNED" \
 			STRIX_DISABLE_PR_SCOPING="0" \
 			STRIX_LLM_FILE="$strix_llm_file" \
 			LLM_API_KEY_FILE="$llm_api_key_file" \
@@ -1985,8 +1985,8 @@ EOF
 	local rc=$?
 	set -e
 
-	assert_equals "0" "$rc" "case=pull-request-target-backend-context-uses-trusted-checkout exit code"
-	assert_file_contains "$output_log" "scan ok with trusted backend context" "case=pull-request-target-backend-context-uses-trusted-checkout output"
+	assert_equals "0" "$rc" "case=pull-request-target-backend-context-uses-pr-head exit code"
+	assert_file_contains "$output_log" "scan ok with PR head backend context" "case=pull-request-target-backend-context-uses-pr-head output"
 
 	rm -rf "$tmp_dir"
 }
@@ -2771,7 +2771,7 @@ run_pull_request_target_head_scope_case \
 	"HEAD_NESTED_CONTENT_SHOULD_BE_SCANNED" \
 	"1"
 
-run_pull_request_target_trusted_context_scope_case
+run_pull_request_target_backend_context_uses_pr_head_case
 
 run_pull_request_target_aborts_on_pr_head_blob_failure_case \
 	"pull-request-target-added-file-pr-head-blob-read-failure" \

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1998,10 +1998,7 @@ run_pull_request_target_aborts_on_pr_head_blob_failure_case() {
 	local head_content="$4"
 	local fake_git_fail_command="$5"
 	local disable_pr_scoping="${6-0}"
-	local expected_exit="1"
-	if [ "$fake_git_fail_command" = "ls-tree" ] || [ "$fake_git_fail_command" = "diff" ] || [ "$disable_pr_scoping" = "1" ]; then
-		expected_exit="2"
-	fi
+	local expected_exit="2"
 	local expected_message="pull request changed file could not be read from PR head; failing closed"
 	if [ "$fake_git_fail_command" = "diff" ]; then
 		expected_message="pull request changed file list could not be read; failing closed"
@@ -2189,6 +2186,91 @@ EOF
 		call_count="$(wc -l <"$call_log" | tr -d ' ')"
 	fi
 	assert_equals "0" "$call_count" "case=$case_name irregular PR-head entry must not invoke Strix"
+
+	rm -rf "$tmp_dir"
+}
+
+run_pull_request_target_irregular_backend_context_entry_fails_closed_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local fake_strix="$bin_dir/strix"
+	local call_log="$tmp_dir/calls.log"
+	local output_log="$tmp_dir/output.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+	local changed_file="backend/api/emails.py"
+	local context_file="backend/core/config.py"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'called\n' >> "${FAKE_STRIX_CALL_LOG:?}"
+echo "Error: Strix should not run after an irregular PR-head backend context entry" >&2
+exit 66
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		mkdir -p "$(dirname -- "$changed_file")" "$(dirname -- "$context_file")"
+		printf '%s\n' 'BASE_CHANGED_CONTENT_SHOULD_NOT_BE_SCANNED' >"$changed_file"
+		printf '%s\n' 'BASE_CONTEXT_SHOULD_NOT_BE_SCANNED' >"$context_file"
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		printf '%s\n' 'HEAD_CHANGED_CONTENT_SHOULD_BE_SCANNED' >"$changed_file"
+		rm -f -- "$context_file"
+		ln -s ../outside-secret "$context_file"
+		git add .
+		git commit -qm 'head symlink backend context commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH \
+			PATH="$bin_dir:$PATH" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			STRIX_TEST_CHANGED_FILES_OVERRIDE="$changed_file" \
+			FAKE_STRIX_CALL_LOG="$call_log" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=pull-request-target-symlink-backend-context-head-entry-fails-closed irregular PR-head backend context entry exits closed"
+	assert_file_contains "$output_log" "pull request context file is not a regular PR-head file; failing closed: $context_file" "case=pull-request-target-symlink-backend-context-head-entry-fails-closed output"
+	local call_count="0"
+	if [ -f "$call_log" ]; then
+		call_count="$(wc -l <"$call_log" | tr -d ' ')"
+	fi
+	assert_equals "0" "$call_count" "case=pull-request-target-symlink-backend-context-head-entry-fails-closed irregular PR-head backend context entry must not invoke Strix"
 
 	rm -rf "$tmp_dir"
 }
@@ -2802,6 +2884,8 @@ run_pull_request_target_irregular_head_entry_fails_closed_case \
 run_pull_request_target_irregular_head_entry_fails_closed_case \
 	"pull-request-target-symlink-infra-head-entry-fails-closed" \
 	"infra/deploy.sh"
+
+run_pull_request_target_irregular_backend_context_entry_fails_closed_case
 
 run_pull_request_target_aborts_on_pr_head_blob_failure_case \
 	"pull-request-target-modified-file-pr-head-tree-lookup-failure" \


### PR DESCRIPTION
## Summary
- Copies privileged PR scan backend context files from the immutable PR head when PR-head blobs are required.
- Fails closed instead of falling back to trusted-base content for unreadable or non-regular PR-head context files.
- Updates Strix quick-gate regression coverage so stale base backend context cannot mask or create scanner findings.

## Verification
- bash scripts/ci/test_strix_quick_gate.sh
- bash -n scripts/ci/strix_quick_gate.sh
- bash -n scripts/ci/test_strix_quick_gate.sh
- git diff --check

## Context
Unblocks PR #126 by ensuring the required Strix workflow scans PR-head backend context as data while keeping trusted executable CI code under trusted-ci-context/.