### PR TITLE
fix: reject JWT critical headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@
   public identity headers such as `X-User-Id`, `X-Organization-Id`,
   `X-Group-Id`, `X-Group-Ids`, `X-User-Role`, or `X-Dev-Auth-Token`;
   tests/mocks must exercise the signed-session path.
+- JWT/session verification must reject unsupported critical headers (`crit`)
+  before trusting payload claims; do not rely only on library defaults for this
+  boundary.
 - Private backend `/api/*` routers must be registered with the default
   `get_auth_context` signed-session dependency; only explicitly documented
   public endpoints such as `/` may omit it. Keep runtime feature/configuration

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -127,6 +127,7 @@ def _cached_oidc_signing_key_from_jwt(token: str) -> Any:
         header = jwt.get_unverified_header(token)
     except Exception:
         raise _authentication_error() from None
+    _reject_unsupported_critical_headers(header)
     key_id = header.get("kid")
     if not isinstance(key_id, str) or not key_id.strip():
         raise _authentication_error()
@@ -134,6 +135,11 @@ def _cached_oidc_signing_key_from_jwt(token: str) -> Any:
         if getattr(signing_key, "key_id", None) == key_id:
             return signing_key
     raise _authentication_error()
+
+
+def _reject_unsupported_critical_headers(header: dict[str, Any]) -> None:
+    if "crit" in header:
+        raise _authentication_error()
 
 
 def _session_secret_bytes() -> bytes:
@@ -216,8 +222,7 @@ def _verify_signed_session_payload(authorization: str | None) -> dict[str, Any]:
     header = _json_object_from_base64url_segment(header_segment)
     if header.get("alg") != SESSION_SIGNING_ALGORITHM:
         raise _authentication_error()
-    if "crit" in header:
-        raise _authentication_error()
+    _reject_unsupported_critical_headers(header)
 
     secret = _session_secret_bytes()
     signing_input = f"{header_segment}.{payload_segment}"

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -216,6 +216,8 @@ def _verify_signed_session_payload(authorization: str | None) -> dict[str, Any]:
     header = _json_object_from_base64url_segment(header_segment)
     if header.get("alg") != SESSION_SIGNING_ALGORITHM:
         raise _authentication_error()
+    if "crit" in header:
+        raise _authentication_error()
 
     secret = _session_secret_bytes()
     signing_input = f"{header_segment}.{payload_segment}"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,4 +25,4 @@ opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-exporter-otlp==1.25.0
 setuptools==78.1.1
 websockets==14.1
-PyJWT==2.8.0
+PyJWT==2.13.0

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -338,6 +338,25 @@ async def test_signed_bearer_session_rejects_rs256_algorithm():
 
 
 @pytest.mark.asyncio
+async def test_signed_bearer_session_rejects_unknown_critical_header():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={
+            "alg": "HS256",
+            "typ": "JWT",
+            "crit": ["x-custom-policy"],
+            "x-custom-policy": "require-mfa",
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_signed_bearer_session_rejects_wrong_secret():
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     token = _signed_session_token(_valid_session_payload(), WRONG_SESSION_HMAC_SECRET)

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -738,6 +738,55 @@ async def test_signed_bearer_session_with_oidc(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_oidc_rejects_unknown_critical_header_before_decode(monkeypatch):
+    import jwt
+
+    previous_issuer_url = settings.OIDC_ISSUER_URL
+    previous_client_id = settings.OIDC_CLIENT_ID
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.OIDC_ISSUER_URL = "http://localhost:8081/realms/naruon"
+    settings.OIDC_CLIENT_ID = "naruon-api"
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+
+    class MockKey:
+        key_id = "test-key"
+        key = "public_key"
+
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (MockKey(),))
+
+    decode_called = False
+
+    def mock_jwt_decode(*args, **kwargs):
+        nonlocal decode_called
+        decode_called = True
+        return {}
+
+    monkeypatch.setattr(jwt, "decode", mock_jwt_decode)
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={
+            "alg": "RS256",
+            "typ": "JWT",
+            "kid": "test-key",
+            "crit": ["x-custom-policy"],
+            "x-custom-policy": "require-mfa",
+        },
+    )
+
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        settings.OIDC_ISSUER_URL = previous_issuer_url
+        settings.OIDC_CLIENT_ID = previous_client_id
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+
+    assert exc.value.status_code == 401
+    assert decode_called is False
+
+
+@pytest.mark.asyncio
 async def test_oidc_validation_failure_does_not_fallback_to_signed_session(monkeypatch):
     import jwt
 


### PR DESCRIPTION
## Summary
- upgrade PyJWT from 2.8.0 to 2.13.0 for GHSA-752w-5fwx-jx9f / CVE-2026-32597
- reject unsupported JWT critical headers in the signed-session HS256 path before trusting payload claims
- record the JWT critical-header bug pattern in AGENTS.md

## Verification
- PYTHONWARNINGS=error pytest backend/tests/test_auth_real.py
- pytest backend/tests/test_auth_real.py backend/tests/test_runtime_config_api.py backend/tests/test_main.py
- python -m bandit -r backend -x backend/tests
- pytest backend/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session authentication to reject tokens containing unsupported critical headers, enhancing security.

* **Chores**
  * Updated PyJWT dependency to a newer version.

* **Tests**
  * Added tests ensuring tokens with unknown `crit` headers are rejected in both session and OIDC flows.

* **Documentation**
  * Added a governance rule requiring JWT/session verification to explicitly reject unsupported critical headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->