### PR TITLE
Expose self-hosted connector manifest in settings

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -93,7 +93,9 @@ jobs:
               exit 1
               ;;
           esac
-          if [ -z "$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')" ]; then
+          sanitized_openai_key="$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')"
+          trimmed_openai_key="$(printf '%s' "$sanitized_openai_key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          if [ -z "$trimmed_openai_key" ]; then
             echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
             exit 1
           fi
@@ -217,7 +219,8 @@ jobs:
           LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}
         run: |
           sanitized="$(printf '%s' "$LLM_API_KEY_SECRET" | tr -d '\r\n')"
-          if [ -z "$sanitized" ]; then
+          trimmed="$(printf '%s' "$sanitized" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          if [ -z "$trimmed" ]; then
             echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
             exit 1
           fi

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -18,7 +18,6 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  models: read
 
 jobs:
   strix:
@@ -81,25 +80,24 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_GITHUB_MODELS_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
+          STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
         run: |
-          strix_model="$(printf '%s' "$STRIX_GITHUB_MODELS_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          strix_model="$(printf '%s' "$STRIX_OPENAI_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
-            openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-            openai/openai/gpt-5.[4-9]* | openai/openai/gpt-5.[1-9][0-9]* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]*)
+            openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo '::error::STRIX_LLM must select an OpenAI GPT-5.4 or newer model, for example openai/gpt-5.4.'
+              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example openai/gpt-5.4.'
               exit 1
               ;;
           esac
-          if [ -n "$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')" ]; then
-            echo 'provider_mode=openai_direct' >> "$GITHUB_OUTPUT"
-          else
-            echo 'provider_mode=github_models' >> "$GITHUB_OUTPUT"
+          if [ -z "$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')" ]; then
+            echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
+            exit 1
           fi
+          echo 'provider_mode=openai_direct' >> "$GITHUB_OUTPUT"
 
       - name: Gate GCP credentials
         id: gcp_gate
@@ -118,11 +116,11 @@ jobs:
         id: auth_gate
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_GITHUB_MODELS_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
+          STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
           DEFAULT_PROVIDER: openai
         run: |
           . "$TRUSTED_WORKSPACE/scripts/ci/strix_model_utils.sh"
-          strix_llm="$(trim_whitespace "$STRIX_GITHUB_MODELS_MODEL")"
+          strix_llm="$(trim_whitespace "$STRIX_OPENAI_MODEL")"
           requires_vertex_auth='false'
           model_auth_rc=0
           model_requires_vertex_auth "$strix_llm" || model_auth_rc=$?
@@ -200,7 +198,7 @@ jobs:
       - name: Mask LLM API key
         if: steps.gate.outputs.enabled == 'true' && steps.auth_gate.outputs.can_run == 'true'
         env:
-          LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY || github.token }}
+          LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
         run: |
           # Sanitize CR/LF before masking to prevent broken ::add-mask::
           # commands and potential workflow command injection.
@@ -216,59 +214,36 @@ jobs:
       - name: Prepare LLM API key input file
         if: steps.gate.outputs.enabled == 'true' && steps.auth_gate.outputs.can_run == 'true'
         env:
-          LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY || github.token }}
+          LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}
         run: |
-          if [ -n "$LLM_API_KEY_SECRET" ]; then
-            umask 077
-            llm_api_key_file="$RUNNER_TEMP/llm_api_key.txt"
-            printf '%s' "$LLM_API_KEY_SECRET" > "$llm_api_key_file"
-            echo "LLM_API_KEY_FILE=$llm_api_key_file" >> "$GITHUB_ENV"
+          sanitized="$(printf '%s' "$LLM_API_KEY_SECRET" | tr -d '\r\n')"
+          if [ -z "$sanitized" ]; then
+            echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
+            exit 1
           fi
+          umask 077
+          llm_api_key_file="$RUNNER_TEMP/llm_api_key.txt"
+          printf '%s' "$sanitized" > "$llm_api_key_file"
+          echo "LLM_API_KEY_FILE=$llm_api_key_file" >> "$GITHUB_ENV"
 
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true' && steps.auth_gate.outputs.can_run == 'true'
         env:
