### PR TITLE
fix: Strix LLM provider URL validation context 포함

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1011,6 +1011,7 @@ backend/services/email_client.py
 backend/services/email_parser.py
 backend/services/embedding.py
 backend/services/exceptions.py
+backend/services/llm_provider_urls.py
 backend/services/threading_service.py
 EOF
 	fi

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -2087,6 +2087,20 @@ if [ -f "$target_path/backend/api/emails.py" ]; then
 	exit 0
 fi
 
+if [ -f "$target_path/backend/api/llm_providers.py" ]; then
+	if [ ! -f "$target_path/backend/services/llm_provider_urls.py" ]; then
+		echo "Error: LLM provider URL validation context missing from PR scope ($target_path)" >&2
+		exit 74
+	fi
+	if ! grep -Fq -- 'HEAD_LLM_PROVIDER_URLS_SHOULD_BE_SCANNED' "$target_path/backend/services/llm_provider_urls.py"; then
+		echo "Error: LLM provider URL validation context did not use PR-head content" >&2
+		cat -- "$target_path/backend/services/llm_provider_urls.py" >&2
+		exit 75
+	fi
+	echo "scan ok with PR-head LLM provider URL validation context"
+	exit 0
+fi
+
 echo "scan ok with non-email backend batch"
 EOF
 	chmod +x "$fake_strix"
@@ -2102,6 +2116,8 @@ EOF
 		mkdir -p backend/api
 		printf '%s\n' 'BASE_AUTH_CONTENT_SHOULD_NOT_BE_SCANNED' >backend/api/auth.py
 		printf '%s\n' 'BASE_EMAILS_CONTENT_SHOULD_NOT_BE_SCANNED' >backend/api/emails.py
+		mkdir -p backend/services
+		printf '%s\n' 'BASE_LLM_PROVIDER_URLS_SHOULD_NOT_BE_SCANNED' >backend/services/llm_provider_urls.py
 		git add .
 		git commit -qm 'base commit'
 	)
@@ -2127,6 +2143,10 @@ HEAD_LLM_CONTENT_SHOULD_BE_SCANNED
 EOF
 		cat >backend/api/llm_providers.py <<'EOF'
 HEAD_LLM_PROVIDERS_CONTENT_SHOULD_BE_SCANNED
+EOF
+		cat >backend/services/llm_provider_urls.py <<'EOF'
+def validate_llm_provider_base_url_async():
+	return 'HEAD_LLM_PROVIDER_URLS_SHOULD_BE_SCANNED'
 EOF
 		cat >backend/api/mailbox_accounts.py <<'EOF'
 HEAD_MAILBOX_ACCOUNTS_CONTENT_SHOULD_BE_SCANNED
@@ -2169,6 +2189,7 @@ EOF
 
 	assert_equals "0" "$rc" "case=pull-request-target-changed-backend-context-uses-head-blob exit code"
 	assert_file_contains "$output_log" "scan ok with PR-head backend dependency context" "case=pull-request-target-changed-backend-context-uses-head-blob output"
+	assert_file_contains "$output_log" "scan ok with PR-head LLM provider URL validation context" "case=pull-request-target-changed-backend-context-includes-llm-provider-url-validation output"
 	assert_equals "3" "$(wc -l <"$call_log" | tr -d ' ')" "case=pull-request-target-changed-backend-context-uses-head-blob strix call count"
 
 	rm -rf "$tmp_dir"


### PR DESCRIPTION
No linked issue.

## 목적
PR #202의 Strix `pull_request_target` 스캔에서 `backend/api/llm_providers.py`가 LLM URL 검증 컨텍스트 없이 분석되어 SSRF 오탐이 발생하는 문제를 막습니다.

## 주요 변경 사항
- Strix quick gate의 backend Python context에 `backend/services/llm_provider_urls.py`를 포함합니다.
- `backend/api/llm_providers.py` 배치가 URL 검증 모듈 없이 스캔되지 않도록 회귀 테스트를 보강합니다.
- privileged `pull_request_target`가 trusted base 스크립트를 쓰는 특성 때문에, 해당 컨텍스트 보강을 `master`에 먼저 반영합니다.

## 검증
- RED: `bash scripts/ci/test_strix_quick_gate.sh`가 LLM provider URL validation context 누락으로 실패하는 것을 확인했습니다.
- `bash -n scripts/ci/strix_quick_gate.sh && bash -n scripts/ci/test_strix_quick_gate.sh`
- `bash scripts/ci/test_strix_quick_gate.sh` → `test_strix_quick_gate: PASS`
- Review subagent: PASS, blocking findings 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CI test harness to validate LLM provider URL configuration during pull request scans.
  * Added test coverage for backend dependency detection and validation.

* **Chores**
  * Updated CI scan scope to include additional backend configuration files in pull request analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->