### PR TITLE
LLM 제공자 관리 수정/삭제(Edit/Delete) 기능 추가

### DIFF
--- a/docs/plans/2026-05-12-settings-provider-edit.md
+++ b/docs/plans/2026-05-12-settings-provider-edit.md
@@ -1,0 +1,15 @@
+# Settings Provider Edit Implementation Plan
+
+## Overview
+The Settings UI currently only allows creating and viewing LLM Providers. We need to add Edit and Delete functionality.
+
+## Tasks
+1. **API Client Extension:** Add `put` and `delete` methods to `frontend/src/lib/api-client.ts`.
+2. **Settings UI Update (`page.tsx`):**
+   - Add Edit/Delete buttons to each provider item.
+   - Implement `handleEdit` which populates the form and switches to edit mode.
+   - Implement `handleDelete` which sends a DELETE request and refreshes.
+   - Update form submission to use `PUT` when in edit mode, and `POST` when in create mode.
+3. **Verification:**
+   - Run tests and linters.
+   - Ensure RBAC and error handling (403, 404) are still intact.

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -31,6 +31,8 @@ export default function SettingsPage() {
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [isDeleting, setIsDeleting] = useState<number | null>(null);
 
   const fetchProviders = async () => {
     try {
@@ -82,7 +84,12 @@ export default function SettingsPage() {
       if (formData.base_url) payload.base_url = formData.base_url;
       if (formData.api_key) payload.api_key = formData.api_key;
 
-      await apiClient.post<LLMProvider>('/api/llm-providers', payload);
+      if (editingId) {
+        await apiClient.put<LLMProvider>(`/api/llm-providers/${editingId}`, payload);
+        setEditingId(null);
+      } else {
+        await apiClient.post<LLMProvider>('/api/llm-providers', payload);
+      }
       setSubmitSuccess(true);
       setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
       fetchProviders();
@@ -135,9 +142,51 @@ export default function SettingsPage() {
                   <div key={p.id} className="p-4 rounded-xl border border-border bg-card/50 flex flex-col gap-2">
                     <div className="flex items-center justify-between">
                       <span className="font-bold">{p.name}</span>
-                      <Badge variant={p.is_active ? "default" : "secondary"}>
-                        {p.is_active ? "활성" : "비활성"}
-                      </Badge>
+                      <div className="flex items-center gap-2">
+                        <Badge variant={p.is_active ? "default" : "secondary"}>
+                          {p.is_active ? "활성" : "비활성"}
+                        </Badge>
+                        <Button 
+                          variant="ghost" 
+                          size="sm" 
+                          className="h-6 text-[11px] px-2"
+                          onClick={() => {
+                            setEditingId(p.id);
+                            setFormData({
+                              name: p.name,
+                              provider_type: p.provider_type,
+                              base_url: p.base_url || '',
+                              api_key: ''
+                            });
+                          }}
+                        >
+                          수정
+                        </Button>
+                        <Button 
+                          variant="ghost" 
+                          size="sm" 
+                          className="h-6 text-[11px] px-2 text-red-500 hover:text-red-600 hover:bg-red-50"
+                          disabled={isDeleting === p.id}
+                          onClick={async () => {
+                            if (!confirm("정말 이 제공자를 삭제하시겠습니까?")) return;
+                            setIsDeleting(p.id);
+                            try {
+                              await apiClient.delete(`/api/llm-providers/${p.id}`);
+                              fetchProviders();
+                              if (editingId === p.id) {
+                                setEditingId(null);
+                                setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
+                              }
+                            } catch (e: unknown) {
+                              alert("삭제 실패: " + ((e as Error).message || ""));
+                            } finally {
+                              setIsDeleting(null);
+                            }
+                          }}
+                        >
+                          {isDeleting === p.id ? "삭제중..." : "삭제"}
+                        </Button>
+                      </div>
                     </div>
                     <div className="text-xs text-muted-foreground font-mono bg-secondary/50 p-2 rounded-lg">
                       <p>Type: {p.provider_type}</p>
@@ -164,7 +213,7 @@ export default function SettingsPage() {
 
         <div>
           <section className="bg-white rounded-2xl border border-border shadow-sm p-5 sticky top-8">
-            <h3 className="font-bold mb-4">새 제공자 추가</h3>
+            <h3 className="font-bold mb-4">{editingId ? "제공자 수정" : "새 제공자 추가"}</h3>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-1.5">
                 <label className="text-xs font-semibold text-muted-foreground">식별 이름</label>
@@ -212,7 +261,25 @@ export default function SettingsPage() {
               {submitError && <div className="text-red-500 text-xs font-medium bg-red-50 p-2 rounded">{submitError}</div>}
               {submitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">제공자가 성공적으로 추가되었습니다.</div>}
 
-              <Button type="submit" className="w-full font-bold">저장 및 활성화</Button>
+              <div className="flex gap-2">
+                <Button type="submit" className="flex-1 font-bold">
+                  {editingId ? "수정 반영" : "저장 및 활성화"}
+                </Button>
+                {editingId && (
+                  <Button 
+                    type="button" 
+                    variant="outline" 
+                    onClick={() => {
+                      setEditingId(null);
+                      setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
+                      setSubmitError(null);
+                      setSubmitSuccess(false);
+                    }}
+                  >
+                    취소
+                  </Button>
+                )}
+              </div>
             </form>
           </section>
         </div>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -259,7 +259,7 @@ export default function SettingsPage() {
               </div>
 
               {submitError && <div className="text-red-500 text-xs font-medium bg-red-50 p-2 rounded">{submitError}</div>}
-              {submitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">제공자가 성공적으로 추가되었습니다.</div>}
+              {submitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">제공자가 성공적으로 저장되었습니다.</div>}
 
               <div className="flex gap-2">
                 <Button type="submit" className="flex-1 font-bold">

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -62,7 +62,9 @@ export class ApiClient {
     if (!response.ok) {
       throw new Error(`API PUT ${endpoint} failed: ${response.statusText}`);
     }
-    return response.json();
+    // PUT might return 204 No Content
+    const text = await response.text();
+    return text ? JSON.parse(text) : ({} as T);
   }
 
   async delete<T>(endpoint: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -51,6 +51,33 @@ export class ApiClient {
     }
     return response.json();
   }
+
+  async put<T>(endpoint: string, body: unknown, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...init,
+      method: 'PUT',
+      headers: this.getHeaders(init),
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`API PUT ${endpoint} failed: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async delete<T>(endpoint: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...init,
+      method: 'DELETE',
+      headers: this.getHeaders(init),
+    });
+    if (!response.ok) {
+      throw new Error(`API DELETE ${endpoint} failed: ${response.statusText}`);
+    }
+    // DELETE might return 204 No Content, handle gracefully
+    const text = await response.text();
+    return text ? JSON.parse(text) : ({} as T);
+  }
 }
 
 export const apiClient = new ApiClient();


### PR DESCRIPTION
## 목표
현재 Naruon 워크스페이스 관리자 설정(`/settings`)에서 제공자(Provider)를 새로 '추가'할 수만 있고, 잘못 입력한 설정을 '수정(Edit)'하거나 불필요한 제공자를 '삭제(Delete)'할 수 없는 UI적 한계를 개선합니다.

## 구현 사항
1. **API Client HTTP 메서드 확장:** 프론트엔드 공통 `apiClient`에 `put`과 `delete` 메서드를 신설하여 204 No Content 등 엣지 케이스를 안전하게 캐스팅 처리하도록 구현했습니다.
2. **제공자 삭제 기능 (Delete):** 각 Provider 아이템에 '삭제' 버튼을 추가하고 클릭 시 1회 확인 창(Confirm)을 띄운 뒤 백엔드 `DELETE /api/llm-providers/{id}` 엔드포인트를 호출하여 삭제합니다.
3. **제공자 수정 기능 (Edit):** '수정' 버튼 클릭 시 우측의 폼 모드가 편집 모드로 변경되며 폼 데이터가 채워집니다. 이후 `PUT /api/llm-providers/{id}`를 호출해 변경 사항을 반영합니다.

## 연관 이슈
사용자 피드백 반영 (UAT: "등록된 AI 모델 제공자 같은 건 수정조차 안 되는데....")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added implementation plan for Settings Provider Edit feature

* **New Features**
  * Edit existing LLM providers directly in Settings
  * Delete LLM providers with confirmation prompts
  * Form switches between create and edit modes with updated title, buttons, and a cancel action

* **Chores**
  * Backend/API client extended to support update and delete operations used by the UI

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/179)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->