### PR TITLE
AI Hub 및 Prompt Studio MVP 구현 (T-006)

### DIFF
--- a/backend/api/prompts.py
+++ b/backend/api/prompts.py
@@ -26,8 +26,8 @@ class PromptResponse(BaseModel):
     created_at: datetime.datetime
     updated_at: datetime.datetime
 
-    class Config:
-        from_attributes = True
+    model_config = {"from_attributes": True}
+
 
 class PromptTestRequest(BaseModel):
     content: str

--- a/backend/api/prompts.py
+++ b/backend/api/prompts.py
@@ -1,0 +1,120 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import List, Optional
+from db.session import get_db
+from db.models import PromptTemplate, LLMProvider, TenantConfig
+from api.auth import get_current_user
+from pydantic import BaseModel
+import datetime
+
+router = APIRouter(prefix="/api/prompts", tags=["prompts"])
+
+class PromptCreate(BaseModel):
+    title: str
+    description: Optional[str] = None
+    content: str
+    is_shared: bool = False
+
+class PromptResponse(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    content: str
+    is_shared: bool
+    created_by: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    class Config:
+        from_attributes = True
+
+class PromptTestRequest(BaseModel):
+    content: str
+    variables: dict[str, str]
+
+class PromptTestResponse(BaseModel):
+    result: str
+
+async def execute_prompt_with_llm(prompt_text: str, api_key: str, base_url: Optional[str] = None) -> dict:
+    from openai import AsyncOpenAI
+    from core.config import settings
+    
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    try:
+        response = await client.chat.completions.create(
+            model=settings.OPENAI_MODEL,
+            messages=[
+                {"role": "user", "content": prompt_text}
+            ],
+            temperature=0.0
+        )
+        content = response.choices[0].message.content
+        return {"result": content if content else ""}
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error(f"Prompt execution failed: {e}")
+        raise HTTPException(status_code=502, detail="Failed to execute prompt with AI provider. Check provider status.")
+
+@router.get("", response_model=List[PromptResponse])
+async def list_prompts(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
+):
+    # Only return prompts created by user OR shared prompts
+    result = await db.execute(
+        select(PromptTemplate).where(
+            (PromptTemplate.created_by == user_id) | (PromptTemplate.is_shared == True)
+        )
+    )
+    return result.scalars().all()
+
+@router.post("", response_model=PromptResponse)
+async def create_prompt(
+    data: PromptCreate,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
+):
+    prompt = PromptTemplate(
+        title=data.title,
+        description=data.description,
+        content=data.content,
+        is_shared=data.is_shared,
+        created_by=user_id
+    )
+    db.add(prompt)
+    await db.commit()
+    await db.refresh(prompt)
+    return prompt
+
+@router.post("/test", response_model=PromptTestResponse)
+async def test_prompt(
+    data: PromptTestRequest,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
+):
+    # Substitute variables
+    prompt_text = data.content
+    for k, v in data.variables.items():
+        prompt_text = prompt_text.replace(f"{{{{{k}}}}}", v)
+        
+    # Find active provider
+    provider_result = await db.execute(select(LLMProvider).where(LLMProvider.is_active == True))
+    active_provider = provider_result.scalars().first()
+    
+    api_key = None
+    base_url = None
+    
+    if active_provider and active_provider.api_key:
+        api_key = active_provider.api_key
+        base_url = active_provider.base_url
+    else:
+        tenant_result = await db.execute(select(TenantConfig).where(TenantConfig.user_id == user_id))
+        tenant_config = tenant_result.scalars().first()
+        if tenant_config and tenant_config.openai_api_key:
+            api_key = tenant_config.openai_api_key
+            
+    if not api_key:
+        raise HTTPException(status_code=400, detail="LLM API key not configured")
+        
+    return await execute_prompt_with_llm(prompt_text, api_key, base_url)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -80,6 +80,18 @@ class LLMProvider(Base):
     updated_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 
 
+class PromptTemplate(Base):
+    __tablename__ = "prompt_templates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str] = mapped_column(Text)
+    is_shared: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_by: Mapped[str] = mapped_column(String, index=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.datetime.now(datetime.timezone.utc))
+    updated_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.datetime.now(datetime.timezone.utc), onupdate=lambda: datetime.datetime.now(datetime.timezone.utc))
+
 class Email(Base):
     __tablename__ = "emails"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from api.emails import router as emails_router
 from api.tenant_config import router as tenant_config_router
 from api.runtime_config import router as runtime_config_router
 from api.llm_providers import router as llm_providers_router
