### PR TITLE
Add sent mail reply tracking route

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -5,10 +5,12 @@ from db.session import get_db
 from db.models import Email, TenantConfig
 from pydantic import BaseModel, EmailStr
 import datetime
+from typing import Literal
 from services.email_client import send_email, validate_smtp_destination
 from services.reply_tracking_service import (
     check_missing_replies,
     configured_email_addresses,
+    message_is_from_user,
     message_is_self_sent,
     thread_requires_reply,
 )
@@ -41,6 +43,20 @@ def email_owner_filters(auth_context: AuthContext):
         else Email.organization_id.is_(None)
     )
     return (Email.user_id == auth_context.user_id, organization_filter)
+
+
+MailFolder = Literal["inbox", "sent"]
+
+
+def thread_matches_folder(
+    thread_messages: list[Email], user_addresses: set[str], folder: MailFolder
+) -> bool:
+    if folder == "sent":
+        return any(
+            message_is_from_user(email_message, user_addresses)
+            for email_message in thread_messages
+        )
+    return True
 
 
 class EmailListItem(BaseModel):
@@ -77,6 +93,7 @@ class EmailDetailResponse(BaseModel):
 @router.get("", response_model=dict[str, list[EmailListItem]])
 async def get_emails(
     limit: int = Query(default=50, ge=1, le=200),
+    folder: MailFolder = Query(default="inbox"),
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(get_auth_context),
 ):
