### PR TITLE
Enterprise RBAC / SSO 기반 정리 + Workspace 반응형 UX 보강 (v2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,8 +72,12 @@ SMTP/IMAP providers as documented in
 the current repo and physical replication/WAL restore remain future work per
 `docs/operations/postgresql-physical-replication.md`.
 
-Authentication remains dummy `X-User-Id` header auth until mailbox ownership,
-Keycloak/Casdoor evaluation, and key rotation are completed; see
+Authentication still uses trusted request headers in local/dev, but the backend
+now normalizes them into an auth context with `platform_admin`,
+`organization_admin`, `group_admin`, and `member` roles plus optional
+organization/group scope. This preserves the current `X-User-Id` development
+flow while preparing the backend for future Keycloak/Casdoor claims and
+organization-scoped resources that should not assume one workspace per user; see
 `docs/operations/auth-key-management.md`. The current Kubernetes ingress assumes
 NGINX, while Traefik is only an evaluated option in
 `docs/operations/traefik-evaluation.md`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Errors should tell a contributor what failed and avoid leaking internals:
 
 ## Current scope contract
 
-This repo still uses dummy header auth and does not persist an owner/mailbox key on email rows. Treat local data as single-user development data until a mailbox ownership migration is added.
+This repo still uses trusted header auth in local/dev and does not persist an owner/mailbox key on email rows. The backend now derives an auth context with platform/organization/group/member scopes, but email data should still be treated as single-user development data until a mailbox ownership migration is added.
 
 ## Operations and release docs
 

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -45,8 +45,6 @@ def _derive_workspace_id(
     organization_id: str | None,
     workspace_id: str | None,
 ) -> str:
-    if workspace_id and workspace_id.strip():
-        return workspace_id.strip()
     if organization_id:
         return f"workspace-{organization_id}"
     return f"workspace-{user_id}"

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,25 +1,134 @@
+from dataclasses import dataclass
+from typing import Literal, cast
+
 from fastapi import Depends, Header, HTTPException
+
 from core.config import settings
 
-async def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id")) -> str:
+
+RoleName = Literal["platform_admin", "organization_admin", "group_admin", "member"]
+SCOPED_ROLES: set[str] = {"platform_admin", "organization_admin", "group_admin", "member"}
+
+
+@dataclass(frozen=True)
+class AuthContext:
+    user_id: str
+    role: RoleName
+    organization_id: str | None
+    group_ids: tuple[str, ...]
+    workspace_id: str
+
+
+def _normalize_header_value(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _derive_role(user_id: str, requested_role: str | None) -> RoleName:
+    if not (settings.DEBUG or settings.TRUST_DEV_HEADERS):
+        return "member"
+    if requested_role in SCOPED_ROLES:
+        return cast(RoleName, requested_role)
+    return "organization_admin" if user_id == "admin" else "member"
+
+
+def _parse_group_ids(group_ids_header: str | None) -> tuple[str, ...]:
+    if not group_ids_header:
+        return ()
+    return tuple(group_id.strip() for group_id in group_ids_header.split(",") if group_id.strip())
+
+
+def _derive_workspace_id(
+    user_id: str,
+    organization_id: str | None,
+    workspace_id: str | None,
+) -> str:
+    if workspace_id and workspace_id.strip():
+        return workspace_id.strip()
+    if organization_id:
+        return f"workspace-{organization_id}"
+    return f"workspace-{user_id}"
+
+
+def ensure_organization_access(auth_context: AuthContext, organization_id: str) -> None:
+    if auth_context.role == "platform_admin":
+        return
+    if auth_context.organization_id != organization_id:
+        raise HTTPException(status_code=403, detail="Resource belongs to a different organization")
+
+
+async def get_auth_context(
+    x_user_id: str | None = Header(None, alias="X-User-Id"),
+    x_user_role: str | None = Header(None, alias="X-User-Role"),
+    x_organization_id: str | None = Header(None, alias="X-Organization-Id"),
+    x_group_ids: str | None = Header(None, alias="X-Group-Ids"),
+    x_workspace_id: str | None = Header(None, alias="X-Workspace-Id"),
+) -> AuthContext:
+
+
+    return build_auth_context(
+        x_user_id=x_user_id,
+        x_user_role=x_user_role,
+        x_organization_id=x_organization_id,
+        x_group_ids=x_group_ids,
+        x_workspace_id=x_workspace_id,
+    )
+
+
+def build_auth_context(
+    x_user_id: object,
+    x_user_role: object = None,
+    x_organization_id: object = None,
+    x_group_ids: object = None,
+    x_workspace_id: object = None,
+) -> AuthContext:
 
     """
-    Extracts the user ID from the X-User-Id header.
-    In a real implementation, this should validate a JWT or Keycloak token.
-    For now, we enforce that it must be present.
+    Builds an auth context from the current request headers.
+    Today this still trusts local/dev headers, but the shape matches future
+    token-derived scope claims from Keycloak or Casdoor.
     """
-    if not x_user_id:
+    user_id = _normalize_header_value(x_user_id)
+    if user_id is None:
         raise HTTPException(status_code=401, detail="Authentication required")
-    return x_user_id
+
+    organization_id = _normalize_header_value(x_organization_id)
+    role = _derive_role(user_id, _normalize_header_value(x_user_role))
+    group_ids = _parse_group_ids(_normalize_header_value(x_group_ids))
+    workspace_id = _derive_workspace_id(user_id, organization_id, _normalize_header_value(x_workspace_id))
+
+    return AuthContext(
+        user_id=user_id,
+        role=role,
+        organization_id=organization_id,
+        group_ids=group_ids,
+        workspace_id=workspace_id,
+    )
 
 
-async def get_current_workspace_id(current_user: str = Depends(get_current_user)) -> str:
-    return f"workspace-{current_user}"
+async def get_current_user(
+    x_user_id: str | None = Header(None, alias="X-User-Id"),
+    x_user_role: str | None = Header(None, alias="X-User-Role"),
+    x_organization_id: str | None = Header(None, alias="X-Organization-Id"),
+    x_group_ids: str | None = Header(None, alias="X-Group-Ids"),
+    x_workspace_id: str | None = Header(None, alias="X-Workspace-Id"),
+) -> str:
+    return build_auth_context(
+        x_user_id=x_user_id,
+        x_user_role=x_user_role,
+        x_organization_id=x_organization_id,
+        x_group_ids=x_group_ids,
+        x_workspace_id=x_workspace_id,
+    ).user_id
+
+
+async def get_current_workspace_id(auth_context: AuthContext = Depends(get_auth_context)) -> str:
+    return auth_context.workspace_id
 
 
 async def get_current_user_role(
-    current_user: str = Depends(get_current_user),
+    auth_context: AuthContext = Depends(get_auth_context),
 ) -> str:
-    if not (settings.DEBUG or settings.TRUST_DEV_HEADERS):
-        return "member"
-    return "organization_admin" if current_user == "admin" else "member"
+    return auth_context.role

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Literal, cast, get_args
 
 from fastapi import Depends, Header, HTTPException
 
@@ -7,7 +7,7 @@ from core.config import settings
 
 
 RoleName = Literal["platform_admin", "organization_admin", "group_admin", "member"]
-SCOPED_ROLES: set[str] = {"platform_admin", "organization_admin", "group_admin", "member"}
+SCOPED_ROLES: set[str] = set(get_args(RoleName))
 
 
 @dataclass(frozen=True)
@@ -27,6 +27,12 @@ def _normalize_header_value(value: object) -> str | None:
 
 
 def _derive_role(user_id: str, requested_role: str | None) -> RoleName:
+    """
+    Derive user role from request headers in trusted dev/test mode.
+
+    In production, header-provided roles are ignored and every request is treated
+    as `member` until SSO/OIDC claims are wired in.
+    """
     if not (settings.DEBUG or settings.TRUST_DEV_HEADERS):
         return "member"
     if requested_role in SCOPED_ROLES:
@@ -43,8 +49,13 @@ def _parse_group_ids(group_ids_header: str | None) -> tuple[str, ...]:
 def _derive_workspace_id(
     user_id: str,
     organization_id: str | None,
-    workspace_id: str | None,
 ) -> str:
+    """
+    Derive workspace identity from organization or user context only.
+
+    Client-provided workspace overrides are intentionally ignored to prevent
+    cross-tenant scope spoofing.
+    """
     if organization_id:
         return f"workspace-{organization_id}"
     return f"workspace-{user_id}"
@@ -62,16 +73,12 @@ async def get_auth_context(
     x_user_role: str | None = Header(None, alias="X-User-Role"),
     x_organization_id: str | None = Header(None, alias="X-Organization-Id"),
     x_group_ids: str | None = Header(None, alias="X-Group-Ids"),
-    x_workspace_id: str | None = Header(None, alias="X-Workspace-Id"),
 ) -> AuthContext:
-
-
     return build_auth_context(
         x_user_id=x_user_id,
         x_user_role=x_user_role,
         x_organization_id=x_organization_id,
         x_group_ids=x_group_ids,
-        x_workspace_id=x_workspace_id,
     )
 
 
@@ -80,13 +87,13 @@ def build_auth_context(
     x_user_role: object = None,
     x_organization_id: object = None,
     x_group_ids: object = None,
-    x_workspace_id: object = None,
 ) -> AuthContext:
 
     """
     Builds an auth context from the current request headers.
     Today this still trusts local/dev headers, but the shape matches future
-    token-derived scope claims from Keycloak or Casdoor.
+    token-derived scope claims from Keycloak or Casdoor. In production,
+    role headers are ignored and requests remain `member` until OIDC is wired.
     """
     user_id = _normalize_header_value(x_user_id)
     if user_id is None:
@@ -95,7 +102,7 @@ def build_auth_context(
     organization_id = _normalize_header_value(x_organization_id)
     role = _derive_role(user_id, _normalize_header_value(x_user_role))
     group_ids = _parse_group_ids(_normalize_header_value(x_group_ids))
-    workspace_id = _derive_workspace_id(user_id, organization_id, _normalize_header_value(x_workspace_id))
+    workspace_id = _derive_workspace_id(user_id, organization_id)
 
     return AuthContext(
         user_id=user_id,
@@ -111,14 +118,12 @@ async def get_current_user(
     x_user_role: str | None = Header(None, alias="X-User-Role"),
     x_organization_id: str | None = Header(None, alias="X-Organization-Id"),
     x_group_ids: str | None = Header(None, alias="X-Group-Ids"),
-    x_workspace_id: str | None = Header(None, alias="X-Workspace-Id"),
 ) -> str:
     return build_auth_context(
         x_user_id=x_user_id,
         x_user_role=x_user_role,
         x_organization_id=x_organization_id,
         x_group_ids=x_group_ids,
-        x_workspace_id=x_workspace_id,
     ).user_id
 
 

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import datetime
 from db.session import get_db
 from db.models import LLMProvider, AuditLog
-from api.auth import get_current_user
+from api.auth import AuthContext, get_auth_context
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/llm-providers", tags=["llm-providers"])
@@ -45,17 +45,15 @@ def _get_fingerprint(api_key: str | None) -> str | None:
         return f"***{api_key[-4:]}"
     return "***"
 
-async def check_admin_access(user_id: str = Depends(get_current_user)):
-    # Mocking role claim check for now since auth.py just returns string
-    user_roles = ["admin"] if user_id == "admin" else []
-    if "admin" not in user_roles:
-        raise HTTPException(status_code=403, detail="Admin access required")
-    return user_id
+async def check_admin_access(auth_context: AuthContext = Depends(get_auth_context)):
+    if auth_context.role not in {"platform_admin", "organization_admin"}:
+        raise HTTPException(status_code=403, detail="Organization admin access required")
+    return auth_context.user_id
 
 @router.get("", response_model=List[LLMProviderResponse])
 async def list_providers(
     db: AsyncSession = Depends(get_db),
-    user_id: str = Depends(get_current_user)
+    auth_context: AuthContext = Depends(get_auth_context)
 ):
     result = await db.execute(select(LLMProvider))
     providers = result.scalars().all()

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.auth import AuthContext, get_auth_context
+from api.auth import AuthContext, ensure_organization_access, get_auth_context
 from db.models import WorkspaceRunnerConfig
 from db.session import get_db
 
@@ -31,7 +31,15 @@ class RunnerRotateResponse(BaseModel):
 def _check_org_admin(auth_context: AuthContext = Depends(get_auth_context)) -> AuthContext:
     if auth_context.role not in {"platform_admin", "organization_admin"}:
         raise HTTPException(status_code=403, detail="Organization admin access required")
+    if auth_context.role == "organization_admin" and not auth_context.organization_id:
+        raise HTTPException(status_code=403, detail="Organization scope is required")
     return auth_context
+
+
+def _get_target_organization_id(auth_context: AuthContext) -> str:
+    if not auth_context.organization_id:
+        raise HTTPException(status_code=403, detail="Organization scope is required")
+    return auth_context.organization_id
 
 
 def _fingerprint(token: str | None) -> str | None:
@@ -45,9 +53,10 @@ async def get_runner_config(
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(_check_org_admin),
 ):
-    workspace_id = auth_context.workspace_id
+    organization_id = _get_target_organization_id(auth_context)
+    workspace_id = f"workspace-{organization_id}"
     result = await db.execute(
-        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.organization_id == organization_id)
     )
     config = result.scalar_one_or_none()
 
@@ -55,6 +64,7 @@ async def get_runner_config(
         return RunnerConfigResponse(workspace_id=workspace_id, configured=False, fingerprint=None, updated_at=None)
 
     try:
+        ensure_organization_access(auth_context, config.organization_id)
         return RunnerConfigResponse(
             workspace_id=config.workspace_id,
             configured=bool(config.registration_token),
@@ -75,17 +85,23 @@ async def rotate_runner_token(
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(_check_org_admin),
 ):
-    workspace_id = auth_context.workspace_id
+    organization_id = _get_target_organization_id(auth_context)
+    workspace_id = f"workspace-{organization_id}"
     result = await db.execute(
-        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
+        select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.organization_id == organization_id)
     )
     config = result.scalar_one_or_none()
 
     token = f"nrn_{secrets.token_urlsafe(24)}"
     if not config:
-        config = WorkspaceRunnerConfig(workspace_id=workspace_id, registration_token=token)
+        config = WorkspaceRunnerConfig(
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            registration_token=token,
+        )
         db.add(config)
     else:
+        ensure_organization_access(auth_context, config.organization_id)
         config.registration_token = token
 
     try:

--- a/backend/api/runner_config.py
+++ b/backend/api/runner_config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.auth import get_current_user_role, get_current_workspace_id
+from api.auth import AuthContext, get_auth_context
 from db.models import WorkspaceRunnerConfig
 from db.session import get_db
 
@@ -28,10 +28,10 @@ class RunnerRotateResponse(BaseModel):
     registration_token: str
 
 
-def _check_org_admin(user_role: str = Depends(get_current_user_role)) -> str:
-    if user_role != "organization_admin":
+def _check_org_admin(auth_context: AuthContext = Depends(get_auth_context)) -> AuthContext:
+    if auth_context.role not in {"platform_admin", "organization_admin"}:
         raise HTTPException(status_code=403, detail="Organization admin access required")
-    return user_role
+    return auth_context
 
 
 def _fingerprint(token: str | None) -> str | None:
@@ -43,9 +43,9 @@ def _fingerprint(token: str | None) -> str | None:
 @router.get("", response_model=RunnerConfigResponse)
 async def get_runner_config(
     db: AsyncSession = Depends(get_db),
-    _: str = Depends(_check_org_admin),
-    workspace_id: str = Depends(get_current_workspace_id),
+    auth_context: AuthContext = Depends(_check_org_admin),
 ):
+    workspace_id = auth_context.workspace_id
     result = await db.execute(
         select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
     )
@@ -73,9 +73,9 @@ async def get_runner_config(
 @router.post("/rotate", response_model=RunnerRotateResponse)
 async def rotate_runner_token(
     db: AsyncSession = Depends(get_db),
-    _: str = Depends(_check_org_admin),
-    workspace_id: str = Depends(get_current_workspace_id),
+    auth_context: AuthContext = Depends(_check_org_admin),
 ):
+    workspace_id = auth_context.workspace_id
     result = await db.execute(
         select(WorkspaceRunnerConfig).where(WorkspaceRunnerConfig.workspace_id == workspace_id)
     )

--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -61,6 +61,9 @@ SECRET_FIELDS = {
     "google_client_secret",
 }
 
+MAILBOX_MANAGE_FORBIDDEN = "Mailbox settings are personal and can only be managed by the authenticated user"
+MAILBOX_VIEW_FORBIDDEN = "Mailbox settings are personal and can only be viewed by the authenticated user"
+
 
 @router.post("")
 async def create_or_update_config(
@@ -69,7 +72,7 @@ async def create_or_update_config(
     current_user: str = Depends(get_current_user)
 ):
     if config.user_id != current_user:
-        raise HTTPException(status_code=403, detail="Not authorized")
+        raise HTTPException(status_code=403, detail=MAILBOX_MANAGE_FORBIDDEN)
 
     result = await db.execute(
         select(TenantConfig).where(TenantConfig.user_id == config.user_id)
@@ -109,7 +112,7 @@ async def get_config(
     current_user: str = Depends(get_current_user)
 ):
     if user_id != current_user:
-        raise HTTPException(status_code=403, detail="Not authorized")
+        raise HTTPException(status_code=403, detail=MAILBOX_VIEW_FORBIDDEN)
 
     result = await db.execute(
         select(TenantConfig).where(TenantConfig.user_id == user_id)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -84,6 +84,7 @@ class WorkspaceRunnerConfig(Base):
     __tablename__ = "workspace_runner_configs"
 
     id: Mapped[int] = mapped_column(primary_key=True)
+    organization_id: Mapped[str] = mapped_column(String, unique=True, index=True)
     workspace_id: Mapped[str] = mapped_column(String, unique=True, index=True)
     registration_token: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     updated_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -91,6 +91,40 @@ class WorkspaceRunnerConfig(Base):
     )
 
 
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    groups: Mapped[list["OrganizationGroup"]] = relationship(back_populates="organization")
+    role_assignments: Mapped[list["ScopedRoleAssignment"]] = relationship(back_populates="organization")
+
+
+class OrganizationGroup(Base):
+    __tablename__ = "organization_groups"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    organization_id: Mapped[str] = mapped_column(ForeignKey("organizations.id"), index=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    organization: Mapped["Organization"] = relationship(back_populates="groups")
+    role_assignments: Mapped[list["ScopedRoleAssignment"]] = relationship(back_populates="group")
+
+
+class ScopedRoleAssignment(Base):
+    __tablename__ = "scoped_role_assignments"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+    role: Mapped[str] = mapped_column(String, index=True)
+    organization_id: Mapped[str | None] = mapped_column(ForeignKey("organizations.id"), nullable=True, index=True)
+    group_id: Mapped[str | None] = mapped_column(ForeignKey("organization_groups.id"), nullable=True, index=True)
+
+    organization: Mapped["Organization | None"] = relationship(back_populates="role_assignments")
+    group: Mapped["OrganizationGroup | None"] = relationship(back_populates="role_assignments")
+
+
 class PromptTemplate(Base):
     __tablename__ = "prompt_templates"
 

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -1,6 +1,16 @@
 import pytest
 from fastapi import HTTPException
-from api.auth import get_current_user
+from api.auth import AuthContext, ensure_organization_access, get_auth_context, get_current_user
+from core.config import settings
+
+
+@pytest.fixture(autouse=True)
+def restore_auth_flags():
+    previous_debug = settings.DEBUG
+    previous_trust = settings.TRUST_DEV_HEADERS
+    yield
+    settings.DEBUG = previous_debug
+    settings.TRUST_DEV_HEADERS = previous_trust
 
 @pytest.mark.asyncio
 async def test_get_current_user_rejects_missing_auth():
@@ -8,3 +18,54 @@ async def test_get_current_user_rejects_missing_auth():
     with pytest.raises(HTTPException) as exc:
         await get_current_user(x_user_id=None)
     assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_auth_context_supports_scoped_enterprise_roles():
+    settings.TRUST_DEV_HEADERS = True
+
+    context = await get_auth_context(
+        x_user_id="alice",
+        x_user_role="group_admin",
+        x_organization_id="org-acme",
+        x_group_ids="group-1,group-2",
+    )
+
+    assert context == AuthContext(
+        user_id="alice",
+        role="group_admin",
+        organization_id="org-acme",
+        group_ids=("group-1", "group-2"),
+        workspace_id="workspace-org-acme",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_auth_context_keeps_legacy_workspace_fallback_for_unscoped_dev_auth():
+    settings.TRUST_DEV_HEADERS = True
+
+    context = await get_auth_context(
+        x_user_id="root",
+        x_user_role="platform_admin",
+    )
+
+    assert context.role == "platform_admin"
+    assert context.organization_id is None
+    assert context.group_ids == ()
+    assert context.workspace_id == "workspace-root"
+
+
+def test_ensure_organization_access_rejects_cross_scope_resource():
+    context = AuthContext(
+        user_id="alice",
+        role="organization_admin",
+        organization_id="org-acme",
+        group_ids=("group-1",),
+        workspace_id="workspace-org-acme",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        ensure_organization_access(context, "org-other")
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Resource belongs to a different organization"

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -1,124 +1,147 @@
+import datetime
+
 import pytest
 from fastapi.testclient import TestClient
+
+from core.config import settings
+from db.models import AuditLog, LLMProvider
+from db.session import get_db
 from main import app
-from db.models import LLMProvider, AuditLog
-from db.session import get_db
-from db.session import get_db
+
+
+class MockScalars:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+
+class MockResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return MockScalars(self._items)
+
 
 class MockSession:
     def __init__(self):
-        self.items = []
-        self.audits = []
-    async def execute(self, stmt):
-        class MockResult:
-            def scalars(self):
-                class MockScalars:
-                    def all(self):
-                        return self.items
-                    def first(self):
-                        if self.items:
-                            return self.items[0]
-                        return None
-                m = MockScalars()
-                
-                # Check for where filtering
-                filtered = self.parent_items
-                stmt_str = str(stmt).lower()
-                if "where" in stmt_str and "llm_providers.id =" in stmt_str:
-                    # super hacky mock for tests
-                    try:
-                        import re
-                        match = re.search(r"llm_providers.id = :id_1", stmt_str)
-                        if match:
-                            # We can just assume it's getting the last created provider id for these tests
-                            pass
-                    except Exception:
-                        pass
-                        
-                # Actually, simpler: Just filter if parameters are passed?
-                # We don't get parameters easily in this mock, so we'll just return the first item if first() is called
-                # unless we are looking for a specific ID. Let's just improve the mock slightly.
-                m.items = getattr(self, 'items', self.parent_items)
-                return m
-        res = MockResult()
-        res.parent_items = self.items
-        return res
+        self.providers: list[LLMProvider] = []
+        self.audits: list[AuditLog] = []
 
-        
+    async def execute(self, stmt):
+        stmt_str = str(stmt).lower()
+        if "llm_providers.id =" in stmt_str:
+            return MockResult(self.providers[:1])
+        return MockResult(self.providers)
+
     def add(self, obj):
         if isinstance(obj, LLMProvider):
-            obj.id = len(self.items) + 1
-            obj.updated_at = "2026-05-11T00:00:00Z"
-            self.items.append(obj)
+            obj.id = len(self.providers) + 1
+            obj.updated_at = datetime.datetime.now(datetime.timezone.utc)
+            self.providers.append(obj)
         elif isinstance(obj, AuditLog):
             self.audits.append(obj)
-            
+
+    async def delete(self, obj):
+        self.providers = [provider for provider in self.providers if provider is not obj]
+
     async def commit(self):
-        pass
+        return None
+
     async def refresh(self, obj):
-        pass
+        return None
+
 
 mock_session = MockSession()
 
+
+@pytest.fixture(autouse=True)
+def enable_dev_headers():
+    previous = settings.TRUST_DEV_HEADERS
+    settings.TRUST_DEV_HEADERS = True
+    yield
+    settings.TRUST_DEV_HEADERS = previous
+
+
 @pytest.fixture(autouse=True)
 def override_get_db():
-    app.dependency_overrides[get_db] = lambda: mock_session
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
     yield
     app.dependency_overrides.clear()
-    mock_session.items = []
+    mock_session.providers = []
     mock_session.audits = []
 
 
 @pytest.fixture
 def admin_client():
-    with TestClient(app, headers={"X-User-Id": "admin"}) as c:
-        yield c
+    with TestClient(
+        app,
+        headers={
+            "X-User-Id": "admin",
+            "X-User-Role": "organization_admin",
+            "X-Organization-Id": "org-acme",
+        },
+    ) as client:
+        yield client
+
 
 @pytest.fixture
 def member_client():
-    with TestClient(app, headers={"X-User-Id": "member"}) as c:
-        yield c
+    with TestClient(
+        app,
+        headers={
+            "X-User-Id": "member",
+            "X-User-Role": "member",
+            "X-Organization-Id": "org-acme",
+        },
+    ) as client:
+        yield client
+
 
 def test_llm_provider_crud_admin(admin_client):
-    mock_session.items = []
-    # Create
-    resp = admin_client.post("/api/llm-providers", json={
-        "name": "Primary OpenAI",
-        "provider_type": "openai",
-        "api_key": "sk-12345"
-    })
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
+    response = admin_client.post(
+        "/api/llm-providers",
+        json={
+            "name": "Primary OpenAI",
+            "provider_type": "openai",
+            "api_key": "sk-12345",
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
     assert data["name"] == "Primary OpenAI"
     assert data["configured"] is True
     assert data["fingerprint"] is not None
     assert "api_key" not in data
-    
+
     provider_id = data["id"]
-    
-    # List
-    resp = admin_client.get("/api/llm-providers")
-    assert resp.status_code == 200
-    assert len(resp.json()) >= 1
-    
-    # Update
-    resp = admin_client.put(f"/api/llm-providers/{provider_id}", json={
-        "is_active": True
-    })
-    assert resp.status_code == 200
-    assert resp.json()["is_active"] is True
-    
-    # Check AuditLog
-    # result = await db_session.execute(select(AuditLog).where(AuditLog.user_id == "admin"))
-    # logs = result.scalars().all()
-    pass
+
+    response = admin_client.get("/api/llm-providers")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+    response = admin_client.put(f"/api/llm-providers/{provider_id}", json={"is_active": True})
+    assert response.status_code == 200
+    assert response.json()["is_active"] is True
+
+    response = admin_client.delete(f"/api/llm-providers/{provider_id}")
+    assert response.status_code == 204
+
 
 def test_llm_provider_member_rejected(member_client):
-    resp = member_client.get("/api/llm-providers")
-    assert resp.status_code == 200
-    
-    resp = member_client.post("/api/llm-providers", json={
-        "name": "Malicious",
-        "provider_type": "openai"
-    })
-    assert resp.status_code == 403
+    response = member_client.get("/api/llm-providers")
+    assert response.status_code == 200
+
+    response = member_client.post(
+        "/api/llm-providers",
+        json={"name": "Malicious", "provider_type": "openai"},
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_runner_config_api.py
+++ b/backend/tests/test_runner_config_api.py
@@ -53,9 +53,11 @@ def member_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app, headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"}) as c:
-        yield c
-    app.dependency_overrides.clear()
+    try:
+        with TestClient(app, headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"}) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 @pytest.fixture
@@ -64,9 +66,18 @@ def admin_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app, headers={"X-User-Id": "admin", "X-Organization-Id": "org-acme"}) as c:
-        yield c
-    app.dependency_overrides.clear()
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "admin",
+                "X-User-Role": "organization_admin",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 @pytest.fixture
@@ -75,16 +86,18 @@ def second_org_admin_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(
-        app,
-        headers={
-            "X-User-Id": "org-admin-2",
-            "X-User-Role": "organization_admin",
-            "X-Organization-Id": "org-acme",
-        },
-    ) as c:
-        yield c
-    app.dependency_overrides.clear()
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "org-admin-2",
+                "X-User-Role": "organization_admin",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 @pytest.fixture
@@ -93,16 +106,18 @@ def platform_admin_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(
-        app,
-        headers={
-            "X-User-Id": "platform-root",
-            "X-User-Role": "platform_admin",
-            "X-Organization-Id": "org-acme",
-        },
-    ) as c:
-        yield c
-    app.dependency_overrides.clear()
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "platform-root",
+                "X-User-Role": "platform_admin",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
 
 
 def test_member_cannot_manage_runner_config(member_client):
@@ -113,12 +128,13 @@ def test_member_cannot_manage_runner_config(member_client):
     assert response.status_code == 403
 
 
-def test_org_scoped_runner_config_uses_shared_workspace(admin_client, second_org_admin_client):
+def test_org_scoped_runner_config_uses_shared_workspace(admin_client, second_org_admin_client, mock_db):
     rotate_response = admin_client.post("/api/runner-config/rotate")
     assert rotate_response.status_code == 200
     rotate_data = rotate_response.json()
     assert rotate_data["workspace_id"] == "workspace-org-acme"
     assert rotate_data["registration_token"].startswith("nrn_")
+    assert mock_db.runner.organization_id == "org-acme"
 
     read_response = second_org_admin_client.get("/api/runner-config")
     assert read_response.status_code == 200
@@ -133,3 +149,23 @@ def test_platform_admin_can_manage_runner_config(platform_admin_client):
     rotate_response = platform_admin_client.post("/api/runner-config/rotate")
     assert rotate_response.status_code == 200
     assert rotate_response.json()["workspace_id"] == "workspace-org-acme"
+
+
+def test_org_admin_without_org_scope_is_rejected(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "admin",
+                "X-User-Role": "organization_admin",
+            },
+        ) as client:
+            response = client.get("/api/runner-config")
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Organization scope is required"
+    finally:
+        app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_runner_config_api.py
+++ b/backend/tests/test_runner_config_api.py
@@ -53,7 +53,7 @@ def member_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app, headers={"X-User-Id": "testuser"}) as c:
+    with TestClient(app, headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"}) as c:
         yield c
     app.dependency_overrides.clear()
 
@@ -64,7 +64,43 @@ def admin_client(mock_db):
         yield mock_db
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app, headers={"X-User-Id": "admin"}) as c:
+    with TestClient(app, headers={"X-User-Id": "admin", "X-Organization-Id": "org-acme"}) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def second_org_admin_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(
+        app,
+        headers={
+            "X-User-Id": "org-admin-2",
+            "X-User-Role": "organization_admin",
+            "X-Organization-Id": "org-acme",
+        },
+    ) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def platform_admin_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(
+        app,
+        headers={
+            "X-User-Id": "platform-root",
+            "X-User-Role": "platform_admin",
+            "X-Organization-Id": "org-acme",
+        },
+    ) as c:
         yield c
     app.dependency_overrides.clear()
 
@@ -77,17 +113,23 @@ def test_member_cannot_manage_runner_config(member_client):
     assert response.status_code == 403
 
 
-def test_admin_can_rotate_and_read_runner_config(admin_client):
+def test_org_scoped_runner_config_uses_shared_workspace(admin_client, second_org_admin_client):
     rotate_response = admin_client.post("/api/runner-config/rotate")
     assert rotate_response.status_code == 200
     rotate_data = rotate_response.json()
-    assert rotate_data["workspace_id"] == "workspace-admin"
+    assert rotate_data["workspace_id"] == "workspace-org-acme"
     assert rotate_data["registration_token"].startswith("nrn_")
 
-    read_response = admin_client.get("/api/runner-config")
+    read_response = second_org_admin_client.get("/api/runner-config")
     assert read_response.status_code == 200
     read_data = read_response.json()
-    assert read_data["workspace_id"] == "workspace-admin"
+    assert read_data["workspace_id"] == "workspace-org-acme"
     assert read_data["configured"] is True
     assert read_data["fingerprint"] is not None
     assert "registration_token" not in read_data
+
+
+def test_platform_admin_can_manage_runner_config(platform_admin_client):
+    rotate_response = platform_admin_client.post("/api/runner-config/rotate")
+    assert rotate_response.status_code == 200
+    assert rotate_response.json()["workspace_id"] == "workspace-org-acme"

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -71,3 +71,37 @@ def test_tenant_config_endpoint(client, mock_db):
     assert data["imap_port"] == 993
     assert data["imap_username"] == "imap-user"
     assert data["google_client_secret"] is None
+
+
+def test_tenant_config_stays_user_owned_even_for_admin_headers(client):
+    response = client.post(
+        "/api/config",
+        json={"user_id": "member-user", "smtp_server": "smtp.example.com"},
+        headers={
+            "X-User-Id": "admin",
+            "X-User-Role": "organization_admin",
+            "X-Organization-Id": "org-acme",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Mailbox settings are personal and can only be managed by the authenticated user"
+    }
+
+
+def test_tenant_config_get_rejects_cross_user_access(client):
+    response = client.get(
+        "/api/config",
+        params={"user_id": "member-user"},
+        headers={
+            "X-User-Id": "admin",
+            "X-User-Role": "platform_admin",
+            "X-Organization-Id": "org-acme",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Mailbox settings are personal and can only be viewed by the authenticated user"
+    }

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -71,4 +71,31 @@ describe("DashboardLayout", () => {
     expect(mobileMenuButton?.getAttribute("aria-expanded")).toBe("true");
       });
 
+  it("keeps the desktop sidebar content reachable through an independent scroll region", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <DashboardLayout>
+          <section>Inbox workspace content</section>
+        </DashboardLayout>,
+      );
+    });
+
+    const sidebar = container.querySelector<HTMLElement>('aside[aria-label="Naruon workspace sidebar"]');
+    const scrollRegion = container.querySelector<HTMLElement>('[data-testid="sidebar-scroll-region"]');
+    const insightHeading = Array.from(container.querySelectorAll("p")).find(
+      (element) => element.textContent === "오늘의 인사이트",
+    );
+
+    expect(sidebar?.className).toContain("overflow-hidden");
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion?.className).toContain("min-h-0");
+    expect(scrollRegion?.className).toContain("overflow-y-auto");
+    expect(scrollRegion?.textContent ?? "").toContain("오늘의 인사이트");
+    expect(insightHeading?.closest('[data-testid="sidebar-scroll-region"]')).toBe(scrollRegion);
+  });
+
 });

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -143,7 +143,7 @@ export function DashboardLayout({
         Skip to main content
       </a>
 
-      <aside aria-label="Naruon workspace sidebar" className="hidden w-60 shrink-0 flex-col border-r border-sidebar-border bg-sidebar/95 px-4 py-5 shadow-[8px_0_32px_rgba(15,23,42,0.04)] lg:flex">
+      <aside aria-label="Naruon workspace sidebar" className="hidden w-60 shrink-0 flex-col overflow-hidden border-r border-sidebar-border bg-sidebar/95 px-4 py-5 shadow-[8px_0_32px_rgba(15,23,42,0.04)] lg:flex">
         <div className="space-y-5">
           <div className="flex items-center gap-3">
             <Image src="/brand/naruon-logo.svg" alt="Naruon" width={150} height={40} priority style={{ width: '150px', height: '40px' }} />
@@ -156,86 +156,88 @@ export function DashboardLayout({
           </div>
         </div>
 
-        <div className="px-3 pb-4">
-          <button className="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold rounded-lg py-2.5 px-4 flex items-center justify-center gap-2 transition-colors">
-            <Edit3 className="w-4 h-4" />
-            메일 작성
-          </button>
-        </div>
-
-        <nav aria-label="Mail sections" className="space-y-0.5">
-          {mailNavItems.map((item) => (
-            <NavLink key={item.label} {...item} />
-          ))}
-        </nav>
-
-        <nav aria-label="AI Hub sections" className="mt-6 space-y-0.5">
-          <div className="flex items-center justify-between px-3 mb-1">
-            <p className="text-[11px] font-bold text-muted-foreground">AI 허브</p>
-            <span className="text-[9px] font-bold bg-primary/10 text-primary px-1.5 py-0.5 rounded">BETA</span>
+        <div data-testid="sidebar-scroll-region" className="min-h-0 flex-1 overflow-y-auto pr-1">
+          <div className="px-3 pb-4 pt-6">
+            <button className="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold rounded-lg py-2.5 px-4 flex items-center justify-center gap-2 transition-colors">
+              <Edit3 className="w-4 h-4" />
+              메일 작성
+            </button>
           </div>
-          {aiHubItems.map((item) => (
-            <NavLink key={item.label} {...item} />
-          ))}
-        </nav>
 
-        <nav aria-label="Projects sections" className="mt-6 space-y-0.5">
-          <div className="flex items-center justify-between px-3 mb-1 cursor-pointer hover:bg-secondary/50 rounded-md py-1">
-            <p className="text-[11px] font-bold text-muted-foreground">프로젝트</p>
-            <svg width="10" height="10" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-muted-foreground"><path d="M4 6H11L7.5 10.5L4 6Z" fill="currentColor"></path></svg>
-          </div>
-          {projectItems.map((item) => (
-            <NavLink key={item.label} {...item} />
-          ))}
-        </nav>
+          <nav aria-label="Mail sections" className="space-y-0.5">
+            {mailNavItems.map((item) => (
+              <NavLink key={item.label} {...item} />
+            ))}
+          </nav>
 
-        <nav aria-label="Labels sections" className="mt-6 space-y-0.5">
-          <div className="flex items-center justify-between px-3 mb-1 cursor-pointer hover:bg-secondary/50 rounded-md py-1">
-            <p className="text-[11px] font-bold text-muted-foreground">라벨</p>
-            <svg width="10" height="10" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-muted-foreground"><path d="M7 7V2H8V7H13V8H8V13H7V8H2V7H7Z" fill="currentColor"></path></svg>
-          </div>
-          {labelItems.map((item) => {
-            const active = pathname === item.href;
-            return (
-              <Link
-                key={item.label}
-                href={item.href}
-                className={`group flex min-h-8 items-center gap-3 rounded-lg px-3 py-1 text-sm transition-all focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${
-                  active
-                    ? 'bg-primary/10 font-bold text-primary'
-                    : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-primary'
-                }`}
-              >
-                <div className={`w-2 h-2 rounded-full ${item.color}`} />
-                {item.label}
-              </Link>
-            )
-          })}
-        </nav>
-        
-        <div className="pt-6 px-3 pb-4">
-          <div className="bg-secondary/30 rounded-xl p-3 border border-border">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-[11px] font-bold text-foreground">오늘의 인사이트</p>
-              <TrendingUp className="w-3 h-3 text-muted-foreground" />
+          <nav aria-label="AI Hub sections" className="mt-6 space-y-0.5">
+            <div className="mb-1 flex items-center justify-between px-3">
+              <p className="text-[11px] font-bold text-muted-foreground">AI 허브</p>
+              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[9px] font-bold text-primary">BETA</span>
             </div>
-            <p className="text-xs text-muted-foreground mb-1">업무 집중 시간</p>
-            <p className="text-xs font-bold">오전 10:00 - 12:00</p>
-            <div className="mt-3 h-12 flex items-end gap-1 opacity-60">
-              <div className="bg-primary/40 w-full rounded-t-sm h-[20%]"></div>
-              <div className="bg-primary/40 w-full rounded-t-sm h-[40%]"></div>
-              <div className="bg-primary/80 w-full rounded-t-sm h-[80%]"></div>
-              <div className="bg-primary w-full rounded-t-sm h-[100%]"></div>
-              <div className="bg-primary/60 w-full rounded-t-sm h-[60%]"></div>
+            {aiHubItems.map((item) => (
+              <NavLink key={item.label} {...item} />
+            ))}
+          </nav>
+
+          <nav aria-label="Projects sections" className="mt-6 space-y-0.5">
+            <div className="mb-1 flex cursor-pointer items-center justify-between rounded-md py-1 px-3 hover:bg-secondary/50">
+              <p className="text-[11px] font-bold text-muted-foreground">프로젝트</p>
+              <svg width="10" height="10" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-muted-foreground"><path d="M4 6H11L7.5 10.5L4 6Z" fill="currentColor"></path></svg>
+            </div>
+            {projectItems.map((item) => (
+              <NavLink key={item.label} {...item} />
+            ))}
+          </nav>
+
+          <nav aria-label="Labels sections" className="mt-6 space-y-0.5">
+            <div className="mb-1 flex cursor-pointer items-center justify-between rounded-md py-1 px-3 hover:bg-secondary/50">
+              <p className="text-[11px] font-bold text-muted-foreground">라벨</p>
+              <svg width="10" height="10" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-muted-foreground"><path d="M7 7V2H8V7H13V8H8V13H7V8H2V7H7Z" fill="currentColor"></path></svg>
+            </div>
+            {labelItems.map((item) => {
+              const active = pathname === item.href;
+              return (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className={`group flex min-h-8 items-center gap-3 rounded-lg px-3 py-1 text-sm transition-all focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${
+                    active
+                      ? 'bg-primary/10 font-bold text-primary'
+                      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-primary'
+                  }`}
+                >
+                  <div className={`w-2 h-2 rounded-full ${item.color}`} />
+                  {item.label}
+                </Link>
+              )
+            })}
+          </nav>
+
+          <div className="px-3 pb-4 pt-6">
+            <div className="rounded-xl border border-border bg-secondary/30 p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-[11px] font-bold text-foreground">오늘의 인사이트</p>
+                <TrendingUp className="w-3 h-3 text-muted-foreground" />
+              </div>
+              <p className="mb-1 text-xs text-muted-foreground">업무 집중 시간</p>
+              <p className="text-xs font-bold">오전 10:00 - 12:00</p>
+              <div className="mt-3 flex h-12 items-end gap-1 opacity-60">
+                <div className="h-[20%] w-full rounded-t-sm bg-primary/40"></div>
+                <div className="h-[40%] w-full rounded-t-sm bg-primary/40"></div>
+                <div className="h-[80%] w-full rounded-t-sm bg-primary/80"></div>
+                <div className="h-[100%] w-full rounded-t-sm bg-primary"></div>
+                <div className="h-[60%] w-full rounded-t-sm bg-primary/60"></div>
+              </div>
             </div>
           </div>
-        </div>
 
-        <nav aria-label="AI workspace sections" className="sr-only">
-          {aiNavItems.map(({ label }) => (
-            <a key={label} href="#main-content">{label}</a>
-          ))}
-        </nav>
+          <nav aria-label="AI workspace sections" className="sr-only">
+            {aiNavItems.map(({ label }) => (
+              <a key={label} href="#main-content">{label}</a>
+            ))}
+          </nav>
+        </div>
 
         <div className="mt-auto rounded-2xl border border-border/80 bg-card p-4 shadow-sm">
           <div className="flex items-center gap-2 text-sm font-semibold text-foreground">

--- a/frontend/src/components/NetworkGraph.test.tsx
+++ b/frontend/src/components/NetworkGraph.test.tsx
@@ -3,9 +3,12 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const destroyMock = vi.fn();
+const fitMock = vi.fn();
+
 vi.mock("vis-network", () => ({
   Network: vi.fn(function MockNetwork() {
-    return { destroy: vi.fn() };
+    return { destroy: destroyMock, fit: fitMock };
   }),
 }));
 
@@ -32,6 +35,17 @@ async function flushAsyncWork() {
 describe("NetworkGraph", () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
+  let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+  class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverCallback = callback;
+    }
+  }
 
   afterEach(() => {
     if (root) {
@@ -40,6 +54,7 @@ describe("NetworkGraph", () => {
     root = null;
     container?.remove();
     container = null;
+    resizeObserverCallback = null;
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -105,5 +120,38 @@ describe("NetworkGraph", () => {
     expect(container.textContent).toContain("1개 관계");
     expect(container.textContent).toContain("김지현");
     expect(container.textContent).not.toContain("nodes and");
+  });
+
+  it("refits the graph when the viewport changes", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          nodes: [{ id: "person-1", label: "김지현", title: "PM" }],
+          edges: [{ from: "person-1", to: "person-1", title: "관련 메일" }],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<NetworkGraph />);
+    });
+    await flushAsyncWork();
+
+    expect(Network).toHaveBeenCalledTimes(1);
+    expect(resizeObserverCallback).not.toBeNull();
+    expect(fitMock).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      resizeObserverCallback?.([] as ResizeObserverEntry[], {} as ResizeObserver);
+      await Promise.resolve();
+    });
+
+    expect(fitMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -70,25 +70,42 @@ export default function NetworkGraph() {
 
   useEffect(() => {
     if (containerRef.current && nodes.length > 0) {
-      const network = new Network(containerRef.current, { nodes, edges }, {
+      const container = containerRef.current;
+      const network = new Network(container, { nodes, edges }, {
         nodes: { shape: 'dot', size: 16 },
         edges: { arrows: 'to' }
       });
-      return () => network.destroy();
+
+      const fitGraph = () => {
+        network.fit({ animation: false });
+      };
+
+      const resizeObserver = typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(() => {
+            fitGraph();
+          });
+
+      resizeObserver?.observe(container);
+
+      return () => {
+        resizeObserver?.disconnect();
+        network.destroy();
+      };
     }
   }, [nodes, edges]);
 
   if (loading) {
-    return <div role="status" aria-live="polite" className="flex h-full min-h-[520px] w-full items-center justify-center text-sm text-muted-foreground">관계 그래프를 불러오는 중입니다...</div>;
+    return <div role="status" aria-live="polite" className="flex h-full min-h-[320px] w-full items-center justify-center text-sm text-muted-foreground sm:min-h-[420px]">관계 그래프를 불러오는 중입니다...</div>;
   }
 
   if (error) {
-    return <div role="alert" className="flex h-full min-h-[520px] w-full items-center justify-center p-6 text-center text-sm text-red-500">관계 그래프를 불러오지 못했습니다.</div>;
+    return <div role="alert" className="flex h-full min-h-[320px] w-full items-center justify-center p-6 text-center text-sm text-red-500 sm:min-h-[420px]">관계 그래프를 불러오지 못했습니다.</div>;
   }
 
   if (nodes.length === 0) {
     return (
-      <div className="flex h-full min-h-[520px] w-full items-center justify-center p-6 text-center">
+      <div className="flex h-full min-h-[320px] w-full items-center justify-center p-6 text-center sm:min-h-[420px]">
         <div className="max-w-xs rounded-2xl border border-primary/15 bg-primary/5 p-5">
           <div className="mx-auto mb-3 grid size-12 place-items-center rounded-2xl bg-primary/10 text-2xl" aria-hidden="true">✦</div>
           <h4 className="font-bold text-foreground">관계 데이터가 없습니다</h4>
@@ -104,7 +121,7 @@ export default function NetworkGraph() {
     .slice(0, 5);
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col">
+    <div className="flex h-full min-h-[320px] flex-col sm:min-h-[420px]">
       <div className="border-b border-border bg-card/80 p-4">
         <h4 className="text-sm font-black text-foreground">관계 이해</h4>
         <p className="mt-1 text-xs text-muted-foreground">
@@ -120,7 +137,7 @@ export default function NetworkGraph() {
       <div
         ref={containerRef}
         aria-label={`${nodes.length}개 노드와 ${edges.length}개 관계가 있는 네트워크 그래프`}
-        className="min-h-0 flex-1 bg-[radial-gradient(circle_at_center,rgb(37_99_255_/_0.08),transparent_32rem)]"
+        className="min-h-0 flex-1 w-full bg-[radial-gradient(circle_at_center,rgb(37_99_255_/_0.08),transparent_32rem)]"
       />
     </div>
   );


### PR DESCRIPTION
## 목표
Issue #188, #189를 함께 처리합니다. 실제 SaaS 운영에 필요한 다층 RBAC 준비 기반을 도입하고, MacBook M1/브라우저 축소 환경에서의 워크스페이스 접근성 문제(사이드바 스크롤, 오늘의 인사이트 접근, DAG 축소 미대응)를 함께 정리합니다.

## 구현 사항
1. **AuthContext / scoped role foundation**
   - `platform_admin`, `organization_admin`, `group_admin`, `member` 역할축을 가진 `AuthContext`를 도입했습니다.
   - 현재는 header fallback 기반이지만, Keycloak/Casdoor OIDC claims로 자연스럽게 이어질 수 있도록 구조를 정리했습니다.
   - `X-Workspace-Id`를 신뢰하지 않고, `organization_id` 중심으로 workspace를 유도하도록 수정해 cross-tenant 우회를 제거했습니다.
2. **Organization-scoped resource authorization 정렬**
   - `runner_config`와 `llm_providers`가 동일한 scoped auth 규칙(`platform_admin` 또는 `organization_admin`)을 사용하도록 일치시켰습니다.
   - `WorkspaceRunnerConfig`를 `organization_id` 기준으로 보유하도록 확장해 조직 스코프를 실제 데이터 모델에 반영했습니다.
   - 개인 메일박스 설정은 기존처럼 사용자 소유(personal scope)로 유지했습니다.
3. **Responsive workspace shell**
   - 좌측 사이드바에 독립 스크롤 영역을 추가해 `오늘의 인사이트`가 축소 환경에서도 도달 가능하도록 만들었습니다.
   - 관계 DAG 그래프가 viewport resize에 따라 `fit()` 되도록 보강했습니다.

## 검증
- backend: `106 passed, 2 skipped`
- frontend: `21 tests passed`
- frontend: `build / lint passed`
- direct browser UAT:
  - sidebar scroll region: `clientHeight 396 / scrollHeight 1091 / overflowY auto`
  - graph width: `217px -> 172px` (1280 -> 1100 resize 시 축소 확인)

## 관련 이슈
Resolves: #188
Resolves: #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dashboard sidebar layout with independent scroll region and updated sidebar actions
  * Network graphs now refit automatically on viewport/resize for better responsiveness

* **Bug Fixes**
  * Tighter authorization checks for provider, runner, and tenant mailbox operations to enforce organization/user scope

* **Documentation**
  * Updated architecture and README notes clarifying dev header auth and scoped auth context

* **Tests**
  * Expanded tests covering auth scopes, provider APIs, runner/tenant config, and sidebar/graph behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/191)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->