### PR TITLE
개발용 RBAC 스위처 (DevAuthSwitcher) 도입

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { DevAuthSwitcher } from "@/components/DevAuthSwitcher";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -17,7 +18,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className="h-full antialiased">
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        {children}
+        <DevAuthSwitcher />
+      </body>
     </html>
   );
 }

--- a/frontend/src/components/DevAuthSwitcher.tsx
+++ b/frontend/src/components/DevAuthSwitcher.tsx
@@ -10,7 +10,9 @@ export function DevAuthSwitcher() {
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('naruon_dev_user');
-      if (stored) setUserId(stored);
+      if (stored) {
+        setTimeout(() => setUserId(stored), 0);
+      }
     }
   }, []);
 

--- a/frontend/src/components/DevAuthSwitcher.tsx
+++ b/frontend/src/components/DevAuthSwitcher.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { UserCircle } from 'lucide-react';
+
+export function DevAuthSwitcher() {
+  const [userId, setUserId] = useState('testuser');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('naruon_dev_user');
+      if (stored) setUserId(stored);
+    }
+  }, []);
+
+  const toggleUser = () => {
+    const nextUser = userId === 'admin' ? 'testuser' : 'admin';
+    localStorage.setItem('naruon_dev_user', nextUser);
+    setUserId(nextUser);
+    window.location.reload();
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <Button 
+        variant={userId === 'admin' ? 'default' : 'outline'}
+        size="sm" 
+        onClick={toggleUser}
+        className="shadow-lg rounded-full"
+        title="개발용 계정 스위처"
+      >
+        <UserCircle className="w-4 h-4 mr-2" />
+        {userId === 'admin' ? '관리자 (Admin)' : '일반 (Member)'}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2,7 +2,6 @@ export class ApiClient {
   private baseUrl: string;
 
   constructor(baseUrl?: string) {
-    // If constructed without URL, fallback to relative path or safe dev URL
     this.baseUrl = baseUrl || (typeof window !== 'undefined' ? '' : 'http://localhost:8000');
   }
 
@@ -14,15 +13,25 @@ export class ApiClient {
     return this.baseUrl;
   }
 
+  private getHeaders(init?: RequestInit): HeadersInit {
+    // Check localStorage for a dev user override, fallback to testuser
+    let userId = 'testuser';
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('naruon_dev_user');
+      if (stored) userId = stored;
+    }
+
+    return {
+      'Content-Type': 'application/json',
+      'X-User-Id': userId,
+      ...init?.headers,
+    };
+  }
+
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...init,
-      headers: {
-        'Content-Type': 'application/json',
-        // In real system, proper token is included
-        'X-User-Id': 'testuser',
-        ...init?.headers,
-      },
+      headers: this.getHeaders(init),
     });
     if (!response.ok) {
       throw new Error(`API GET ${endpoint} failed: ${response.statusText}`);
@@ -34,11 +43,7 @@ export class ApiClient {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...init,
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-User-Id': 'testuser',
-        ...init?.headers,
-      },
+      headers: this.getHeaders(init),
       body: JSON.stringify(body),
     });
     if (!response.ok) {
@@ -48,5 +53,4 @@ export class ApiClient {
   }
 }
 
-// Global default client instance
 export const apiClient = new ApiClient();


### PR DESCRIPTION
## 목표
현재 브라우저 환경에서 하드코딩된 일반 유저 권한(`testuser`)으로 인해 UI 렌더링 검증 및 관리자 전용 권한 통제 화면(`/settings`) UAT가 불가능한 문제를 해결합니다.

## 변경 사항
1. `api-client.ts`: 요청 헤더에 주입할 `X-User-Id`를 LocalStorage에 담긴 세션 키로 동적 변경하도록 구성.
2. `DevAuthSwitcher.tsx`: 우측 하단 플로팅 버튼으로 Admin과 Member 계정을 원클릭 스위칭하는 컴포넌트 신설.
3. `layout.tsx`: 스위처 전역 삽입.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development authentication switcher: a fixed UI element to toggle between account roles, persists selection in local storage, and is rendered across the app layout.

* **Chores**
  * API requests now derive the user-role header from the persisted local preference (with a fallback), ensuring requests reflect the selected role.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->