### PR TITLE
설정 화면 실제 운용화: 개인 메일 계정 + 조직 Runner 토큰

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -12,16 +12,11 @@ async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id
     return x_user_id
 
 
-async def get_current_workspace_id(
-    x_workspace_id: str | None = Header("default-workspace", alias="X-Workspace-Id")
-) -> str:
-    return x_workspace_id or "default-workspace"
+async def get_current_workspace_id() -> str:
+    return "default-workspace"
 
 
 async def get_current_user_role(
-    x_user_role: str | None = Header(None, alias="X-User-Role"),
     current_user: str = Header(None, alias="X-User-Id"),
 ) -> str:
-    if x_user_role:
-        return x_user_role
     return "organization_admin" if current_user == "admin" else "member"

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -10,3 +10,18 @@ async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id
     if not x_user_id:
         raise HTTPException(status_code=401, detail="Authentication required")
     return x_user_id
+
+
+async def get_current_workspace_id(
+    x_workspace_id: str | None = Header("default-workspace", alias="X-Workspace-Id")
+) -> str:
+    return x_workspace_id or "default-workspace"
+
+
+async def get_current_user_role(
+    x_user_role: str | None = Header(None, alias="X-User-Role"),
+    current_user: str = Header(None, alias="X-User-Id"),
+) -> str:
+    if x_user_role:
+        return x_user_role
+    return "organization_admin" if current_user == "admin" else "member"

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, Header, HTTPException
+from core.config import settings
 
 async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id")) -> str:
 
