### PR TITLE
Strix PR 스코프에서 Next.js 동적 라우트 경로 허용

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -506,7 +506,7 @@ target_path = Path(raw_target)
 if not target_path.is_absolute():
     target_path = repo_root / target_path
 
-resolved = target_path.resolve(strict=False)
+resolved = target_path.resolve(strict=True)
 print(resolved)
 PY
 	})" || {
@@ -538,7 +538,7 @@ import sys
 
 raw_target = sys.argv[1]
 target_path = Path(raw_target)
-resolved = target_path.resolve(strict=False)
+resolved = target_path.resolve(strict=True)
 print(resolved)
 PY
 	})" || {

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -177,7 +177,7 @@ if "\\" in relative_path_str:
 normalized = posixpath.normpath(relative_path_str)
 if normalized in (".", "") or normalized.startswith("../") or normalized == "..":
     raise SystemExit(1)
-if not re.fullmatch(r"[A-Za-z0-9_./ -]+", normalized):
+if not re.fullmatch(r"[A-Za-z0-9_./ \[\]-]+", normalized):
     raise SystemExit(1)
 relative_path = Path(normalized)
 if relative_path.is_absolute():

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -82,6 +82,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 assert_strix_gate_target_scope_separated() {
 	assert_file_not_contains "$GATE_SCRIPT" "or generated PR scope directories" "strix gate keeps user target validation separate from internal PR scopes"
 	assert_file_contains "$GATE_SCRIPT" "TARGET_PATH_IS_INTERNAL_PR_SCOPE" "strix gate marks internally generated PR scan scopes explicitly"
+	assert_file_not_contains "$GATE_SCRIPT" "resolved = target_path.resolve(strict=False)" "strix gate must resolve scan targets strictly"
 }
 
 assert_internal_pr_scope_targets() {

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -2748,6 +2748,12 @@ run_pull_request_target_head_scope_case \
 	"BASE_CONTENT_WITH_SPACE_SHOULD_NOT_BE_SCANNED" \
 	"HEAD_CONTENT_WITH_SPACE_SHOULD_BE_SCANNED"
 
+run_pull_request_target_head_scope_case \
+	"pull-request-target-nextjs-bracket-route-uses-head-blob" \
+	"frontend/src/app/labels/[slug]/page.tsx" \
+	"BASE_BRACKET_ROUTE_CONTENT_SHOULD_NOT_BE_SCANNED" \
+	"HEAD_BRACKET_ROUTE_CONTENT_SHOULD_BE_SCANNED"
+
 run_pull_request_target_rejects_unsafe_changed_path_case \
 	"pull-request-target-parent-directory-changed-path-fails-closed" \
 	"../outside.py"


### PR DESCRIPTION
No linked issue.

## 목적
`pull_request_target` 기반 Strix 스코프 검증이 `frontend/src/app/labels/[slug]/page.tsx` 같은 Next.js 동적 라우트 경로를 잘못 거부해 필수 Strix 스캔이 시작 전 실패하는 문제를 수정합니다.

## 주요 변경
- 변경 파일 경로 정규화 regex에서 리터럴 `[` / `]`를 허용합니다.
- `:` pathspec magic, `*`, traversal, absolute path, backslash, 앞뒤 공백은 계속 차단합니다.
- symlink/non-regular file 차단과 PR-head blob read 실패 시 fail-closed 동작은 기존 검사로 유지합니다.
- `pull-request-target-nextjs-bracket-route-uses-head-blob` 회귀 케이스를 추가했습니다.

## 검증
- `bash scripts/ci/test_strix_quick_gate.sh`: PASS
- `git diff --check`: PASS
- `python3 "$HOME/.config/opencode/scripts/lint_by_filetype.py" --json`: ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI path validation now accepts parameterized paths that include square brackets (e.g., framework-style dynamic routes).
  * Target-path resolution in the CI gate is stricter: unresolved paths now cause validation to fail rather than be lenient.

* **Tests**
  * Added coverage for dynamic/parameterized route files to ensure correct scanning during pull-request validation.
  * Strengthened self-tests to assert strict path resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/200)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->