### PR TITLE
Strix trusted-base PR 컨텍스트 범위 보강

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -47,6 +47,7 @@ INFRA_ERROR_DETECTED=0
 ZERO_FINDINGS_REPORTED=0
 PR_FINDINGS_DECISION="not_applicable"
 CHANGED_FILES=()
+NORMALIZED_CHANGED_FILES=()
 PULL_REQUEST_SCOPE_DIRS=()
 PULL_REQUEST_SCOPE_FILE_BATCHES=()
 CURRENT_PULL_REQUEST_BATCH_FILE_COUNT=0
@@ -188,6 +189,18 @@ candidate = (repo_root / relative_path).resolve(strict=False)
 candidate.relative_to(repo_root)
 print(relative_path.as_posix())
 PY
+}
+
+normalize_changed_files_cache() {
+	NORMALIZED_CHANGED_FILES=()
+	local changed_file normalized_changed_file
+	for changed_file in "${CHANGED_FILES[@]}"; do
+		normalized_changed_file="$(normalize_changed_file_path "$changed_file")" || {
+			echo "ERROR: pull request changed file path is unsafe: $changed_file" >&2
+			return 2
+		}
+		NORMALIZED_CHANGED_FILES+=("$normalized_changed_file")
+	done
 }
 
 pull_request_head_blob_required() {
@@ -587,6 +600,7 @@ load_pull_request_changed_files() {
 				CHANGED_FILES+=("$changed_file")
 			fi
 		done <<<"$STRIX_TEST_CHANGED_FILES_OVERRIDE"
+		normalize_changed_files_cache || return 2
 		return 0
 	fi
 
@@ -654,6 +668,7 @@ PY
 			CHANGED_FILES+=("$changed_file")
 		fi
 	done <<<"$changed_files_output"
+	normalize_changed_files_cache || return 2
 
 	return 0
 }
@@ -938,10 +953,9 @@ EOF
 }
 
 changed_file_list_contains() {
-	local candidate normalized_candidate changed_file normalized_changed_file
+	local candidate normalized_candidate normalized_changed_file
 	normalized_candidate="$(normalize_changed_file_path "$1")" || return 2
-	for changed_file in "${CHANGED_FILES[@]}"; do
-		normalized_changed_file="$(normalize_changed_file_path "$changed_file")" || return 2
+	for normalized_changed_file in "${NORMALIZED_CHANGED_FILES[@]}"; do
 		if [ "$normalized_changed_file" = "$normalized_candidate" ]; then
 			return 0
 		fi

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -919,6 +919,7 @@ backend/requirements.txt
 backend/api/__init__.py
 backend/api/auth.py
 backend/api/mailbox_scope.py
+backend/api/runner_config.py
 backend/core/__init__.py
 backend/core/config.py
 backend/core/exceptions.py

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -177,7 +177,7 @@ if "\\" in relative_path_str:
 normalized = posixpath.normpath(relative_path_str)
 if normalized in (".", "") or normalized.startswith("../") or normalized == "..":
     raise SystemExit(1)
-if not re.fullmatch(r"[A-Za-z0-9_./ -]+", normalized):
+if not re.fullmatch(r"[A-Za-z0-9_./ \[\]-]+", normalized):
     raise SystemExit(1)
 relative_path = Path(normalized)
 if relative_path.is_absolute():

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -918,6 +918,7 @@ pull_request_scope_context_files() {
 backend/requirements.txt
 backend/api/__init__.py
 backend/api/auth.py
+backend/api/mailbox_scope.py
 backend/core/__init__.py
 backend/core/config.py
 backend/core/exceptions.py
@@ -933,6 +934,18 @@ backend/services/exceptions.py
 backend/services/threading_service.py
 EOF
 	fi
+}
+
+changed_file_list_contains() {
+	local candidate normalized_candidate changed_file normalized_changed_file
+	normalized_candidate="$(normalize_changed_file_path "$1")" || return 2
+	for changed_file in "${CHANGED_FILES[@]}"; do
+		normalized_changed_file="$(normalize_changed_file_path "$changed_file")" || return 2
+		if [ "$normalized_changed_file" = "$normalized_candidate" ]; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 build_pull_request_scope_dir() {
@@ -1005,6 +1018,30 @@ PY
 		if [ -e "$dst_path" ]; then
 			return 0
 		fi
+		local changed_context_rc=0
+		changed_file_list_contains "$relative_path" || changed_context_rc=$?
+		case "$changed_context_rc" in
+		0)
+			mkdir -p -- "$(dirname -- "$dst_path")"
+			local copy_rc=1
+			local head_sha_for_copy
+			head_sha_for_copy="$(trim_whitespace "${PR_HEAD_SHA:-}")"
+			if pull_request_head_blob_required || { [ -n "$head_sha_for_copy" ] && git cat-file -e "$head_sha_for_copy^{commit}" 2>/dev/null; }; then
+				copy_rc=0
+				copy_pr_head_blob_to_file "$relative_path" "$dst_path" || copy_rc=$?
+			fi
+			if [ "$copy_rc" -eq 0 ]; then
+				return 0
+			fi
+			if pull_request_head_blob_required || [ "$copy_rc" -eq 2 ]; then
+				echo "ERROR: pull request changed context file could not be read from PR head; failing closed: $context_file" >&2
+				return 2
+			fi
+			;;
+		2)
+			return 2
+			;;
+		esac
 		local src_path="$REPO_ROOT/$relative_path"
 		if [ ! -e "$src_path" ]; then
 			return 0

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1294,10 +1294,10 @@ import sys
 
 text = Path(sys.argv[1]).read_text(encoding='utf-8', errors='replace')
 patterns = [
-    re.compile(r'(?P<path>/workspace/[^\s`]+|[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+):\d+'),
-    re.compile(r'^[^\S\r\n│]*[│]?[ \t]*(?:\*\*)?Target:(?:\*\*)?[ \t]*(?:File:[ \t]*)?(?P<path>/workspace/[^\s`│]+|[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)', re.MULTILINE),
-    re.compile(r'^[^\S\r\n│]*[│]?[ \t]*(?:\*\*)?Endpoint:(?:\*\*)?[ \t]*(?P<path>/workspace/[^\s`│]+|[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)', re.MULTILINE),
-    re.compile(r'(?i)(?:in\s+)?file\s+`(?P<path>(?:\.\.?/)?[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)`'),
+    re.compile(r'(?P<path>/workspace/[^\s`]+|[A-Za-z0-9_./\[\]-]+\.[A-Za-z0-9_]+):\d+'),
+    re.compile(r'^[^\S\r\n│]*[│]?[ \t]*(?:\*\*)?Target:(?:\*\*)?[ \t]*(?:File:[ \t]*)?(?P<path>/workspace/[^\s`│]+|[A-Za-z0-9_./\[\]-]+\.[A-Za-z0-9_]+)', re.MULTILINE),
+    re.compile(r'^[^\S\r\n│]*[│]?[ \t]*(?:\*\*)?Endpoint:(?:\*\*)?[ \t]*(?P<path>/workspace/[^\s`│]+|[A-Za-z0-9_./\[\]-]+\.[A-Za-z0-9_]+)', re.MULTILINE),
+    re.compile(r'(?i)(?:in\s+)?file\s+`(?P<path>(?:\.\.?/)?[A-Za-z0-9_./\[\]-]+\.[A-Za-z0-9_]+)`'),
 ]
 seen = set()
 for pattern in patterns:

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -84,6 +84,12 @@ assert_strix_gate_target_scope_separated() {
 	assert_file_contains "$GATE_SCRIPT" "TARGET_PATH_IS_INTERNAL_PR_SCOPE" "strix gate marks internally generated PR scan scopes explicitly"
 }
 
+assert_changed_file_membership_uses_cached_normalized_paths() {
+	assert_file_contains "$GATE_SCRIPT" "NORMALIZED_CHANGED_FILES=()" "strix gate caches normalized PR changed paths"
+	assert_file_contains "$GATE_SCRIPT" 'NORMALIZED_CHANGED_FILES+=("$normalized_changed_file")' "strix gate populates cached normalized PR changed paths"
+	assert_file_contains "$GATE_SCRIPT" "for normalized_changed_file in \"\${NORMALIZED_CHANGED_FILES[@]}\"" "strix gate uses cached normalized paths for membership checks"
+}
+
 assert_internal_pr_scope_targets() {
 	local target_log_file="$1"
 	local repo_root_dir="$2"
@@ -2033,10 +2039,19 @@ if [ -f "$target_path/backend/api/emails.py" ]; then
 		echo "Error: changed backend dependency context missing from PR scope ($target_path)" >&2
 		exit 68
 	fi
+	if [ ! -f "$target_path/backend/api/runner_config.py" ]; then
+		echo "Error: runner config backend dependency context missing from PR scope ($target_path)" >&2
+		exit 70
+	fi
 	if ! grep -Fq -- 'HEAD_MAILBOX_SCOPE_SHOULD_BE_SCANNED' "$target_path/backend/api/mailbox_scope.py"; then
 		echo "Error: changed backend dependency context did not use PR-head content" >&2
 		cat -- "$target_path/backend/api/mailbox_scope.py" >&2
 		exit 69
+	fi
+	if ! grep -Fq -- 'HEAD_RUNNER_CONFIG_SHOULD_BE_SCANNED' "$target_path/backend/api/runner_config.py"; then
+		echo "Error: runner config backend dependency context did not use PR-head content" >&2
+		cat -- "$target_path/backend/api/runner_config.py" >&2
+		exit 71
 	fi
 	echo "scan ok with PR-head backend dependency context"
 	exit 0
@@ -2090,6 +2105,10 @@ EOF
 def require_owned_mailbox_account():
 	return 'HEAD_MAILBOX_SCOPE_SHOULD_BE_SCANNED'
 EOF
+		cat >backend/api/runner_config.py <<'EOF'
+def require_workspace_admin():
+	return 'HEAD_RUNNER_CONFIG_SHOULD_BE_SCANNED'
+EOF
 		git add .
 		git commit -qm 'head commit'
 	)
@@ -2119,7 +2138,7 @@ EOF
 
 	assert_equals "0" "$rc" "case=pull-request-target-changed-backend-context-uses-head-blob exit code"
 	assert_file_contains "$output_log" "scan ok with PR-head backend dependency context" "case=pull-request-target-changed-backend-context-uses-head-blob output"
-	assert_equals "2" "$(wc -l <"$call_log" | tr -d ' ')" "case=pull-request-target-changed-backend-context-uses-head-blob strix call count"
+	assert_equals "3" "$(wc -l <"$call_log" | tr -d ' ')" "case=pull-request-target-changed-backend-context-uses-head-blob strix call count"
 
 	rm -rf "$tmp_dir"
 }
