### PR TITLE
fix: Strix calendar validation context 포함

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1640,6 +1640,24 @@ fallback_models_config_name_for_model() {
 	printf '%s\n' "STRIX_FALLBACK_MODELS"
 }
 
+llm_api_base_has_public_url_components_only() {
+	local url="$1"
+	local authority
+	case "$url" in
+	*\?* | *#*)
+		return 1
+		;;
+	esac
+	authority="${url#https://}"
+	authority="${authority%%/*}"
+	case "$authority" in
+	*@*)
+		return 1
+		;;
+	esac
+	return 0
+}
+
 resolved_llm_api_base_for_model() {
 	local model="$1"
 
@@ -1657,8 +1675,6 @@ resolved_llm_api_base_for_model() {
 
 	local llm_api_base_value
 	llm_api_base_value="$(cat -- "$LLM_API_BASE_FILE")"
-	llm_api_base_value="${llm_api_base_value%%/generateContent*}"
-	llm_api_base_value="${llm_api_base_value%%:generateContent*}"
 	llm_api_base_value="$(trim_whitespace "$llm_api_base_value")"
 	if [ -z "$llm_api_base_value" ]; then
 		return 0
@@ -1671,6 +1687,12 @@ resolved_llm_api_base_for_model() {
 		echo "ERROR: LLM_API_BASE must be an https URL when configured." >&2
 		return 2
 	fi
+	if ! llm_api_base_has_public_url_components_only "$llm_api_base_value"; then
+		echo "ERROR: LLM_API_BASE must not contain URL userinfo, query, or fragment components." >&2
+		return 2
+	fi
+	llm_api_base_value="${llm_api_base_value%%/generateContent*}"
+	llm_api_base_value="${llm_api_base_value%%:generateContent*}"
 	printf '%s\n' "$llm_api_base_value"
 }
 

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -943,6 +943,7 @@ backend/db/models.py
 backend/db/session.py
 backend/services/__init__.py
 backend/services/archive.py
+backend/services/calendar_service.py
 backend/services/email_client.py
 backend/services/email_parser.py
 backend/services/embedding.py

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -2015,6 +2015,117 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+run_pull_request_target_calendar_service_context_scope_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local bin_dir="$tmp_dir/bin"
+	local repo_root_dir="$tmp_dir/repo"
+	mkdir -p "$bin_dir" "$repo_root_dir/scripts/ci"
+	cp "$GATE_SCRIPT" "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+	cp "$REPO_ROOT/scripts/ci/strix_model_utils.sh" "$repo_root_dir/scripts/ci/strix_model_utils.sh"
+	chmod +x "$repo_root_dir/scripts/ci/strix_quick_gate.sh"
+
+	local fake_strix="$bin_dir/strix"
+	local output_log="$tmp_dir/output.log"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+	local changed_file="backend/api/calendar.py"
+	local context_file="backend/services/calendar_service.py"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path=""
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-t" ] && [ "$#" -ge 2 ]; then
+		target_path="$2"
+		break
+	fi
+	shift
+done
+
+changed_file="$target_path/${FAKE_STRIX_EXPECTED_CHANGED_FILE:?}"
+context_file="$target_path/${FAKE_STRIX_EXPECTED_CONTEXT_FILE:?}"
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_HEAD_CONTENT:?}" "$changed_file"; then
+	echo "Error: PR head calendar API content was not scanned" >&2
+	cat -- "$changed_file" >&2
+	exit 72
+fi
+if [ ! -f "$context_file" ]; then
+	echo "Error: calendar service validation context missing from PR scope ($target_path)" >&2
+	exit 73
+fi
+if ! grep -Fq -- "${FAKE_STRIX_EXPECTED_CONTEXT_CONTENT:?}" "$context_file"; then
+	echo "Error: calendar service validation context content missing" >&2
+	cat -- "$context_file" >&2
+	exit 74
+fi
+echo "scan ok with calendar service validation context"
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' 'gemini/test-model' >"$strix_llm_file"
+	printf '%s' 'dummy' >"$llm_api_key_file"
+
+	(
+		cd "$repo_root_dir"
+		git init -q
+		git config user.name 'Strix Test'
+		git config user.email 'strix-test@example.invalid'
+		mkdir -p "$(dirname -- "$changed_file")" "$(dirname -- "$context_file")"
+		printf '%s\n' 'BASE_CALENDAR_CONTENT_SHOULD_NOT_BE_SCANNED' >"$changed_file"
+		cat >"$context_file" <<'EOF'
+def validate_calendar_todo_text(value):
+	return 'TRUSTED_CALENDAR_VALIDATOR_SHOULD_BE_SCANNED'
+EOF
+		git add .
+		git commit -qm 'base commit'
+	)
+	local base_sha
+	base_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	(
+		cd "$repo_root_dir"
+		cat >"$changed_file" <<'EOF'
+from services.calendar_service import validate_calendar_todo_text
+
+HEAD_CALENDAR_SYNC_SHOULD_BE_SCANNED
+EOF
+		git add .
+		git commit -qm 'head commit'
+	)
+	local head_sha
+	head_sha="$(git -C "$repo_root_dir" rev-parse HEAD)"
+	git -C "$repo_root_dir" checkout -q "$base_sha"
+
+	set +e
+	(
+		cd "$repo_root_dir"
+		env -u GITHUB_EVENT_PATH \
+			PATH="$bin_dir:$PATH" \
+			GITHUB_EVENT_NAME="pull_request_target" \
+			PR_BASE_SHA="$base_sha" \
+			PR_HEAD_SHA="$head_sha" \
+			STRIX_TEST_CHANGED_FILES_OVERRIDE="$changed_file" \
+			FAKE_STRIX_EXPECTED_CHANGED_FILE="$changed_file" \
+			FAKE_STRIX_EXPECTED_CONTEXT_FILE="$context_file" \
+			FAKE_STRIX_EXPECTED_HEAD_CONTENT="HEAD_CALENDAR_SYNC_SHOULD_BE_SCANNED" \
+			FAKE_STRIX_EXPECTED_CONTEXT_CONTENT="TRUSTED_CALENDAR_VALIDATOR_SHOULD_BE_SCANNED" \
+			STRIX_DISABLE_PR_SCOPING="0" \
+			STRIX_LLM_FILE="$strix_llm_file" \
+			LLM_API_KEY_FILE="$llm_api_key_file" \
+			STRIX_TARGET_PATH="." \
+			STRIX_REPORTS_DIR="$repo_root_dir/strix_runs" \
+			bash "./scripts/ci/strix_quick_gate.sh" >"$output_log" 2>&1
+	)
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=pull-request-target-calendar-service-validation-context exit code"
+	assert_file_contains "$output_log" "scan ok with calendar service validation context" "case=pull-request-target-calendar-service-validation-context output"
+
+	rm -rf "$tmp_dir"
+}
+
 run_pull_request_target_changed_backend_context_scope_case() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