+from api.prompts import router as prompts_router
 from services.imap_worker import ImapSyncWorker
 from prometheus_fastapi_instrumentator import Instrumentator
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -74,6 +75,7 @@ app.include_router(emails_router)
 app.include_router(tenant_config_router)
 app.include_router(runtime_config_router)
 app.include_router(llm_providers_router)
+app.include_router(prompts_router)
 
 
 app.add_middleware(

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -1,0 +1,91 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from db.models import PromptTemplate
+from db.session import get_db
+
+class MockSession:
+    def __init__(self):
+        self.items = []
+        
+    async def execute(self, stmt):
+        class MockResult:
+            def scalars(self):
+                class MockScalars:
+                    def all(self):
+                        return self.items
+                    def first(self):
+                        return self.items[0] if self.items else None
+                m = MockScalars()
+                m.items = getattr(self, 'items', self.parent_items)
+                return m
+        res = MockResult()
+        res.parent_items = self.items
+        return res
+        
+    def add(self, obj):
+        import datetime
+        if isinstance(obj, PromptTemplate):
+            obj.id = len(self.items) + 1
+            obj.created_at = datetime.datetime.now(datetime.timezone.utc)
+            obj.updated_at = datetime.datetime.now(datetime.timezone.utc)
+            self.items.append(obj)
+            
+    async def commit(self):
+        pass
+        
+    async def refresh(self, obj):
+        pass
+
+mock_session = MockSession()
+
+@pytest.fixture(autouse=True)
+def override_get_db():
+    app.dependency_overrides[get_db] = lambda: mock_session
+    yield
+    app.dependency_overrides.clear()
+    mock_session.items = []
+
+@pytest.fixture
+def auth_client():
+    with TestClient(app, headers={"X-User-Id": "testuser"}) as c:
+        yield c
+
+def test_prompt_crud(auth_client):
+    # Create
+    resp = auth_client.post("/api/prompts", json={
+        "title": "Test Prompt",
+        "description": "A test prompt",
+        "content": "Summarize this: {{email}}",
+        "is_shared": False
+    })
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["title"] == "Test Prompt"
+    
+    # List
+    resp = auth_client.get("/api/prompts")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+def test_prompt_test_execution_mocked(auth_client, monkeypatch):
+    import api.prompts as prompts_module
+    
+    # Mock LLM service
+    async def mock_execute(*args, **kwargs):
+        return {"result": "Mocked LLM result"}
+        
+    monkeypatch.setattr(prompts_module, "execute_prompt_with_llm", mock_execute)
+    
+    # Mock the db to have a provider
+    from db.models import LLMProvider
+    p = LLMProvider(id=1, name="Test", provider_type="openai", api_key="test-key", is_active=True)
+    mock_session.items.append(p)
+    
+    resp = auth_client.post("/api/prompts/test", json={
+        "content": "Summarize this: {{email}}",
+        "variables": {"email": "hello world"}
+    })
+    
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "Mocked LLM result"

--- a/docs/plans/2026-05-11-ai-hub-prompt-studio.md
+++ b/docs/plans/2026-05-11-ai-hub-prompt-studio.md
@@ -1,0 +1,17 @@
+# AI Hub and Prompt Studio Implementation Plan
+
+## Overview
+Implement the AI Hub and Prompt Studio MVP for Naruon workspace (Task T-006).
+
+## Objectives
+1. Create a central AI Hub page that lists recent insights or saved prompts.
+2. Build Prompt Studio functionality to create/edit/test prompts.
+3. Ensure server-side RBAC and redaction of logs when testing prompts.
+
+## Implementation Details
+1. **Database:** Add `PromptTemplate` model in `backend/db/models.py`.
+2. **Backend API:** `backend/api/prompts.py` for CRUD operations on prompts and an endpoint to test prompt execution using the provider-neutral LLM service.
+3. **Frontend Routes:**
+   - `/ai-hub`: Dashboard for AI activities.
+   - `/prompt-studio`: Prompt management interface.
+4. **Validation:** Write Pytest test to ensure prompt CRUD works and test endpoint executes safely without leaking secrets or failing.

--- a/frontend/src/app/ai-hub/page.tsx
+++ b/frontend/src/app/ai-hub/page.tsx
@@ -6,14 +6,14 @@ import { InsightCard } from '@/components/InsightCard';
 import { Network, Sparkles, BookOpen } from 'lucide-react';
 
 export default function AIHubPage() {
-  const [prompts, setPrompts] = useState<any[]>([]);
+  const [prompts, setPrompts] = useState<{ id: number; title: string; description?: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadData = async () => {
       try {
-        const data = await apiClient.get<any[]>('/api/prompts');
+        const data = await apiClient.get<{ id: number; title: string; description?: string }[]>('/api/prompts');
         setPrompts(data);
       } catch (err: unknown) {
         setError(((err as Error).message || '') || "데이터를 불러오는 데 실패했습니다.");

--- a/frontend/src/app/ai-hub/page.tsx
+++ b/frontend/src/app/ai-hub/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { InsightCard } from '@/components/InsightCard';
+import { Network, Sparkles, BookOpen } from 'lucide-react';
+
+export default function AIHubPage() {
+  const [prompts, setPrompts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await apiClient.get<any[]>('/api/prompts');
+        setPrompts(data);
+      } catch (err: unknown) {
+        setError(((err as Error).message || '') || "데이터를 불러오는 데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, []);
+
+  return (
+    <div className="p-8 max-w-6xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-2xl font-black text-foreground flex items-center gap-2 mb-2">
+          <Network className="w-6 h-6 text-primary" />
+          AI Hub
+        </h1>
+        <p className="text-muted-foreground text-sm">최근 인사이트와 저장된 프롬프트를 확인하세요.</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <InsightCard 
+          title="최근 AI 요약" 
+          icon={<Sparkles className="w-4 h-4" />}
+          loading={loading}
+          error={error}
+          empty={!loading && prompts.length === 0}
+          emptyMessage="저장된 프롬프트나 최근 요약이 없습니다."
+        >
+          <div className="space-y-4">
+            {prompts.map(p => (
+              <div key={p.id} className="p-3 bg-secondary/20 rounded-lg border border-border">
+                <h4 className="font-bold text-sm flex items-center gap-2">
+                  <BookOpen className="w-4 h-4 text-primary" />
+                  {p.title}
+                </h4>
+                <p className="text-xs text-muted-foreground mt-1 truncate">{p.description || "설명 없음"}</p>
+              </div>
+            ))}
+          </div>
+        </InsightCard>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -26,7 +26,7 @@ export default function PromptStudioPage() {
     setTesting(true);
     setError(null);
     try {
-      const data = await apiClient.post<any>('/api/prompts/test', {
+      const data = await apiClient.post<{ result?: string }>('/api/prompts/test', {
         content: formData.content,
         variables: { email: testVariable }
       });
@@ -42,7 +42,7 @@ export default function PromptStudioPage() {
     setSaving(true);
     setError(null);
     try {
-      await apiClient.post<any>('/api/prompts', formData);
+      await apiClient.post<{ result?: string }>('/api/prompts', formData);
       alert("성공적으로 저장되었습니다.");
     } catch (err: unknown) {
       setError(((err as Error).message || '') || '저장 실패');

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useState } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Play, Save, Code } from 'lucide-react';
+
+export default function PromptStudioPage() {
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    content: '요약해주세요: {{email}}',
+    is_shared: false
+  });
+  
+  const [testVariable, setTestVariable] = useState('이메일 내용 예시입니다.');
+  const [testResult, setTestResult] = useState('');
+  const [testing, setTesting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleTest = async () => {
+    setTesting(true);
+    setError(null);
+    try {
+      const data = await apiClient.post<any>('/api/prompts/test', {
+        content: formData.content,
+        variables: { email: testVariable }
+      });
+      setTestResult(data.result || '응답이 없습니다.');
+    } catch (err: unknown) {
+      setError(((err as Error).message || '') || '테스트 실패');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiClient.post<any>('/api/prompts', formData);
+      alert("성공적으로 저장되었습니다.");
+    } catch (err: unknown) {
+      setError(((err as Error).message || '') || '저장 실패');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-2xl font-black text-foreground flex items-center gap-2 mb-2">
+          <Code className="w-6 h-6 text-primary" />
+          Prompt Studio
+        </h1>
+        <p className="text-muted-foreground text-sm">프롬프트를 작성, 테스트, 저장하세요.</p>
+      </div>
+
+      <div className="space-y-4">
+        {error && <div className="text-red-500 text-sm bg-red-50 p-3 rounded-lg border border-red-100">{error}</div>}
+        
+        <Input 
+          placeholder="프롬프트 이름" 
+          value={formData.title} 
+          onChange={e => setFormData({ ...formData, title: e.target.value })} 
+        />
+        <Input 
+          placeholder="설명" 
+          value={formData.description} 
+          onChange={e => setFormData({ ...formData, description: e.target.value })} 
+        />
+        <Textarea 
+          className="min-h-[200px] font-mono text-sm"
+          value={formData.content} 
+          onChange={e => setFormData({ ...formData, content: e.target.value })} 
+        />
+        <div className="flex items-center space-x-2">
+          <Checkbox 
+            id="is_shared" 
+            checked={formData.is_shared} 
+            onCheckedChange={(checked) => setFormData({ ...formData, is_shared: !!checked })}
+          />
+          <label htmlFor="is_shared" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+            워크스페이스에 공유하기
+          </label>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 border-t border-border pt-6">
+        <div className="space-y-3">
+          <h3 className="font-bold text-sm">테스트 변수 입력</h3>
+          <Textarea 
+            placeholder="{{email}} 변수 값" 
+            value={testVariable} 
+            onChange={e => setTestVariable(e.target.value)} 
+          />
+          <Button onClick={handleTest} disabled={testing} className="w-full">
+            <Play className="w-4 h-4 mr-2" /> {testing ? '테스트 중...' : '실행 (Test)'}
+          </Button>
+        </div>
+        <div className="space-y-3">
+          <h3 className="font-bold text-sm">실행 결과</h3>
+          <div className="p-4 bg-secondary/30 rounded-lg min-h-[100px] text-sm whitespace-pre-wrap border border-border">
+            {testResult || '실행 결과가 여기에 표시됩니다.'}
+          </div>
+          <Button onClick={handleSave} disabled={saving} variant="secondary" className="w-full">
+            <Save className="w-4 h-4 mr-2" /> {saving ? '저장 중...' : '프롬프트 저장 (Save)'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 목표
Naruon 워크스페이스의 중앙 뷰인 `AI Hub`와 재사용 가능한 프롬프트를 만들고 테스트할 수 있는 `Prompt Studio` MVP를 추가합니다. (T-006)

## 구현 사항
1. **DB/Backend:** `PromptTemplate` 모델을 신설하고 `/api/prompts` CRUD 및 `/api/prompts/test` 엔드포인트를 추가했습니다. 이 테스트 엔드포인트는 Provider-Neutral 기반()에서 활성화된 모델 제공자를 통해 프롬프트와 변수를 조합해 LLM 호출 결과를 테스트합니다.
2. **AI Hub 화면:** 최근 인사이트 카드 및 저장된 프롬프트를 리스트 업하여 워크스페이스 맥락을 한 눈에 볼 수 있는  엔드포인트를 구성했습니다.
3. **Prompt Studio 화면:** 새 프롬프트를 작성하고 테스트 변수( 등)를 주입하여 곧장 테스트해본 뒤 저장(공유 포함)할 수 있는  화면을 구성했습니다.

## 관련 이슈
Resolves: T-006 (Vooster)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Hub page to discover and browse prompts
  * Prompt Studio to create, edit, share, and save prompts
  * Built-in prompt testing: substitute variables and run prompts against an AI model with live results

* **Documentation**
  * Added implementation plan detailing AI Hub and Prompt Studio scope

* **Tests**
  * Added tests covering prompt CRUD and prompt testing execution

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/164)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->