### PR TITLE
feat: add source-linked task status tracking

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -46,6 +46,13 @@ class CreateTasksFromEmailResponse(BaseModel):
     tasks: list[TicketTaskResponse]
 
 
+class UpdateTicketTaskRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: TaskStatus | None = None
+    priority: TaskPriority | None = None
+
+
 def _normalize_execution_items(items: list[str]) -> list[str]:
     normalized = []
     for item in items:
@@ -105,6 +112,50 @@ async def list_ticket_tasks(
     return [
         _task_response(task, source_email_id) for task, source_email_id in result.all()
     ]
+
+
+@router.patch("/{task_uid}", response_model=TicketTaskResponse)
+async def update_ticket_task(
+    task_uid: str,
+    request: UpdateTicketTaskRequest,
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> TicketTaskResponse:
+    if request.status is None and request.priority is None:
+        raise HTTPException(
+            status_code=422, detail="At least one ticket field is required"
+        )
+
+    result = await db.execute(
+        select(TicketTask, Email.message_id)
+        .outerjoin(
+            Email,
+            and_(
+                TicketTask.related_email_id == Email.id,
+                Email.user_id == auth_context.user_id,
+                Email.organization_id == auth_context.organization_id,
+            ),
+        )
+        .where(
+            TicketTask.task_uid == task_uid,
+            TicketTask.user_id == auth_context.user_id,
+            TicketTask.organization_id == auth_context.organization_id,
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    task, source_email_id = row
+    if request.status is not None:
+        task.status = request.status
+    if request.priority is not None:
+        task.priority = request.priority
+    task.updated_at = datetime.datetime.now(datetime.timezone.utc)
+
+    await db.commit()
+    await db.refresh(task)
+    return _task_response(task, source_email_id)
 
 
 @router.post("/from-email", response_model=CreateTasksFromEmailResponse)

--- a/backend/tests/test_tasks_api.py
+++ b/backend/tests/test_tasks_api.py
@@ -96,6 +96,9 @@ class MockTaskSession:
                     raise AssertionError("Mock result expected at most one row")
                 return self._items[0]
 
+            def one_or_none(self):
+                return self.scalar_one_or_none()
+
         if descriptions and descriptions[0].get("entity") is Email:
             params = stmt.compile().params
             source_email_id = params.get("message_id_1")
@@ -113,6 +116,10 @@ class MockTaskSession:
 
         if descriptions and descriptions[0].get("entity") is TicketTask:
             statement_text = str(stmt).lower()
+            params = stmt.compile().params
+            task_uid = params.get("task_uid_1")
+            user_id = params.get("user_id_1")
+            organization_id = params.get("organization_id_1")
             scoped_email_join = (
                 "emails.user_id" in statement_text
                 and "emails.organization_id" in statement_text
@@ -131,7 +138,18 @@ class MockTaskSession:
                     return None
                 return source_email.message_id
 
-            return MockResult([(task, source_message_id(task)) for task in self.tasks])
+            return MockResult(
+                [
+                    (task, source_message_id(task))
+                    for task in self.tasks
+                    if (task_uid is None or task.task_uid == task_uid)
+                    and (user_id is None or task.user_id == user_id)
+                    and (
+                        organization_id is None
+                        or task.organization_id == organization_id
+                    )
+                ]
+            )
 
         return MockResult(self.tasks)
 
@@ -235,6 +253,80 @@ def test_list_ticket_tasks_does_not_leak_cross_tenant_source_email(auth_client):
     assert body[0]["id"] == "opaque-task-id"
     assert body[0]["source_email_id"] is None
     assert body[0]["related_thread_id"] is None
+
+
+def test_update_ticket_task_status_uses_opaque_id_and_keeps_source(auth_client):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mock_session.emails[14] = make_email()
+    mock_session.tasks.append(
+        TicketTask(
+            id=1,
+            task_uid="opaque-task-update-id",
+            user_id="alice",
+            organization_id="org-acme",
+            title="회신 상태 추적",
+            status="open",
+            priority="normal",
+            source_type="email",
+            related_email_id=14,
+            related_thread_id="thread-123",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    response = auth_client.patch(
+        "/api/tasks/opaque-task-update-id",
+        json={"status": "in_progress", "priority": "high"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == "opaque-task-update-id"
+    assert body["status"] == "in_progress"
+    assert body["priority"] == "high"
+    assert body["source_email_id"] == "<message-14@example.com>"
+    assert body["related_thread_id"] == "thread-123"
+    assert "task_id" not in body
+    assert "related_email_id" not in body
+    assert mock_session.tasks[0].status == "in_progress"
+    assert mock_session.tasks[0].priority == "high"
+    assert mock_session.tasks[0].updated_at > now
+
+
+def test_update_ticket_task_rejects_cross_tenant_task(auth_client):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mock_session.tasks.append(
+        TicketTask(
+            id=1,
+            task_uid="opaque-rival-task",
+            user_id="bob",
+            organization_id="org-rival",
+            title="권한 밖 작업",
+            status="open",
+            priority="normal",
+            source_type="email",
+            related_email_id=None,
+            related_thread_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    response = auth_client.patch(
+        "/api/tasks/opaque-rival-task", json={"status": "done"}
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Task not found"}
+    assert mock_session.tasks[0].status == "open"
+
+
+def test_update_ticket_task_rejects_empty_payload(auth_client):
+    response = auth_client.patch("/api/tasks/missing-fields", json={})
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "At least one ticket field is required"}
 
 
 def make_email(

--- a/docs/plans/2026-05-27-task-ticket-status-tracking.md
+++ b/docs/plans/2026-05-27-task-ticket-status-tracking.md
@@ -1,0 +1,54 @@
+# Source-Linked Ticket Status Tracking Slice
+
+<!-- markdownlint-disable MD013 -->
+
+## Goal
+
+Move Naruon task management beyond passive todos by letting users update the
+status of source-linked ticket tasks through the signed API. The task remains
+linked to the originating email/thread and continues to expose only the opaque
+`task_uid` as the public `id`.
+
+## Product Research Notes
+
+- Atlassian describes ticket workflows as status plus transitions; status shows
+  where a work item is in the workflow, and transition is the action that moves
+  it between statuses:
+  <https://www.atlassian.com/software/jira/guides/workflows/overview>
+- Jira's default work item model keeps status and priority as first-class
+  reporting fields:
+  <https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-statuses-priorities-and-resolutions/>
+- Jira board columns map statuses to visible workflow lanes, with simple default
+  columns such as To Do, In Progress, and Done:
+  <https://support.atlassian.com/jira-software-cloud/docs/configure-columns/>
+
+## Implementation
+
+- Add `PATCH /api/tasks/{task_uid}` with signed-session auth and tenant owner
+  scope. The endpoint accepts `status` and/or `priority`, rejects empty payloads,
+  returns 404 for tasks outside the authenticated tenant, and never exposes
+  sequential database ids.
+- Add `apiClient.patch` so browser writes keep the stored
+  `naruon_session_token` as `Authorization: Bearer` and continue stripping
+  public identity headers.
+- Update `/tasks` so actual API ticket cards expose status transition buttons
+  for `open`, `in_progress`, `blocked`, and `done`; counts update from the
+  server response.
+- Keep the existing mock kanban demonstration for now, but make the route header
+  responsive so mobile screenshots do not overflow while the live ticket queue
+  is being operated.
+
+## Verification
+
+```bash
+python3 -m pytest backend/tests/test_tasks_api.py -q
+npm test -- src/app/tasks/page.test.tsx
+npm run lint
+npm run typecheck
+npm run build
+PLAYWRIGHT_PORT=18170 LIVE_BASE_URL=http://127.0.0.1:18170 npx playwright test tests/e2e/dashboard-branding.spec.ts --project=desktop -g "task ticket status"
+```
+
+The Playwright run must capture desktop, mobile, and mobile-scroll screenshots
+and verify the PATCH request uses the signed session without public identity
+headers.

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -103,6 +103,64 @@ describe("TasksPage", () => {
     expect(container.textContent).toContain("thread_public_789");
   });
 
+  it("updates ticket status through the signed task API", async () => {
+    localStorage.setItem("naruon_session_token", "signed.task.status");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/tasks/task_public_123" && init?.method === "PATCH") {
+        expect(init.headers).toEqual(expect.objectContaining({
+          Authorization: "Bearer signed.task.status",
+          "Content-Type": "application/json",
+        }));
+        expect(JSON.parse(String(init.body))).toEqual({ status: "done" });
+        return jsonResponse({
+          id: "task_public_123",
+          title: "보낸 메일 회신 추적",
+          status: "done",
+          priority: "high",
+          source_type: "email",
+          source_email_id: "mail_public_456",
+          related_thread_id: "thread_public_789",
+          updated_at: "2026-05-26T10:00:00.000Z",
+        });
+      }
+      return jsonResponse([
+        {
+          id: "task_public_123",
+          title: "보낸 메일 회신 추적",
+          status: "in_progress",
+          priority: "high",
+          source_type: "email",
+          source_email_id: "mail_public_456",
+          related_thread_id: "thread_public_789",
+          updated_at: "2026-05-26T09:00:00.000Z",
+        },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<TasksPage />);
+    });
+    await flushAsyncWork();
+
+    const doneButton = container.querySelector<HTMLButtonElement>('button[aria-label="보낸 메일 회신 추적 상태를 완료로 변경"]');
+    expect(doneButton).not.toBeNull();
+    await act(async () => {
+      doneButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks/task_public_123", expect.objectContaining({
+      method: "PATCH",
+    }));
+    expect(container.textContent).toContain("보낸 메일 회신 추적 상태를 완료로 변경했습니다.");
+    expect(doneButton?.getAttribute("aria-pressed")).toBe("true");
+  });
+
   it("distinguishes signed-session authorization failures from generic task API errors", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ detail: "forbidden" }, false, 403)));
     container = document.createElement("div");

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -39,6 +39,15 @@ const taskStatusLabels: Record<TicketTask['status'], string> = {
   done: '완료',
 };
 
+const taskStatusChangeLabels: Record<TicketTask['status'], string> = {
+  open: '접수로',
+  in_progress: '진행으로',
+  blocked: '차단으로',
+  done: '완료로',
+};
+
+const ticketStatusOptions: TicketTask['status'][] = ['open', 'in_progress', 'blocked', 'done'];
+
 const taskPriorityLabels: Record<TicketTask['priority'], string> = {
   low: '낮음',
   normal: '보통',
@@ -62,6 +71,7 @@ export function TasksLayout() {
   const [draggedTask, setDraggedTask] = useState<{id: string, sourceCol: string} | null>(null);
   const [ticketTasks, setTicketTasks] = useState<TicketTask[]>([]);
   const [ticketStatus, setTicketStatus] = useState<TicketStatus>('loading');
+  const [ticketActionStatus, setTicketActionStatus] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -118,6 +128,19 @@ export function TasksLayout() {
     setDraggedTask(null);
   };
 
+  const handleTicketStatusChange = async (taskId: string, status: TicketTask['status']) => {
+    setTicketActionStatus(null);
+    try {
+      const updatedTask = await apiClient.patch<TicketTask>(`/api/tasks/${encodeURIComponent(taskId)}`, { status });
+      setTicketTasks((currentTasks) =>
+        currentTasks.map((task) => (task.id === updatedTask.id ? updatedTask : task)),
+      );
+      setTicketActionStatus(`${updatedTask.title} 상태를 ${taskStatusChangeLabels[updatedTask.status]} 변경했습니다.`);
+    } catch {
+      setTicketActionStatus('티켓 상태 변경에 실패했습니다.');
+    }
+  };
+
   const currentColumns = [
     { id: 'open', title: '접수', count: tasks.open.length, color: 'bg-blue-100 text-blue-700' },
     { id: 'in_progress', title: '진행', count: tasks.in_progress.length, color: 'bg-orange-100 text-orange-700' },
@@ -138,26 +161,26 @@ export function TasksLayout() {
   return (
     <div className="flex h-full min-h-0 bg-background text-foreground flex-col">
       {/* Top Header */}
-      <header className="flex h-16 shrink-0 items-center justify-between border-b border-border px-6 bg-card">
-        <div className="flex items-center gap-6">
+      <header className="flex shrink-0 flex-col gap-3 border-b border-border bg-card px-4 py-3 lg:h-16 lg:flex-row lg:items-center lg:justify-between lg:px-6 lg:py-0">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center lg:gap-6">
           <h1 className="text-xl font-bold">할 일 추적</h1>
           <p className="sr-only">리소스 배정 검토 회의</p>
-          <div className="flex overflow-hidden rounded-md border border-border">
+          <div className="flex max-w-full overflow-x-auto rounded-md border border-border">
             {['내 작업', '위임한 작업', '칸반', '작업 상세'].map((mode) => (
               <button
                 key={mode}
                 onClick={() => setViewMode(mode as '내 작업' | '위임한 작업' | '칸반' | '작업 상세')}
-                className={`px-4 py-1.5 text-sm font-semibold transition-colors ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
+                className={`shrink-0 px-4 py-1.5 text-sm font-semibold transition-colors ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
               >
                 {mode}
               </button>
             ))}
           </div>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="relative">
+        <div className="flex flex-wrap items-center gap-2 lg:gap-3">
+          <div className="relative min-w-[180px] flex-1 sm:flex-none">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-            <input type="text" placeholder="작업 검색..." className="h-9 w-64 rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
+            <input type="text" placeholder="작업 검색..." className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64" />
           </div>
           <button className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary">
             <Filter className="size-4" /> 필터
@@ -170,7 +193,7 @@ export function TasksLayout() {
 
       {/* Kanban Board Area */}
       <main className="flex-1 overflow-x-auto overflow-y-auto p-6 bg-secondary/20">
-        <section aria-label="API 연결 작업" className="mb-6 rounded-xl border border-border bg-card p-4 shadow-sm">
+        <section aria-label="source-linked ticket status board" className="mb-6 rounded-xl border border-border bg-card p-4 shadow-sm">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
               <h2 className="text-base font-bold">실제 티켓 큐</h2>
@@ -197,7 +220,7 @@ export function TasksLayout() {
           </div>
 
           {ticketStatus === 'ready' ? (
-            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            <div aria-label="source-linked ticket list" className="mt-4 grid gap-3 lg:grid-cols-2">
               {ticketTasks.slice(0, 4).map((task) => (
                 <article key={task.id} className="rounded-lg border border-border bg-background/75 p-3 text-sm">
                   <div className="flex flex-wrap items-center justify-between gap-2">
@@ -220,9 +243,33 @@ export function TasksLayout() {
                       <dd suppressHydrationWarning>{new Date(task.updated_at).toLocaleString('ko-KR')}</dd>
                     </div>
                   </dl>
+                  <div className="mt-3 flex flex-wrap gap-2" aria-label={`${task.title} 상태 변경`}>
+                    {ticketStatusOptions.map((status) => (
+                      <button
+                        key={status}
+                        type="button"
+                        aria-label={`${task.title} 상태를 ${taskStatusChangeLabels[status]} 변경`}
+                        aria-pressed={task.status === status}
+                        onClick={() => void handleTicketStatusChange(task.id, status)}
+                        className={`rounded-md border px-2.5 py-1 text-xs font-bold transition-colors ${
+                          task.status === status
+                            ? 'border-primary bg-primary text-primary-foreground'
+                            : 'border-border bg-card text-foreground hover:border-primary/60 hover:bg-secondary'
+                        }`}
+                      >
+                        {taskStatusLabels[status]}
+                      </button>
+                    ))}
+                  </div>
                 </article>
               ))}
             </div>
+          ) : null}
+
+          {ticketActionStatus ? (
+            <p role="status" aria-live="polite" className="mt-3 rounded-lg border border-border bg-background/70 p-3 text-sm font-semibold text-foreground">
+              {ticketActionStatus}
+            </p>
           ) : null}
 
           {ticketStatus === 'empty' ? (

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -132,6 +132,21 @@ export class ApiClient {
     return text ? JSON.parse(text) : ({} as T);
   }
 
+  async patch<T>(endpoint: string, body: unknown, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...init,
+      method: 'PATCH',
+      headers: this.getHeaders(init),
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const error = new Error(`API PATCH ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+    return response.json();
+  }
+
   async delete<T>(endpoint: string, init?: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...init,

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -259,6 +259,67 @@ test('renders sent mail reply tracking route with signed API headers', async ({ 
   await page.screenshot({ path: testInfo.outputPath('sent-mail-reply-tracking-mobile-scroll.png'), fullPage: false });
 });
 
+test('updates source-linked task ticket status with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-task-status-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  const patchRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks/task-q2-owner' && request.method() === 'PATCH';
+  });
+
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'source-linked ticket status board' })).toBeVisible();
+  await page.getByRole('button', { name: '리소스 배정 검토 회의 상태를 완료로 변경' }).click();
+  const requestHeaders = (await patchRequest).headers();
+  expect(requestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(requestHeaders[headerName]).toBeUndefined();
+  }
+
+  await expect(page.getByText('리소스 배정 검토 회의 상태를 완료로 변경했습니다.')).toBeVisible();
+  await expect(page.getByRole('button', { name: '리소스 배정 검토 회의 상태를 완료로 변경' })).toHaveAttribute('aria-pressed', 'true');
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('task-ticket-status-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'source-linked ticket status board' })).toBeVisible();
+  await expect(page.getByText('실제 티켓 큐')).toBeVisible();
+  await expect(page.getByText('4개 티켓 연결')).toBeVisible();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('task-ticket-status-mobile.png'), fullPage: false });
+  const taskScrollMetrics = await page.locator('main').nth(1).evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(taskScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(taskScrollMetrics.after).toBeGreaterThan(taskScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('task-ticket-status-mobile-scroll.png'), fullPage: false });
+});
+
 test('renders the settings self-hosted connector manifest with mobile scrolling', async ({ page }, testInfo) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await mockDashboardApi(page);

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -314,6 +314,39 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
           created_at: '2026-05-19T00:00:00Z',
           updated_at: '2026-05-21T00:00:00Z',
         },
+        {
+          id: 'task-reply-followup',
+          title: '보낸 메일 회신 SLA 확인',
+          status: 'in_progress',
+          priority: 'high',
+          source_type: 'email',
+          source_email_id: '<sent-q2@example.com>',
+          related_thread_id: 'thread-sent-q2',
+          created_at: '2026-05-19T00:00:00Z',
+          updated_at: '2026-05-22T00:00:00Z',
+        },
+        {
+          id: 'task-calendar-writeback',
+          title: '회의 후보 CalDAV 반영 검토',
+          status: 'open',
+          priority: 'normal',
+          source_type: 'calendar',
+          source_email_id: '<q2@example.com>',
+          related_thread_id: 'thread-q2',
+          created_at: '2026-05-19T00:00:00Z',
+          updated_at: '2026-05-23T00:00:00Z',
+        },
+        {
+          id: 'task-webdav-evidence',
+          title: '첨부파일 WebDAV 폴더 정리',
+          status: 'done',
+          priority: 'low',
+          source_type: 'webdav',
+          source_email_id: '<q2@example.com>',
+          related_thread_id: 'thread-q2',
+          created_at: '2026-05-19T00:00:00Z',
+          updated_at: '2026-05-24T00:00:00Z',
+        },
       ]);
       return;
     }
@@ -345,6 +378,21 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
             updated_at: '2026-05-19T00:00:00Z',
           },
         ],
+      });
+      return;
+    }
+
+    if (path === '/api/tasks/task-q2-owner' && request.method() === 'PATCH') {
+      await fulfillJson(route, {
+        id: 'task-q2-owner',
+        title: '리소스 배정 검토 회의',
+        status: 'done',
+        priority: 'urgent',
+        source_type: 'email',
+        source_email_id: '<q2@example.com>',
+        related_thread_id: 'thread-q2',
+        created_at: '2026-05-19T00:00:00Z',
+        updated_at: '2026-05-27T08:00:00Z',
       });
       return;
     }


### PR DESCRIPTION
## Summary
- add signed `PATCH /api/tasks/{task_uid}` for source-linked ticket status/priority updates
- update `/tasks` live ticket cards so status transitions call the signed API and keep source email/thread provenance visible
- add desktop/mobile Playwright coverage for signed PATCH headers, horizontal overflow, and mobile scroll screenshots

## Verification
- `python3 -m pytest backend/tests/test_tasks_api.py -q`
- `cd frontend && npm test -- src/app/tasks/page.test.tsx`
- `cd frontend && npm run lint`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `cd frontend && env -u FORCE_COLOR -u NO_COLOR PLAYWRIGHT_PORT=18170 LIVE_BASE_URL=http://127.0.0.1:18170 npx playwright test tests/e2e/dashboard-branding.spec.ts --project=desktop -g "task ticket status"`
- `git diff --check`

## Screenshot evidence
- `task-ticket-status-desktop.png`
- `task-ticket-status-mobile.png`
- `task-ticket-status-mobile-scroll.png`

## Notes
- No new DB table or column is introduced in this slice.
- Public API responses continue to expose only opaque task ids, not sequential database ids.
- Browser writes use `Authorization: Bearer naruon_session_token`; public identity headers are asserted absent in E2E.