@@ -19,4 +20,6 @@ async def get_current_workspace_id(current_user: str = Depends(get_current_user)
 async def get_current_user_role(
     current_user: str = Depends(get_current_user),
 ) -> str:
+    if not (settings.DEBUG or settings.TRUST_DEV_HEADERS):
+        return "member"
     return "organization_admin" if current_user == "admin" else "member"

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -12,8 +12,8 @@ async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id
     return x_user_id
 
 
-async def get_current_workspace_id() -> str:
-    return "default-workspace"
+async def get_current_workspace_id(current_user: str = Depends(get_current_user)) -> str:
+    return f"workspace-{current_user}"
 
 
 async def get_current_user_role(

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Header, HTTPException
+from fastapi import Depends, Header, HTTPException
 
 async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id")) -> str:
 
@@ -17,6 +17,6 @@ async def get_current_workspace_id() -> str:
 
 
 async def get_current_user_role(
-    current_user: str = Header(None, alias="X-User-Id"),
+    current_user: str = Depends(get_current_user),
 ) -> str:
     return "organization_admin" if current_user == "admin" else "member"

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -185,7 +185,7 @@ async def send_email_endpoint(
         smtp_server = tenant_config.smtp_server
         smtp_port = tenant_config.smtp_port
         smtp_username = tenant_config.smtp_username
-        smtp_password = getattr(tenant_config, "smtp_password", None)
+        smtp_password = tenant_config.smtp_password
         
         send_result = await send_email(
             request.to, 

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -185,6 +185,7 @@ async def send_email_endpoint(
         smtp_server = tenant_config.smtp_server
         smtp_port = tenant_config.smtp_port
         smtp_username = tenant_config.smtp_username
+        smtp_password = getattr(tenant_config, "smtp_password", None)
         
         send_result = await send_email(
             request.to, 
@@ -193,6 +194,7 @@ async def send_email_endpoint(
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             smtp_username=smtp_username,
+            smtp_password=smtp_password,
             in_reply_to=request.in_reply_to,
             references=request.references,
         )

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -181,11 +181,19 @@ async def send_email_endpoint(
         
         if not tenant_config or not tenant_config.smtp_server or not tenant_config.smtp_port or not tenant_config.smtp_username:
             raise HTTPException(status_code=400, detail="SMTP is not configured")
-            
-        smtp_server = tenant_config.smtp_server
-        smtp_port = tenant_config.smtp_port
-        smtp_username = tenant_config.smtp_username
-        smtp_password = tenant_config.smtp_password
+
+        try:
+            smtp_server = tenant_config.smtp_server
+            smtp_port = tenant_config.smtp_port
+            smtp_username = tenant_config.smtp_username
+            smtp_password = tenant_config.smtp_password
+        except Exception as exc:
+            if "ENCRYPTION_KEY is required" in str(exc):
+                raise HTTPException(
+                    status_code=503,
+                    detail="Server encryption key is not configured. Contact your workspace administrator.",
+                ) from exc
+            raise
         
         send_result = await send_email(
             request.to, 

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -80,6 +80,14 @@ async def rotate_runner_token(
     else:
         config.registration_token = token
 
-    await db.commit()
-    await db.refresh(config)
+    try:
+        await db.commit()
+        await db.refresh(config)
+    except Exception as exc:
+        if "ENCRYPTION_KEY is required" not in str(exc):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail="Server encryption key is not configured. Contact your workspace administrator.",
+        ) from exc
     return RunnerRotateResponse(workspace_id=config.workspace_id, registration_token=token)

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -1,0 +1,85 @@
+import datetime
+import hashlib
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import get_current_user
+from db.models import WorkspaceRunnerConfig
+from db.session import get_db
+
+router = APIRouter(prefix="/api/runner-config", tags=["runner-config"])
+
+WORKSPACE_ID = "default-workspace"
+
+
+class RunnerConfigResponse(BaseModel):
+    workspace_id: str
+    configured: bool
+    fingerprint: str | None = None
+    updated_at: datetime.datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RunnerRotateResponse(BaseModel):
+    workspace_id: str
+    registration_token: str
+
+
+def _check_org_admin(user_id: str = Depends(get_current_user)) -> str:
+    if user_id != "admin":
+        raise HTTPException(status_code=403, detail="Organization admin access required")
+    return user_id
+
+
+def _fingerprint(token: str | None) -> str | None:
+    if not token:
+        return None
+    return f"***{hashlib.sha256(token.encode('utf-8')).hexdigest()[:8]}"
+
+
+@router.get("", response_model=RunnerConfigResponse)
+async def get_runner_config(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(_check_org_admin),
+):
+    result = await db.execute(
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == WORKSPACE_ID)
+    )
+    config = result.scalar_one_or_none()
+
+    if not config:
+        return RunnerConfigResponse(workspace_id=WORKSPACE_ID, configured=False, fingerprint=None, updated_at=None)
+
+    return RunnerConfigResponse(
+        workspace_id=config.workspace_id,
+        configured=bool(config.registration_token),
+        fingerprint=_fingerprint(config.registration_token),
+        updated_at=config.updated_at,
+    )
+
+
+@router.post("/rotate", response_model=RunnerRotateResponse)
+async def rotate_runner_token(
+    db: AsyncSession = Depends(get_db),
+    _: str = Depends(_check_org_admin),
+):
+    result = await db.execute(
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == WORKSPACE_ID)
+    )
+    config = result.scalar_one_or_none()
+
+    token = f"nrn_{secrets.token_urlsafe(24)}"
+    if not config:
+        config = WorkspaceRunnerConfig(workspace_id=WORKSPACE_ID, registration_token=token)
+        db.add(config)
+    else:
+        config.registration_token = token
+
+    await db.commit()
+    await db.refresh(config)
+    return RunnerRotateResponse(workspace_id=config.workspace_id, registration_token=token)

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -54,12 +54,20 @@ async def get_runner_config(
     if not config:
         return RunnerConfigResponse(workspace_id=workspace_id, configured=False, fingerprint=None, updated_at=None)
 
-    return RunnerConfigResponse(
-        workspace_id=config.workspace_id,
-        configured=bool(config.registration_token),
-        fingerprint=_fingerprint(config.registration_token),
-        updated_at=config.updated_at,
-    )
+    try:
+        return RunnerConfigResponse(
+            workspace_id=config.workspace_id,
+            configured=bool(config.registration_token),
+            fingerprint=_fingerprint(config.registration_token),
+            updated_at=config.updated_at,
+        )
+    except Exception as exc:
+        if "ENCRYPTION_KEY is required" not in str(exc):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail="Server encryption key is not configured. Contact your workspace administrator.",
+        ) from exc
 
 
 @router.post("/rotate", response_model=RunnerRotateResponse)

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -7,13 +7,11 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.auth import get_current_user
+from api.auth import get_current_user_role, get_current_workspace_id
 from db.models import WorkspaceRunnerConfig
 from db.session import get_db
 
 router = APIRouter(prefix="/api/runner-config", tags=["runner-config"])
-
-WORKSPACE_ID = "default-workspace"
 
 
 class RunnerConfigResponse(BaseModel):
@@ -30,10 +28,10 @@ class RunnerRotateResponse(BaseModel):
     registration_token: str
 
 
-def _check_org_admin(user_id: str = Depends(get_current_user)) -> str:
-    if user_id != "admin":
+def _check_org_admin(user_role: str = Depends(get_current_user_role)) -> str:
+    if user_role != "organization_admin":
         raise HTTPException(status_code=403, detail="Organization admin access required")
-    return user_id
+    return user_role
 
 
 def _fingerprint(token: str | None) -> str | None:
@@ -46,14 +44,15 @@ def _fingerprint(token: str | None) -> str | None:
 async def get_runner_config(
     db: AsyncSession = Depends(get_db),
     _: str = Depends(_check_org_admin),
+    workspace_id: str = Depends(get_current_workspace_id),
 ):
     result = await db.execute(
-        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == WORKSPACE_ID)
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
     )
     config = result.scalar_one_or_none()
 
     if not config:
-        return RunnerConfigResponse(workspace_id=WORKSPACE_ID, configured=False, fingerprint=None, updated_at=None)
+        return RunnerConfigResponse(workspace_id=workspace_id, configured=False, fingerprint=None, updated_at=None)
 
     return RunnerConfigResponse(
         workspace_id=config.workspace_id,
@@ -67,15 +66,16 @@ async def get_runner_config(
 async def rotate_runner_token(
     db: AsyncSession = Depends(get_db),
     _: str = Depends(_check_org_admin),
+    workspace_id: str = Depends(get_current_workspace_id),
 ):
     result = await db.execute(
-        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == WORKSPACE_ID)
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
     )
     config = result.scalar_one_or_none()
 
     token = f"nrn_{secrets.token_urlsafe(24)}"
     if not config:
-        config = WorkspaceRunnerConfig(workspace_id=WORKSPACE_ID, registration_token=token)
+        config = WorkspaceRunnerConfig(workspace_id=workspace_id, registration_token=token)
         db.add(config)
     else:
         config.registration_token = token

--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -90,7 +90,15 @@ async def create_or_update_config(
         db_config = TenantConfig(**config_data)
         db.add(db_config)
 
-    await db.commit()
+    try:
+        await db.commit()
+    except Exception as exc:
+        if "ENCRYPTION_KEY is required" not in str(exc):
+            raise
+        raise HTTPException(
+            status_code=503,
+            detail="Server encryption key is not configured. Contact your workspace administrator.",
+        ) from exc
     return {"status": "ok"}
 
 

--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -16,8 +16,11 @@ class TenantConfigCreate(BaseModel):
     smtp_server: Optional[str] = None
     smtp_port: Optional[int] = None
     smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
     imap_server: Optional[str] = None
     imap_port: Optional[int] = None
+    imap_username: Optional[str] = None
+    imap_password: Optional[str] = None
     pop3_server: Optional[str] = None
     pop3_port: Optional[int] = None
     oauth_client_id: Optional[str] = None
@@ -33,8 +36,11 @@ class TenantConfigResponse(BaseModel):
     smtp_server: Optional[str] = None
     smtp_port: Optional[int] = None
     smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
     imap_server: Optional[str] = None
     imap_port: Optional[int] = None
+    imap_username: Optional[str] = None
+    imap_password: Optional[str] = None
     pop3_server: Optional[str] = None
     pop3_port: Optional[int] = None
     oauth_client_id: Optional[str] = None
@@ -47,7 +53,13 @@ class TenantConfigResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-SECRET_FIELDS = {"oauth_client_secret", "openai_api_key", "google_client_secret"}
+SECRET_FIELDS = {
+    "smtp_password",
+    "imap_password",
+    "oauth_client_secret",
+    "openai_api_key",
+    "google_client_secret",
+}
 
 
 @router.post("")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -5,6 +5,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/ai_email"
     DEBUG: bool = False
+    TRUST_DEV_HEADERS: bool = False
     ENCRYPTION_KEY: SecretStr | None = None
 
     # OpenAI Settings

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -80,6 +80,17 @@ class LLMProvider(Base):
     updated_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 
 
+class WorkspaceRunnerConfig(Base):
+    __tablename__ = "workspace_runner_configs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(String, unique=True, index=True)
+    registration_token: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+    )
+
+
 class PromptTemplate(Base):
     __tablename__ = "prompt_templates"
 
@@ -134,8 +145,11 @@ class TenantConfig(Base):
     smtp_server: Mapped[str | None] = mapped_column(String, nullable=True)
     smtp_port: Mapped[int | None] = mapped_column(nullable=True)
     smtp_username: Mapped[str | None] = mapped_column(String, nullable=True)
+    smtp_password: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     imap_server: Mapped[str | None] = mapped_column(String, nullable=True)
     imap_port: Mapped[int | None] = mapped_column(nullable=True)
+    imap_username: Mapped[str | None] = mapped_column(String, nullable=True)
+    imap_password: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     pop3_server: Mapped[str | None] = mapped_column(String, nullable=True)
     pop3_port: Mapped[int | None] = mapped_column(nullable=True)
 
@@ -156,6 +170,8 @@ class TenantConfig(Base):
         return (
             f"<TenantConfig(id={self.id}, user_id='{self.user_id}', "
             f"smtp_server='{self.smtp_server}', imap_server='{self.imap_server}', "
+            f"has_smtp_password={self.smtp_password is not None}, "
+            f"has_imap_password={self.imap_password is not None}, "
             f"has_oauth_secret={self.oauth_client_secret is not None}, "
             f"has_openai_key={self.openai_api_key is not None}, "
             f"has_google_secret={self.google_client_secret is not None})>"

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from api.llm import router as llm_router
 from api.calendar import router as calendar_router
 from api.network import router as network_router
 from api.emails import router as emails_router
+from api.runner_config import router as runner_config_router
 from api.tenant_config import router as tenant_config_router
 from api.runtime_config import router as runtime_config_router
 from api.llm_providers import router as llm_providers_router
@@ -72,6 +73,7 @@ app.include_router(llm_router)
 app.include_router(calendar_router)
 app.include_router(network_router)
 app.include_router(emails_router)
+app.include_router(runner_config_router)
 app.include_router(tenant_config_router)
 app.include_router(runtime_config_router)
 app.include_router(llm_providers_router)

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -51,6 +51,7 @@ async def send_email(
     smtp_server: str | None = None,
     smtp_port: int | None = None,
     smtp_username: str | None = None,
+    smtp_password: str | None = None,
     in_reply_to: str | None = None,
     references: str | None = None,
 ) -> SendEmailResult:
@@ -70,14 +71,17 @@ async def send_email(
         return {"status": "simulated", "simulated": True}
 
     try:
-        await aiosmtplib.send(
-            message,
-            hostname=smtp_server,
-            port=smtp_port,
-            use_tls=True,
-            # In a real system, we'd use OAuth2 or password auth here.
-            # Currently we just attempt connection. If it fails, aiosmtplib raises an exception.
-        )
+        send_kwargs: dict[str, object] = {
+            "hostname": smtp_server,
+            "port": smtp_port,
+            "use_tls": True,
+        }
+        if smtp_username:
+            send_kwargs["username"] = smtp_username
+        if smtp_password:
+            send_kwargs["password"] = smtp_password
+
+        await aiosmtplib.send(message, **send_kwargs)
         logger.info("Successfully sent email to %s via %s", safe_to_address, smtp_server)
         return {"status": "sent", "simulated": False}
     except Exception as e:

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -325,6 +325,7 @@ def test_send_email_endpoint(mock_send_email):
         smtp_server="smtp.example.com",
         smtp_port=587,
         smtp_username="testuser",
+        smtp_password=None,
         in_reply_to="<parent@example.com>",
         references="<root@example.com> <parent@example.com>",
     )

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -20,6 +20,7 @@ class MockTenantConfig:
         self.smtp_server = "smtp.example.com"
         self.smtp_port = 587
         self.smtp_username = "testuser"
+        self.smtp_password = None
 
 _DEFAULT_TENANT_CONFIG = object()
 

--- a/backend/tests/test_runner_config_api.py
+++ b/backend/tests/test_runner_config_api.py
@@ -72,13 +72,13 @@ def test_admin_can_rotate_and_read_runner_config(admin_client):
     rotate_response = admin_client.post("/api/runner-config/rotate")
     assert rotate_response.status_code == 200
     rotate_data = rotate_response.json()
-    assert rotate_data["workspace_id"] == "default-workspace"
+    assert rotate_data["workspace_id"] == "workspace-admin"
     assert rotate_data["registration_token"].startswith("nrn_")
 
     read_response = admin_client.get("/api/runner-config")
     assert read_response.status_code == 200
     read_data = read_response.json()
-    assert read_data["workspace_id"] == "default-workspace"
+    assert read_data["workspace_id"] == "workspace-admin"
     assert read_data["configured"] is True
     assert read_data["fingerprint"] is not None
     assert "registration_token" not in read_data

--- a/backend/tests/test_runner_config_api.py
+++ b/backend/tests/test_runner_config_api.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 import pytest
 
+from core.config import settings
 from db.models import WorkspaceRunnerConfig
 from db.session import get_db
 from main import app
@@ -36,6 +37,14 @@ class MockAsyncSession:
 @pytest.fixture
 def mock_db():
     return MockAsyncSession()
+
+
+@pytest.fixture(autouse=True)
+def enable_dev_headers():
+    previous = settings.TRUST_DEV_HEADERS
+    settings.TRUST_DEV_HEADERS = True
+    yield
+    settings.TRUST_DEV_HEADERS = previous
 
 
 @pytest.fixture

--- a/backend/tests/test_runner_config_api.py
+++ b/backend/tests/test_runner_config_api.py
@@ -1,0 +1,84 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from db.models import WorkspaceRunnerConfig
+from db.session import get_db
+from main import app
+
+
+class MockResult:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def scalar_one_or_none(self):
+        return self.obj
+
+
+class MockAsyncSession:
+    def __init__(self):
+        self.runner = None
+
+    async def execute(self, query):
+        return MockResult(self.runner)
+
+    def add(self, obj):
+        if isinstance(obj, WorkspaceRunnerConfig):
+            obj.id = 1
+            self.runner = obj
+
+    async def commit(self):
+        pass
+
+    async def refresh(self, obj):
+        pass
+
+
+@pytest.fixture
+def mock_db():
+    return MockAsyncSession()
+
+
+@pytest.fixture
+def member_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, headers={"X-User-Id": "testuser"}) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def admin_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, headers={"X-User-Id": "admin"}) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_member_cannot_manage_runner_config(member_client):
+    response = member_client.get("/api/runner-config")
+    assert response.status_code == 403
+
+    response = member_client.post("/api/runner-config/rotate")
+    assert response.status_code == 403
+
+
+def test_admin_can_rotate_and_read_runner_config(admin_client):
+    rotate_response = admin_client.post("/api/runner-config/rotate")
+    assert rotate_response.status_code == 200
+    rotate_data = rotate_response.json()
+    assert rotate_data["workspace_id"] == "default-workspace"
+    assert rotate_data["registration_token"].startswith("nrn_")
+
+    read_response = admin_client.get("/api/runner-config")
+    assert read_response.status_code == 200
+    read_data = read_response.json()
+    assert read_data["workspace_id"] == "default-workspace"
+    assert read_data["configured"] is True
+    assert read_data["fingerprint"] is not None
+    assert "registration_token" not in read_data

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -43,6 +43,12 @@ def test_tenant_config_endpoint(client, mock_db):
         "user_id": "test_user",
         "openai_api_key": "sk-123",
         "smtp_server": "smtp.example.com",
+        "smtp_username": "sender@example.com",
+        "smtp_password": "smtp-secret",
+        "imap_server": "imap.example.com",
+        "imap_port": 993,
+        "imap_username": "imap-user",
+        "imap_password": "imap-secret",
         "oauth_client_secret": "secret-456",
     }
     response = client.post("/api/config", json=post_payload, headers={"X-User-Id": "test_user"})
@@ -57,6 +63,11 @@ def test_tenant_config_endpoint(client, mock_db):
     assert data["user_id"] == "test_user"
     assert data["openai_api_key"] == "********"
     assert data["oauth_client_secret"] == "********"
+    assert data["smtp_password"] == "********"
+    assert data["imap_password"] == "********"
     assert data["smtp_server"] == "smtp.example.com"
+    assert data["smtp_username"] == "sender@example.com"
+    assert data["imap_server"] == "imap.example.com"
+    assert data["imap_port"] == 993
+    assert data["imap_username"] == "imap-user"
     assert data["google_client_secret"] is None
-

--- a/backend/tests/test_tenant_config_model.py
+++ b/backend/tests/test_tenant_config_model.py
@@ -28,7 +28,13 @@ def test_tenant_config_model_exists():
 
 
 def test_tenant_config_model_encryption(db_session):
-    config = TenantConfig(user_id="test_user2", openai_api_key="test_key2")
+    config = TenantConfig(
+        user_id="test_user2",
+        openai_api_key="test_key2",
+        imap_username="mail-user",
+        imap_password="imap-secret",
+        smtp_password="smtp-secret",
+    )
     db_session.add(config)
     db_session.commit()
 
@@ -46,7 +52,23 @@ def test_tenant_config_model_encryption(db_session):
     assert result is not None
     assert isinstance(result, str)
 
+    imap_pw = db_session.execute(
+        text("SELECT imap_password FROM tenant_configs WHERE user_id='test_user2'")
+    ).scalar()
+    smtp_pw = db_session.execute(
+        text("SELECT smtp_password FROM tenant_configs WHERE user_id='test_user2'")
+    ).scalar()
+    assert imap_pw != "imap-secret"
+    assert smtp_pw != "smtp-secret"
+    assert saved_config.imap_username == "mail-user"
+    assert saved_config.imap_password == "imap-secret"
+    assert saved_config.smtp_password == "smtp-secret"
+
     # Verify __repr__ does not expose sensitive keys
     repr_str = repr(saved_config)
     assert "test_key2" not in repr_str
+    assert "imap-secret" not in repr_str
+    assert "smtp-secret" not in repr_str
     assert "has_openai_key=True" in repr_str
+    assert "has_imap_password=True" in repr_str
+    assert "has_smtp_password=True" in repr_str

--- a/backend/tests/test_tenant_config_model.py
+++ b/backend/tests/test_tenant_config_model.py
@@ -4,6 +4,10 @@ from sqlalchemy.orm import Session
 from db.models import TenantConfig
 from core.config import settings
 
+TEST_OPENAI_KEY = "test_key2"  # noqa: S105
+TEST_IMAP_PASSWORD = "imap-secret"  # noqa: S105
+TEST_SMTP_PASSWORD = "smtp-secret"  # noqa: S105
+
 @pytest.fixture(autouse=True)
 def mock_debug():
     old_debug = settings.DEBUG
@@ -30,10 +34,10 @@ def test_tenant_config_model_exists():
 def test_tenant_config_model_encryption(db_session):
     config = TenantConfig(
         user_id="test_user2",
-        openai_api_key="test_key2",
+        openai_api_key=TEST_OPENAI_KEY,
         imap_username="mail-user",
-        imap_password="imap-secret",
-        smtp_password="smtp-secret",
+        imap_password=TEST_IMAP_PASSWORD,
+        smtp_password=TEST_SMTP_PASSWORD,
     )
     db_session.add(config)
     db_session.commit()
@@ -42,7 +46,7 @@ def test_tenant_config_model_encryption(db_session):
     saved_config = (
         db_session.query(TenantConfig).filter_by(user_id="test_user2").first()
     )
-    assert saved_config.openai_api_key == "test_key2"
+    assert saved_config.openai_api_key == TEST_OPENAI_KEY
 
     # Verify that the value in the database is actually encrypted
     result = db_session.execute(
@@ -58,17 +62,17 @@ def test_tenant_config_model_encryption(db_session):
     smtp_pw = db_session.execute(
         text("SELECT smtp_password FROM tenant_configs WHERE user_id='test_user2'")
     ).scalar()
-    assert imap_pw != "imap-secret"
-    assert smtp_pw != "smtp-secret"
+    assert imap_pw != TEST_IMAP_PASSWORD
+    assert smtp_pw != TEST_SMTP_PASSWORD
     assert saved_config.imap_username == "mail-user"
-    assert saved_config.imap_password == "imap-secret"
-    assert saved_config.smtp_password == "smtp-secret"
+    assert saved_config.imap_password == TEST_IMAP_PASSWORD
+    assert saved_config.smtp_password == TEST_SMTP_PASSWORD
 
     # Verify __repr__ does not expose sensitive keys
     repr_str = repr(saved_config)
-    assert "test_key2" not in repr_str
-    assert "imap-secret" not in repr_str
-    assert "smtp-secret" not in repr_str
+    assert TEST_OPENAI_KEY not in repr_str
+    assert TEST_IMAP_PASSWORD not in repr_str
+    assert TEST_SMTP_PASSWORD not in repr_str
     assert "has_openai_key=True" in repr_str
     assert "has_imap_password=True" in repr_str
     assert "has_smtp_password=True" in repr_str

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -19,6 +19,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -31,6 +32,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -43,6 +45,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -19,7 +19,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
-      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -32,7 +32,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
-      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -45,7 +45,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
-      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-}
+      TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
       OPENAI_API_KEY: ""
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -18,6 +18,7 @@ services:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -29,6 +30,7 @@ services:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
     depends_on:
@@ -40,6 +42,7 @@ services:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
       DEBUG: "false"
       OPENAI_API_KEY: ""
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}

--- a/docs/plans/2026-05-12-settings-operationalization.md
+++ b/docs/plans/2026-05-12-settings-operationalization.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Extend tenant config model and API for real mailbox settings
+## Task 1: Extend tenant config model and API for real mailbox settings
 
 **Files:**
 - Modify: `backend/db/models.py`
@@ -44,7 +44,7 @@ Run the same pytest command and confirm PASS.
 
 `git add backend/db/models.py backend/api/tenant_config.py backend/api/emails.py backend/services/email_client.py backend/tests/test_tenant_config_api.py backend/tests/test_tenant_config_model.py && git commit -m "feat(settings): add real mailbox credential fields"`
 
-### Task 2: Add organization-scoped runner token aggregate and API
+## Task 2: Add organization-scoped runner token aggregate and API
 
 **Files:**
 - Modify: `backend/db/models.py`
@@ -79,7 +79,7 @@ Run the same pytest command and confirm PASS.
 
 `git add backend/db/models.py backend/api/runner_config.py backend/main.py backend/tests/test_runner_config_api.py && git commit -m "feat(settings): add organization runner token endpoints"`
 
-### Task 3: Replace personal settings placeholder UI with real mailbox form
+## Task 3: Replace personal settings placeholder UI with real mailbox form
 
 **Files:**
 - Modify: `frontend/src/lib/api-client.ts`
@@ -113,7 +113,7 @@ Expected: PASS.
 
 `git add frontend/src/lib/api-client.ts frontend/src/app/settings/page.tsx && git commit -m "feat(settings): replace personal mailbox placeholder with real config form"`
 
-### Task 4: Replace runner placeholder UI with token issuance and scoped explanation
+## Task 4: Replace runner placeholder UI with token issuance and scoped explanation
 
 **Files:**
 - Modify: `frontend/src/app/settings/page.tsx`
@@ -137,7 +137,7 @@ Expected: PASS.
 
 `git add frontend/src/app/settings/page.tsx && git commit -m "feat(settings): replace runner placeholder with token issuance flow"`
 
-### Task 5: End-to-end verification and review loop
+## Task 5: End-to-end verification and review loop
 
 **Files:**
 - Modify if needed based on review feedback

--- a/docs/plans/2026-05-12-settings-operationalization.md
+++ b/docs/plans/2026-05-12-settings-operationalization.md
@@ -1,0 +1,165 @@
+# Settings Operationalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the current placeholder settings tabs into real user workflows for personal mailbox configuration and organization-scoped self-hosted runner token management.
+
+**Architecture:** Reuse the existing tenant config aggregate for personal mailbox settings, extending it with missing IMAP/SMTP credential fields and secret masking. Add a small organization-scoped runner-token aggregate with admin-only API endpoints, then wire the existing `/settings` tabs to those APIs while keeping BYOK configuration in the workspace tab.
+
+**Tech Stack:** FastAPI, SQLAlchemy, encrypted model fields, Next.js App Router, TypeScript, existing `apiClient`, pytest.
+
+---
+
+### Task 1: Extend tenant config model and API for real mailbox settings
+
+**Files:**
+- Modify: `backend/db/models.py`
+- Modify: `backend/api/tenant_config.py`
+- Modify: `backend/api/emails.py`
+- Modify: `backend/services/email_client.py`
+- Test: `backend/tests/test_tenant_config_model.py`
+- Test: `backend/tests/test_tenant_config_api.py`
+
+**Step 1: Write failing tests for new personal mailbox fields**
+
+Add tests that assert `imap_username`, `imap_password`, and `smtp_password` are persisted and masked in API responses.
+
+**Step 2: Run tests to verify failure**
+
+Run: `cd backend && DISABLE_BACKGROUND_WORKERS=1 PYTHONWARNINGS=error python3 -m pytest tests/test_tenant_config_api.py tests/test_tenant_config_model.py -q`
+
+Expected: FAIL because fields do not exist.
+
+**Step 3: Implement minimal backend support**
+
+- Add `imap_username`, `imap_password`, `smtp_password` to `TenantConfig`.
+- Extend request/response models and masking logic.
+- Pass `smtp_password` into the send-email path.
+
+**Step 4: Run tests to verify pass**
+
+Run the same pytest command and confirm PASS.
+
+**Step 5: Commit**
+
+`git add backend/db/models.py backend/api/tenant_config.py backend/api/emails.py backend/services/email_client.py backend/tests/test_tenant_config_api.py backend/tests/test_tenant_config_model.py && git commit -m "feat(settings): add real mailbox credential fields"`
+
+### Task 2: Add organization-scoped runner token aggregate and API
+
+**Files:**
+- Modify: `backend/db/models.py`
+- Create: `backend/api/runner_config.py`
+- Modify: `backend/main.py`
+- Test: `backend/tests/test_runner_config_api.py`
+
+**Step 1: Write failing tests for runner token endpoints**
+
+Add tests for:
+- member GET/POST forbidden
+- admin GET returns current runner metadata
+- admin POST rotate returns a new raw token and stores masked metadata on subsequent GET
+
+**Step 2: Run test to verify failure**
+
+Run: `cd backend && DISABLE_BACKGROUND_WORKERS=1 PYTHONWARNINGS=error python3 -m pytest tests/test_runner_config_api.py -q`
+
+Expected: FAIL because router/model do not exist.
+
+**Step 3: Implement minimal backend support**
+
+- Add `WorkspaceRunnerConfig` model with `workspace_id`, encrypted `registration_token`, `updated_at`.
+- Add admin-only `GET /api/runner-config` and `POST /api/runner-config/rotate`.
+- Generate tokens with `secrets.token_urlsafe`.
+
+**Step 4: Run test to verify pass**
+
+Run the same pytest command and confirm PASS.
+
+**Step 5: Commit**
+
+`git add backend/db/models.py backend/api/runner_config.py backend/main.py backend/tests/test_runner_config_api.py && git commit -m "feat(settings): add organization runner token endpoints"`
+
+### Task 3: Replace personal settings placeholder UI with real mailbox form
+
+**Files:**
+- Modify: `frontend/src/lib/api-client.ts`
+- Modify: `frontend/src/app/settings/page.tsx`
+
+**Step 1: Write the minimal failing behavior check**
+
+Define the expected visible workflow:
+- personal tab loads current config
+- save button posts config
+- masked secrets remain masked when unchanged
+
+Verification by direct browser exercise is acceptable because frontend component tests for this repo are sparse.
+
+**Step 2: Implement UI**
+
+- Add a `getCurrentUserId()` helper to `apiClient`.
+- Load `/api/config?user_id=<currentUser>`.
+- Render IMAP/SMTP fields and save button.
+- Reuse `********` masking convention.
+
+**Step 3: Verify locally**
+
+Run:
+- `cd frontend && npm run build`
+- direct browser/Playwright check against live stack
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+`git add frontend/src/lib/api-client.ts frontend/src/app/settings/page.tsx && git commit -m "feat(settings): replace personal mailbox placeholder with real config form"`
+
+### Task 4: Replace runner placeholder UI with token issuance and scoped explanation
+
+**Files:**
+- Modify: `frontend/src/app/settings/page.tsx`
+
+**Step 1: Implement UI**
+
+- Load `/api/runner-config` in admin mode.
+- Show current runner metadata and a one-time raw token after rotation.
+- Add rotate/regenerate button.
+- Keep scope explanation explicit: organization-scoped, not personal, not Naruon-global.
+
+**Step 2: Verify locally**
+
+Run:
+- `cd frontend && npm run build`
+- direct browser/Playwright check against live stack in admin mode
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+`git add frontend/src/app/settings/page.tsx && git commit -m "feat(settings): replace runner placeholder with token issuance flow"`
+
+### Task 5: End-to-end verification and review loop
+
+**Files:**
+- Modify if needed based on review feedback
+
+**Step 1: Run backend verification**
+
+Run: `cd backend && DISABLE_BACKGROUND_WORKERS=1 PYTHONWARNINGS=error python3 -m pytest -q`
+
+**Step 2: Run frontend verification**
+
+Run:
+- `cd frontend && npm run build`
+- `cd frontend && npm test`
+- `cd frontend && npm run lint`
+
+**Step 3: Run direct live UAT**
+
+Verify in live stack:
+- personal mailbox form saves successfully
+- member cannot rotate runner token
+- admin can rotate runner token and see raw token once
+
+**Step 4: Commit final polish**
+
+`git add <files> && git commit -m "fix(settings): polish mailbox and runner workflows"`

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -102,6 +102,10 @@ export default function SettingsPage() {
   };
 
   const fetchPersonalConfig = useCallback(async () => {
+    if (!currentUserId) {
+      setPersonalLoading(false);
+      return;
+    }
     try {
       const data = await apiClient.get<PersonalMailboxConfig>(`/api/config?user_id=${encodeURIComponent(currentUserId)}`);
       setPersonalForm({
@@ -196,6 +200,9 @@ export default function SettingsPage() {
     setPersonalSubmitSuccess(null);
 
     try {
+      if (!currentUserId) {
+        throw new Error('개인 이메일 계정을 저장하려면 인증된 사용자 세션이 필요합니다.');
+      }
       const smtpPortNum = Number(personalForm.smtp_port);
       const imapPortNum = Number(personalForm.imap_port);
       if (!Number.isInteger(smtpPortNum) || smtpPortNum < 1 || smtpPortNum > 65535) {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Activity, AlertCircle, CheckCircle2, Key, Mail, Server, Settings, Shield } from 'lucide-react';
+
 import { apiClient } from '@/lib/api-client';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { Settings, Shield, Server, CheckCircle2, AlertCircle, Mail, Activity, Key } from 'lucide-react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface LLMProvider {
   id: number;
@@ -19,88 +20,221 @@ interface LLMProvider {
   updated_at: string;
 }
 
-export default function SettingsPage() {
-  const [providers, setProviders] = useState<LLMProvider[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+interface PersonalMailboxConfig {
+  user_id: string;
+  smtp_server: string | null;
+  smtp_port: number | null;
+  smtp_username: string | null;
+  smtp_password: string | null;
+  imap_server: string | null;
+  imap_port: number | null;
+  imap_username: string | null;
+  imap_password: string | null;
+}
 
-  const [formData, setFormData] = useState({
+interface RunnerConfig {
+  workspace_id: string;
+  configured: boolean;
+  fingerprint: string | null;
+  updated_at: string | null;
+}
+
+function getScopedErrorMessage(err: unknown, forbiddenMessage: string, fallbackMessage: string) {
+  const message = (err as Error).message || '';
+  if (message.includes('403')) return forbiddenMessage;
+  return message || fallbackMessage;
+}
+
+export default function SettingsPage() {
+  const currentUserId = apiClient.getCurrentUserId();
+
+  const [providers, setProviders] = useState<LLMProvider[]>([]);
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [providerError, setProviderError] = useState<string | null>(null);
+  const [providerForm, setProviderForm] = useState({
     name: '',
     provider_type: 'openai',
     base_url: '',
-    api_key: ''
+    api_key: '',
   });
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [providerSubmitError, setProviderSubmitError] = useState<string | null>(null);
+  const [providerSubmitSuccess, setProviderSubmitSuccess] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [isDeleting, setIsDeleting] = useState<number | null>(null);
 
-  useEffect(() => {
-    const fetchProvidersData = async () => {
-      try {
-        const data = await apiClient.get<LLMProvider[]>('/api/llm-providers');
-        setProviders(data);
-        setError(null);
-      } catch (err: unknown) {
-        if (((err as Error).message || '').includes('403')) {
-          setError('워크스페이스(Organization) 관리자 권한이 필요합니다. 관리자 계정으로 로그인해주세요.');
-        } else {
-          setError('데이터를 불러오는 데 실패했습니다.');
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-    void fetchProvidersData();
-  }, []);
+  const [personalForm, setPersonalForm] = useState({
+    smtp_server: '',
+    smtp_port: '587',
+    smtp_username: '',
+    smtp_password: '',
+    imap_server: '',
+    imap_port: '993',
+    imap_username: '',
+    imap_password: '',
+  });
+  const [personalLoading, setPersonalLoading] = useState(true);
+  const [personalSubmitError, setPersonalSubmitError] = useState<string | null>(null);
+  const [personalSubmitSuccess, setPersonalSubmitSuccess] = useState<string | null>(null);
+
+  const [runnerConfig, setRunnerConfig] = useState<RunnerConfig | null>(null);
+  const [runnerLoading, setRunnerLoading] = useState(true);
+  const [runnerError, setRunnerError] = useState<string | null>(null);
+  const [runnerToken, setRunnerToken] = useState<string | null>(null);
+  const [runnerBusy, setRunnerBusy] = useState(false);
 
   const fetchProviders = async () => {
     try {
       const data = await apiClient.get<LLMProvider[]>('/api/llm-providers');
       setProviders(data);
-      setError(null);
+      setProviderError(null);
     } catch (err: unknown) {
-      if (((err as Error).message || '').includes('403')) {
-        setError('워크스페이스(Organization) 관리자 권한이 필요합니다. 관리자 계정으로 로그인해주세요.');
-      } else {
-        setError('데이터를 불러오는 데 실패했습니다.');
-      }
+      setProviderError(
+        getScopedErrorMessage(
+          err,
+          '워크스페이스(Organization) 관리자 권한이 필요합니다. 관리자 계정으로 로그인해주세요.',
+          '제공자 목록을 불러오는 데 실패했습니다.',
+        ),
+      );
     } finally {
-      setLoading(false);
+      setLoadingProviders(false);
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const fetchPersonalConfig = useCallback(async () => {
+    try {
+      const data = await apiClient.get<PersonalMailboxConfig>(`/api/config?user_id=${encodeURIComponent(currentUserId)}`);
+      setPersonalForm({
+        smtp_server: data.smtp_server ?? '',
+        smtp_port: data.smtp_port ? String(data.smtp_port) : '587',
+        smtp_username: data.smtp_username ?? '',
+        smtp_password: data.smtp_password ?? '',
+        imap_server: data.imap_server ?? '',
+        imap_port: data.imap_port ? String(data.imap_port) : '993',
+        imap_username: data.imap_username ?? '',
+        imap_password: data.imap_password ?? '',
+      });
+    } catch {
+      // keep defaults for first-time setup
+    } finally {
+      setPersonalLoading(false);
+    }
+  }, [currentUserId]);
+
+  const fetchRunnerConfig = async () => {
+    try {
+      const data = await apiClient.get<RunnerConfig>('/api/runner-config');
+      setRunnerConfig(data);
+      setRunnerError(null);
+    } catch (err: unknown) {
+      setRunnerError(
+        getScopedErrorMessage(
+          err,
+          '워크스페이스(Organization) 관리자 권한이 필요합니다. 관리자 계정으로 로그인해주세요.',
+          'Runner 설정을 불러오는 데 실패했습니다.',
+        ),
+      );
+    } finally {
+      setRunnerLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void fetchProviders();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void fetchPersonalConfig();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [fetchPersonalConfig]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void fetchRunnerConfig();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const handleProviderSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setSubmitError(null);
-    setSubmitSuccess(false);
+    setProviderSubmitError(null);
+    setProviderSubmitSuccess(null);
 
     try {
       const payload: Record<string, unknown> = {
-        name: formData.name,
-        provider_type: formData.provider_type,
-        is_active: true
+        name: providerForm.name,
+        provider_type: providerForm.provider_type,
+        is_active: true,
       };
-      if (formData.base_url) payload.base_url = formData.base_url;
-      if (formData.api_key) payload.api_key = formData.api_key;
+      if (providerForm.base_url) payload.base_url = providerForm.base_url;
+      if (providerForm.api_key) payload.api_key = providerForm.api_key;
 
-      if (editingId) {
+      if (editingId !== null) {
         await apiClient.put<LLMProvider>(`/api/llm-providers/${editingId}`, payload);
         setEditingId(null);
+        setProviderSubmitSuccess('제공자가 성공적으로 수정되었습니다.');
       } else {
         await apiClient.post<LLMProvider>('/api/llm-providers', payload);
+        setProviderSubmitSuccess('제공자가 성공적으로 추가되었습니다.');
       }
 
-      setSubmitSuccess(true);
-      setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
-      fetchProviders();
+      setProviderForm({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
+      await fetchProviders();
     } catch (err: unknown) {
-      setSubmitError(((err as Error).message || '') || '저장에 실패했습니다.');
+      setProviderSubmitError((err as Error).message || '저장에 실패했습니다.');
     }
   };
 
+  const handlePersonalSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPersonalSubmitError(null);
+    setPersonalSubmitSuccess(null);
+
+    try {
+      await apiClient.post<{ status: string }>('/api/config', {
+        user_id: currentUserId,
+        smtp_server: personalForm.smtp_server || null,
+        smtp_port: personalForm.smtp_port ? Number(personalForm.smtp_port) : null,
+        smtp_username: personalForm.smtp_username || null,
+        smtp_password: personalForm.smtp_password || null,
+        imap_server: personalForm.imap_server || null,
+        imap_port: personalForm.imap_port ? Number(personalForm.imap_port) : null,
+        imap_username: personalForm.imap_username || null,
+        imap_password: personalForm.imap_password || null,
+      });
+      setPersonalSubmitSuccess('이메일 계정 설정이 성공적으로 저장되었습니다.');
+    } catch (err: unknown) {
+      setPersonalSubmitError((err as Error).message || '이메일 계정 저장에 실패했습니다.');
+    }
+  };
+
+  const handleRotateRunnerToken = async () => {
+    setRunnerBusy(true);
+    setRunnerError(null);
+    setRunnerToken(null);
+
+    try {
+      const data = await apiClient.post<{ workspace_id: string; registration_token: string }>('/api/runner-config/rotate', {});
+      setRunnerToken(data.registration_token);
+      await fetchRunnerConfig();
+    } catch (err: unknown) {
+      setRunnerError((err as Error).message || 'Runner 토큰 발급에 실패했습니다.');
+    } finally {
+      setRunnerBusy(false);
+    }
+  };
+
+  const loading = loadingProviders || personalLoading || runnerLoading;
   if (loading) {
-    return <div className="p-8 text-muted-foreground flex items-center gap-2"><Settings className="animate-spin w-5 h-5"/> 설정을 불러오는 중...</div>;
+    return (
+      <div className="p-8 text-muted-foreground flex items-center gap-2">
+        <Settings className="animate-spin w-5 h-5" /> 설정을 불러오는 중...
+      </div>
+    );
   }
 
   return (
@@ -110,40 +244,53 @@ export default function SettingsPage() {
           <Settings className="w-6 h-6 text-primary" />
           설정 (Settings)
         </h1>
-        <p className="text-muted-foreground text-sm">
-          워크스페이스 단위의 통합 관리 및 개인 계정 설정을 구성합니다.
-        </p>
+        <p className="text-muted-foreground text-sm">워크스페이스 단위의 통합 관리 및 개인 계정 설정을 구성합니다.</p>
       </div>
 
       <Tabs defaultValue="personal" className="w-full">
         <TabsList className="grid w-full grid-cols-3 mb-8">
-          <TabsTrigger value="personal" className="font-bold"><Mail className="w-4 h-4 mr-2"/> 개인 이메일 계정</TabsTrigger>
-          <TabsTrigger value="workspace-llm" className="font-bold"><Key className="w-4 h-4 mr-2"/> 워크스페이스 BYOK (관리자)</TabsTrigger>
-          <TabsTrigger value="workspace-runner" className="font-bold"><Activity className="w-4 h-4 mr-2"/> Self-hosted Runner (관리자)</TabsTrigger>
+          <TabsTrigger value="personal" className="font-bold"><Mail className="w-4 h-4 mr-2" /> 개인 이메일 계정</TabsTrigger>
+          <TabsTrigger value="workspace-llm" className="font-bold"><Key className="w-4 h-4 mr-2" /> 워크스페이스 BYOK (관리자)</TabsTrigger>
+          <TabsTrigger value="workspace-runner" className="font-bold"><Activity className="w-4 h-4 mr-2" /> Self-hosted Runner (관리자)</TabsTrigger>
         </TabsList>
 
         <TabsContent value="personal" className="space-y-6">
           <section className="bg-white rounded-2xl border border-border shadow-sm p-6">
             <h2 className="font-bold text-lg mb-2">개인 이메일 계정 연결</h2>
-            <p className="text-sm text-muted-foreground mb-6">
-              Naruon 워크스페이스에서 사용할 본인의 IMAP/SMTP 이메일 계정을 연결합니다. (개인 단위 설정)
-            </p>
-            <div className="bg-secondary/30 border border-border rounded-xl p-8 flex flex-col items-center justify-center text-center">
-              <Mail className="w-10 h-10 text-muted-foreground mb-3 opacity-50" />
-              <h3 className="font-bold text-foreground mb-1">등록된 이메일 계정이 없습니다.</h3>
-              <p className="text-sm text-muted-foreground mb-4">현재 IMAP/SMTP 연동 기능 UI는 준비 중입니다. 백엔드는 구현 완료되었습니다.</p>
-              <Button disabled variant="outline">계정 추가하기 (준비 중)</Button>
-            </div>
+            <p className="text-sm text-muted-foreground mb-6">Naruon 워크스페이스에서 사용할 본인의 IMAP/SMTP 이메일 계정을 연결합니다. (개인 단위 설정)</p>
+            <form onSubmit={handlePersonalSubmit} className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="space-y-4">
+                <h3 className="font-bold text-sm">SMTP 발송 설정</h3>
+                <Input placeholder="smtp.example.com" value={personalForm.smtp_server} onChange={(e) => setPersonalForm({ ...personalForm, smtp_server: e.target.value })} />
+                <Input placeholder="587" value={personalForm.smtp_port} onChange={(e) => setPersonalForm({ ...personalForm, smtp_port: e.target.value })} />
+                <Input placeholder="smtp 사용자명" value={personalForm.smtp_username} onChange={(e) => setPersonalForm({ ...personalForm, smtp_username: e.target.value })} />
+                <Input type="password" placeholder="smtp 비밀번호 또는 앱 비밀번호" value={personalForm.smtp_password} onChange={(e) => setPersonalForm({ ...personalForm, smtp_password: e.target.value })} />
+              </div>
+              <div className="space-y-4">
+                <h3 className="font-bold text-sm">IMAP 수신 설정</h3>
+                <Input placeholder="imap.example.com" value={personalForm.imap_server} onChange={(e) => setPersonalForm({ ...personalForm, imap_server: e.target.value })} />
+                <Input placeholder="993" value={personalForm.imap_port} onChange={(e) => setPersonalForm({ ...personalForm, imap_port: e.target.value })} />
+                <Input placeholder="imap 사용자명" value={personalForm.imap_username} onChange={(e) => setPersonalForm({ ...personalForm, imap_username: e.target.value })} />
+                <Input type="password" placeholder="imap 비밀번호 또는 앱 비밀번호" value={personalForm.imap_password} onChange={(e) => setPersonalForm({ ...personalForm, imap_password: e.target.value })} />
+              </div>
+              <div className="lg:col-span-2 space-y-3">
+                {personalSubmitError && <div className="text-red-500 text-xs font-medium bg-red-50 p-2 rounded">{personalSubmitError}</div>}
+                {personalSubmitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">{personalSubmitSuccess}</div>}
+                <div className="flex justify-end">
+                  <Button type="submit">계정 저장</Button>
+                </div>
+              </div>
+            </form>
           </section>
         </TabsContent>
 
         <TabsContent value="workspace-llm" className="space-y-6">
-          {error ? (
+          {providerError ? (
             <div className="bg-red-50 text-red-600 p-4 rounded-xl border border-red-100 flex items-start gap-3">
               <Shield className="w-5 h-5 shrink-0 mt-0.5" />
               <div>
                 <h3 className="font-bold">접근 거부</h3>
-                <p className="text-sm mt-1">{error}</p>
+                <p className="text-sm mt-1">{providerError}</p>
                 <p className="text-xs mt-2 opacity-80">※ 현재 Naruon 시스템 관리자가 아닌 조직(Organization) 단위의 관리자 권한이 필요합니다.</p>
               </div>
             </div>
@@ -160,53 +307,51 @@ export default function SettingsPage() {
                   {providers.length === 0 ? (
                     <div className="text-sm text-muted-foreground text-center py-8">등록된 제공자가 없습니다.</div>
                   ) : (
-                    providers.map(p => (
+                    providers.map((p) => (
                       <div key={p.id} className="p-4 rounded-xl border border-border bg-card/50 flex flex-col gap-2">
                         <div className="flex items-center justify-between">
                           <span className="font-bold">{p.name}</span>
                           <div className="flex items-center gap-2">
-                            <Badge variant={p.is_active ? "default" : "secondary"}>
-                              {p.is_active ? "활성" : "비활성"}
-                            </Badge>
-                            <Button 
-                              variant="ghost" 
-                              size="sm" 
+                            <Badge variant={p.is_active ? 'default' : 'secondary'}>{p.is_active ? '활성' : '비활성'}</Badge>
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               className="h-6 text-[11px] px-2"
                               onClick={() => {
                                 setEditingId(p.id);
-                                setFormData({
+                                setProviderForm({
                                   name: p.name,
                                   provider_type: p.provider_type,
                                   base_url: p.base_url || '',
-                                  api_key: ''
+                                  api_key: '',
                                 });
                               }}
                             >
                               수정
                             </Button>
-                            <Button 
-                              variant="ghost" 
-                              size="sm" 
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               className="h-6 text-[11px] px-2 text-red-500 hover:text-red-600 hover:bg-red-50"
                               disabled={isDeleting === p.id}
                               onClick={async () => {
-                                if (!confirm("정말 이 제공자를 삭제하시겠습니까?")) return;
+                                if (!confirm('정말 이 제공자를 삭제하시겠습니까?')) return;
                                 setIsDeleting(p.id);
                                 try {
                                   await apiClient.delete(`/api/llm-providers/${p.id}`);
-                                  fetchProviders();
+                                  await fetchProviders();
                                   if (editingId === p.id) {
                                     setEditingId(null);
-                                    setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
+                                    setProviderForm({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
                                   }
                                 } catch (e: unknown) {
-                                  alert("삭제 실패: " + ((e as Error).message || ""));
+                                  alert('삭제 실패: ' + ((e as Error).message || ''));
                                 } finally {
                                   setIsDeleting(null);
                                 }
                               }}
                             >
-                              {isDeleting === p.id ? "삭제중..." : "삭제"}
+                              {isDeleting === p.id ? '삭제중...' : '삭제'}
                             </Button>
                           </div>
                         </div>
@@ -214,7 +359,7 @@ export default function SettingsPage() {
                           <p>Type: {p.provider_type}</p>
                           {p.base_url && <p>Base URL: {p.base_url}</p>}
                           <p className="flex items-center gap-1 mt-1">
-                            Secret: 
+                            Secret:
                             {p.configured ? (
                               <span className="text-green-600 font-bold bg-green-50 px-1.5 py-0.5 rounded flex items-center gap-1">
                                 <CheckCircle2 className="w-3 h-3" /> Configured ({p.fingerprint})
@@ -233,67 +378,42 @@ export default function SettingsPage() {
               </section>
 
               <section className="bg-white rounded-2xl border border-border shadow-sm p-5 h-fit">
-                <h3 className="font-bold mb-4">{editingId ? "제공자 수정" : "새 제공자 추가 (BYOK)"}</h3>
-                <form onSubmit={handleSubmit} className="space-y-4">
+                <h3 className="font-bold mb-4">{editingId !== null ? '제공자 수정' : '새 제공자 추가 (BYOK)'}</h3>
+                <form onSubmit={handleProviderSubmit} className="space-y-4">
                   <div className="space-y-1.5">
                     <label className="text-xs font-semibold text-muted-foreground">식별 이름</label>
-                    <Input 
-                      required
-                      placeholder="예: 사내 보안용 Ollama" 
-                      value={formData.name} 
-                      onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    />
+                    <Input required placeholder="예: 사내 보안용 Ollama" value={providerForm.name} onChange={(e) => setProviderForm({ ...providerForm, name: e.target.value })} />
                   </div>
-                  
                   <div className="space-y-1.5">
                     <label className="text-xs font-semibold text-muted-foreground">제공자 유형</label>
-                    <select 
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      value={formData.provider_type}
-                      onChange={e => setFormData({ ...formData, provider_type: e.target.value })}
-                    >
+                    <select className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2" value={providerForm.provider_type} onChange={(e) => setProviderForm({ ...providerForm, provider_type: e.target.value })}>
                       <option value="openai">OpenAI 호환</option>
                       <option value="anthropic">Anthropic</option>
                       <option value="gemini">Google Gemini</option>
                       <option value="ollama">Local Ollama</option>
                     </select>
                   </div>
-
                   <div className="space-y-1.5">
                     <label className="text-xs font-semibold text-muted-foreground">Base URL (선택)</label>
-                    <Input 
-                      placeholder="https://api.openai.com/v1" 
-                      value={formData.base_url} 
-                      onChange={e => setFormData({ ...formData, base_url: e.target.value })}
-                    />
+                    <Input placeholder="https://api.openai.com/v1" value={providerForm.base_url} onChange={(e) => setProviderForm({ ...providerForm, base_url: e.target.value })} />
                   </div>
-
                   <div className="space-y-1.5">
                     <label className="text-xs font-semibold text-muted-foreground">API Key (시크릿)</label>
-                    <Input 
-                      type="password"
-                      placeholder={editingId ? "변경하려면 새 키를 입력하세요" : "새로운 키를 입력하세요"} 
-                      value={formData.api_key} 
-                      onChange={e => setFormData({ ...formData, api_key: e.target.value })}
-                    />
+                    <Input type="password" placeholder={editingId !== null ? '변경하려면 새 키를 입력하세요' : '새로운 키를 입력하세요'} value={providerForm.api_key} onChange={(e) => setProviderForm({ ...providerForm, api_key: e.target.value })} />
                   </div>
-
-                  {submitError && <div className="text-red-500 text-xs font-medium bg-red-50 p-2 rounded">{submitError}</div>}
-                  {submitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">제공자가 성공적으로 저장되었습니다.</div>}
-
+                  {providerSubmitError && <div className="text-red-500 text-xs font-medium bg-red-50 p-2 rounded">{providerSubmitError}</div>}
+                  {providerSubmitSuccess && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded">{providerSubmitSuccess}</div>}
                   <div className="flex gap-2 pt-2">
-                    <Button type="submit" className="flex-1 font-bold">
-                      {editingId ? "수정 반영" : "저장 및 활성화"}
-                    </Button>
-                    {editingId && (
-                      <Button 
-                        type="button" 
-                        variant="outline" 
+                    <Button type="submit" className="flex-1 font-bold">{editingId !== null ? '수정 반영' : '저장 및 활성화'}</Button>
+                    {editingId !== null && (
+                      <Button
+                        type="button"
+                        variant="outline"
                         onClick={() => {
                           setEditingId(null);
-                          setFormData({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
-                          setSubmitError(null);
-                          setSubmitSuccess(false);
+                          setProviderForm({ name: '', provider_type: 'openai', base_url: '', api_key: '' });
+                          setProviderSubmitError(null);
+                          setProviderSubmitSuccess(null);
                         }}
                       >
                         취소
@@ -307,12 +427,12 @@ export default function SettingsPage() {
         </TabsContent>
 
         <TabsContent value="workspace-runner" className="space-y-6">
-          {error ? (
+          {runnerError ? (
             <div className="bg-red-50 text-red-600 p-4 rounded-xl border border-red-100 flex items-start gap-3">
               <Shield className="w-5 h-5 shrink-0 mt-0.5" />
               <div>
                 <h3 className="font-bold">접근 거부</h3>
-                <p className="text-sm mt-1">{error}</p>
+                <p className="text-sm mt-1">{runnerError}</p>
               </div>
             </div>
           ) : (
@@ -329,22 +449,29 @@ export default function SettingsPage() {
                   </p>
                 </div>
               </div>
+
+              <div className="mb-4 rounded-xl border border-border bg-secondary/20 p-4 text-sm">
+                <p className="font-semibold">현재 Runner 구성</p>
+                <p className="text-muted-foreground mt-1">조직 스코프: {runnerConfig?.workspace_id || 'default-workspace'}</p>
+                <p className="text-muted-foreground">토큰 상태: {runnerConfig?.configured ? `Configured (${runnerConfig.fingerprint})` : '미발급'}</p>
+              </div>
+
               <div className="bg-slate-900 rounded-xl p-4 font-mono text-sm text-slate-300 mb-6">
                 <p className="text-slate-500 mb-2"># 사내망 서버에서 아래 명령어로 Runner를 실행하세요.</p>
                 <p><span className="text-green-400">docker run</span> -d --name naruon-runner \\</p>
-                <p>  -e <span className="text-blue-300">RUNNER_TOKEN</span>=<span className="text-yellow-300">&quot;발급받은_조직_토큰&quot;</span> \\</p>
+                <p>  -e <span className="text-blue-300">RUNNER_TOKEN</span>=<span className="text-yellow-300">&quot;{runnerToken || '발급받은_조직_토큰'}&quot;</span> \\</p>
                 <p>  ghcr.io/seongho-bae/naruon-runner:latest</p>
               </div>
 
+              {runnerToken && <div className="text-green-600 text-xs font-medium bg-green-50 p-2 rounded mb-3">새 Runner 토큰이 발급되었습니다. 지금 복사해 두세요.</div>}
+
               <div className="flex justify-end">
-                <Button disabled>새 Runner 토큰 발급 (준비 중)</Button>
+                <Button disabled={runnerBusy} onClick={handleRotateRunnerToken}>{runnerBusy ? '발급 중...' : '새 Runner 토큰 발급'}</Button>
               </div>
             </section>
           )}
         </TabsContent>
       </Tabs>
-
-
     </div>
   );
 }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -40,8 +40,9 @@ interface RunnerConfig {
 }
 
 function getScopedErrorMessage(err: unknown, forbiddenMessage: string, fallbackMessage: string) {
+  const status = (err as Error & { status?: number }).status;
+  if (status === 403) return forbiddenMessage;
   const message = (err as Error).message || '';
-  if (message.includes('403')) return forbiddenMessage;
   return message || fallbackMessage;
 }
 
@@ -107,11 +108,11 @@ export default function SettingsPage() {
         smtp_server: data.smtp_server ?? '',
         smtp_port: data.smtp_port ? String(data.smtp_port) : '587',
         smtp_username: data.smtp_username ?? '',
-        smtp_password: data.smtp_password ?? '',
+        smtp_password: data.smtp_password === '********' ? '' : (data.smtp_password ?? ''),
         imap_server: data.imap_server ?? '',
         imap_port: data.imap_port ? String(data.imap_port) : '993',
         imap_username: data.imap_username ?? '',
-        imap_password: data.imap_password ?? '',
+        imap_password: data.imap_password === '********' ? '' : (data.imap_password ?? ''),
       });
     } catch {
       // keep defaults for first-time setup
@@ -195,16 +196,29 @@ export default function SettingsPage() {
     setPersonalSubmitSuccess(null);
 
     try {
-      await apiClient.post<{ status: string }>('/api/config', {
+      const smtpPortNum = Number(personalForm.smtp_port);
+      const imapPortNum = Number(personalForm.imap_port);
+      if (!Number.isInteger(smtpPortNum) || smtpPortNum < 1 || smtpPortNum > 65535) {
+        throw new Error('SMTP 포트는 1~65535 범위의 정수여야 합니다.');
+      }
+      if (!Number.isInteger(imapPortNum) || imapPortNum < 1 || imapPortNum > 65535) {
+        throw new Error('IMAP 포트는 1~65535 범위의 정수여야 합니다.');
+      }
+
+      const payload: Record<string, unknown> = {
         user_id: currentUserId,
         smtp_server: personalForm.smtp_server || null,
-        smtp_port: personalForm.smtp_port ? Number(personalForm.smtp_port) : null,
+        smtp_port: smtpPortNum,
         smtp_username: personalForm.smtp_username || null,
-        smtp_password: personalForm.smtp_password || null,
         imap_server: personalForm.imap_server || null,
-        imap_port: personalForm.imap_port ? Number(personalForm.imap_port) : null,
+        imap_port: imapPortNum,
         imap_username: personalForm.imap_username || null,
-        imap_password: personalForm.imap_password || null,
+      };
+      if (personalForm.smtp_password.trim()) payload.smtp_password = personalForm.smtp_password;
+      if (personalForm.imap_password.trim()) payload.imap_password = personalForm.imap_password;
+
+      await apiClient.post<{ status: string }>('/api/config', {
+        ...payload,
       });
       setPersonalSubmitSuccess('이메일 계정 설정이 성공적으로 저장되었습니다.');
     } catch (err: unknown) {

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { DashboardLayout } from "./DashboardLayout";
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -15,25 +15,29 @@ export class ApiClient {
 
   private getHeaders(init?: RequestInit): HeadersInit {
     const userId = this.getCurrentUserId();
-
-    return {
+    const headers: HeadersInit = {
       'Content-Type': 'application/json',
-      'X-User-Id': userId,
       ...init?.headers,
     };
+    if (userId) {
+      return {
+        ...headers,
+        'X-User-Id': userId,
+      };
+    }
+    return headers;
   }
 
   getCurrentUserId() {
-    const fallbackUserId = 'testuser';
-    if (typeof window === 'undefined') return fallbackUserId;
+    if (typeof window === 'undefined') return null;
 
     const isLocalHost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
     const isPrivateLan = window.location.hostname.startsWith('192.168.');
     const allowDevOverride = process.env.NODE_ENV !== 'production' || isLocalHost || isPrivateLan;
-    if (!allowDevOverride) return fallbackUserId;
+    if (!allowDevOverride) return null;
 
     const stored = localStorage.getItem('naruon_dev_user')?.trim();
-    return stored || fallbackUserId;
+    return stored || 'testuser';
   }
 
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -19,8 +19,6 @@ export class ApiClient {
     return {
       'Content-Type': 'application/json',
       'X-User-Id': userId,
-      'X-Workspace-Id': this.getCurrentWorkspaceId(),
-      'X-User-Role': this.getCurrentUserRole(),
       ...init?.headers,
     };
   }
@@ -36,23 +34,6 @@ export class ApiClient {
 
     const stored = localStorage.getItem('naruon_dev_user')?.trim();
     return stored || fallbackUserId;
-  }
-
-  getCurrentWorkspaceId() {
-    const fallbackWorkspaceId = 'default-workspace';
-    if (typeof window === 'undefined') return fallbackWorkspaceId;
-
-    const isLocalHost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
-    const isPrivateLan = window.location.hostname.startsWith('192.168.');
-    const allowDevOverride = process.env.NODE_ENV !== 'production' || isLocalHost || isPrivateLan;
-    if (!allowDevOverride) return fallbackWorkspaceId;
-
-    const stored = localStorage.getItem('naruon_dev_workspace')?.trim();
-    return stored || fallbackWorkspaceId;
-  }
-
-  getCurrentUserRole() {
-    return this.getCurrentUserId() === 'admin' ? 'organization_admin' : 'member';
   }
 
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -14,23 +14,45 @@ export class ApiClient {
   }
 
   private getHeaders(init?: RequestInit): HeadersInit {
-    // Check localStorage for a dev user override, fallback to testuser
     const userId = this.getCurrentUserId();
 
     return {
       'Content-Type': 'application/json',
       'X-User-Id': userId,
+      'X-Workspace-Id': this.getCurrentWorkspaceId(),
+      'X-User-Role': this.getCurrentUserRole(),
       ...init?.headers,
     };
   }
 
   getCurrentUserId() {
-    let userId = 'testuser';
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('naruon_dev_user');
-      if (stored) userId = stored;
-    }
-    return userId;
+    const fallbackUserId = 'testuser';
+    if (typeof window === 'undefined') return fallbackUserId;
+
+    const isLocalHost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const isPrivateLan = window.location.hostname.startsWith('192.168.');
+    const allowDevOverride = process.env.NODE_ENV !== 'production' || isLocalHost || isPrivateLan;
+    if (!allowDevOverride) return fallbackUserId;
+
+    const stored = localStorage.getItem('naruon_dev_user')?.trim();
+    return stored || fallbackUserId;
+  }
+
+  getCurrentWorkspaceId() {
+    const fallbackWorkspaceId = 'default-workspace';
+    if (typeof window === 'undefined') return fallbackWorkspaceId;
+
+    const isLocalHost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const isPrivateLan = window.location.hostname.startsWith('192.168.');
+    const allowDevOverride = process.env.NODE_ENV !== 'production' || isLocalHost || isPrivateLan;
+    if (!allowDevOverride) return fallbackWorkspaceId;
+
+    const stored = localStorage.getItem('naruon_dev_workspace')?.trim();
+    return stored || fallbackWorkspaceId;
+  }
+
+  getCurrentUserRole() {
+    return this.getCurrentUserId() === 'admin' ? 'organization_admin' : 'member';
   }
 
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -15,11 +15,7 @@ export class ApiClient {
 
   private getHeaders(init?: RequestInit): HeadersInit {
     // Check localStorage for a dev user override, fallback to testuser
-    let userId = 'testuser';
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('naruon_dev_user');
-      if (stored) userId = stored;
-    }
+    const userId = this.getCurrentUserId();
 
     return {
       'Content-Type': 'application/json',
@@ -28,13 +24,24 @@ export class ApiClient {
     };
   }
 
+  getCurrentUserId() {
+    let userId = 'testuser';
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('naruon_dev_user');
+      if (stored) userId = stored;
+    }
+    return userId;
+  }
+
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...init,
       headers: this.getHeaders(init),
     });
     if (!response.ok) {
-      throw new Error(`API GET ${endpoint} failed: ${response.statusText}`);
+      const error = new Error(`API GET ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
     return response.json();
   }
@@ -47,7 +54,9 @@ export class ApiClient {
       body: JSON.stringify(body),
     });
     if (!response.ok) {
-      throw new Error(`API POST ${endpoint} failed: ${response.statusText}`);
+      const error = new Error(`API POST ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
     return response.json();
   }
@@ -60,7 +69,9 @@ export class ApiClient {
       body: JSON.stringify(body),
     });
     if (!response.ok) {
-      throw new Error(`API PUT ${endpoint} failed: ${response.statusText}`);
+      const error = new Error(`API PUT ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
     // PUT might return 204 No Content
     const text = await response.text();
@@ -74,7 +85,9 @@ export class ApiClient {
       headers: this.getHeaders(init),
     });
     if (!response.ok) {
-      throw new Error(`API DELETE ${endpoint} failed: ${response.statusText}`);
+      const error = new Error(`API DELETE ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
     // DELETE might return 204 No Content, handle gracefully
     const text = await response.text();


### PR DESCRIPTION
## 목표\n질문만 정리해 두는 수준을 넘어서,  화면에서 실제로 쓸 수 있는 설정 플로우를 구현합니다.\n\n## 구현 사항\n1. **개인 이메일 계정 연결 실제 구현**: 기존 placeholder를 제거하고 를 사용하는 실저장 폼으로 교체했습니다. SMTP/IMAP 서버, 포트, 사용자명, 비밀번호를 개인 단위로 저장합니다.\n2. **조직 Self-hosted Runner 토큰 실제 구현**:  및  엔드포인트를 추가하고, 설정 UI에서 조직 단위 Runner 토큰을 발급/재발급할 수 있게 했습니다.\n3. **BYOK/개인/조직 스코프 명확화**: 설정 페이지를 개인 이메일 계정 / 워크스페이스 BYOK / Self-hosted Runner 탭으로 분리해 질문하신 스코프 혼란을 제거했습니다.\n4. **백엔드 설정 필드 확장**: , , 를 암호화 저장 및 마스킹 반환하도록 추가하고, SMTP 전송 경로에 비밀번호를 연결했습니다.\n\n## 검증\n- backend: 99 passed, 2 skipped\n- frontend: build / test / lint passed\n\n## 관련 피드백\n- "이메일 계정 추가는 어디에 있나?"\n- "Self-hosted runner 추가는 어디에 있나?"\n- "팀/개인/조직/Naruon 제공 중 어떤 스코프인지 정확하지 않다"\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMTP password support and personal IMAP/SMTP mailbox credential management
  * Workspace runner token management for admins (view metadata, rotate tokens)
  * Redesigned Settings page with tabs for mailbox, providers, and runner controls
  * API client now surfaces HTTP status codes in error messages

* **Bug Fixes / Behavior**
  * Secrets consistently masked in API responses; missing server encryption returns clear 503

* **Tests**
  * Added/expanded tests for runner-config and tenant-config behaviors

* **Documentation**
  * Added rollout plan for settings operationalization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->