### PR TITLE
fix: retry trusted PR governance materialization

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -38,17 +38,55 @@ jobs:
         run: |
           set -euo pipefail
 
+          gh_api_with_retry() {
+            local attempt output_file rc
+            output_file="$(mktemp)"
+            for attempt in 1 2 3 4; do
+              rc=0
+              gh api "$@" > "$output_file" || rc=$?
+              if [ "$rc" -eq 0 ]; then
+                cat "$output_file"
+                rm -f "$output_file"
+                return 0
+              fi
+              if [ "$attempt" -lt 4 ]; then
+                echo "GitHub API request attempt ${attempt} did not complete; retrying." >&2
+                sleep $((attempt * 3))
+              fi
+            done
+            echo "::error::GitHub API request did not complete after 4 attempts: gh api $*" >&2
+            rm -f "$output_file"
+            return "$rc"
+          }
+
           if [ -n "$TRUSTED_PR_NUMBER" ]; then
-            trusted_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${TRUSTED_PR_NUMBER}" --jq '.base.sha')"
+            trusted_ref="$(gh_api_with_retry "repos/${GITHUB_REPOSITORY}/pulls/${TRUSTED_PR_NUMBER}" --jq '.base.sha')"
           else
-            default_branch="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')"
-            trusted_ref="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${default_branch}" --jq '.commit.sha')"
+            default_branch="$(gh_api_with_retry "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')"
+            trusted_ref="$(gh_api_with_retry "repos/${GITHUB_REPOSITORY}/branches/${default_branch}" --jq '.commit.sha')"
+          fi
+          if [[ ! "$trusted_ref" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Trusted governance ref must be a full commit SHA." >&2
+            exit 1
           fi
 
           trusted_workspace="$RUNNER_TEMP/trusted-governance"
           trusted_archive="$RUNNER_TEMP/trusted-governance.tar.gz"
+          trusted_archive_candidate="$RUNNER_TEMP/trusted-governance.tar.gz.candidate"
           mkdir -p "$trusted_workspace"
-          gh api "/repos/${GITHUB_REPOSITORY}/tarball/${trusted_ref}" > "$trusted_archive"
+          for attempt in 1 2 3 4; do
+            rm -f "$trusted_archive" "$trusted_archive_candidate"
+            if gh api "/repos/${GITHUB_REPOSITORY}/tarball/${trusted_ref}" > "$trusted_archive_candidate" && tar -tzf "$trusted_archive_candidate" >/dev/null 2>&1; then
+              mv "$trusted_archive_candidate" "$trusted_archive"
+              break
+            fi
+            if [ "$attempt" -eq 4 ]; then
+              echo "::error::Trusted governance archive could not be materialized after 4 attempts." >&2
+              exit 1
+            fi
+            echo "Trusted governance archive materialization attempt ${attempt} did not produce a valid archive; retrying." >&2
+            sleep $((attempt * 3))
+          done
           tar -xzf "$trusted_archive" -C "$trusted_workspace" --strip-components=1
           test -f "$trusted_workspace/scripts/ci/pr_governance_gate.sh"
           echo "GOVERNANCE_GATE=$trusted_workspace/scripts/ci/pr_governance_gate.sh" >> "$GITHUB_ENV"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@
   only because the current head has not been reviewed yet.
 - `STARTUP_FAILURE` in required PR governance/check metadata is a hard blocker
   and should use the same idempotent metadata-gate comment path.
+- Trusted-base governance materialization must tolerate transient GitHub API
+  truncation such as `unexpected end of JSON input` with bounded retries and
+  archive validation; do not convert that infrastructure flake into a CodeRabbit
+  or review blocker.
 
 ## Workspace and task tracking defaults
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -195,6 +195,13 @@ def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge
     assert ".base.sha" in workflow
     assert "github.sha" not in workflow
     assert "tarball/${trusted_ref}" in workflow
+    assert "gh_api_with_retry" in workflow
+    assert "GitHub API request attempt" in workflow
+    assert "Trusted governance ref must be a full commit SHA" in workflow
+    assert "trusted_archive_candidate" in workflow
+    assert "tar -tzf" in workflow
+    assert "Trusted governance archive materialization attempt" in workflow
+    assert "after 4 attempts" in workflow
     assert 'bash "$GOVERNANCE_GATE"' in workflow
     assert "CHECK_RUN_PR_NUMBER" in workflow
     assert "headRefOid" in gate_script
@@ -218,4 +225,5 @@ def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge
     assert "git clone" not in combined
     assert "--admin" not in combined
     assert "contents: write" not in combined
+    assert "continue-on-error: true" not in combined
     assert "dismiss" not in combined.lower()

--- a/docs/development/merge-gate-policy.md
+++ b/docs/development/merge-gate-policy.md
@@ -21,6 +21,9 @@ CodeRabbit/robot-review evidence. Human review is not awaited by default.
   current-head gates are satisfied.
 - PR Governance runs trusted-base logic only. The workflow materializes the base
   repository script from a trusted tarball and must not execute PR-head scripts.
+  Trusted tarball materialization uses bounded retry plus archive validation for
+  transient GitHub API truncation and fails closed instead of falling back to
+  PR-head or local scripts.
 - Pending, queued, requested, waiting, or in-progress checks are wait states, not
   hard failure findings. Failed, cancelled, timed-out, and action-required states
   are blockers.

--- a/docs/plans/2026-05-27-pr-governance-tarball-retry.md
+++ b/docs/plans/2026-05-27-pr-governance-tarball-retry.md
@@ -1,0 +1,40 @@
+# PR Governance Trusted Tarball Retry Slice
+
+<!-- markdownlint-disable MD013 -->
+
+## Goal
+
+Prevent transient GitHub API response truncation from leaving PR Governance in a
+false failed state. The metadata gate must still fail closed when trusted-base
+materialization cannot be proven, but it should retry bounded infrastructure
+flakes before declaring failure.
+
+## Evidence
+
+- PR #239 saw `metadata-only gate evaluation` fail twice during
+  `Materialize trusted governance gate` with `unexpected end of JSON input`.
+- The same run succeeded after a delayed rerun without code changes, proving the
+  failure was infrastructure/API truncation rather than a PR-head code issue.
+
+## Implementation
+
+- Add `gh_api_with_retry` for trusted PR/base metadata lookups.
+- Add a four-attempt trusted tarball download loop that validates the archive
+  with `tar -tzf` before extraction, using a candidate archive file until
+  validation succeeds.
+- Reject non-SHA trusted refs before requesting a tarball.
+- Preserve fail-closed behavior after bounded retries. Do not use
+  `continue-on-error`, do not execute PR-head code, and do not add admin merge
+  behavior.
+- Record the bug pattern in `AGENTS.md` so future agents rerun or harden the
+  materialization path instead of reporting a stale CodeRabbit/review blocker.
+
+## Verification
+
+```bash
+python3 -m pytest backend/tests/test_release_governance.py -q
+bash scripts/ci/test_pr_governance_gate.sh
+git diff --check
+```
+
+No browser screenshot is required for this CI-only governance slice.


### PR DESCRIPTION
## Summary
- add bounded retry around trusted PR/base metadata reads in PR Governance
- validate trusted tarball downloads with `tar -tzf` before extraction and use a candidate archive file
- document the repeated `unexpected end of JSON input` materialization flake in AGENTS and merge-gate policy

## Verification
- `python3 -m pytest backend/tests/test_release_governance.py -q`
- `bash scripts/ci/test_pr_governance_gate.sh`
- `git diff --check`

## Notes
- No PR-head checkout or local-script fallback is introduced.
- No `continue-on-error`, admin merge, or GitHub Models path is used.