### PR TITLE
feat: wire data webdav intent UI

### DIFF
--- a/docs/plans/2026-05-27-data-webdav-writeback-intent-ui.md
+++ b/docs/plans/2026-05-27-data-webdav-writeback-intent-ui.md
@@ -1,0 +1,46 @@
+# Data WebDAV Writeback Intent UI
+
+## Goal
+
+Wire the Data workspace to Naruon's customer-owned WebDAV writeback-intent
+contract so users can inspect source selection and conflict requirements before
+AI-organized files or attachments are written back to their own storage.
+
+## Architecture
+
+- Naruon is not a WebDAV storage provider or long-term source of truth.
+- Customer WebDAV accounts remain the writeback target.
+- The browser calls `POST /api/webdav/writeback-intent` through the signed
+  `apiClient` session path.
+- The UI shows intent, source id, server URL, If-Match requirement, and
+  provenance only. It does not claim provider write execution.
+- Public identity headers must not be emitted by browser write requests.
+
+## Implementation
+
+- `/data` now exposes a WebDAV writeback intent approval panel.
+- The intent panel uses the first connected customer WebDAV account as the
+  target source and fails closed when no source or signed session is available.
+- Data repository cards now use responsive grid tracks so mobile verification
+  does not depend on desktop-only three-column layouts.
+- Unit and Playwright tests assert signed `Authorization: Bearer` handling and
+  absence of public identity headers for `/api/webdav/writeback-intent`.
+
+## Verification
+
+```bash
+npm test -- src/app/data/page.test.tsx
+```
+
+```bash
+LIVE_BASE_URL=http://127.0.0.1:18140 \
+  npx playwright test tests/e2e/dashboard-branding.spec.ts \
+  --project=desktop -g "data WebDAV"
+```
+
+Screenshots to inspect:
+
+- `data-webdav-writeback-intent-desktop.png`
+- `data-webdav-writeback-intent-mobile.png`
+- `data-webdav-writeback-intent-mobile-scroll.png`
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /app
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 
 COPY frontend/package*.json ./
-RUN npm ci
+ARG TARGETARCH
+RUN npm ci \
+    && if [ "$TARGETARCH" = "arm64" ] \
+      && [ ! -f node_modules/lightningcss-linux-arm64-gnu/lightningcss.linux-arm64-gnu.node ]; then \
+      npm install --no-save --package-lock=false lightningcss-linux-arm64-gnu@1.32.0; \
+    fi
 
 COPY frontend ./
 