-          STRIX_GITHUB_MODELS_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
+          STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
-          strix_model="$(printf '%s' "$STRIX_GITHUB_MODELS_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-          if [ "${{ steps.gate.outputs.provider_mode }}" = 'openai_direct' ]; then
-            case "$strix_model" in
-              openai/openai/*)
-                printf '%s' "${strix_model#openai/}" > "$strix_llm_file"
-                ;;
-              openai/*)
-                printf '%s' "$strix_model" > "$strix_llm_file"
-                ;;
-              *)
-                echo '::error::STRIX_LLM must select an OpenAI GPT-5.4 or newer model, for example openai/gpt-5.4.'
-                exit 1
-                ;;
-            esac
-          else
-            case "$strix_model" in
-              openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
-                printf 'openai/%s' "$strix_model" > "$strix_llm_file"
-                ;;
-              openai/openai/gpt-5.[4-9]* | openai/openai/gpt-5.[1-9][0-9]* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]*)
-                printf '%s' "$strix_model" > "$strix_llm_file"
-                ;;
-              *)
-                echo '::error::STRIX_LLM must select a GitHub Models OpenAI GPT-5.4 or newer model, for example openai/gpt-5.4.'
-                exit 1
-                ;;
-            esac
-          fi
+          strix_model="$(printf '%s' "$STRIX_OPENAI_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          case "$strix_model" in
+            openai/*)
+              printf '%s' "$strix_model" > "$strix_llm_file"
+              ;;
+            *)
+              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example openai/gpt-5.4.'
+              exit 1
+              ;;
+          esac
           echo "STRIX_LLM_FILE=$strix_llm_file" >> "$GITHUB_ENV"
-
-      - name: Prepare LLM API base input file
-        if: steps.gate.outputs.enabled == 'true' && steps.auth_gate.outputs.can_run == 'true' && steps.gate.outputs.provider_mode == 'github_models'
-        run: |
-          umask 077
-          llm_api_base_file="$RUNNER_TEMP/llm_api_base.txt"
-          printf '%s' "https://models.github.ai/inference" > "$llm_api_base_file"
-          echo "LLM_API_BASE_FILE=$llm_api_base_file" >> "$GITHUB_ENV"
 
       - name: Run Strix (quick)
         if: steps.gate.outputs.enabled == 'true' && steps.auth_gate.outputs.can_run == 'true'
@@ -276,7 +251,6 @@ jobs:
           STRIX_LLM_FILE: ${{ env.STRIX_LLM_FILE }}
           STRIX_LLM_DEFAULT_PROVIDER: openai
           LLM_API_KEY_FILE: ${{ env.LLM_API_KEY_FILE }}
-          LLM_API_BASE_FILE: ${{ env.LLM_API_BASE_FILE }}
           STRIX_TARGET_PATH: ./
           STRIX_SOURCE_DIRS: .
           STRIX_REASONING_EFFORT: low

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,10 @@
   explicit `if: ${{ always() }}` upload steps when needed.
 - Prefer upgrading or removing vulnerable dependencies over downgrading patched
   packages unless compatibility evidence is recorded in the PR.
-- Strix Security Scan must use an OpenAI GPT-5.4-or-newer model. Prefer GitHub
-  Models with `models: read`, but verify actual inference availability, not only
-  catalog presence. If the repo token cannot invoke GitHub Models GPT-5.4, use
-  only an explicitly named `STRIX_OPENAI_API_KEY` direct GPT-5.4 credential rather
-  than downgrading to Gemini, GPT-4o, or GPT-4.1; record the inference evidence
-  in the PR. Do not repurpose generic `LLM_API_KEY` for direct OpenAI Strix
-  calls, because it may hold a GitHub Models token or PAT.
+- Strix Security Scan must use an explicitly named `STRIX_OPENAI_API_KEY`
+  OpenAI Platform credential with an OpenAI GPT-5.4-or-newer model. Do not route
+  Strix through GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini,
+  GPT-4o, or GPT-4.1; record direct-provider evidence in the PR.
 
 ## PR automation and review defaults
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ mail/calendar/file systems.
   open-source observability.
 - PR automation is metadata-only and uses current-head robot-review evidence plus
   required checks. Human approval is not awaited by default under repo policy.
-- Strix PR/security evidence requires an OpenAI GPT-5+ model. The workflow
-  prefers GitHub Models with `models: read`, verifies real inference
-  availability, and uses only an explicit `STRIX_OPENAI_API_KEY` direct GPT-5
-  credential instead of downgrading to GPT-4-era models when GitHub Models has
-  not enabled GPT-5 for the repo token. Pending CodeRabbit or check evidence is
-  a wait state, not a hard blocker.
+- Strix PR/security evidence requires an OpenAI GPT-5.4-or-newer model through
+  an explicit `STRIX_OPENAI_API_KEY` OpenAI Platform credential. The workflow
+  fails closed rather than falling back to GitHub Models, `github.token`, or
+  GPT-4-era models. Pending CodeRabbit or check evidence is a wait state, not a
+  hard blocker.
   
 ## Agentic Ontology & Auto-Organization
 

--- a/docs/plans/2026-05-19-north-star-gap-closure.md
+++ b/docs/plans/2026-05-19-north-star-gap-closure.md
@@ -36,11 +36,10 @@ connector, and PR governance is metadata-only.
   the exact `Strix Security Scan` workflow, runs a trusted-base governance script,
   separates pending/waiting states from failures, and updates an idempotent marker
   comment instead of posting duplicates.
-- [x] Strix GPT-5 hardening: direct inference checks showed the repo's GitHub
-  Models token sees `openai/gpt-5` in the catalog but cannot invoke it yet, so
-  the workflow keeps GPT-5 as the model requirement and uses only an explicitly
-  named `STRIX_OPENAI_API_KEY` direct GPT-5 credential before GitHub-token
-  fallback rather than downgrading the scanner to GPT-4-era models.
+- [x] Strix GPT-5 hardening: the workflow keeps GPT-5.4-or-newer as the model
+  requirement and uses only an explicitly named `STRIX_OPENAI_API_KEY` OpenAI
+  Platform credential. It fails closed instead of routing scanner traffic
+  through GitHub Models, `github.token`, Gemini, GPT-4o, or GPT-4.1.
 
 ## Verification evidence
 

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -1,0 +1,129 @@
+/* @vitest-environment jsdom */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("lucide-react", () => ({
+  AlertCircle: () => <svg aria-hidden="true" />,
+  Bell: () => <svg aria-hidden="true" />,
+  Mail: () => <svg aria-hidden="true" />,
+  Monitor: () => <svg aria-hidden="true" />,
+  Plus: () => <svg aria-hidden="true" />,
+  RefreshCw: () => <svg aria-hidden="true" />,
+  Settings: () => <svg aria-hidden="true" />,
+  Shield: () => <svg aria-hidden="true" />,
+  Smartphone: () => <svg aria-hidden="true" />,
+  User: () => <svg aria-hidden="true" />,
+}));
+
+import { SettingsLayout } from "./SettingsLayout";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("SettingsLayout", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    localStorage.setItem("naruon_session_token", "signed-runner-session-token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/runner-config") {
+          return jsonResponse({
+            workspace_id: "workspace-org-acme",
+            configured: true,
+            fingerprint: "***abc12345",
+            updated_at: "2026-05-27T06:00:00Z",
+            connector_manifest: {
+              role: "self-hosted_connector",
+              network_mode: "outbound_only",
+              control_plane_domain: "naruon.net",
+              local_protocols: ["imap", "pop3", "smtp", "caldav", "carddav", "webdav"],
+              prohibited_roles: ["smtp_server", "imap_server", "mx_host"],
+              runner_usage: "ci_smoke_only",
+            },
+          });
+        }
+        return jsonResponse({});
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount());
+    root = null;
+    container?.remove();
+    container = null;
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it("renders the self-hosted connector manifest and keeps mobile settings tabs reachable", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+    });
+
+    const mobileSettingsNav = container.querySelector('nav[aria-label="설정 섹션"]');
+    expect(mobileSettingsNav?.textContent).toContain("개발자");
+
+    const developerButtons = Array.from(container.querySelectorAll("button")).filter((button) => button.textContent?.includes("개발자"));
+    await act(async () => {
+      developerButtons[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/runner-config",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer signed-runner-session-token",
+        }),
+      }),
+    );
+    expect(container.textContent).toContain("Self-hosted connector manifest");
+    expect(container.textContent).toContain("Naruon은 이메일 서버가 아닙니다");
+    expect(container.textContent).toContain("self-hosted_connector");
+    expect(container.textContent).toContain("outbound_only");
+    expect(container.textContent).toContain("naruon.net");
+    expect(container.textContent).toContain("ci_smoke_only");
+    expect(container.textContent).toContain("caldav");
+    expect(container.textContent).toContain("webdav");
+    expect(container.textContent).toContain("smtp_server");
+    expect(container.textContent).toContain("imap_server");
+    expect(container.textContent).toContain("mx_host");
+  });
+
+  it("renders settings tabs as detail surfaces instead of placeholder dead space", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+    });
+
+    for (const tabName of ["멤버", "알림", "자동화", "결제"]) {
+      const button = Array.from(container.querySelectorAll("button")).find((candidate) => candidate.textContent === tabName);
+      expect(button).toBeTruthy();
+      await act(async () => {
+        button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain(`${tabName === "멤버" ? "멤버와 역할" : tabName === "알림" ? "알림 정책" : tabName === "자동화" ? "자동화 규칙" : "결제와 사용량"}`);
+      expect(container.textContent).not.toContain("다음 릴리즈");
+    }
+  });
+});

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1,38 +1,150 @@
 "use client";
 
 import { Settings, User, Mail, Bell, Shield, Smartphone, Plus, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
+import { apiClient } from '@/lib/api-client';
 import { useWorkspaceStartupView, setWorkspaceStartupView } from '@/lib/workspace-preferences';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+type SettingsTab = '워크스페이스' | '멤버' | '연결 계정' | '알림' | '자동화' | '결제' | '개발자';
+
+interface RunnerConfig {
+  workspace_id: string;
+  configured: boolean;
+  fingerprint: string | null;
+  updated_at: string | null;
+  connector_manifest: {
+    role: string;
+    network_mode: string;
+    control_plane_domain: string;
+    local_protocols: string[];
+    prohibited_roles: string[];
+    runner_usage: string;
+  };
+}
+
+const settingsTabs: { id: SettingsTab; icon: typeof Monitor }[] = [
+  { id: '워크스페이스', icon: Monitor },
+  { id: '멤버', icon: User },
+  { id: '연결 계정', icon: Mail },
+  { id: '알림', icon: Bell },
+  { id: '자동화', icon: Settings },
+  { id: '결제', icon: Shield },
+  { id: '개발자', icon: Smartphone },
+];
+
+const settingsDetailSurfaces: Partial<Record<SettingsTab, {
+  heading: string;
+  copy: string;
+  items: { title: string; detail: string; status: string }[];
+}>> = {
+  멤버: {
+    heading: '멤버와 역할',
+    copy: '조직 관리자, 보안 담당자, 팀 리드, 개인 사용자의 역할과 ABAC 조건을 한 화면에서 점검합니다.',
+    items: [
+      { title: '관리자 경계', detail: 'platform_admin과 organization_admin 권한을 분리하고 customer-policy deny를 우선 적용합니다.', status: 'RBAC/ABAC' },
+      { title: '팀 스코프', detail: '그룹/본부/팀 단위 멤버십과 workspace scope를 감사 로그와 함께 추적합니다.', status: '조직 계층' },
+      { title: '초대 검토', detail: '외부 공유와 신규 초대는 보안 정책, consent, data-region 조건을 통과해야 합니다.', status: '정책 점검' },
+    ],
+  },
+  알림: {
+    heading: '알림 정책',
+    copy: '메일 회신 추적, 일정 충돌, writeback conflict, connector health 이벤트를 사용자별 채널 정책으로 정리합니다.',
+    items: [
+      { title: '답변 추적', detail: '보낸 메일 SLA가 지연되면 홈 대기 작업과 알림 큐에 같은 사건으로 표시합니다.', status: '메일 연동' },
+      { title: '일정 충돌', detail: 'CalDAV writeback 후보가 충돌하거나 ETag가 맞지 않으면 재확인 알림을 생성합니다.', status: '캘린더' },
+      { title: 'Connector health', detail: 'self-hosted connector heartbeat, sync lag, provider throttling을 운영 알림으로 묶습니다.', status: '운영' },
+    ],
+  },
+  자동화: {
+    heading: '자동화 규칙',
+    copy: '메일, 일정, 할 일, 프로젝트 상태를 source-linked rule로 연결하되 provider write는 명시적 intent로 남깁니다.',
+    items: [
+      { title: '메일에서 작업 생성', detail: '실행 항목을 ticket task로 만들고 원본 message/thread provenance를 유지합니다.', status: 'source-linked' },
+      { title: '캘린더 writeback', detail: 'AI가 정리한 일정은 source capability와 owner policy를 확인한 뒤 원천 계정에 반영합니다.', status: 'intent-first' },
+      { title: '지식 정리', detail: '내가 나에게 보낸 메일은 개인 지식 후보로 분류하고 연결 프로젝트를 제안합니다.', status: 'knowledge' },
+    ],
+  },
+  결제: {
+    heading: '결제와 사용량',
+    copy: 'B2C, SOHO, 조직 계정이 같은 tenant 구조에서 quota, connector, AI 사용량을 분리해 봅니다.',
+    items: [
+      { title: '워크스페이스 quota', detail: '메일 본문 저장소가 아니라 metadata/index/action intent 중심으로 사용량을 계산합니다.', status: 'data sovereignty' },
+      { title: 'Connector seat', detail: '사내망 connector는 조직 스코프별 등록 토큰과 운영 감사 대상으로 계산합니다.', status: 'B2B2C' },
+      { title: 'AI 사용량', detail: '프롬프트 실행, 평가, 요약, writeback 제안을 provider별 비용 항목으로 분리합니다.', status: 'BYOK' },
+    ],
+  },
+};
 
 export function SettingsLayout() {
-  const [activeTab, setActiveTab] = useState<'워크스페이스' | '멤버' | '연결 계정' | '알림' | '자동화' | '결제' | '개발자'>('워크스페이스');
+  const [activeTab, setActiveTab] = useState<SettingsTab>('워크스페이스');
+  const [runnerConfig, setRunnerConfig] = useState<RunnerConfig | null>(null);
+  const [runnerError, setRunnerError] = useState<string | null>(null);
+  const [runnerLoading, setRunnerLoading] = useState(true);
   const startupView = useWorkspaceStartupView();
+  const connectorManifest = runnerConfig?.connector_manifest;
+  const detailSurface = settingsDetailSurfaces[activeTab];
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void apiClient
+      .get<RunnerConfig>('/api/runner-config')
+      .then((config) => {
+        if (cancelled) return;
+        setRunnerConfig(config);
+        setRunnerError(null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setRunnerError(error.message || 'Self-hosted connector 설정을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setRunnerLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="flex h-full min-w-0 min-h-0 bg-background text-foreground flex-col overflow-x-hidden">
       <header className="flex h-20 shrink-0 items-center border-b border-border bg-card px-4 md:px-8 overflow-hidden">
         <h1 className="text-xl md:text-2xl font-bold flex shrink-0 items-center gap-3">
-          <Settings className="size-6 text-primary" /> <span className="hidden sm:inline">설정 (Settings)</span>
+          <Settings className="size-6 text-primary" />
+          <span className="sm:hidden">설정</span>
+          <span className="hidden sm:inline">설정 (Settings)</span>
         </h1>
         <p className="sr-only">Self-hosted Runner</p>
       </header>
+
+      <nav aria-label="설정 섹션" className="md:hidden border-b border-border bg-card px-3 py-2">
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {settingsTabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`min-h-10 shrink-0 rounded-xl px-4 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${
+                activeTab === tab.id
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'bg-background text-muted-foreground hover:bg-secondary hover:text-foreground'
+              }`}
+            >
+              {tab.id}
+            </button>
+          ))}
+        </div>
+      </nav>
 
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Left Sidebar - Settings Tabs */}
         <aside className="w-64 shrink-0 border-r border-border bg-card overflow-y-auto hidden md:block">
           <div className="p-4 space-y-1">
-            {[
-              { id: '워크스페이스', icon: Monitor },
-              { id: '멤버', icon: User },
-              { id: '연결 계정', icon: Mail },
-              { id: '알림', icon: Bell },
-              { id: '자동화', icon: Settings },
-              { id: '결제', icon: Shield },
-              { id: '개발자', icon: Smartphone },
-            ].map((tab) => (
+            {settingsTabs.map((tab) => (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id as '워크스페이스' | '멤버' | '연결 계정' | '알림' | '자동화' | '결제' | '개발자')}
+                onClick={() => setActiveTab(tab.id)}
                 className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-bold transition-colors ${activeTab === tab.id ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}`}
               >
                 <tab.icon className="size-4" /> {tab.id}
@@ -152,6 +264,67 @@ export function SettingsLayout() {
                     <p className="text-sm text-muted-foreground mt-1">Naruon 인프라 모니터링, 추적 및 보안 로그에 접근합니다.</p>
                   </div>
                 </div>
+
+                <section aria-label="Self-hosted connector manifest" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-bold text-lg">Self-hosted connector manifest</h3>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        Naruon은 이메일 서버가 아닙니다. 고객망의 self-hosted connector가 outbound-only로 naruon.net control plane에 연결해 IMAP/SMTP/CalDAV/WebDAV 접근을 중계합니다.
+                      </p>
+                    </div>
+                    {connectorManifest ? (
+                      <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-xs font-bold text-foreground">
+                        {connectorManifest.role}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {runnerLoading ? (
+                    <p className="mt-4 rounded-xl bg-secondary/60 p-3 text-sm font-semibold text-muted-foreground">connector manifest를 불러오는 중입니다.</p>
+                  ) : null}
+                  {runnerError ? (
+                    <p className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{runnerError}</p>
+                  ) : null}
+                  {connectorManifest ? (
+                    <div className="mt-5 space-y-4">
+                      <dl className="grid gap-3 border-t border-border pt-4 sm:grid-cols-3">
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">network_mode</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{connectorManifest.network_mode}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">control_plane_domain</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{connectorManifest.control_plane_domain}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">runner_usage</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{connectorManifest.runner_usage}</dd>
+                        </div>
+                      </dl>
+
+                      <div className="grid gap-4 border-t border-border pt-4 md:grid-cols-2">
+                        <div>
+                          <p className="text-xs font-bold uppercase tracking-wide text-muted-foreground">local_protocols</p>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            {connectorManifest.local_protocols.map((protocol) => (
+                              <span key={protocol} className="rounded-full bg-secondary px-2.5 py-1 font-mono text-xs font-semibold text-foreground">{protocol}</span>
+                            ))}
+                          </div>
+                        </div>
+                        <div>
+                          <p className="text-xs font-bold uppercase tracking-wide text-muted-foreground">prohibited_roles</p>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            {connectorManifest.prohibited_roles.map((role) => (
+                              <span key={role} className="rounded-full bg-red-50 px-2.5 py-1 font-mono text-xs font-semibold text-red-700">{role}</span>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+                </section>
+
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
                   <a href="http://localhost:3000" target="_blank" rel="noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
                     <Monitor className="size-8 text-orange-500 mb-2" />
@@ -177,15 +350,23 @@ export function SettingsLayout() {
               </div>
             )}
 
-            {activeTab !== '연결 계정' && activeTab !== '워크스페이스' && activeTab !== '개발자' && (
-              <div className="flex flex-col items-center justify-center py-24 text-center rounded-2xl border border-dashed border-border bg-card">
-                <Settings className="size-10 text-muted-foreground mb-4 opacity-50" />
-                <h2 className="text-xl font-bold mb-2">{activeTab} 메뉴</h2>
-                <p className="text-muted-foreground max-w-sm">
-                  사용자 및 조직 관리를 위한 세부 설정 화면이 다음 릴리즈에 포함될 예정입니다.
-                </p>
-              </div>
-            )}
+            {detailSurface ? (
+              <section aria-label={`${activeTab} 상세 설정`} className="space-y-5">
+                <div>
+                  <h2 className="font-bold text-xl">{detailSurface.heading}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">{detailSurface.copy}</p>
+                </div>
+                <div className="grid gap-4 md:grid-cols-3">
+                  {detailSurface.items.map((item) => (
+                    <article key={item.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                      <p className="rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary inline-flex">{item.status}</p>
+                      <h3 className="mt-4 font-bold text-base">{item.title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.detail}</p>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ) : null}
             
           </div>
         </main>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -199,6 +199,42 @@ for (const destination of [
   });
 }
 
+test('renders the settings self-hosted connector manifest with mobile scrolling', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockDashboardApi(page);
+
+  await page.goto('/settings');
+  await page.getByRole('button', { name: '개발자' }).first().click();
+
+  await expect(page.getByText('Self-hosted connector manifest')).toBeVisible();
+  await expect(page.getByText('Naruon은 이메일 서버가 아닙니다')).toBeVisible();
+  await expect(page.getByText('naruon.net', { exact: true })).toBeVisible();
+  await expect(page.getByText('ci_smoke_only')).toBeVisible();
+  await expect(page.getByText('smtp_server')).toBeVisible();
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(overflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('settings-runner-mobile-manifest.png'), fullPage: false });
+
+  const scrollMetrics = await page.evaluate(() => {
+    const scroller = Array.from(document.querySelectorAll('body, body *')).find((element) => {
+      const style = window.getComputedStyle(element);
+      return style.overflowY !== 'hidden' && element.scrollHeight > element.clientHeight + 10;
+    });
+    if (!scroller) return null;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(scrollMetrics).not.toBeNull();
+  expect(scrollMetrics?.maxScroll).toBeGreaterThan(0);
+  expect(scrollMetrics?.after).toBeGreaterThan(scrollMetrics?.before ?? 0);
+  await page.screenshot({ path: testInfo.outputPath('settings-runner-mobile-scroll.png'), fullPage: false });
+});
+
 test('captures responsive startup evidence for desktop tablet mobile and the mobile drawer', async ({ page }, testInfo) => {
   await mockDashboardApi(page);
   for (const viewport of [

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -55,6 +55,21 @@ const aiHubPrompts = [
   { id: 103, title: '후속 실행 항목', description: '답장, 일정, 할 일을 담당자별 실행 흐름으로 나눕니다.' },
 ];
 
+const runnerConfig = {
+  workspace_id: 'workspace-org-acme',
+  configured: true,
+  fingerprint: '***abc12345',
+  updated_at: '2026-05-27T06:00:00Z',
+  connector_manifest: {
+    role: 'self-hosted_connector',
+    network_mode: 'outbound_only',
+    control_plane_domain: 'naruon.net',
+    local_protocols: ['imap', 'pop3', 'smtp', 'caldav', 'carddav', 'webdav'],
+    prohibited_roles: ['smtp_server', 'imap_server', 'mx_host'],
+    runner_usage: 'ci_smoke_only',
+  },
+};
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
@@ -92,6 +107,11 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
 
     if (path === '/api/prompts' && request.method() === 'GET') {
       await fulfillJson(route, aiHubPrompts);
+      return;
+    }
+
+    if (path === '/api/runner-config' && request.method() === 'GET') {
+      await fulfillJson(route, runnerConfig);
       return;
     }
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -55,7 +55,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 
 	assert_file_contains "$workflow_file" "branches: [master]" "strix workflow scans the protected default branch"
 	assert_file_contains "$workflow_file" "pull_request_target:" "strix workflow uses trusted PR trigger"
-	assert_file_contains "$workflow_file" "models: read" "strix workflow grants GitHub Models read permission"
+	assert_file_not_contains "$workflow_file" "models: read" "strix workflow must not grant GitHub Models read permission"
 	assert_file_contains "$workflow_file" "Materialize trusted workspace" "strix workflow materializes trusted workspace"
 	assert_file_contains "$workflow_file" "TRUSTED_WORKSPACE_SHA" "strix workflow pins trusted workspace SHA"
 	assert_file_contains "$workflow_file" "TRUSTED_WORKSPACE=\$trusted_workspace" "strix workflow exports a trusted workspace path"
@@ -80,18 +80,22 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "timeout-minutes: 90" "strix workflow job budget covers PR-scoped Strix batches"
 	assert_file_contains "$workflow_file" "STRIX_TOTAL_TIMEOUT_SECONDS: 4800" "strix workflow total Strix budget covers PR-scoped batches"
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
-	assert_file_contains "$workflow_file" 'STRIX_GITHUB_MODELS_MODEL: ${{ secrets.STRIX_LLM || '"'"'openai/gpt-5.4'"'"' }}' "strix workflow defaults STRIX_LLM to GPT-5.4"
-	assert_file_contains "$workflow_file" "STRIX_LLM must select an OpenAI GPT-5.4 or newer model" "strix workflow rejects older GPT inputs"
-	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow can use configured OpenAI GPT-5 credentials"
-	assert_file_contains "$workflow_file" "provider_mode=github_models" "strix workflow can use GitHub Models when direct credentials are absent"
-	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY || github.token }}' "strix workflow uses explicit direct GPT-5 credentials before GitHub token"
-	assert_file_contains "$workflow_file" "steps.gate.outputs.provider_mode == 'github_models'" "strix workflow limits GitHub Models API base to GitHub Models mode"
-	assert_file_contains "$workflow_file" "https://models.github.ai/inference" "strix workflow routes Strix through GitHub Models inference"
-	assert_file_contains "$workflow_file" "STRIX_LLM_DEFAULT_PROVIDER: openai" "strix workflow uses the OpenAI-compatible provider for GitHub Models"
+	assert_file_contains "$workflow_file" 'STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || '"'"'openai/gpt-5.4'"'"' }}' "strix workflow defaults STRIX_LLM to GPT-5.4"
+	assert_file_contains "$workflow_file" "STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model" "strix workflow rejects older GPT inputs"
+	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
+	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow uses only explicit direct GPT-5 credentials"
+	assert_file_contains "$workflow_file" 'LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow masks only the direct OpenAI credential"
+	assert_file_contains "$workflow_file" "STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans" "strix workflow fails closed when direct credentials are absent"
+	assert_file_contains "$workflow_file" "STRIX_LLM_DEFAULT_PROVIDER: openai" "strix workflow uses the OpenAI-compatible provider for OpenAI Platform"
+	assert_file_not_contains "$workflow_file" "provider_mode=github_models" "strix workflow must not fall back to GitHub Models"
+	assert_file_not_contains "$workflow_file" "steps.gate.outputs.provider_mode == 'github_models'" "strix workflow must not prepare GitHub Models API base"
+	assert_file_not_contains "$workflow_file" "https://models.github.ai/inference" "strix workflow must not route Strix through GitHub Models inference"
+	assert_file_not_contains "$workflow_file" '${{ secrets.STRIX_OPENAI_API_KEY || github.token }}' "strix workflow must not use github.token as an LLM API key"
 	assert_file_not_contains "$workflow_file" "openai/gpt-5 |" "strix workflow must not accept plain GPT-5 when GPT-5.4 is required"
 	assert_file_not_contains "$workflow_file" "openai/gpt-5-*" "strix workflow must not accept older GPT-5 variants when GPT-5.4 is required"
+	assert_file_not_contains "$workflow_file" "openai/openai/gpt-5" "strix workflow must not accept GitHub Models OpenAI model prefixes"
 	assert_file_not_contains "$workflow_file" "github/gpt-4o" "strix workflow must not default to GPT-4o when GPT-5 is required"
-	assert_file_not_contains "$workflow_file" "gemini/gemini-pro-3.1-preview" "strix workflow must not default to Gemini when GitHub Models is required"
+	assert_file_not_contains "$workflow_file" "gemini/gemini-pro-3.1-preview" "strix workflow must not default to Gemini when OpenAI Platform is required"
 	assert_file_not_contains "$workflow_file" "if-no-files-found: warn" "strix workflow must not downgrade missing security artifacts to warnings"
 	if grep -Eq '^[[:space:]]+pull_request:[[:space:]]*$' "$workflow_file"; then
 		record_failure "strix workflow must not expose secrets on pull_request events"
@@ -102,8 +106,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 assert_strix_gpt54_model_guard_semantics() {
 	local model="$1"
 	case "$model" in
-	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-		openai/openai/gpt-5.[4-9]* | openai/openai/gpt-5.[1-9][0-9]* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]*)
+	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
 		return 0
 		;;
 	*)
@@ -119,8 +122,8 @@ assert_strix_gpt54_model_guard_cases() {
 	if ! assert_strix_gpt54_model_guard_semantics "openai/gpt-5.4"; then
 		record_failure "strix GPT-5.4 guard must accept openai/gpt-5.4"
 	fi
-	if ! assert_strix_gpt54_model_guard_semantics "openai/openai/gpt-5.4"; then
-		record_failure "strix GPT-5.4 guard must accept GitHub Models openai/openai/gpt-5.4"
+	if assert_strix_gpt54_model_guard_semantics "openai/openai/gpt-5.4"; then
+		record_failure "strix GPT-5.4 guard must reject GitHub Models openai/openai/gpt-5.4"
 	fi
 }
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -86,6 +86,8 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow uses only explicit direct GPT-5 credentials"
 	assert_file_contains "$workflow_file" 'LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow masks only the direct OpenAI credential"
 	assert_file_contains "$workflow_file" "STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans" "strix workflow fails closed when direct credentials are absent"
+	assert_file_contains "$workflow_file" 'trimmed_openai_key="$(printf '"'"'%s'"'"' "$sanitized_openai_key" | sed '"'"'s/^[[:space:]]*//;s/[[:space:]]*$//'"'"')"' "strix workflow trims whitespace-only OpenAI keys before gate validation"
+	assert_file_contains "$workflow_file" 'trimmed="$(printf '"'"'%s'"'"' "$sanitized" | sed '"'"'s/^[[:space:]]*//;s/[[:space:]]*$//'"'"')"' "strix workflow trims whitespace-only OpenAI keys before input file creation"
 	assert_file_contains "$workflow_file" "STRIX_LLM_DEFAULT_PROVIDER: openai" "strix workflow uses the OpenAI-compatible provider for OpenAI Platform"
 	assert_file_not_contains "$workflow_file" "provider_mode=github_models" "strix workflow must not fall back to GitHub Models"
 	assert_file_not_contains "$workflow_file" "steps.gate.outputs.provider_mode == 'github_models'" "strix workflow must not prepare GitHub Models API base"


### PR DESCRIPTION
## Summary
- Exposes the backend self-hosted connector manifest in Settings > Developer/System.
- Adds mobile settings tab access so the Developer section is reachable on small screens.
- Adds unit and Playwright coverage for outbound-only connector boundaries, scrollability, and no horizontal overflow.

## Verification
- PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 pytest tests/test_runner_config_api.py -q
- npm test -- src/components/SettingsLayout.test.tsx
- npm test
- npm run typecheck
- npm run build
- env -u FORCE_COLOR -u NO_COLOR LIVE_BASE_URL=http://127.0.0.1:18120 npx playwright test tests/e2e/dashboard-branding.spec.ts --project=mobile -g "settings self-hosted connector manifest"

## Notes
- Naruon remains a web client/control plane, not an SMTP/IMAP/MX server.
- The connector contract stays outbound-only to naruon.net and labels GitHub self-hosted runner usage as CI smoke only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer settings now include a Self-hosted connector manifest view with role, network/control-plane, domain, runner usage, and protocol/prohibition details plus loading/error states.

* **Tests**
  * Added unit and end-to-end tests validating settings navigation, manifest rendering (mobile/desktop), API-backed manifest content, and scrolling/visual behavior.

* **Documentation**
  * Updated governance/docs to require an explicit OpenAI GPT-5.4+ credential for Strix scanning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->