### PR TITLE
feat: add source scoped sender DAG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@
   stay idempotent per source email, preserve email/thread provenance, and store
   only plain-text task titles. Do not create unlinked knowledge tasks from raw
   dict payloads when the source email row is unavailable.
+- Sender ontology and relationship DAG APIs must stay scoped to the signed
+  session owner and organization. Source-backed UI panels must request
+  `source_message_id` and `source_thread_id` filters instead of presenting a
+  global relationship graph as if it were current-thread evidence.
 
 ## Development environment and tooling defaults
 

--- a/backend/api/ontology.py
+++ b/backend/api/ontology.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from pydantic import BaseModel
@@ -14,6 +14,8 @@ router = APIRouter(prefix="/api/ontology", tags=["ontology"])
 class RelationshipResponse(BaseModel):
     sender_email: str
     parent_sender_email: str | None = None
+    source_message_id: str | None = None
+    source_thread_id: str | None = None
     relationship_type: str
     confidence_score: float
     next_action: str
@@ -22,22 +24,45 @@ class RelationshipResponse(BaseModel):
 class RelationshipCreate(BaseModel):
     sender_email: str
     parent_sender_email: str | None = None
+    source_message_id: str | None = None
+    source_thread_id: str | None = None
     relationship_type: str
     confidence_score: float = 1.0
 
 @router.get("/relationships", response_model=List[RelationshipResponse])
 async def get_relationships(
+    source_message_id: str | None = Query(default=None),
+    source_thread_id: str | None = Query(default=None),
     auth_ctx: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db)
 ):