--- a/frontend/src/app/data/page.test.tsx
+++ b/frontend/src/app/data/page.test.tsx
@@ -18,9 +18,52 @@ vi.mock("lucide-react", () => ({
   AlertCircle: () => <svg aria-hidden="true" />,
   FileText: () => <svg aria-hidden="true" />,
   CheckCircle2: () => <svg aria-hidden="true" />,
+  Server: () => <svg aria-hidden="true" />,
 }));
 
 import DataPage from "./page";
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  };
+}
+
+function mockWebdavFetch() {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const path = String(input);
+    if (path === "/api/webdav/accounts") {
+      return jsonResponse([
+        {
+          account_id: 1,
+          server_url: "https://webdav.naruon.net",
+          username: "demo_user",
+        },
+      ]);
+    }
+    if (path === "/api/webdav/folders") {
+      return jsonResponse([
+        {
+          folder_id: 1,
+          project_name: "Naruon Roadmap 2026",
+          webdav_path: "/Projects/Naruon_Roadmap_2026",
+        },
+      ]);
+    }
+    if (path === "/api/webdav/writeback-intent") {
+      void init;
+      return jsonResponse({
+        intent: "writeback",
+        source_id: 1,
+        server_url: "https://webdav.naruon.net",
+        requires_if_match: true,
+        provenance: "server-authoritative",
+      });
+    }
+    throw new Error(`Unhandled fetch: ${path}`);
+  });
+}
 
 describe("DataPage", () => {
   let root: Root | null = null;
@@ -31,14 +74,17 @@ describe("DataPage", () => {
     root = null;
     container?.remove();
     container = null;
+    localStorage.clear();
+    vi.unstubAllGlobals();
   });
 
-  it("renders document repository ingestion embeddings quality and WebDAV writeback details", () => {
+  it("renders document repository ingestion embeddings quality and WebDAV writeback details", async () => {
+    vi.stubGlobal("fetch", mockWebdavFetch());
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root?.render(<DataPage />);
     });
 
@@ -47,5 +93,57 @@ describe("DataPage", () => {
     expect(container.textContent).toContain("데이터와 파일");
     expect(container.textContent).toContain("WebDAV 원본");
     expect(container.textContent).toContain("로컬 캐시");
+    expect(container.textContent).toContain("WebDAV writeback intent 승인");
+  });
+
+  it("creates a signed customer-owned WebDAV writeback intent", async () => {
+    localStorage.setItem("naruon_session_token", "signed-webdav-session");
+    const fetchMock = mockWebdavFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<DataPage />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("WebDAV intent 승인 점검"),
+    );
+    expect(button).toBeDefined();
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const writebackCall = fetchMock.mock.calls.find(([input]) => String(input) === "/api/webdav/writeback-intent");
+    expect(writebackCall).toBeDefined();
+    const [, init] = writebackCall ?? [];
+    expect(init?.method).toBe("POST");
+    const headerEntries =
+      init?.headers instanceof Headers
+        ? Array.from(init.headers.entries())
+        : Object.entries((init?.headers as Record<string, string>) ?? {});
+    const requestHeaders = Object.fromEntries(
+      headerEntries.map(([key, value]) => [key.toLowerCase(), String(value)]),
+    );
+    expect(requestHeaders).toEqual(expect.objectContaining({
+      authorization: "Bearer signed-webdav-session",
+      "content-type": "application/json",
+    }));
+    for (const publicHeader of [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ]) {
+      expect(requestHeaders[publicHeader]).toBeUndefined();
+    }
+    expect(JSON.parse(String(init?.body))).toEqual({ target_account_id: 1 });
+    expect(container.textContent).toContain("server-authoritative");
+    expect(container.textContent).toContain("https://webdav.naruon.net");
   });
 });

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -1,8 +1,27 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { Database, HardDrive, RefreshCw, FolderOpen, AlertCircle, FileText, CheckCircle2, Server } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
+
+type WebdavWritebackIntentResponse = {
+  intent: string;
+  source_id: number | null;
+  server_url: string | null;
+  requires_if_match: boolean;
+  provenance: string;
+  status?: string | null;
+  message?: string | null;
+};
+
+type WritebackStatus = 'idle' | 'loading' | 'success' | 'no_source' | 'auth' | 'error';
+
+function getApiErrorStatus(error: unknown) {
+  const shapedError = error as { status?: unknown; response?: { status?: unknown } } | null;
+  if (typeof shapedError?.status === 'number') return shapedError.status;
+  if (typeof shapedError?.response?.status === 'number') return shapedError.response.status;
+  return null;
+}
 
 export function DataLayout() {
   const [activeTab, setActiveTab] = useState<'문서 저장소' | '수집 파이프라인' | '임베딩' | '품질 점검'>('문서 저장소');
@@ -21,6 +40,8 @@ export function DataLayout() {
   
   const [webdavAccounts, setWebdavAccounts] = useState<WebdavAccount[]>([]);
   const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>([]);
+  const [writebackStatus, setWritebackStatus] = useState<WritebackStatus>('idle');
+  const [writebackResult, setWritebackResult] = useState<WebdavWritebackIntentResponse | null>(null);
 
   useEffect(() => {
     apiClient.get<WebdavAccount[]>('/api/webdav/accounts')
@@ -32,11 +53,36 @@ export function DataLayout() {
       .catch(console.error);
   }, []);
 
+  const requestWebdavWritebackIntent = useCallback(async () => {
+    setWritebackStatus('loading');
+    setWritebackResult(null);
+    try {
+      const targetAccountId = webdavAccounts[0]?.account_id;
+      const result = await apiClient.post<WebdavWritebackIntentResponse>(
+        '/api/webdav/writeback-intent',
+        typeof targetAccountId === 'number' ? { target_account_id: targetAccountId } : {},
+      );
+      setWritebackResult(result);
+      setWritebackStatus('success');
+    } catch (error: unknown) {
+      const status = getApiErrorStatus(error);
+      if (status === 422) {
+        setWritebackStatus('no_source');
+      } else if (status === 401 || status === 403) {
+        setWritebackStatus('auth');
+      } else {
+        setWritebackStatus('error');
+      }
+    }
+  }, [webdavAccounts]);
+
+  const isWritebackLoading = writebackStatus === 'loading';
+
   return (
     <div className="flex h-full min-w-0 min-h-0 bg-background text-foreground flex-col overflow-x-hidden">
       <header className="flex h-20 shrink-0 items-center border-b border-border bg-card px-4 md:px-8 overflow-hidden">
         <h1 className="text-xl md:text-2xl font-bold flex shrink-0 items-center gap-3">
-          <Database className="size-6 text-primary" /> <span className="hidden sm:inline">데이터와 파일</span>
+          <Database className="size-6 text-primary" /> <span className="sr-only sm:not-sr-only sm:inline">데이터와 파일</span>
         </h1>
         <p className="sr-only">중복 반입과 thread 정리</p>
         <div className="ml-4 md:ml-8 flex flex-1 min-w-0 gap-2 overflow-x-auto pb-1 scrollbar-hide">
@@ -52,12 +98,12 @@ export function DataLayout() {
         </div>
       </header>
 
-      <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden p-4 md:p-8 bg-background">
+      <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden p-4 pb-[calc(7rem+env(safe-area-inset-bottom))] md:p-8 bg-background">
         <div className="max-w-5xl mx-auto space-y-8">
           
           {activeTab === '문서 저장소' && (
             <div className="space-y-6">
-              <div className="grid grid-cols-3 gap-6">
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
                 <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
                   <div className="flex items-center gap-3 mb-4">
                     <div className="rounded-xl bg-blue-100 p-3"><HardDrive className="size-5 text-blue-700" /></div>
@@ -100,11 +146,72 @@ export function DataLayout() {
                 </div>
               </div>
 
+              <section aria-label="WebDAV writeback intent 승인" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-xs font-black uppercase text-primary">Customer-owned file intent</p>
+                    <h2 className="mt-1 text-lg font-black">WebDAV writeback intent 승인</h2>
+                    <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+                      첨부파일과 AI가 구조화한 산출물은 Naruon 저장소에만 남기지 않고 고객 WebDAV 원본에 반영할 intent로 점검합니다.
+                      실제 provider write는 원본 계정, If-Match 충돌 조건, provenance를 통과한 뒤 별도 실행됩니다.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void requestWebdavWritebackIntent()}
+                    disabled={isWritebackLoading}
+                    className="w-full whitespace-nowrap rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto"
+                  >
+                    WebDAV intent 승인 점검
+                  </button>
+                </div>
+
+                <div role="status" aria-live="polite" className="mt-4 rounded-xl border border-border bg-background/70 p-4 text-sm">
+                  {writebackStatus === 'idle' && (
+                    <p className="text-muted-foreground">아직 WebDAV provider write는 실행하지 않았습니다. 원본 source와 충돌 조건만 확인합니다.</p>
+                  )}
+                  {writebackStatus === 'loading' && <p className="font-bold text-primary">WebDAV writeback intent 요청 중입니다.</p>}
+                  {writebackStatus === 'no_source' && (
+                    <p className="font-bold text-amber-700">연결된 고객 WebDAV 원본 계정이 없어 writeback intent를 만들 수 없습니다.</p>
+                  )}
+                  {writebackStatus === 'auth' && (
+                    <p className="font-bold text-red-700">signed session이 필요합니다. 공개 identity header로는 WebDAV intent를 만들 수 없습니다.</p>
+                  )}
+                  {writebackStatus === 'error' && (
+                    <p className="font-bold text-red-700">WebDAV writeback intent 점검에 실패했습니다.</p>
+                  )}
+                  {writebackStatus === 'success' && writebackResult && (
+                    <dl className="grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+                      <div>
+                        <dt className="font-black text-muted-foreground">INTENT</dt>
+                        <dd className="mt-1 font-mono text-sm text-foreground">{writebackResult.intent}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-black text-muted-foreground">SOURCE_ID</dt>
+                        <dd className="mt-1 font-mono text-sm text-foreground">{writebackResult.source_id ?? 'none'}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-black text-muted-foreground">IF_MATCH</dt>
+                        <dd className="mt-1 font-mono text-sm text-foreground">{writebackResult.requires_if_match ? 'required' : 'not_required'}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-black text-muted-foreground">PROVENANCE</dt>
+                        <dd className="mt-1 font-mono text-sm text-foreground">{writebackResult.provenance}</dd>
+                      </div>
+                      <div className="min-w-0 sm:col-span-2 lg:col-span-4">
+                        <dt className="font-black text-muted-foreground">SERVER_URL</dt>
+                        <dd className="mt-1 break-all font-mono text-sm text-foreground">{writebackResult.server_url ?? 'none'}</dd>
+                      </div>
+                    </dl>
+                  )}
+                </div>
+              </section>
+
               <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden">
                 <div className="p-5 border-b border-border bg-secondary/30">
                   <h2 className="font-bold text-lg flex items-center gap-2"><FolderOpen className="size-5" /> AI 프로젝트 구조화된 첨부파일 (WebDAV)</h2>
                 </div>
-                <div className="p-4 grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div className="p-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
                   {projectFolders.length > 0 ? projectFolders.map(folder => (
                     <div key={folder.folder_id} className="border border-border rounded-xl p-4 bg-background hover:bg-secondary/20 transition-colors">
                       <div className="flex items-center gap-3 mb-2">
@@ -234,7 +341,7 @@ export function DataLayout() {
 
           {activeTab === '품질 점검' && (
             <div className="space-y-6">
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
                   <p className="text-xs font-bold text-muted-foreground mb-1">인덱싱 실패</p>
                   <p className="text-xl font-bold text-red-500">23건</p>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -309,6 +309,81 @@ test('renders calendar writeback intent status without direct provider writes', 
   await page.screenshot({ path: testInfo.outputPath('calendar-writeback-intent-mobile-scroll.png'), fullPage: false });
 });
 
+test('renders data WebDAV writeback intent status without direct provider writes', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-webdav-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  await page.goto('/data');
+  const desktopWritebackRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/webdav/writeback-intent' && request.method() === 'POST';
+  });
+  await page.getByRole('button', { name: 'WebDAV intent 승인 점검' }).click();
+  const desktopHeaders = (await desktopWritebackRequest).headers();
+  expect(desktopHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(desktopHeaders[headerName]).toBeUndefined();
+  }
+
+  await expect(page.getByText('writeback', { exact: true })).toBeVisible();
+  await expect(page.getByText('server-authoritative')).toBeVisible();
+  await expect(page.getByText('https://webdav.naruon.net').first()).toBeVisible();
+  await expect(page.getByText('required', { exact: true })).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('data-webdav-writeback-intent-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/data');
+  await expect(page.getByRole('heading', { name: '데이터와 파일' })).toBeVisible();
+  const mobileWritebackRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/webdav/writeback-intent' && request.method() === 'POST';
+  });
+  await page.getByRole('button', { name: 'WebDAV intent 승인 점검' }).click();
+  const mobileHeaders = (await mobileWritebackRequest).headers();
+  expect(mobileHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(mobileHeaders[headerName]).toBeUndefined();
+  }
+  await expect(page.getByText('server-authoritative')).toBeVisible();
+  await page.getByText('server-authoritative').scrollIntoViewIfNeeded();
+  await page.mouse.wheel(0, 140);
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('data-webdav-writeback-intent-mobile.png'), fullPage: false });
+  const dataScrollMetrics = await page.evaluate(() => {
+    const scroller = Array.from(document.querySelectorAll('main, main *')).find((element) => {
+      const style = window.getComputedStyle(element);
+      return style.overflowY !== 'hidden' && element.scrollHeight > element.clientHeight + 10;
+    });
+    if (!scroller) return null;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(dataScrollMetrics).not.toBeNull();
+  expect(dataScrollMetrics?.maxScroll).toBeGreaterThan(0);
+  expect(dataScrollMetrics?.after).toBeGreaterThan(dataScrollMetrics?.before ?? 0);
+  await page.screenshot({ path: testInfo.outputPath('data-webdav-writeback-intent-mobile-scroll.png'), fullPage: false });
+});
+
 test('captures responsive startup evidence for desktop tablet mobile and the mobile drawer', async ({ page }, testInfo) => {
   await mockDashboardApi(page);
   for (const viewport of [

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -178,6 +178,44 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
       return;
     }
 
+    if (path === '/api/webdav/accounts' && request.method() === 'GET') {
+      await fulfillJson(route, [
+        {
+          account_id: 1,
+          server_url: 'https://webdav.naruon.net',
+          username: 'demo_user',
+        },
+      ]);
+      return;
+    }
+
+    if (path === '/api/webdav/folders' && request.method() === 'GET') {
+      await fulfillJson(route, [
+        {
+          folder_id: 1,
+          project_name: 'Naruon Roadmap 2026',
+          webdav_path: '/Projects/Naruon_Roadmap_2026',
+        },
+        {
+          folder_id: 2,
+          project_name: 'Marketing Assets',
+          webdav_path: '/Projects/Marketing_Assets',
+        },
+      ]);
+      return;
+    }
+
+    if (path === '/api/webdav/writeback-intent' && request.method() === 'POST') {
+      await fulfillJson(route, {
+        intent: 'writeback',
+        source_id: 1,
+        server_url: 'https://webdav.naruon.net',
+        requires_if_match: true,
+        provenance: 'server-authoritative',
+      });
+      return;
+    }
+
     if (path === '/api/tasks' && request.method() === 'GET') {
       await fulfillJson(route, [
         {


### PR DESCRIPTION
## Summary
- Adds a Data workspace WebDAV writeback intent approval panel wired through signed `apiClient.post('/api/webdav/writeback-intent')`.
- Shows intent, source id, If-Match requirement, provenance, and server URL without claiming provider write execution.
- Adds unit and Playwright coverage for signed Authorization and absent public identity headers on the WebDAV write path.
- Documents the slice in `docs/plans/2026-05-27-data-webdav-writeback-intent-ui.md`.

## Verification
- `npm test -- src/app/data/page.test.tsx`
- `npm test -- src/lib/api-client.test.ts`
- `npm run typecheck`
- `npm run build`
- `env -u FORCE_COLOR -u NO_COLOR LIVE_BASE_URL=http://127.0.0.1:18140 npx playwright test tests/e2e/dashboard-branding.spec.ts --project=desktop -g "data WebDAV"`

## Screenshot Evidence
- `data-webdav-writeback-intent-desktop.png`
- `data-webdav-writeback-intent-mobile.png`
- `data-webdav-writeback-intent-mobile-scroll.png`