@@ -2862,6 +2881,8 @@ EOF
 assert_strix_workflow_pr_trigger_hardened
 
 assert_strix_gate_target_scope_separated
+
+assert_changed_file_membership_uses_cached_normalized_paths
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1991,6 +1991,133 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+run_pull_request_target_changed_backend_context_scope_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local fake_strix="$bin_dir/strix"
+	local output_log="$tmp_dir/output.log"
+	local call_log="$tmp_dir/calls.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'called\n' >> "${FAKE_STRIX_CALL_LOG:?}"
+
+target_path=""
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-t" ] && [ "$#" -ge 2 ]; then
+		target_path="$2"
+		break
+	fi
+	shift
+done
+
+if [ -f "$target_path/backend/api/emails.py" ]; then
+	if [ ! -f "$target_path/backend/api/mailbox_scope.py" ]; then
+		echo "Error: changed backend dependency context missing from PR scope ($target_path)" >&2
+		exit 68
+	fi
+	if ! grep -Fq -- 'HEAD_MAILBOX_SCOPE_SHOULD_BE_SCANNED' "$target_path/backend/api/mailbox_scope.py"; then
+		echo "Error: changed backend dependency context did not use PR-head content" >&2
+		cat -- "$target_path/backend/api/mailbox_scope.py" >&2
+		exit 69
+	fi
+	echo "scan ok with PR-head backend dependency context"
+	exit 0
+fi
+
+echo "scan ok with non-email backend batch"
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		echo 'seed' >README.md
+		mkdir -p backend/api
+		printf '%s\n' 'BASE_AUTH_CONTENT_SHOULD_NOT_BE_SCANNED' >backend/api/auth.py
+		printf '%s\n' 'BASE_EMAILS_CONTENT_SHOULD_NOT_BE_SCANNED' >backend/api/emails.py
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		cat >backend/api/auth.py <<'EOF'
+HEAD_AUTH_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/calendar.py <<'EOF'
+HEAD_CALENDAR_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/emails.py <<'EOF'
+from api.mailbox_scope import require_owned_mailbox_account
+HEAD_EMAILS_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/execution_items.py <<'EOF'
+HEAD_EXECUTION_ITEMS_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/llm.py <<'EOF'
+HEAD_LLM_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/llm_providers.py <<'EOF'
+HEAD_LLM_PROVIDERS_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/mailbox_accounts.py <<'EOF'
+HEAD_MAILBOX_ACCOUNTS_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/api/mailbox_scope.py <<'EOF'
+def require_owned_mailbox_account():
+	return 'HEAD_MAILBOX_SCOPE_SHOULD_BE_SCANNED'
+EOF
+		git add .
+		git commit -qm 'head commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+			PATH="$bin_dir:$PATH" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			STRIX_PR_SCOPE_MAX_FILES_PER_BATCH="4" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			FAKE_STRIX_CALL_LOG="$call_log" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=pull-request-target-changed-backend-context-uses-head-blob exit code"
+	assert_file_contains "$output_log" "scan ok with PR-head backend dependency context" "case=pull-request-target-changed-backend-context-uses-head-blob output"
+	assert_equals "2" "$(wc -l <"$call_log" | tr -d ' ')" "case=pull-request-target-changed-backend-context-uses-head-blob strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
 run_pull_request_target_aborts_on_pr_head_blob_failure_case() {
 	local case_name="$1"
 	local changed_file="$2"
@@ -2778,6 +2905,8 @@ run_pull_request_target_head_scope_case \
 	"1"
 
 run_pull_request_target_trusted_context_scope_case
+
+run_pull_request_target_changed_backend_context_scope_case
 
 run_pull_request_target_aborts_on_pr_head_blob_failure_case \
 	"pull-request-target-added-file-pr-head-blob-read-failure" \

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -2748,6 +2748,12 @@ run_pull_request_target_head_scope_case \
 	"BASE_CONTENT_WITH_SPACE_SHOULD_NOT_BE_SCANNED" \
 	"HEAD_CONTENT_WITH_SPACE_SHOULD_BE_SCANNED"
 
+run_pull_request_target_head_scope_case \
+	"pull-request-target-nextjs-bracket-route-uses-head-blob" \
+	"frontend/src/app/labels/[slug]/page.tsx" \
+	"BASE_BRACKET_ROUTE_CONTENT_SHOULD_NOT_BE_SCANNED" \
+	"HEAD_BRACKET_ROUTE_CONTENT_SHOULD_BE_SCANNED"
+
 run_pull_request_target_rejects_unsafe_changed_path_case \
 	"pull-request-target-parent-directory-changed-path-fails-closed" \
 	"../outside.py"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1387,6 +1387,10 @@ EOS
 			echo "Error: backend service exceptions context missing from scoped target ($target_path)" >&2
 			exit 60
 		fi
+		if ! grep -Fq -- 'ensure_organization_access(auth_context, config.organization_id)' "$target_path/backend/api/runner_config.py"; then
+			echo "Error: backend organization access context missing from scoped target ($target_path)" >&2
+			exit 61
+		fi
 		echo "scan ok with python dependency scope"
 		exit 0
 		;;
@@ -1574,6 +1578,8 @@ EOF
 		touch "$repo_root_dir/backend/db/__init__.py"
 		touch "$repo_root_dir/backend/services/__init__.py"
 		echo 'from db.session import get_db' >"$repo_root_dir/backend/api/emails.py"
+		echo 'from api.auth import ensure_organization_access' >"$repo_root_dir/backend/api/runner_config.py"
+		echo 'ensure_organization_access(auth_context, config.organization_id)' >>"$repo_root_dir/backend/api/runner_config.py"
 		echo 'TRUSTED_CONFIG = True' >"$repo_root_dir/backend/core/config.py"
 		echo 'class LocalError(Exception): pass' >"$repo_root_dir/backend/core/exceptions.py"
 		echo 'engine = object()' >"$repo_root_dir/backend/db/session.py"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1134,6 +1134,16 @@ EOS
 		echo "Penetration test failed: changed critical finding"
 		exit 1
 		;;
+	pr-critical-changed-bracketed-next-route)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-pr-changed-bracketed-next-route/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-pr-changed-bracketed-next-route/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: CRITICAL
+Location 1:
+frontend/src/app/labels/[slug]/page.tsx:12
+EOS
+		echo "Penetration test failed: changed bracketed Next.js route finding"
+		exit 1
+		;;
 	pr-critical-unmapped)
 		mkdir -p "$STRIX_REPORTS_DIR/fake-pr-unmapped/vulnerabilities"
 		cat >"$STRIX_REPORTS_DIR/fake-pr-unmapped/vulnerabilities/vuln-0001.md" <<'EOS'