@@ -2944,6 +3055,8 @@ run_pull_request_target_head_scope_case \
 	"1"
 
 run_pull_request_target_trusted_context_scope_case
+
+run_pull_request_target_calendar_service_context_scope_case
 
 run_pull_request_target_changed_backend_context_scope_case
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1788,6 +1788,12 @@ EOF
 			"scenario=$scenario runtime env forwarding"
 	fi
 
+	case "$scenario" in
+	api-base-query-token-rejected | api-base-fragment-token-rejected)
+		assert_file_not_contains "$output_log" "SUPER_SECRET_TOKEN_123" "scenario=$scenario output redacts rejected API base secret"
+		;;
+	esac
+
 	if [ "$scenario" = "pr-changed-scope-max-batches" ]; then
 		assert_internal_pr_scope_targets "$target_log" "$repo_root_dir" "$expected_calls"
 	fi
@@ -3131,6 +3137,28 @@ run_gate_case "runtime-env-forwarding" \
 	"<unset>" \
 	"gemini" \
 	""
+
+run_gate_case "api-base-query-token-rejected" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"1" \
+	"LLM_API_BASE must not contain URL userinfo, query, or fragment components." \
+	"0" \
+	"" \
+	"" \
+	"gemini" \
+	"https://example.invalid/generateContent?token=SUPER_SECRET_TOKEN_123"
+
+run_gate_case "api-base-fragment-token-rejected" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"1" \
+	"LLM_API_BASE must not contain URL userinfo, query, or fragment components." \
+	"0" \
+	"" \
+	"" \
+	"gemini" \
+	"https://example.invalid:generateContent#SUPER_SECRET_TOKEN_123"
 
 run_gate_case "vertex-primary-notfound-fallback-success" \
 	"vertex_ai/missing-primary" \


### PR DESCRIPTION
## 요약
- `pull_request_target` Strix PR scope에 `backend/services/calendar_service.py`를 trusted backend context로 포함합니다.
- `backend/api/calendar.py` 변경 시 calendar todo validator context가 누락되지 않도록 회귀 테스트를 추가했습니다.

## 검증
- `bash scripts/ci/test_strix_quick_gate.sh` → `test_strix_quick_gate: PASS`
- `git diff --check` → PASS
- `PYTHONPATH="${OPENCODE_HOME:-$HOME/.config/opencode}" python3 -m scripts.lint_by_filetype --json` → `ok: true`
- review subagent → PASS

## 배경
- PR #202의 Strix privileged PR scan은 base/master의 trusted 스크립트를 실행하므로, base 쪽 context inventory가 calendar validator를 알아야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

Internal CI and test infrastructure enhancements.

* **Chores**
  * Expanded PR trusted-context bundle to include backend calendar service files.
  * Added validation to reject API base values containing URL userinfo, query, or fragment components.
* **Tests**
  * New test verifying calendar service files are scanned and included in trusted context.
  * Regression tests ensuring API-base tokens in query/fragment are rejected and secrets are not exposed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->