@@ -108,7 +125,12 @@ async def get_emails(
             if email.date > grouped[group_key].date:
                 grouped[group_key] = email
 
-    sorted_groups = sorted(grouped.values(), key=lambda x: x.date, reverse=True)[:limit]
+    visible_groups = [
+        email
+        for group_key, email in grouped.items()
+        if thread_matches_folder(thread_messages[group_key], user_addresses, folder)
+    ]
+    sorted_groups = sorted(visible_groups, key=lambda x: x.date, reverse=True)[:limit]
 
     items = []
     for email in sorted_groups:

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -316,6 +316,68 @@ async def test_get_emails_marks_self_sent_and_pending_reply_threads(
     assert by_thread["note-thread"]["requires_reply"] is False
 
 
+@pytest.mark.asyncio
+async def test_get_emails_sent_folder_returns_user_sent_threads_only(
+    client: AsyncClient, db_session
+):
+    class MailTenantConfig:
+        smtp_username = "Me <testuser@example.com>"
+        imap_username = None
+
+    external_inbox = Email(
+        id=20,
+        user_id="testuser",
+        message_id="external-msg",
+        thread_id="external-thread",
+        sender="partner@example.com",
+        recipients="testuser@example.com",
+        subject="Incoming only",
+        date=datetime.datetime(2026, 4, 27, 9, 0, tzinfo=datetime.timezone.utc),
+        body="FYI only.",
+    )
+    sent_waiting = Email(
+        id=21,
+        user_id="testuser",
+        message_id="sent-waiting-msg",
+        thread_id="sent-waiting-thread",
+        sender="Test User <testuser@example.com>",
+        recipients="partner@example.com",
+        subject="Can you confirm?",
+        date=datetime.datetime(2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Can you confirm this plan?",
+    )
+    self_note = Email(
+        id=22,
+        user_id="testuser",
+        message_id="sent-note-msg",
+        thread_id="sent-note-thread",
+        sender="testuser@example.com",
+        recipients="testuser@example.com",
+        subject="Note to self",
+        date=datetime.datetime(2026, 4, 27, 11, 0, tzinfo=datetime.timezone.utc),
+        body="Turn this into knowledge.",
+    )
+    db_session.tenant_config = MailTenantConfig()
+    db_session.items = [self_note, sent_waiting, external_inbox]
+
+    response = await client.get("/api/emails?folder=sent&limit=10")
+
+    assert response.status_code == 200
+    by_thread = {item["thread_id"]: item for item in response.json()["emails"]}
+    assert set(by_thread) == {"sent-waiting-thread", "sent-note-thread"}
+    assert by_thread["sent-waiting-thread"]["requires_reply"] is True
+    assert by_thread["sent-note-thread"]["is_self_sent"] is True
+    assert by_thread["sent-note-thread"]["requires_reply"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_emails_rejects_unknown_folder(client: AsyncClient):
+    response = await client.get("/api/emails?folder=archive")
+
+    assert response.status_code == 422
+    assert "folder" in response.text
+
+
 @pytest.mark.postgres
 @pytest.mark.asyncio
 async def test_get_emails_reply_tracking_real_postgres_smoke():

--- a/docs/plans/2026-05-27-sent-mail-reply-tracking-route.md
+++ b/docs/plans/2026-05-27-sent-mail-reply-tracking-route.md
@@ -1,0 +1,55 @@
+# Sent Mail Reply Tracking Route
+
+Date: 2026-05-27
+
+## Scope
+
+Make `/mail?folder=sent` a real API-backed sent-mail lane instead of a menu-only
+promise. The slice reuses existing email rows and reply-tracking fields; it does
+not add database tables or provider write execution.
+
+## Confirmed Inputs
+
+- The workspace navigation already links to `/mail?folder=sent` as "보낸 메일".
+- `backend/api/emails.py` already returns `is_self_sent` and `requires_reply`.
+- `services/reply_tracking_service.py` already derives user-owned addresses from
+  configured SMTP/IMAP usernames and detects self-sent notes.
+- `EmailList.tsx` only called `/api/emails`, so the sent route was visually
+  indistinguishable from the inbox.
+
+## Product Research Notes
+
+- Gmail Help documents follow-up nudges for sent emails that may need a reply:
+  https://support.google.com/mail/answer/6585
+- Microsoft Outlook best-practice guidance treats follow-up timing as part of
+  mail workflow hygiene:
+  https://support.microsoft.com/en-us/office/best-practices-for-outlook-f90e5f69-8832-4d89-95b3-bfdf76c82ef8
+- Inbox Zero's Reply Zero pattern separates "awaiting reply" sent threads into a
+  waiting lane:
+  https://docs.getinboxzero.com/essentials/reply-zero
+
+## Implementation Plan
+
+1. Backend folder filter
+   - Add `folder=inbox|sent` to `GET /api/emails`.
+   - Keep the default inbox behavior compatible with existing grouped-thread
+     results.
+   - For `folder=sent`, return only threads containing a message from the
+     authenticated user's configured SMTP/IMAP address.
+   - Preserve owner and organization scoping.
+
+2. Frontend route wiring
+   - Parse `folder=sent` in `/mail`.
+   - Pass the folder to `WorkspaceHome` and all `EmailList` instances.
+   - Fetch `/api/emails?folder=sent` with the stored signed session token.
+
+3. Sent-mail surface
+   - Render "보낸 메일", "답변 추적", and "지식 정리" copy.
+   - Keep existing `응답 대기 중` and `지식 정리` badges from API fields.
+   - Preserve safe text rendering for sender, subject, and snippet.
+
+4. Verification
+   - Backend tests for sent filtering and invalid folder rejection.
+   - Frontend tests for sent mode endpoint and labels.
+   - E2E screenshots for desktop and mobile including scroll.
+

--- a/frontend/src/app/mail/page.tsx
+++ b/frontend/src/app/mail/page.tsx
@@ -1,7 +1,18 @@
-"use client";
-
 import { WorkspaceHome } from '@/components/WorkspaceHome';
+import type { MailFolder } from '@/components/EmailList';
 
-export default function MailPage() {
-  return <WorkspaceHome forcedStartupView="email" />;
+type MailPageProps = {
+  searchParams?: Promise<{
+    folder?: string | string[];
+  }>;
+};
+
+function normalizeMailFolder(value: string | string[] | undefined): MailFolder {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  return rawValue === 'sent' ? 'sent' : 'inbox';
+}
+
+export default async function MailPage({ searchParams }: MailPageProps) {
+  const params = searchParams ? await searchParams : {};
+  return <WorkspaceHome forcedStartupView="email" mailFolder={normalizeMailFolder(params.folder)} />;
 }

--- a/frontend/src/components/EmailList.test.tsx
+++ b/frontend/src/components/EmailList.test.tsx
@@ -112,6 +112,53 @@ describe("EmailList", () => {
     expect(container.textContent).toContain("(제목 없음)");
   });
 
+  it("renders sent mail reply tracking mode from the sent folder API", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          emails: [
+            {
+              id: 12,
+              sender: "Seongho <user@naruon.ai>",
+              subject: "계약 검토 확인 요청",
+              date: "2026-05-11T09:30:00Z",
+              snippet: "Please reply when the contract review is complete.",
+              unread: false,
+              reply_count: 1,
+              requires_reply: true,
+            },
+            {
+              id: 13,
+              sender: "user@naruon.ai",
+              subject: "나에게 보낸 회의 메모",
+              date: "2026-05-11T10:30:00Z",
+              snippet: "다음 회의 전까지 지식으로 정리할 메모입니다.",
+              unread: false,
+              reply_count: 1,
+              is_self_sent: true,
+            },
+          ],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<EmailList onSelectEmail={vi.fn()} selectedEmailId={null} folder="sent" />);
+    });
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/emails?folder=sent", expect.any(Object));
+    expect(container.textContent).toContain("보낸 메일");
+    expect(container.textContent).toContain("답변 추적");
+    expect(container.textContent).toContain("응답 대기 중");
+    expect(container.textContent).toContain("지식 정리");
+  });
+
   it("keeps untrusted email fields on the React text-node path", async () => {
     const fetchMock = vi.fn(() =>
       Promise.resolve(

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { apiClient } from '@/lib/api-client';
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -24,23 +24,34 @@ interface EmailItem {
   schedule_conflict?: boolean;
 }
 
-let inboxRequest: Promise<EmailItem[]> | null = null;
+export type MailFolder = 'inbox' | 'sent';
 
-async function fetchInboxEmails() {
-  inboxRequest ??= apiClient.get<{ emails: EmailItem[] }>('/api/emails')
+const folderRequests = new Map<MailFolder, Promise<EmailItem[]>>();
+
+function folderEndpoint(folder: MailFolder) {
+  return folder === 'sent' ? '/api/emails?folder=sent' : '/api/emails';
+}
+
+async function fetchFolderEmails(folder: MailFolder) {
+  if (folderRequests.has(folder)) return folderRequests.get(folder)!;
+
+  const request = apiClient.get<{ emails: EmailItem[] }>(folderEndpoint(folder))
     .then((data) => data.emails || [])
     .finally(() => {
-      inboxRequest = null;
+      folderRequests.delete(folder);
     });
-  return inboxRequest;
+  folderRequests.set(folder, request);
+  return request;
 }
 
 export function EmailList({
   onSelectEmail,
   selectedEmailId,
+  folder = 'inbox',
 }: {
   onSelectEmail: (id: number) => void;
   selectedEmailId?: number | null;
+  folder?: MailFolder;
 }) {
   const [emails, setEmails] = useState<EmailItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -48,12 +59,12 @@ export function EmailList({
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearching, setIsSearching] = useState(false);
 
-  const fetchEmails = async (query = "") => {
+  const fetchEmails = useCallback(async (query = "") => {
     setLoading(true);
     setError(null);
     try {
       if (query.trim() === "") {
-        setEmails(await fetchInboxEmails());
+        setEmails(await fetchFolderEmails(folder));
       } else {
         setIsSearching(true);
         const data = await apiClient.post<{ results: EmailItem[] }>('/api/search', { query });
@@ -65,15 +76,37 @@ export function EmailList({
       setLoading(false);
       setIsSearching(false);
     }
-  };
+  }, [folder]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Initial inbox fetch synchronizes client state with the backend.
     fetchEmails();
-  }, []);
+  }, [fetchEmails]);
+
+  const folderCopy = folder === 'sent'
+    ? {
+        title: '보낸 메일',
+        description: '답변 대기, 회신 완료, 나에게 보낸 지식 정리 후보를 추적합니다.',
+        primaryBadge: '답변 추적',
+        secondaryBadge: '지식 정리',
+        focusLabel: '보낸 메일 추적',
+        focusText: '응답 대기 스레드와 self-sent 지식 후보를 표시합니다',
+        emptyTitle: '보낸 메일이 없습니다',
+        emptyBody: 'SMTP/IMAP 동기화 후 보낸 스레드와 답변 대기 상태가 표시됩니다.',
+      }
+    : {
+        title: '받은편지함',
+        description: '중요 메일을 맥락과 실행 흐름으로 정리합니다.',
+        primaryBadge: '맥락 종합',
+        secondaryBadge: '실행 항목',
+        focusLabel: '오늘의 판단 포인트',
+        focusText: '메일 데이터 기반으로 판단 포인트를 표시합니다',
+        emptyTitle: '검색 결과가 없습니다',
+        emptyBody: '검색어를 바꾸거나 메일 동기화 상태를 확인하세요.',
+      };
 
   return (
-    <div className="h-full flex w-full flex-col border-r border-border/80 bg-card/95">
+    <div className="flex h-full min-h-0 w-full flex-col border-r border-border/80 bg-card/95">
       <div className="border-b border-border/80 bg-gradient-to-br from-card via-card to-primary/5 p-4">
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
@@ -81,22 +114,22 @@ export function EmailList({
               <Sparkles className="size-3.5" aria-hidden="true" />
               Naruon Mail
             </div>
-            <h2 className="mt-1 text-2xl font-black tracking-tight text-foreground">받은편지함</h2>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">중요 메일을 맥락과 실행 흐름으로 정리합니다.</p>
+            <h2 className="mt-1 text-2xl font-black tracking-tight text-foreground">{folderCopy.title}</h2>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">{folderCopy.description}</p>
             <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-bold">
               <span className="inline-flex items-center gap-1 rounded-full border border-primary/15 bg-primary/10 px-2.5 py-1 text-primary">
                 <Network className="size-3" aria-hidden="true" />
-                맥락 종합
+                {folderCopy.primaryBadge}
               </span>
               <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/15 bg-emerald-500/10 px-2.5 py-1 text-emerald-700">
                 <CheckCircle2 className="size-3" aria-hidden="true" />
-                실행 항목
+                {folderCopy.secondaryBadge}
               </span>
             </div>
             <div className="mt-3 rounded-2xl border border-primary/15 bg-background/80 px-3 py-2 text-xs leading-5 shadow-inner shadow-slate-950/[0.02]">
-              <span className="font-bold text-primary">오늘의 판단 포인트</span>
+              <span className="font-bold text-primary">{folderCopy.focusLabel}</span>
               <span className="mx-2 text-muted-foreground">·</span>
-              <span className="font-semibold text-foreground">메일 데이터 기반으로 판단 포인트를 표시합니다</span>
+              <span className="font-semibold text-foreground">{folderCopy.focusText}</span>
             </div>
           </div>
           <span className="grid size-10 shrink-0 place-items-center rounded-2xl bg-primary text-primary-foreground shadow-[0_12px_28px_rgba(37,99,255,0.28)]">
@@ -127,7 +160,7 @@ export function EmailList({
           </Button>
         </form>
       </div>
-      <ScrollArea className="flex-1 w-full">
+      <ScrollArea className="min-h-0 flex-1 w-full">
         <div className="flex flex-col gap-2 p-3 pb-[calc(7rem+env(safe-area-inset-bottom))] lg:pb-3">
           {loading ? (
             <div role="status" aria-live="polite" className="rounded-2xl border border-border bg-background/70 p-4 text-sm text-muted-foreground">메일을 불러오는 중입니다...</div>
@@ -135,8 +168,8 @@ export function EmailList({
             <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">{error}</div>
           ) : emails.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-border bg-background/70 p-5 text-sm text-muted-foreground">
-              <p className="font-bold text-foreground">검색 결과가 없습니다</p>
-              <p className="mt-1 text-xs leading-5">검색어를 바꾸거나 메일 동기화 상태를 확인하세요.</p>
+              <p className="font-bold text-foreground">{folderCopy.emptyTitle}</p>
+              <p className="mt-1 text-xs leading-5">{folderCopy.emptyBody}</p>
             </div>
           ) : (
             emails.map((email: EmailItem) => {

--- a/frontend/src/components/WorkspaceHome.tsx
+++ b/frontend/src/components/WorkspaceHome.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { EmailList } from '@/components/EmailList';
+import type { MailFolder } from '@/components/EmailList';
 import { EmailDetail } from '@/components/EmailDetail';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import dynamic from 'next/dynamic';
@@ -426,7 +427,13 @@ function StartupCalendar({ onOpenView }: { onOpenView: (view: WorkspaceStartupVi
   );
 }
 
-export function WorkspaceHome({ forcedStartupView }: { forcedStartupView?: WorkspaceStartupView } = {}) {
+export function WorkspaceHome({
+  forcedStartupView,
+  mailFolder = 'inbox',
+}: {
+  forcedStartupView?: WorkspaceStartupView;
+  mailFolder?: MailFolder;
+} = {}) {
   const [selectedEmail, setSelectedEmail] = useState<number | null>(null);
   const [workspaceActionNotice, setWorkspaceActionNotice] = useState<string | null>(null);
   const [desktopDetailActionCommand, setDesktopDetailActionCommand] = useState<WorkspaceActionCommand | null>(null);
@@ -588,7 +595,7 @@ export function WorkspaceHome({ forcedStartupView }: { forcedStartupView?: Works
         {viewportReady && !isMobileViewport && !isTabletViewport ? (
         <ResizablePanelGroup orientation="horizontal" className="h-full items-stretch rounded-3xl border border-border/80 bg-card/70 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur-xl">
           <ResizablePanel defaultSize={27} minSize={22}>
-            <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} />
+            <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} folder={mailFolder} />
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={48} minSize={34}>
@@ -624,7 +631,7 @@ export function WorkspaceHome({ forcedStartupView }: { forcedStartupView?: Works
         {viewportReady && isTabletViewport ? (
           <>
         <div className="min-w-0 basis-[38%] overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-          <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} />
+          <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} folder={mailFolder} />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-hidden">
           <div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
@@ -659,7 +666,7 @@ export function WorkspaceHome({ forcedStartupView }: { forcedStartupView?: Works
             role="region"
             className={`mobile-workspace-panel mobile-workspace-panel-inbox h-full ${effectiveMobileView === 'inbox' ? 'block' : 'hidden'}`}
           >
-            <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} />
+            <EmailList onSelectEmail={handleSelectEmail} selectedEmailId={selectedEmail} folder={mailFolder} />
           </section>
           <section
             id="mobile-detail"

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -199,6 +199,66 @@ for (const destination of [
   });
 }
 
+test('renders sent mail reply tracking route with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-sent-mail-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  const sentRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/emails' && url.searchParams.get('folder') === 'sent' && request.method() === 'GET';
+  });
+
+  await page.goto('/mail?folder=sent');
+  const requestHeaders = (await sentRequest).headers();
+  expect(requestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(requestHeaders[headerName]).toBeUndefined();
+  }
+
+  await expect(page.getByRole('heading', { name: '보낸 메일' }).first()).toBeVisible();
+  await expect(page.getByText('답변 대기').first()).toBeVisible();
+  await expect(page.getByText('응답 대기 중').first()).toBeVisible();
+  await expect(page.getByText('지식 정리').first()).toBeVisible();
+  await expect(page.getByText('벤더 계약 답변 요청').first()).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('sent-mail-reply-tracking-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/mail?folder=sent');
+  await expect(page.getByRole('heading', { name: '보낸 메일' }).first()).toBeVisible();
+  await expect(page.getByText('응답 대기 중').first()).toBeVisible();
+  await expect(page.getByText('나에게 보낸 지식 메모').first()).toBeVisible();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('sent-mail-reply-tracking-mobile.png'), fullPage: false });
+  const sentScrollMetrics = await page.locator('#mobile-inbox [data-slot="scroll-area-viewport"]').evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(sentScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(sentScrollMetrics.after).toBeGreaterThan(sentScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('sent-mail-reply-tracking-mobile-scroll.png'), fullPage: false });
+});
+
 test('renders the settings self-hosted connector manifest with mobile scrolling', async ({ page }, testInfo) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await mockDashboardApi(page);

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -23,6 +23,86 @@ const sibling = {
   body: '파트너 미팅 전까지 일정 확인이 필요합니다.',
 };
 
+const sentEmail = {
+  ...email,
+  id: 31,
+  message_id: '<sent-q2@example.com>',
+  thread_id: 'thread-sent-q2',
+  sender: 'Seongho <user@naruon.ai>',
+  recipients: 'partner@example.com',
+  subject: '벤더 계약 답변 요청',
+  date: '2026-05-11T12:30:00Z',
+  snippet: 'Please reply when the vendor contract review is ready.',
+  unread: false,
+  reply_count: 1,
+  requires_reply: true,
+  is_self_sent: false,
+};
+
+const selfSentNote = {
+  ...email,
+  id: 32,
+  message_id: '<self-note@example.com>',
+  thread_id: 'thread-self-note',
+  sender: 'user@naruon.ai',
+  recipients: 'user@naruon.ai',
+  subject: '나에게 보낸 지식 메모',
+  date: '2026-05-11T13:10:00Z',
+  snippet: '다음 분기 전략 회의 전에 지식으로 정리할 메모입니다.',
+  unread: false,
+  reply_count: 1,
+  requires_reply: false,
+  is_self_sent: true,
+};
+
+const sentFollowUp = {
+  ...email,
+  id: 33,
+  message_id: '<sent-follow-up@example.com>',
+  thread_id: 'thread-sent-follow-up',
+  sender: 'Seongho <user@naruon.ai>',
+  recipients: 'finance@example.com',
+  subject: '예산 승인 후속 확인',
+  date: '2026-05-11T14:20:00Z',
+  snippet: 'Can you confirm whether the budget approval is ready?',
+  unread: false,
+  reply_count: 1,
+  requires_reply: true,
+  is_self_sent: false,
+};
+
+const sentResolved = {
+  ...email,
+  id: 34,
+  message_id: '<sent-resolved@example.com>',
+  thread_id: 'thread-sent-resolved',
+  sender: 'Seongho <user@naruon.ai>',
+  recipients: 'ops@example.com',
+  subject: '운영 점검 회신 완료',
+  date: '2026-05-11T15:00:00Z',
+  snippet: '운영 점검 후속 메일이며 이미 회신이 연결된 스레드입니다.',
+  unread: false,
+  reply_count: 2,
+  requires_reply: false,
+  is_self_sent: false,
+};
+
+const sentKnowledge = {
+  ...email,
+  id: 35,
+  message_id: '<sent-knowledge@example.com>',
+  thread_id: 'thread-sent-knowledge',
+  sender: 'user@naruon.ai',
+  recipients: 'user@naruon.ai',
+  subject: '고객 미팅 지식 정리',
+  date: '2026-05-11T16:00:00Z',
+  snippet: '고객 미팅에서 나온 판단 포인트를 지식으로 정리합니다.',
+  unread: false,
+  reply_count: 1,
+  requires_reply: false,
+  is_self_sent: true,
+};
+
 const mobileAttachmentResult = {
   ...email,
   id: 17,
@@ -102,6 +182,10 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
     }
 
     if (path === '/api/emails' && request.method() === 'GET') {
+      if (url.searchParams.get('folder') === 'sent') {
+        await fulfillJson(route, { emails: [sentEmail, selfSentNote, sentFollowUp, sentResolved, sentKnowledge] });
+        return;
+      }
       await fulfillJson(route, { emails: [email] });
       return;
     }


### PR DESCRIPTION
## Summary
- Add `folder=sent` support to `GET /api/emails` using configured user mail addresses and existing reply-tracking helpers.
- Wire `/mail?folder=sent` through WorkspaceHome/EmailList and render sent-mail reply tracking/self-sent knowledge labels.
- Add backend, unit, and responsive E2E coverage with signed-session header assertions.

## Verification
- `python3 -m pytest backend/tests/test_emails_api.py -q`
- `npm test -- src/components/EmailList.test.tsx src/components/DashboardLayout.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `env -u FORCE_COLOR -u NO_COLOR PLAYWRIGHT_PORT=18160 LIVE_BASE_URL=http://127.0.0.1:18160 npx playwright test tests/e2e/dashboard-branding.spec.ts --project=desktop -g "sent mail"`

## Notes
- Strix remains OpenAI Platform direct only; no GitHub Models fallback is configured.