-    user_id = auth_ctx.user_id
-    stmt = select(SenderRelationship).where(SenderRelationship.user_id == user_id)
+    organization_filter = (
+        SenderRelationship.organization_id == auth_ctx.organization_id
+        if auth_ctx.organization_id is not None
+        else SenderRelationship.organization_id.is_(None)
+    )
+    filters = [SenderRelationship.user_id == auth_ctx.user_id, organization_filter]
+    if source_message_id is not None:
+        filters.append(SenderRelationship.source_message_id == source_message_id)
+    if source_thread_id is not None:
+        filters.append(SenderRelationship.source_thread_id == source_thread_id)
+
+    stmt = (
+        select(SenderRelationship)
+        .where(*filters)
+        .order_by(
+            SenderRelationship.confidence_score.desc(),
+            SenderRelationship.updated_at.desc(),
+        )
+    )
     result = await db.execute(stmt)
     rels = result.scalars().all()
     return [
         RelationshipResponse(
             sender_email=r.sender_email,
             parent_sender_email=r.parent_sender_email,
+            source_message_id=r.source_message_id,
+            source_thread_id=r.source_thread_id,
             relationship_type=r.relationship_type,
             confidence_score=r.confidence_score,
             **ontology_service.next_action_for_relationship(r.relationship_type),
@@ -51,11 +76,17 @@ async def create_relationship(
     auth_ctx: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db)
 ):
-    user_id = auth_ctx.user_id
-    
+    organization_filter = (
+        SenderRelationship.organization_id == auth_ctx.organization_id
+        if auth_ctx.organization_id is not None
+        else SenderRelationship.organization_id.is_(None)
+    )
     stmt = select(SenderRelationship).where(
-        SenderRelationship.user_id == user_id,
-        SenderRelationship.sender_email == req.sender_email
+        SenderRelationship.user_id == auth_ctx.user_id,
+        organization_filter,
+        SenderRelationship.sender_email == req.sender_email,
+        SenderRelationship.source_message_id == req.source_message_id,
+        SenderRelationship.source_thread_id == req.source_thread_id,
     )
     result = await db.execute(stmt)
     rel = result.scalars().first()
@@ -65,11 +96,16 @@ async def create_relationship(
         rel.confidence_score = req.confidence_score
         if "parent_sender_email" in req.model_fields_set:
             rel.parent_sender_email = req.parent_sender_email
+        rel.source_message_id = req.source_message_id
+        rel.source_thread_id = req.source_thread_id
     else:
         rel = SenderRelationship(
-            user_id=user_id,
+            user_id=auth_ctx.user_id,
+            organization_id=auth_ctx.organization_id,
             sender_email=req.sender_email,
             parent_sender_email=req.parent_sender_email,
+            source_message_id=req.source_message_id,
+            source_thread_id=req.source_thread_id,
             relationship_type=req.relationship_type,
             confidence_score=req.confidence_score
         )
@@ -81,6 +117,8 @@ async def create_relationship(
     return RelationshipResponse(
         sender_email=rel.sender_email,
         parent_sender_email=rel.parent_sender_email,
+        source_message_id=rel.source_message_id,
+        source_thread_id=rel.source_thread_id,
         relationship_type=rel.relationship_type,
         confidence_score=rel.confidence_score,
         **ontology_service.next_action_for_relationship(rel.relationship_type),

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -20,6 +20,7 @@ class SearchRequest(BaseModel):
 
 class SearchResultItem(BaseModel):
     id: int
+    source_message_id: str | None = None
     subject: str | None
     sender: str
     date: datetime.datetime
@@ -107,6 +108,7 @@ async def hybrid_search(
         stmt_email = (
             select(
                 Email.id,
+                Email.message_id.label("source_message_id"),
                 Email.subject,
                 Email.sender,
                 Email.date,
@@ -130,6 +132,7 @@ async def hybrid_search(
         stmt_att = (
             select(
                 Email.id,
+                Email.message_id.label("source_message_id"),
                 Email.subject,
                 Email.sender,
                 Email.date,
@@ -149,6 +152,7 @@ async def hybrid_search(
         stmt = (
             select(
                 combined.c.id,
+                combined.c.source_message_id,
                 combined.c.subject,
                 combined.c.sender,
                 combined.c.date,
@@ -182,6 +186,7 @@ async def hybrid_search(
             search_results.append(
                 SearchResultItem(
                     id=row.id,
+                    source_message_id=row.source_message_id,
                     subject=row.subject,
                     sender=row.sender,
                     date=row.date,

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -4,7 +4,16 @@ import uuid
 
 from cryptography.fernet import Fernet, InvalidToken
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import declarative_base, Mapped, mapped_column, relationship
 from sqlalchemy.types import TypeDecorator
 
@@ -185,7 +194,6 @@ class PromptTemplate(Base):
         onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
     )
 
-
 class Email(Base):
     __tablename__ = "emails"
     __table_args__ = (
@@ -322,19 +330,14 @@ class TenantConfig(Base):
 
 class SenderRelationship(Base):
     __tablename__ = "sender_relationships"
-    __table_args__ = (
-        UniqueConstraint(
-            "user_id",
-            "sender_email",
-            name="uq_sender_relationships_user_email",
-        ),
-    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
     organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     sender_email: Mapped[str] = mapped_column(String, index=True, nullable=False)
     parent_sender_email: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    source_message_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    source_thread_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     relationship_type: Mapped[str] = mapped_column(String, nullable=False)
     confidence_score: Mapped[float] = mapped_column(default=1.0)
     created_at: Mapped[datetime.datetime] = mapped_column(
@@ -345,6 +348,17 @@ class SenderRelationship(Base):
         DateTime(timezone=True),
         default=lambda: datetime.datetime.now(datetime.timezone.utc),
         onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+    __table_args__ = (
+        Index(
+            "uq_sender_relationships_scope_source",
+            "user_id",
+            func.coalesce(organization_id, ""),
+            "sender_email",
+            func.coalesce(source_message_id, ""),
+            func.coalesce(source_thread_id, ""),
+            unique=True,
+        ),
     )
 
 

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -35,10 +35,23 @@ def schema_backfill_sql():
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
         text('ALTER TABLE emails ADD COLUMN IF NOT EXISTS "references" varchar'),
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS reply_to varchar"),
+        text(
+            "ALTER TABLE sender_relationships "
+            "ADD COLUMN IF NOT EXISTS source_message_id varchar"
+        ),
+        text(
+            "ALTER TABLE sender_relationships "
+            "ADD COLUMN IF NOT EXISTS source_thread_id varchar"
+        ),
         text("CREATE INDEX IF NOT EXISTS ix_emails_user_id ON emails (user_id)"),
         text(
             "CREATE INDEX IF NOT EXISTS ix_emails_organization_id "
             "ON emails (organization_id)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_sender_relationships_owner_source "
+            "ON sender_relationships "
+            "(user_id, organization_id, source_message_id, source_thread_id)"
         ),
         text(
             "CREATE INDEX IF NOT EXISTS ix_llm_providers_user_id "
@@ -49,6 +62,10 @@ def schema_backfill_sql():
             "ON llm_providers (organization_id)"
         ),
         text("ALTER TABLE emails DROP CONSTRAINT IF EXISTS emails_message_id_key"),
+        text(
+            "ALTER TABLE sender_relationships "
+            "DROP CONSTRAINT IF EXISTS uq_sender_relationships_user_email"
+        ),
         text(
             "ALTER TABLE llm_providers DROP CONSTRAINT IF EXISTS llm_providers_name_key"
         ),
@@ -123,6 +140,13 @@ def schema_backfill_sql():
             ),
             text(
                 "CREATE INDEX IF NOT EXISTS ix_emails_thread_id ON emails (thread_id)"
+            ),
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "uq_sender_relationships_scope_source "
+                "ON sender_relationships "
+                "(user_id, coalesce(organization_id, ''), sender_email, "
+                "coalesce(source_message_id, ''), coalesce(source_thread_id, ''))"
             ),
         ]
     )

--- a/backend/services/ontology_service.py
+++ b/backend/services/ontology_service.py
@@ -76,6 +76,8 @@ class OntologyService:
         email_content: str,
         user_id: str,
         organization_id: str | None,
+        source_message_id: str | None = None,
+        source_thread_id: str | None = None,
     ):
         analysis = self.analyze_sender_relationship(
             user_email, sender_email, email_content
@@ -85,6 +87,8 @@ class OntologyService:
             SenderRelationship.user_id == user_id,
             SenderRelationship.organization_id == organization_id,
             SenderRelationship.sender_email == sender_email,
+            SenderRelationship.source_message_id == source_message_id,
+            SenderRelationship.source_thread_id == source_thread_id,
         )
         result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
@@ -92,11 +96,15 @@ class OntologyService:
         if existing:
             existing.relationship_type = analysis["type"]
             existing.confidence_score = analysis["confidence"]
+            existing.source_message_id = source_message_id
+            existing.source_thread_id = source_thread_id
         else:
             new_rel = SenderRelationship(
                 user_id=user_id,
                 organization_id=organization_id,
                 sender_email=sender_email,
+                source_message_id=source_message_id,
+                source_thread_id=source_thread_id,
                 relationship_type=analysis["type"],
                 confidence_score=analysis["confidence"],
             )

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -1,4 +1,5 @@
 from scripts.bootstrap_db import schema_backfill_sql
+from db.models import SenderRelationship
 
 
 def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch):
@@ -25,6 +26,30 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
     )
     assert any(
         "alter table emails add column if not exists in_reply_to" in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table sender_relationships add column if not exists source_message_id"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table sender_relationships add column if not exists source_thread_id"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "drop constraint if exists uq_sender_relationships_user_email" in statement
+        for statement in statements
+    )
+    assert any(
+        "create index if not exists ix_sender_relationships_owner_source"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "create unique index if not exists uq_sender_relationships_scope_source"
+        in statement
         for statement in statements
     )
     assert any(
@@ -151,3 +176,20 @@ def test_schema_backfill_rejects_default_owner_ids(monkeypatch):
     assert not any(
         "update emails set organization_id" in statement for statement in statements
     )
+
+
+def test_sender_relationship_model_declares_source_unique_index():
+    indexes = {index.name: index for index in SenderRelationship.__table__.indexes}
+
+    source_index = indexes["uq_sender_relationships_scope_source"]
+
+    assert source_index.unique is True
+    expression_text = " ".join(
+        str(expression).lower() for expression in source_index.expressions
+    )
+    assert "user_id" in expression_text
+    assert "coalesce" in expression_text
+    assert "organization_id" in expression_text
+    assert "sender_email" in expression_text
+    assert "source_message_id" in expression_text
+    assert "source_thread_id" in expression_text

--- a/backend/tests/test_ontology_api.py
+++ b/backend/tests/test_ontology_api.py
@@ -6,11 +6,21 @@ from db.session import get_db
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
 class MockRow:
-    def __init__(self, sender_email, relationship_type, confidence_score, parent_sender_email=None):
+    def __init__(
+        self,
+        sender_email,
+        relationship_type,
+        confidence_score,
+        parent_sender_email=None,
+        source_message_id=None,
+        source_thread_id=None,
+    ):
         self.sender_email = sender_email
         self.relationship_type = relationship_type
         self.confidence_score = confidence_score
         self.parent_sender_email = parent_sender_email
+        self.source_message_id = source_message_id
+        self.source_thread_id = source_thread_id
 
 class MockResult:
     def __init__(self, items):
@@ -27,9 +37,20 @@ class MockResult:
 
 class MockSession:
     def __init__(self):
-        self.items = [MockRow("boss@example.com", "manager", 0.95, "ceo@example.com")]
+        self.items = [
+            MockRow(
+                "boss@example.com",
+                "manager",
+                0.95,
+                "ceo@example.com",
+                "<q2@example.com>",
+                "thread-q2",
+            )
+        ]
+        self.statements = []
         
     async def execute(self, stmt):
+        self.statements.append(stmt)
         compiled = str(stmt)
         # SQLAlchemy select compiled string won't contain vendor@example.com literally.
         # But we can check if it's the GET request by looking at the statement.
@@ -67,14 +88,46 @@ def client():
 
 
 def test_get_relationships(client: TestClient):
-    resp = client.get("/api/ontology/relationships")
+    resp = client.get(
+        "/api/ontology/relationships",
+        params={"source_message_id": "<q2@example.com>", "source_thread_id": "thread-q2"},
+    )
     assert resp.status_code == 200
     items = resp.json()
     assert len(items) == 1
     assert items[0]["sender_email"] == "boss@example.com"
     assert items[0]["parent_sender_email"] == "ceo@example.com"
+    assert items[0]["source_message_id"] == "<q2@example.com>"
+    assert items[0]["source_thread_id"] == "thread-q2"
     assert items[0]["relationship_type"] == "manager"
     assert items[0]["next_action"] == "classify_sender"
+
+
+def test_get_relationships_filters_by_source_and_owner_scope():
+    session = MockSession()
+
+    async def override_scoped_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_scoped_get_db
+    try:
+        with TestClient(app, headers={"X-User-Id": "testuser"}) as test_client:
+            resp = test_client.get(
+                "/api/ontology/relationships",
+                params={
+                    "source_message_id": "<q2@example.com>",
+                    "source_thread_id": "thread-q2",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    query_text = str(session.statements[-1]).lower()
+    assert "sender_relationships.user_id" in query_text
+    assert "sender_relationships.organization_id" in query_text
+    assert "sender_relationships.source_message_id" in query_text
+    assert "sender_relationships.source_thread_id" in query_text
 
 def test_create_relationship(client: TestClient):
     resp = client.post(
@@ -82,6 +135,8 @@ def test_create_relationship(client: TestClient):
         json={
             "sender_email": "vendor@example.com",
             "parent_sender_email": "buyer@example.com",
+            "source_message_id": "<vendor@example.com>",
+            "source_thread_id": "thread-vendor",
             "relationship_type": "vendor",
             "confidence_score": 0.8
         }
@@ -90,6 +145,8 @@ def test_create_relationship(client: TestClient):
     data = resp.json()
     assert data["sender_email"] == "vendor@example.com"
     assert data["parent_sender_email"] == "buyer@example.com"
+    assert data["source_message_id"] == "<vendor@example.com>"
+    assert data["source_thread_id"] == "thread-vendor"
     assert data["relationship_type"] == "vendor"
     assert data["next_action"] == "prepare_response_draft"
 

--- a/backend/tests/test_ontology_pipeline.py
+++ b/backend/tests/test_ontology_pipeline.py
@@ -20,7 +20,9 @@ async def test_sender_relationship_insertion():
         sender_email="colleague@test.com",
         email_content="Hey let's talk about the project",
         user_id="user_1",
-        organization_id="org_1"
+        organization_id="org_1",
+        source_message_id="<project@test.com>",
+        source_thread_id="thread-project",
     )
     
     session_mock.add.assert_called_once()
@@ -30,6 +32,8 @@ async def test_sender_relationship_insertion():
     assert added_rel.user_id == "user_1"
     assert added_rel.organization_id == "org_1"
     assert added_rel.sender_email == "colleague@test.com"
+    assert added_rel.source_message_id == "<project@test.com>"
+    assert added_rel.source_thread_id == "thread-project"
     assert relationship["next_action"] == "track_reply_and_tasks"
 
 @pytest.mark.asyncio

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 class MockRow:
     def __init__(self, id, subject, sender, content, score):
         self.id = id
+        self.source_message_id = "<test@example.com>"
         self.subject = subject
         self.sender = sender
         self.content = content
@@ -77,6 +78,7 @@ def test_search_endpoint_success(mock_generate_embeddings, client):
     assert data["results"][0]["id"] == 1
     assert data["results"][0]["subject"] == "Test Subject"
     assert data["results"][0]["date"] == "2026-04-27T10:00:00Z"
+    assert data["results"][0]["source_message_id"] == "<test@example.com>"
     assert data["results"][0]["thread_id"] == "thread-123"
     assert data["results"][0]["reply_count"] == 2
 

--- a/docs/plans/2026-05-24-phase11-implementation.md
+++ b/docs/plans/2026-05-24-phase11-implementation.md
@@ -30,15 +30,19 @@
 - Test: `backend/tests/test_ontology_pipeline.py`
 
 - [x] **Step 1: Write a test that inserts a `SenderRelationship` to DB based on `analyze_sender_relationship`**
-- [ ] **Step 2: Update `ontology_service.py` to accept DB session and save the relationship including explicit tenant_id and source_id/thread_id fields**
+- [x] **Step 2: Update `ontology_service.py` to accept DB session and save the relationship including explicit tenant_id and source_id/thread_id fields**
 - [x] **Step 3: If `process_self_to_self` is true, trigger a knowledge extraction task passing tenant and source context**
-- [ ] **Step 4: Create/Update `/api/ontology/relationships` to fetch the DAG for the frontend, filtering by tenant_id and source_id. Explicitly require the default signed-session authentication by registering the router with the `get_auth_context` dependency.**
+- [x] **Step 4: Create/Update `/api/ontology/relationships` to fetch the DAG for the frontend, filtering by tenant_id and source_id. Explicitly require the default signed-session authentication by registering the router with the `get_auth_context` dependency.**
 
 2026-05-26 implementation note: IMAP import now triggers idempotent
 `self_sent_knowledge` ticket-task capture for true self-to-self messages, and
 ontology analysis/API responses include deterministic `next_action` metadata.
-The remaining gap is durable source/thread graph fields plus source-id filtered
-relationship reads.
+2026-05-27 implementation note: Search detail now receives `source_message_id`
+from `/api/search`, reads `/api/ontology/relationships` with signed-session
+Authorization and source/thread filters, and renders the source-backed sender DAG
+with deterministic `next_action` metadata. `sender_relationships` now has
+durable `source_message_id` and `source_thread_id` fields plus owner/source
+backfill indexes.
 
 ## Task 3: Reply Tracking Background Job
 

--- a/docs/plans/2026-05-27-source-thread-sender-dag.md
+++ b/docs/plans/2026-05-27-source-thread-sender-dag.md
@@ -1,0 +1,37 @@
+# Source-Thread Sender DAG Slice
+
+## Goal
+
+Search detail must show what a sender means to the signed-in user in the exact
+source email/thread context, so the agent can choose a next action from durable
+ontology evidence instead of a global, unscoped relationship graph.
+
+## Scope
+
+- Persist sender relationship provenance on `sender_relationships` with
+  `source_message_id` and `source_thread_id`.
+- Backfill existing databases with idempotent column/index SQL and replace the
+  old user/sender-only uniqueness with owner/source-aware uniqueness.
+- Return `/api/ontology/relationships` only for the signed session owner and
+  organization, with optional `source_message_id` and `source_thread_id`
+  filters.
+- Include `source_message_id` in `/api/search` results so the frontend can load
+  the matching sender DAG without exposing new sequential database ids.
+- Render a Search detail sender DAG panel that shows relationship type,
+  confidence, next action, and source/thread provenance.
+
+## Non-Goals
+
+- No provider writeback.
+- No GitHub Models path.
+- No mailbox data sovereignty change: Naruon stores ontology metadata and
+  source references only for the connected customer-owned mail context.
+
+## Verification
+
+- Backend ontology API/pipeline/search/bootstrap tests.
+- Frontend Search route unit test proving signed-session ontology requests and
+  absence of public identity headers.
+- Playwright desktop/mobile Search screenshots with scroll checks.
+- Real PostgreSQL bootstrap/smoke for DB-affecting schema changes before merge
+  evidence is complete.

--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -75,6 +75,7 @@ describe("SearchPage", () => {
             results: [
               {
                 id: 7,
+                source_message_id: "<q2@example.com>",
                 subject: "Q2 출시 계획 및 우선순위 조정",
                 sender: "김지현 PM",
                 date: "2026-05-11T09:30:00Z",
@@ -85,6 +86,22 @@ describe("SearchPage", () => {
               },
             ],
           }),
+        );
+      }
+      if (url.includes("/api/ontology/relationships")) {
+        return Promise.resolve(
+          jsonResponse([
+            {
+              sender_email: "jihyun@naruon.ai",
+              parent_sender_email: "user@naruon.ai",
+              source_message_id: "<q2@example.com>",
+              source_thread_id: "thread-q2",
+              relationship_type: "colleague",
+              confidence_score: 0.85,
+              next_action: "track_reply_and_tasks",
+              action_reason: "Same-domain sender; preserve reply and task follow-up.",
+            },
+          ]),
         );
       }
       if (url.endsWith("/api/network/graph")) {
@@ -112,6 +129,9 @@ describe("SearchPage", () => {
     expect(container.textContent).toContain("thread-q2");
     expect(container.textContent).toContain("답장 3건");
     expect(container.textContent).toContain("관계 그래프와 타임라인");
+    expect(container.textContent).toContain("발신자 DAG");
+    expect(container.textContent).toContain("track_reply_and_tasks");
+    expect(container.textContent).toContain("source=<q2@example.com>");
 
     const searchCall = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/api/search"));
     expect(searchCall).toBeDefined();
@@ -122,6 +142,16 @@ describe("SearchPage", () => {
     for (const headerName of ["x-user-id", "x-organization-id", "x-group-id", "x-group-ids", "x-user-role", "x-dev-auth-token"]) {
       expect(headers[headerName]).toBeUndefined();
     }
+
+    const ontologyCall = fetchMock.mock.calls.find(([input]) => String(input).includes("/api/ontology/relationships"));
+    expect(ontologyCall).toBeDefined();
+    expect(String(ontologyCall?.[0])).toContain("source_message_id=%3Cq2%40example.com%3E");
+    expect(String(ontologyCall?.[0])).toContain("source_thread_id=thread-q2");
+    const ontologyHeaders = lowerCaseHeaders(ontologyCall?.[1]?.headers);
+    expect(ontologyHeaders.authorization).toBe("Bearer signed-search-session");
+    for (const headerName of ["x-user-id", "x-organization-id", "x-group-id", "x-group-ids", "x-user-role", "x-dev-auth-token"]) {
+      expect(ontologyHeaders[headerName]).toBeUndefined();
+    }
   });
 
   it("renders a fail-closed error state when the search API rejects the query", async () => {
@@ -130,6 +160,7 @@ describe("SearchPage", () => {
       vi.fn((input: RequestInfo | URL) => {
         const url = String(input);
         if (url.endsWith("/api/search")) return Promise.resolve(jsonResponse({ detail: "OpenAI API key not configured" }, false, 400));
+        if (url.includes("/api/ontology/relationships")) return Promise.resolve(jsonResponse([]));
         if (url.endsWith("/api/network/graph")) return Promise.resolve(jsonResponse({ nodes: [], edges: [] }));
         return Promise.resolve(jsonResponse({}, false, 404));
       }),

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -13,6 +13,7 @@ const DEFAULT_QUERY = '런칭 캠페인';
 
 type SearchResultItem = {
   id: number;
+  source_message_id?: string | null;
   subject: string | null;
   sender: string;
   date: string;
@@ -24,6 +25,23 @@ type SearchResultItem = {
 
 type SearchResponse = {
   results: SearchResultItem[];
+};
+
+type SenderRelationship = {
+  sender_email: string;
+  parent_sender_email: string | null;
+  source_message_id: string | null;
+  source_thread_id: string | null;
+  relationship_type: string;
+  confidence_score: number;
+  next_action: string;
+  action_reason: string;
+};
+
+type RelationshipState = {
+  sourceKey: string | null;
+  items: SenderRelationship[];
+  error: string | null;
 };
 
 type ResultFilter = 'all' | 'thread' | 'single';
@@ -50,12 +68,100 @@ function resultTitle(result: SearchResultItem) {
   return result.subject?.trim() || '(제목 없음)';
 }
 
+function ontologySourceKey(result: SearchResultItem | null) {
+  if (!result) return null;
+  return `${result.id}:${result.source_message_id ?? ''}:${result.thread_id ?? ''}`;
+}
+
+function buildOntologyUrl(result: SearchResultItem) {
+  const params = new URLSearchParams();
+  if (result.source_message_id) params.set('source_message_id', result.source_message_id);
+  if (result.thread_id) params.set('source_thread_id', result.thread_id);
+  const query = params.toString();
+  return query ? `/api/ontology/relationships?${query}` : '/api/ontology/relationships';
+}
+
+function SenderDagPanel({
+  relationships,
+  loading,
+  error,
+}: {
+  relationships: SenderRelationship[];
+  loading: boolean;
+  error: string | null;
+}) {
+  if (loading) {
+    return (
+      <div role="status" aria-live="polite" className="rounded-lg border border-border bg-background p-4 text-sm font-semibold text-muted-foreground">
+        발신자 DAG를 불러오는 중입니다.
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm font-semibold text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (relationships.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 text-sm font-semibold text-muted-foreground">
+        이 검색 결과에 연결된 발신자 관계가 아직 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {relationships.map((relationship) => (
+        <article
+          key={`${relationship.sender_email}:${relationship.source_message_id ?? 'global'}:${relationship.source_thread_id ?? 'none'}`}
+          className="rounded-lg border border-border bg-background p-4"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-black text-foreground">{relationship.sender_email}</p>
+              <p className="mt-1 text-xs font-semibold text-muted-foreground">
+                상위 맥락: {relationship.parent_sender_email ?? '사용자 직접 관계'}
+              </p>
+            </div>
+            <div className="shrink-0 rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary">
+              {relationship.relationship_type} · {(relationship.confidence_score * 100).toFixed(0)}%
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2 text-xs font-semibold text-muted-foreground sm:grid-cols-2">
+            <div className="rounded border border-border bg-card px-3 py-2">
+              <p className="break-all text-foreground">{relationship.next_action}</p>
+              <p className="mt-1">Agent next action</p>
+            </div>
+            <div className="rounded border border-border bg-card px-3 py-2">
+              <p className="break-words text-foreground">{relationship.action_reason}</p>
+              <p className="mt-1">판단 근거</p>
+            </div>
+          </div>
+          <p className="mt-3 break-words rounded bg-secondary/40 px-3 py-2 text-[11px] font-semibold text-muted-foreground">
+            source={relationship.source_message_id ?? 'global'} / thread={relationship.source_thread_id ?? 'none'}
+          </p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
 export function SearchLayout() {
   const [query, setQuery] = useState(DEFAULT_QUERY);
   const [submittedQuery, setSubmittedQuery] = useState(DEFAULT_QUERY);
   const [activeFilter, setActiveFilter] = useState<ResultFilter>('all');
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [activeResultId, setActiveResultId] = useState<number | null>(null);
+  const [relationshipState, setRelationshipState] = useState<RelationshipState>({
+    sourceKey: null,
+    items: [],
+    error: null,
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -92,6 +198,40 @@ export function SearchLayout() {
   }, [activeFilter, results]);
 
   const activeResult = filteredResults.find((result) => result.id === activeResultId) ?? filteredResults[0] ?? null;
+  const activeOntologySourceKey = ontologySourceKey(activeResult);
+  const activeOntologyUrl = activeResult ? buildOntologyUrl(activeResult) : null;
+  const relationshipsLoading = Boolean(
+    activeOntologySourceKey && relationshipState.sourceKey !== activeOntologySourceKey,
+  );
+  const relationships = relationshipsLoading ? [] : relationshipState.items;
+  const relationshipError = relationshipsLoading ? null : relationshipState.error;
+
+  useEffect(() => {
+    if (!activeOntologyUrl || !activeOntologySourceKey) return;
+
+    const controller = new AbortController();
+
+    apiClient
+      .get<SenderRelationship[]>(activeOntologyUrl, { signal: controller.signal })
+      .then((response) => {
+        if (controller.signal.aborted) return;
+        setRelationshipState({
+          sourceKey: activeOntologySourceKey,
+          items: response,
+          error: null,
+        });
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setRelationshipState({
+          sourceKey: activeOntologySourceKey,
+          items: [],
+          error: '발신자 DAG를 불러오지 못했습니다.',
+        });
+      });
+
+    return () => controller.abort();
+  }, [activeOntologySourceKey, activeOntologyUrl]);
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -230,7 +370,7 @@ export function SearchLayout() {
                     </div>
                     <div className="grid grid-cols-3 gap-2 text-center text-xs font-bold text-muted-foreground">
                       <div className="rounded-lg border border-border bg-background px-3 py-2">
-                        <p className="text-foreground">{activeResult.thread_id ?? 'thread 없음'}</p>
+                        <p className="break-all text-foreground">{activeResult.thread_id ?? 'thread 없음'}</p>
                         <p className="mt-1">THREAD_ID</p>
                       </div>
                       <div className="rounded-lg border border-border bg-background px-3 py-2">
@@ -251,7 +391,7 @@ export function SearchLayout() {
                 <div className="flex items-center justify-between gap-3">
                   <h2 className="text-lg font-bold">관계 그래프와 타임라인</h2>
                   <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary">
-                    API 근거 연결
+                    source/thread API 연결
                   </span>
                 </div>
 
@@ -259,8 +399,11 @@ export function SearchLayout() {
                   <section className="flex min-h-[420px] flex-col rounded-lg border border-border bg-card p-5 shadow-sm md:p-6">
                     <div className="mb-4 flex items-center gap-2">
                       <Network className="size-5 text-primary" aria-hidden="true" />
-                      <h3 className="text-lg font-bold">관계 그래프 (Relationship)</h3>
+                      <h3 className="text-lg font-bold">발신자 DAG (Ontology)</h3>
                     </div>
+                    <SenderDagPanel relationships={relationships} loading={relationshipsLoading} error={relationshipError} />
+                    <div className="my-4 border-t border-border" />
+                    <h4 className="mb-3 text-sm font-black text-foreground">네트워크 그래프</h4>
                     <div className="relative min-h-[320px] flex-1 overflow-hidden rounded-lg border border-border bg-background shadow-inner">
                       <NetworkGraph />
                     </div>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -529,15 +529,26 @@ test('renders API-backed context search sender DAG and reply tracking', async ({
     const url = new URL(request.url());
     return url.pathname === '/api/network/graph' && request.method() === 'GET';
   });
+  const ontologyRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/ontology/relationships' && request.method() === 'GET';
+  });
 
   await page.goto('/search');
   const searchHeaders = (await searchRequest).headers();
   const graphHeaders = (await graphRequest).headers();
+  const ontologyCall = await ontologyRequest;
+  const ontologyHeaders = ontologyCall.headers();
   expect(searchHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
   expect(graphHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  expect(ontologyHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  const ontologyUrl = new URL(ontologyCall.url());
+  expect(ontologyUrl.searchParams.get('source_message_id')).toBe('<q2@example.com>');
+  expect(ontologyUrl.searchParams.get('source_thread_id')).toBe('thread-q2');
   for (const headerName of publicIdentityHeaders) {
     expect(searchHeaders[headerName]).toBeUndefined();
     expect(graphHeaders[headerName]).toBeUndefined();
+    expect(ontologyHeaders[headerName]).toBeUndefined();
   }
 
   await expect(page.getByRole('heading', { name: '맥락 검색' })).toBeAttached();
@@ -545,6 +556,9 @@ test('renders API-backed context search sender DAG and reply tracking', async ({
   await expect(page.getByText('thread-q2').first()).toBeVisible();
   await expect(page.getByText('답장 2건').first()).toBeVisible();
   await expect(page.getByText('관계 그래프와 타임라인')).toBeVisible();
+  await expect(page.getByText('발신자 DAG (Ontology)')).toBeVisible();
+  await expect(page.getByText('track_reply_and_tasks')).toBeVisible();
+  await expect(page.getByText('source=<q2@example.com> / thread=thread-q2')).toBeVisible();
   await expect(page.getByText('김지현 PM').first()).toBeVisible();
   const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(desktopOverflow).toBeLessThanOrEqual(1);
@@ -580,6 +594,10 @@ test('renders API-backed context search sender DAG and reply tracking', async ({
   });
   expect(detailScrollMetrics.maxScroll).toBeGreaterThan(0);
   expect(detailScrollMetrics.after).toBeGreaterThan(detailScrollMetrics.before);
+  await page.getByText('발신자 DAG (Ontology)').scrollIntoViewIfNeeded();
+  await expect(page.getByText('track_reply_and_tasks')).toBeVisible();
+  await page.getByText('track_reply_and_tasks').scrollIntoViewIfNeeded();
+  await page.screenshot({ path: testInfo.outputPath('search-dag-reply-mobile-dag.png'), fullPage: false });
   await page.getByText('관계 이해').scrollIntoViewIfNeeded();
   await expect(page.getByText('관계 이해')).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('search-dag-reply-mobile-scroll.png'), fullPage: false });

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -3,6 +3,7 @@ import type { Page, Route } from '@playwright/test';
 const email = {
   id: 7,
   message_id: '<q2@example.com>',
+  source_message_id: '<q2@example.com>',
   thread_id: 'thread-q2',
   sender: '김지현 PM',
   recipients: 'user@naruon.ai',
@@ -405,6 +406,22 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
         ],
         edges: [{ source: 'sender-1', target: 'owner-1', weight: 2, title: '관련 메일' }],
       });
+      return;
+    }
+
+    if (path === '/api/ontology/relationships' && request.method() === 'GET') {
+      await fulfillJson(route, [
+        {
+          sender_email: 'jihyun@naruon.ai',
+          parent_sender_email: 'user@naruon.ai',
+          source_message_id: '<q2@example.com>',
+          source_thread_id: 'thread-q2',
+          relationship_type: 'colleague',
+          confidence_score: 0.85,
+          next_action: 'track_reply_and_tasks',
+          action_reason: 'Same-domain sender; preserve reply and task follow-up.',
+        },
+      ]);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Adds source/thread provenance to sender ontology persistence and bootstrap backfill.
- Scopes `/api/ontology/relationships` to signed-session user/org plus optional `source_message_id` and `source_thread_id` filters.
- Wires Search detail to load and render the source-backed sender DAG with next-action metadata, while preserving signed-session Authorization and no public identity headers.

## Verification
- `python3 -m pytest backend/tests/test_ontology_api.py backend/tests/test_ontology_pipeline.py backend/tests/test_bootstrap_db.py backend/tests/test_search.py -q`
- `npm test -- --run src/app/search/page.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run build`
- Real PostgreSQL smoke with temporary `pgvector/pgvector:pg16`: verified `source_message_id`, `source_thread_id`, `ix_sender_relationships_owner_source`, and `uq_sender_relationships_scope_source`.
- Browser E2E: `env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18081 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=desktop -g "renders API-backed context search sender DAG"`

## Screenshot Evidence Inspected
- `frontend/test-results/dashboard-branding-renders-546cd-nder-DAG-and-reply-tracking-desktop/search-dag-reply-desktop.png`
- `frontend/test-results/dashboard-branding-renders-546cd-nder-DAG-and-reply-tracking-desktop/search-dag-reply-mobile.png`
- `frontend/test-results/dashboard-branding-renders-546cd-nder-DAG-and-reply-tracking-desktop/search-dag-reply-mobile-dag.png`
- `frontend/test-results/dashboard-branding-renders-546cd-nder-DAG-and-reply-tracking-desktop/search-dag-reply-mobile-scroll.png`

## Notes
- No GitHub Models path is added or used.
- No provider writeback is implemented in this slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source message and thread tracking to sender relationships for enhanced contextual provenance.
  * Implemented scoped sender DAG visualization panel displaying relationships filtered to specific source context.
  * Enhanced search results with source message identifiers for improved relationship context linking.

* **Documentation**
  * Updated implementation plans documenting feature completion and scope changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->