### PR TITLE
GitHub Actions Node 20 경고 제거 (Node 24 전환, clean replay)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,9 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  # Keep the explicit opt-in as belt-and-suspenders. The real warning removal
+  # comes from the Node24-native action SHAs below because the runner may still
+  # emit a deprecation annotation before the override takes effect.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   pull_request_image_validation:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   pull_request_image_validation:
@@ -42,14 +41,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build PR image without publishing
         id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -98,13 +97,13 @@ jobs:
           printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,7 +111,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
@@ -121,7 +120,7 @@ jobs:
 
       - name: Build and publish Docker image
         id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
 # Install system dependencies if any are needed for pgvector/psycopg2

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -132,6 +132,15 @@ def test_frontend_dockerfile_builds_and_starts_production_artifact() -> None:
     assert "npm run dev" not in dockerfile
 
 
+def test_backend_dockerfile_uses_modern_env_syntax() -> None:
+    dockerfile = read_repo_text("Dockerfile")
+
+    assert "ENV PYTHONDONTWRITEBYTECODE=1" in dockerfile
+    assert "ENV PYTHONUNBUFFERED=1" in dockerfile
+    assert "ENV PYTHONDONTWRITEBYTECODE 1" not in dockerfile
+    assert "ENV PYTHONUNBUFFERED 1" not in dockerfile
+
+
 def test_compose_log_scanner_exists_for_warning_policy() -> None:
     scanner = read_repo_text("scripts/check_compose_logs.py")
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -104,7 +104,7 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
 
     assert "pull_request:" in workflow
     assert "push:" in workflow
-    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
     assert "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0" in workflow
     assert "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0" in workflow
     assert "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0" in workflow

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -104,7 +104,12 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
 
     assert "pull_request:" in workflow
     assert "push:" in workflow
-    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" not in workflow
+    assert "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0" in workflow
+    assert "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0" in workflow
+    assert "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0" in workflow
+    assert "docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0" in workflow
+    assert "docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0" in workflow
     push_block = workflow.split("push:", 1)[1].split("pull_request:", 1)[0]
     assert "tags:" in push_block
     assert "branches:" not in push_block

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -104,6 +104,7 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
 
     assert "pull_request:" in workflow
     assert "push:" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow
     push_block = workflow.split("push:", 1)[1].split("pull_request:", 1)[0]
     assert "tags:" in push_block
     assert "branches:" not in push_block

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -105,11 +105,11 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
     assert "pull_request:" in workflow
     assert "push:" in workflow
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow
-    assert "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0" in workflow
-    assert "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0" in workflow
+    assert workflow.count("docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0") == 2
+    assert workflow.count("docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0") == 2
     assert "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0" in workflow
     assert "docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0" in workflow
-    assert "docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0" in workflow
+    assert workflow.count("docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0") == 2
     push_block = workflow.split("push:", 1)[1].split("pull_request:", 1)[0]
     assert "tags:" in push_block
     assert "branches:" not in push_block

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -104,7 +104,7 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
 
     assert "pull_request:" in workflow
     assert "push:" in workflow
-    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in workflow
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow
     assert "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0" in workflow
     assert "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0" in workflow
     assert "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0" in workflow

--- a/docs/plans/2026-05-13-node24-actions-remediation.md
+++ b/docs/plans/2026-05-13-node24-actions-remediation.md
@@ -1,7 +1,5 @@
 # Node24 Actions Remediation Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Remove GitHub Actions Node 20 deprecation warnings from the Docker publish pipeline by explicitly opting the affected JavaScript actions into Node 24.
 
 **Architecture:** Add the documented `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable at workflow scope for the Docker-image workflow so every JavaScript action in that pipeline runs on Node 24. Lock the expectation with a release-governance regression test so the warning cannot silently return.
@@ -17,7 +15,7 @@
 - Test: `backend/tests/test_release_governance.py`
 
 **Step 1: Write the failing test**
-Add an assertion that `.github/workflows/docker-publish.yml` contains `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.
+Add an assertion that `.github/workflows/docker-publish.yml` contains `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`.
 
 **Step 2: Run test to verify it fails**
 Run: `cd backend && python3 -m pytest tests/test_release_governance.py -q`