@@ -1541,6 +1551,8 @@ EOF
 		echo 'class BaselineUserService {}' >"$repo_root_dir/sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/service/impl/SysUserServiceImpl.java"
 		echo 'class ChangedPlaywright {}' >"$repo_root_dir/sync-module-system/smart-crawling-playwright/src/main/java/org/empasy/sync/mcp/service/PlayWrightService.java"
 		echo 'class ChangedJwtUtil {}' >"$repo_root_dir/sync-module-system/smart-crawling-common/src/main/java/org/empasy/sync/common/system/util/JwtUtil.java"
+		mkdir -p "$repo_root_dir/frontend/src/app/labels/[slug]"
+		echo 'export default function Page() { return null }' >"$repo_root_dir/frontend/src/app/labels/[slug]/page.tsx"
 		if [ -n "$current_pr_number" ]; then
 			cat >"$event_payload_file" <<EOF
 {
@@ -4267,6 +4279,27 @@ run_gate_case "pr-critical-changed" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
+
+run_gate_case "pr-critical-changed-bracketed-next-route" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"1" \
+	"Strix finding intersects files changed in this pull request." \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://example.invalid" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"0" \
+	"CRITICAL" \
+	"0" \
+	"" \
+	"" \
+	"1200" \
+	"0" \
+	"pull_request" \
+	"frontend/src/app/labels/[slug]/page.tsx"
 
 run_gate_case "pr-critical-changed-absolute-target" \
 	"openai/gpt-4o-mini" \


### PR DESCRIPTION
No linked issue.

## 목적
- `pull_request_target` 기반 Strix quick gate의 trusted-base 스코프가 PR head에서 변경된 백엔드 컨텍스트 파일을 누락하지 않도록 보강합니다.
- `mailbox_scope` / `runner_config` 컨텍스트와 Next.js bracket route 경로를 Strix 분석 범위에 안전하게 포함합니다.

## 주요 변경 사항
- PR head changed backend context 파일을 trusted-base Strix scope에 포함
- `backend/api/mailbox_scope.py`, `backend/api/runner_config.py`를 백엔드 컨텍스트 목록에 추가
- Next.js bracket route 경로(`[...]`)를 changed path validation에서 허용
- 위 동작을 고정하는 Strix quick gate 테스트 케이스 추가

## 변경 범위 / 영향도
- 영향 범위: Strix CI quick gate의 PR 컨텍스트 수집/경로 검증 로직
- 런타임 영향: 애플리케이션 런타임 코드 변경 없음
- 보안 영향: `pull_request_target`에서 base checkout만 보는 누락을 줄이되, PR head blob 읽기 실패 시 fail-closed 동작을 유지

## 검증
- `bash scripts/ci/test_strix_quick_gate.sh` → PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cache and normalize PR changed-file paths with stricter path-safety validation for more reliable membership checks.
  * Prefer PR-head content when applying trusted backend context files if those files changed in the PR; otherwise fall back to prior behavior.
  * CI now fails closed on unreadable context files and improves changed-file membership handling.

* **Tests**
  * Added assertions and scenarios validating cached membership, PR-head scoping, batching behavior, and invocation counts; includes dynamic frontend-route and backend-context scoping cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->