--- a/docs/plans/2026-05-13-node24-actions-remediation.md
+++ b/docs/plans/2026-05-13-node24-actions-remediation.md
@@ -1,0 +1,64 @@
+# Node24 Actions Remediation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove GitHub Actions Node 20 deprecation warnings from the Docker publish pipeline by explicitly opting the affected JavaScript actions into Node 24.
+
+**Architecture:** Add the documented `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable at workflow scope for the Docker-image workflow so every JavaScript action in that pipeline runs on Node 24. Lock the expectation with a release-governance regression test so the warning cannot silently return.
+
+**Tech Stack:** GitHub Actions YAML, pytest-based repository governance tests.
+
+---
+
+## Task 1: Add failing governance test
+
+**Files:**
+- Modify: `backend/tests/test_release_governance.py`
+- Test: `backend/tests/test_release_governance.py`
+
+**Step 1: Write the failing test**
+Add an assertion that `.github/workflows/docker-publish.yml` contains `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.
+
+**Step 2: Run test to verify it fails**
+Run: `cd backend && python3 -m pytest tests/test_release_governance.py -q`
+Expected: FAIL because the workflow does not contain the new env var yet.
+
+**Step 3: Commit after green later**
+Deferred until workflow fix is applied.
+
+## Task 2: Implement workflow Node24 opt-in
+
+**Files:**
+- Modify: `.github/workflows/docker-publish.yml`
+
+**Step 1: Add minimal implementation**
+At workflow `env:` scope, add:
+```yaml
+FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+```
+so the Docker JavaScript actions run on Node 24 and stop emitting the GitHub deprecation warning.
+
+**Step 2: Run test to verify it passes**
+Run: `cd backend && python3 -m pytest tests/test_release_governance.py -q`
+Expected: PASS.
+
+**Step 3: Run workflow hygiene verification**
+Run: `git diff --check`
+Expected: PASS.
+
+**Step 4: Commit**
+`git add .github/workflows/docker-publish.yml backend/tests/test_release_governance.py && git commit -m "fix(ci): opt docker publish actions into Node 24"`
+
+## Task 3: Review, merge, release sync
+
+**Files:**
+- Modify as needed based on review feedback
+
+**Step 1: Open PR referencing #193**
+Create a PR that resolves #193.
+
+**Step 2: Request CodeRabbit approval**
+Use the CodeRabbit approval flow on the current head.
+
+**Step 3: Merge and release sync**
+If merged cleanly, create the next version/tag sync PR and publish the matching release tag so GHCR reflects the warning-free workflow state.


### PR DESCRIPTION
## 목표
Issue #193을 해결합니다. Docker publish 파이프라인의 JavaScript 기반 GitHub Actions가 Node 20 deprecation warning을 내지 않도록 실제 Node24-native action revisions로 전환합니다.

## 구현 사항
1. `.github/workflows/docker-publish.yml`의 Docker 관련 action pin을 Node24-native release SHA로 교체했습니다.
2. 명시적 opt-in 계약 유지 차원에서 workflow env에 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`를 함께 유지했습니다.
3. `backend/tests/test_release_governance.py`에 Node24-native SHA와 explicit opt-in 값을 고정하는 회귀 테스트를 추가했습니다.
4. `docs/plans/2026-05-13-node24-actions-remediation.md`에 stepwise 구현 계획을 기록했습니다.

## 검증
- `cd backend && python3 -m pytest tests/test_release_governance.py -q` => 9 passed
- `git diff --check` => clean

## 관련 이슈
Resolves: #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: Opted JavaScript actions into Node 24 at workflow scope and upgraded pinned Docker-related GitHub Actions used in the publish pipeline.
  * Docker image build: Modernized ENV assignment syntax for environment variables.

* **Tests**
  * Added and extended tests to ensure the CI workflow includes the Node 24 opt-in and updated action pins, and to enforce modern ENV syntax in Dockerfiles.

* **Documentation**
  * Added an implementation plan describing the Node 24 remediation and release steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/195)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->