### PR TITLE
Add self-sent knowledge WebDAV intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,12 @@
   opaque task uid, re-check owner and organization scope server-side, reject
   non-`self_sent_knowledge` tasks, and return intent metadata only until the
   connector/provider write path has source-backed ETag conflict handling.
+- Private API services should return deterministic `error_code` values for
+  expected failures; route layers must not derive HTTP status from human-readable
+  message substrings.
+- UI async state for repeated task/action rows must be keyed by the row's opaque
+  public id so one row's loading, error, or result state cannot overwrite another
+  row.
 - Sender ontology and relationship DAG APIs must stay scoped to the signed
   session owner and organization. Source-backed UI panels must request
   `source_message_id` and `source_thread_id` filters instead of presenting a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@
   stay idempotent per source email, preserve email/thread provenance, and store
   only plain-text task titles. Do not create unlinked knowledge tasks from raw
   dict payloads when the source email row is unavailable.
+- Self-sent knowledge WebDAV/Notes materialization requests must start from an
+  opaque task uid, re-check owner and organization scope server-side, reject
+  non-`self_sent_knowledge` tasks, and return intent metadata only until the
+  connector/provider write path has source-backed ETag conflict handling.
 - Sender ontology and relationship DAG APIs must stay scoped to the signed
   session owner and organization. Source-backed UI panels must request
   `source_message_id` and `source_thread_id` filters instead of presenting a

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ mail/calendar/file systems.
   still an episode task.
 - **Self-sent knowledge capture**: IMAP-imported emails sent from a user to the
   same address now create one idempotent, source-linked `self_sent_knowledge`
-  ticket task with a plain-text memo title. WebDAV/Notes materialization remains
-  future work and must write back to customer-owned sources.
+  ticket task with a plain-text memo title. The Tasks workspace can request a
+  signed WebDAV/Notes materialization intent for that task and shows the planned
+  customer-owned target with `provider_write_executed=false`; actual provider
+  mutation remains connector execution work.
 
 ## Five-minute local path
 

--- a/backend/api/webdav.py
+++ b/backend/api/webdav.py
@@ -8,6 +8,13 @@ from db.session import get_db
 from services.webdav_service import webdav_service
 
 router = APIRouter(prefix="/api/webdav", tags=["webdav"])
+WEB_DAV_ERROR_STATUS_CODES = {
+    "not_found": 404,
+    "validation_error": 422,
+    "missing_provenance": 422,
+    "no_webdav_account": 422,
+    "webdav_account_not_found": 422,
+}
 
 class WebdavAccountResponse(BaseModel):
     account_id: int
@@ -99,8 +106,9 @@ async def get_knowledge_materialization_intent(
         target_account_id=req.target_account_id,
     )
     if result.get("status") == "error":
-        status_code = (
-            404 if "not found" in str(result.get("message", "")).lower() else 422
+        status_code = WEB_DAV_ERROR_STATUS_CODES.get(
+            str(result.get("error_code") or ""),
+            422,
         )
         raise HTTPException(status_code=status_code, detail=result.get("message"))
     return KnowledgeMaterializationIntentResponse(**result)

--- a/backend/api/webdav.py
+++ b/backend/api/webdav.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
@@ -31,6 +31,25 @@ class WritebackIntentResponse(BaseModel):
     status: str | None = None
     message: str | None = None
 
+class KnowledgeMaterializationIntentRequest(BaseModel):
+    source_task_id: str
+    target_account_id: int | None = None
+
+class KnowledgeMaterializationIntentResponse(BaseModel):
+    intent: str
+    status: str
+    task_id: str
+    source_type: str
+    source_email_id: str | None
+    source_thread_id: str | None
+    source_id: int | None
+    server_url: str | None
+    target_path: str
+    requires_if_match: bool
+    provenance: str
+    provider_write_executed: bool
+    audit_event: str
+
 @router.get("/accounts", response_model=List[WebdavAccountResponse])
 async def get_webdav_accounts(
     auth_context: AuthContext = Depends(get_auth_context),
@@ -62,3 +81,26 @@ async def get_webdav_writeback_intent(
     if result.get("status") == "error":
         raise HTTPException(status_code=422, detail=result.get("message"))
     return WritebackIntentResponse(**result)
+
+@router.post(
+    "/knowledge-materialization-intent",
+    response_model=KnowledgeMaterializationIntentResponse,
+)
+async def get_knowledge_materialization_intent(
+    req: KnowledgeMaterializationIntentRequest,
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await webdav_service.determine_knowledge_materialization_intent_from_db(
+        db,
+        auth_context.user_id,
+        auth_context.organization_id,
+        req.source_task_id,
+        target_account_id=req.target_account_id,
+    )
+    if result.get("status") == "error":
+        status_code = (
+            404 if "not found" in str(result.get("message", "")).lower() else 422
+        )
+        raise HTTPException(status_code=status_code, detail=result.get("message"))
+    return KnowledgeMaterializationIntentResponse(**result)

--- a/backend/services/webdav_service.py
+++ b/backend/services/webdav_service.py
@@ -151,6 +151,7 @@ class WebDavService:
         if row is None:
             return {
                 "status": "error",
+                "error_code": "not_found",
                 "message": "Self-sent knowledge task was not found.",
             }
 
@@ -158,7 +159,14 @@ class WebDavService:
         if task.source_type != SELF_SENT_KNOWLEDGE_SOURCE:
             return {
                 "status": "error",
+                "error_code": "validation_error",
                 "message": "Task is not self-sent knowledge.",
+            }
+        if source_email_id is None:
+            return {
+                "status": "error",
+                "error_code": "missing_provenance",
+                "message": "Self-sent knowledge task missing source email provenance.",
             }
 
         result = await self.determine_webdav_writeback_intent_from_db(
@@ -191,7 +199,11 @@ class WebDavService:
         target_account_id: int | None = None,
     ) -> Dict[str, Any]:
         if not accounts:
-            return {"status": "error", "message": "No connected WebDAV accounts found."}
+            return {
+                "status": "error",
+                "error_code": "no_webdav_account",
+                "message": "No connected WebDAV accounts found.",
+            }
             
         selected_account = accounts[0]
         if target_account_id is not None:
@@ -203,6 +215,7 @@ class WebDavService:
             if selected_account is None:
                 return {
                     "status": "error",
+                    "error_code": "webdav_account_not_found",
                     "message": "Requested WebDAV account was not found.",
                 }
                     

--- a/backend/services/webdav_service.py
+++ b/backend/services/webdav_service.py
@@ -4,7 +4,8 @@ from typing import Dict, Any, List
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import ProjectFolder, WebdavAccount
+from db.models import Email, ProjectFolder, TicketTask, WebdavAccount
+from services.knowledge_extractor import SELF_SENT_KNOWLEDGE_SOURCE
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,66 @@ class WebDavService:
             accounts,
             target_account_id=target_account_id,
         )
+
+    async def determine_knowledge_materialization_intent_from_db(
+        self,
+        session: AsyncSession,
+        user_id: str,
+        organization_id: str | None,
+        source_task_id: str,
+        target_account_id: int | None = None,
+    ) -> Dict[str, Any]:
+        task_result = await session.execute(
+            select(TicketTask, Email.message_id)
+            .outerjoin(
+                Email,
+                (TicketTask.related_email_id == Email.id)
+                & (Email.user_id == user_id)
+                & (Email.organization_id == organization_id),
+            )
+            .where(
+                TicketTask.task_uid == source_task_id,
+                TicketTask.user_id == user_id,
+                TicketTask.organization_id == organization_id,
+            )
+        )
+        row = task_result.one_or_none()
+        if row is None:
+            return {
+                "status": "error",
+                "message": "Self-sent knowledge task was not found.",
+            }
+
+        task, source_email_id = row
+        if task.source_type != SELF_SENT_KNOWLEDGE_SOURCE:
+            return {
+                "status": "error",
+                "message": "Task is not self-sent knowledge.",
+            }
+
+        result = await self.determine_webdav_writeback_intent_from_db(
+            session,
+            user_id,
+            target_account_id=target_account_id,
+        )
+        if result.get("status") == "error":
+            return result
+
+        return {
+            "intent": "knowledge_materialization",
+            "status": "intent_ready",
+            "task_id": task.task_uid,
+            "source_type": SELF_SENT_KNOWLEDGE_SOURCE,
+            "source_email_id": source_email_id,
+            "source_thread_id": task.related_thread_id,
+            "source_id": result["source_id"],
+            "server_url": result["server_url"],
+            "target_path": f"/Naruon/Notes/{task.task_uid}.md",
+            "requires_if_match": result["requires_if_match"],
+            "provenance": result["provenance"],
+            "provider_write_executed": False,
+            "audit_event": "webdav.self_sent_knowledge_intent.created",
+        }
 
     def determine_webdav_writeback_intent_from_accounts(
         self,

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -93,11 +93,13 @@ def stub_webdav_service(monkeypatch):
         if source_task_id == "task-email":
             return {
                 "status": "error",
+                "error_code": "validation_error",
                 "message": "Task is not self-sent knowledge.",
             }
         if source_task_id != "task-self-knowledge":
             return {
                 "status": "error",
+                "error_code": "not_found",
                 "message": "Self-sent knowledge task was not found.",
             }
         result = await fake_intent(db, user_id, target_account_id=target_account_id)
@@ -283,6 +285,14 @@ def test_get_self_sent_knowledge_webdav_intent_accepts_signed_bearer_session():
 
 @pytest.mark.asyncio
 async def test_knowledge_materialization_rejects_non_self_sent_task(monkeypatch):
+    monkeypatch.setattr(
+        webdav_service,
+        "determine_knowledge_materialization_intent_from_db",
+        WebDavService.determine_knowledge_materialization_intent_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
     task = TicketTask(
         user_id="alice",
         organization_id="org-acme",
@@ -315,7 +325,49 @@ async def test_knowledge_materialization_rejects_non_self_sent_task(monkeypatch)
 
     assert result == {
         "status": "error",
+        "error_code": "validation_error",
         "message": "Task is not self-sent knowledge.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_knowledge_materialization_requires_source_email_provenance(monkeypatch):
+    monkeypatch.setattr(
+        webdav_service,
+        "determine_knowledge_materialization_intent_from_db",
+        WebDavService.determine_knowledge_materialization_intent_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
+    task = TicketTask(
+        user_id="alice",
+        organization_id="org-acme",
+        title="Self sent task without email",
+        source_type="self_sent_knowledge",
+    )
+    task.task_uid = "task-self-no-email"
+    task.related_thread_id = "thread-self-note"
+
+    class Result:
+        def one_or_none(self):
+            return (task, None)
+
+    class Session:
+        async def execute(self, stmt):
+            return Result()
+
+    result = await webdav_service.determine_knowledge_materialization_intent_from_db(
+        Session(),
+        "alice",
+        "org-acme",
+        "task-self-no-email",
+    )
+
+    assert result == {
+        "status": "error",
+        "error_code": "missing_provenance",
+        "message": "Self-sent knowledge task missing source email provenance.",
     }
 
 
@@ -451,3 +503,262 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
     assert body["source_id"] == account_id
     assert body["server_url"] == "https://real-webdav.naruon.net"
     assert body["provenance"] == "server-authoritative"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
+    monkeypatch,
+):
+    smoke_id = 10_000 + (uuid.uuid4().int % 1_000_000)
+    schema_name = f"webdav_knowledge_{uuid.uuid4().hex}"
+    user_id = f"knowledge-smoke-{smoke_id}"
+    task_uid = f"task{uuid.uuid4().hex[:28]}"
+    message_id = f"<self-knowledge-{smoke_id}@example.com>"
+    thread_id = f"thread-knowledge-{smoke_id}"
+    account_id = smoke_id + 1
+    monkeypatch.setattr(
+        webdav_service,
+        "get_connected_accounts_from_db",
+        WebDavService.get_connected_accounts_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
+    monkeypatch.setattr(
+        webdav_service,
+        "determine_webdav_writeback_intent_from_db",
+        WebDavService.determine_webdav_writeback_intent_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
+    monkeypatch.setattr(
+        webdav_service,
+        "determine_knowledge_materialization_intent_from_db",
+        WebDavService.determine_knowledge_materialization_intent_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
+
+    admin_engine = create_async_engine(settings.DATABASE_URL)
+    try:
+        async with admin_engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(text(f"CREATE SCHEMA {schema_name}"))
+    except (
+        ConnectionRefusedError,
+        OSError,
+        OperationalError,
+        asyncpg.CannotConnectNowError,
+        asyncpg.InvalidAuthorizationSpecificationError,
+        asyncpg.InvalidCatalogNameError,
+        asyncpg.InvalidPasswordError,
+    ):
+        await admin_engine.dispose()
+        pytest.skip("PostgreSQL smoke path unavailable")
+    except Exception:
+        await admin_engine.dispose()
+        raise
+
+    engine = create_async_engine(
+        settings.DATABASE_URL,
+        connect_args={"server_settings": {"search_path": schema_name}},
+    )
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE emails (
+                        id INTEGER PRIMARY KEY,
+                        user_id VARCHAR NOT NULL,
+                        organization_id VARCHAR NOT NULL,
+                        message_id VARCHAR NOT NULL,
+                        thread_id VARCHAR
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE ticket_tasks (
+                        task_id INTEGER PRIMARY KEY,
+                        task_uid VARCHAR(32) UNIQUE NOT NULL,
+                        user_id VARCHAR NOT NULL,
+                        organization_id VARCHAR,
+                        task_title VARCHAR NOT NULL,
+                        status_code VARCHAR NOT NULL,
+                        priority_code VARCHAR NOT NULL,
+                        source_type VARCHAR NOT NULL,
+                        email_id INTEGER,
+                        thread_id VARCHAR,
+                        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE webdav_accounts (
+                        account_id INTEGER PRIMARY KEY,
+                        user_id VARCHAR NOT NULL,
+                        server_url VARCHAR NOT NULL,
+                        username VARCHAR NOT NULL,
+                        credentials_encrypted VARCHAR NOT NULL,
+                        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO emails (
+                        id,
+                        user_id,
+                        organization_id,
+                        message_id,
+                        thread_id
+                    )
+                    VALUES (
+                        :email_id,
+                        :user_id,
+                        :organization_id,
+                        :message_id,
+                        :thread_id
+                    )
+                    """
+                ),
+                {
+                    "email_id": smoke_id,
+                    "user_id": user_id,
+                    "organization_id": "org-acme",
+                    "message_id": message_id,
+                    "thread_id": thread_id,
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO ticket_tasks (
+                        task_id,
+                        task_uid,
+                        user_id,
+                        organization_id,
+                        task_title,
+                        status_code,
+                        priority_code,
+                        source_type,
+                        email_id,
+                        thread_id
+                    )
+                    VALUES (
+                        :task_id,
+                        :task_uid,
+                        :user_id,
+                        :organization_id,
+                        :task_title,
+                        'open',
+                        'normal',
+                        'self_sent_knowledge',
+                        :email_id,
+                        :thread_id
+                    )
+                    """
+                ),
+                {
+                    "task_id": smoke_id,
+                    "task_uid": task_uid,
+                    "user_id": user_id,
+                    "organization_id": "org-acme",
+                    "task_title": "Memo: source-backed smoke",
+                    "email_id": smoke_id,
+                    "thread_id": thread_id,
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO webdav_accounts (
+                        account_id,
+                        user_id,
+                        server_url,
+                        username,
+                        credentials_encrypted
+                    )
+                    VALUES (
+                        :account_id,
+                        :user_id,
+                        :server_url,
+                        :username,
+                        :credentials_encrypted
+                    )
+                    """
+                ),
+                {
+                    "account_id": account_id,
+                    "user_id": user_id,
+                    "server_url": "https://real-webdav.naruon.net",
+                    "username": user_id,
+                    "credentials_encrypted": "test-only-placeholder",
+                },
+            )
+    except Exception:
+        await engine.dispose()
+        async with admin_engine.begin() as conn:
+            await conn.execute(text(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE"))
+        await admin_engine.dispose()
+        raise
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_real_db():
+        async with session_factory() as session:
+            yield session
+
+    previous_override = app.dependency_overrides.pop(get_auth_context, None)
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    app.dependency_overrides[get_db] = override_real_db
+    token = _signed_session_token(
+        _valid_session_payload(sub=user_id, org="org-acme", workspace="workspace-org-acme")
+    )
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as client:
+            response = await client.post(
+                "/api/webdav/knowledge-materialization-intent",
+                json={
+                    "target_account_id": account_id,
+                    "source_task_id": task_uid,
+                },
+            )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        if previous_override is not None:
+            app.dependency_overrides[get_auth_context] = previous_override
+        app.dependency_overrides.pop(get_db, None)
+        await engine.dispose()
+        async with admin_engine.begin() as conn:
+            await conn.execute(text(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE"))
+        await admin_engine.dispose()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["intent"] == "knowledge_materialization"
+    assert body["status"] == "intent_ready"
+    assert body["task_id"] == task_uid
+    assert body["source_type"] == "self_sent_knowledge"
+    assert body["source_email_id"] == message_id
+    assert body["source_thread_id"] == thread_id
+    assert body["source_id"] == account_id
+    assert body["target_path"] == f"/Naruon/Notes/{task_uid}.md"
+    assert body["provider_write_executed"] is False

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -1,19 +1,64 @@
+import base64
+import hashlib
+import hmac
+import json
+import time
 import uuid
 
 import asyncpg
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from core.config import settings
 from main import app
+from api.auth import get_auth_context
+from db.models import TicketTask
 from db.session import get_db
 from services.webdav_service import WebDavService, webdav_service
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
+TEST_SESSION_HMAC_SECRET = "webdav-knowledge-hmac-material-32-bytes"  # noqa: S105
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _signed_session_token(payload: dict[str, object]) -> str:
+    header_segment = _base64url_encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode()
+    )
+    payload_segment = _base64url_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature = hmac.new(
+        TEST_SESSION_HMAC_SECRET.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _valid_session_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ver": 1,
+        "iss": "naruon-control-plane",
+        "aud": "naruon-api",
+        "sub": "alice",
+        "role": "tenant_admin",
+        "org": "org-acme",
+        "groups": ["group-1", "group-2"],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
 
 @pytest.fixture(autouse=True)
 def stub_webdav_service(monkeypatch):
@@ -38,12 +83,54 @@ def stub_webdav_service(monkeypatch):
             target_account_id=target_account_id,
         )
 
+    async def fake_knowledge_intent(
+        db,
+        user_id,
+        organization_id,
+        source_task_id,
+        target_account_id=None,
+    ):
+        if source_task_id == "task-email":
+            return {
+                "status": "error",
+                "message": "Task is not self-sent knowledge.",
+            }
+        if source_task_id != "task-self-knowledge":
+            return {
+                "status": "error",
+                "message": "Self-sent knowledge task was not found.",
+            }
+        result = await fake_intent(db, user_id, target_account_id=target_account_id)
+        if result.get("status") == "error":
+            return result
+        return {
+            **result,
+            "intent": "knowledge_materialization",
+            "status": "intent_ready",
+            "task_id": source_task_id,
+            "source_type": "self_sent_knowledge",
+            "source_email_id": "<self-note@example.com>",
+            "source_thread_id": "thread-self-note",
+            "source_id": result["source_id"],
+            "server_url": result["server_url"],
+            "target_path": f"/Naruon/Notes/{source_task_id}.md",
+            "requires_if_match": result["requires_if_match"],
+            "provenance": result["provenance"],
+            "provider_write_executed": False,
+            "audit_event": "webdav.self_sent_knowledge_intent.created",
+        }
+
     monkeypatch.setattr(webdav_service, "get_connected_accounts_from_db", fake_accounts)
     monkeypatch.setattr(webdav_service, "get_project_folders_from_db", fake_folders)
     monkeypatch.setattr(
         webdav_service,
         "determine_webdav_writeback_intent_from_db",
         fake_intent,
+    )
+    monkeypatch.setattr(
+        webdav_service,
+        "determine_knowledge_materialization_intent_from_db",
+        fake_knowledge_intent,
     )
 
 @pytest.fixture
@@ -102,6 +189,134 @@ def test_get_webdav_writeback_intent_with_invalid_target_account(auth_client):
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "Requested WebDAV account was not found."
+
+
+def test_get_self_sent_knowledge_webdav_intent(auth_client):
+    response = auth_client.post(
+        "/api/webdav/knowledge-materialization-intent",
+        json={
+            "target_account_id": 1,
+            "source_task_id": "task-self-knowledge",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["intent"] == "knowledge_materialization"
+    assert body["status"] == "intent_ready"
+    assert body["task_id"] == "task-self-knowledge"
+    assert body["source_type"] == "self_sent_knowledge"
+    assert body["source_email_id"] == "<self-note@example.com>"
+    assert body["source_thread_id"] == "thread-self-note"
+    assert body["target_path"] == "/Naruon/Notes/task-self-knowledge.md"
+    assert body["provider_write_executed"] is False
+    assert body["audit_event"] == "webdav.self_sent_knowledge_intent.created"
+    assert "related_email_id" not in body
+    assert "user_id" not in body
+    assert "organization_id" not in body
+
+
+def test_self_sent_knowledge_webdav_intent_requires_source_task(auth_client):
+    response = auth_client.post(
+        "/api/webdav/knowledge-materialization-intent",
+        json={},
+    )
+    assert response.status_code == 422
+
+
+def test_self_sent_knowledge_webdav_intent_returns_not_found_for_other_owner_task(
+    auth_client,
+):
+    response = auth_client.post(
+        "/api/webdav/knowledge-materialization-intent",
+        json={"source_task_id": "task-other-owner"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Self-sent knowledge task was not found."
+
+
+def test_self_sent_knowledge_webdav_intent_rejects_non_self_sent_task(auth_client):
+    response = auth_client.post(
+        "/api/webdav/knowledge-materialization-intent",
+        json={"source_task_id": "task-email"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Task is not self-sent knowledge."
+
+
+def test_self_sent_knowledge_webdav_intent_requires_connected_webdav_account():
+    with TestClient(
+        app,
+        headers={"X-User-Id": "bob", "X-Organization-Id": "org-acme"},
+    ) as client:
+        response = client.post(
+            "/api/webdav/knowledge-materialization-intent",
+            json={"source_task_id": "task-self-knowledge"},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "No connected WebDAV accounts found."
+
+
+def test_get_self_sent_knowledge_webdav_intent_accepts_signed_bearer_session():
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    previous_override = app.dependency_overrides.pop(get_auth_context, None)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(_valid_session_payload())
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/webdav/knowledge-materialization-intent",
+                json={
+                    "target_account_id": 1,
+                    "source_task_id": "task-self-knowledge",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        if previous_override is not None:
+            app.dependency_overrides[get_auth_context] = previous_override
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task_id"] == "task-self-knowledge"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_materialization_rejects_non_self_sent_task(monkeypatch):
+    task = TicketTask(
+        user_id="alice",
+        organization_id="org-acme",
+        title="Ordinary task",
+        source_type="email",
+    )
+    task.task_uid = "task-email"
+    task.related_thread_id = "thread-email"
+
+    class Result:
+        def one_or_none(self):
+            return (task, "<email@example.com>")
+
+    class Session:
+        async def execute(self, stmt):
+            return Result()
+
+    monkeypatch.setattr(
+        webdav_service,
+        "get_connected_accounts_from_db",
+        lambda session, user_id: [],
+    )
+
+    result = await webdav_service.determine_knowledge_materialization_intent_from_db(
+        Session(),
+        "alice",
+        "org-acme",
+        "task-email",
+    )
+
+    assert result == {
+        "status": "error",
+        "message": "Task is not self-sent knowledge.",
+    }
 
 
 def test_get_webdav_writeback_intent_no_accounts():

--- a/docs/operations/source-of-truth-and-writeback-sovereignty.md
+++ b/docs/operations/source-of-truth-and-writeback-sovereignty.md
@@ -41,11 +41,12 @@ claims.
 
 Implemented slices currently cover signed task/mail provenance, dedupe/threading
 contracts, source-linked ticket tasks, self-sent knowledge capture into
-idempotent ticket tasks, deterministic sender ontology action hints, and
-writeback intent documentation. Real CalDAV/WebDAV mutation, WebDAV/Notes
-materialization of synthesized knowledge, POP3 runtime sync, durable
-reply-tracking notifications, and source-id filtered sender graph views remain
-episode work and must preserve this registry boundary.
+idempotent ticket tasks, deterministic sender ontology action hints, generic
+WebDAV writeback intent, and self-sent knowledge WebDAV/Notes materialization
+intent. Real CalDAV/WebDAV mutation, ETag-aware WebDAV/Notes provider execution
+for synthesized knowledge, POP3 runtime sync, durable reply-tracking
+notifications, and source-id filtered sender graph views remain episode work and
+must preserve this registry boundary.
 
 ## Policy and audit requirements
 

--- a/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
+++ b/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
@@ -44,10 +44,15 @@
   only after proving a true self-to-self message from a tenant-owned address; it
   preserves email/thread provenance, stores plain-text titles, and skips raw
   payloads without a source email row.
+- Self-sent knowledge WebDAV/Notes materialization now has a signed
+  `/api/webdav/knowledge-materialization-intent` path from Tasks. It validates
+  the opaque task id against owner/org scope, rejects non-self-sent tasks, returns
+  customer WebDAV target intent metadata, and keeps
+  `provider_write_executed=false`.
 - The remaining connector/writeback items stay as explicit future episodes:
   real CalDAV/WebDAV mutation, full POP3 message import/runtime sync, durable
-  reply-tracking notifications, WebDAV/Notes materialization of self-sent
-  knowledge, and source-id filtered sender DAG views.
+  reply-tracking notifications, ETag-aware WebDAV/Notes provider execution for
+  self-sent knowledge, and source-id filtered sender DAG views.
 
 ## Task 1: Governance wait-state correction
 

--- a/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
+++ b/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
@@ -1,0 +1,59 @@
+# Self-Sent Knowledge WebDAV Materialization Intent
+
+## Goal
+
+Turn self-sent knowledge ticket tasks into a source-scoped WebDAV/Notes
+materialization intent without performing a provider write from the browser or
+from an unscoped backend path.
+
+## Contract
+
+- Naruon remains a control plane, not a WebDAV or Notes storage provider.
+- The request starts from an opaque `source_task_id`; clients must not submit raw
+  email ids, owner ids, organization ids, provider credentials, or target paths.
+- The backend verifies the task belongs to the signed session owner and
+  organization, and that `source_type` is `self_sent_knowledge`.
+- Same-tenant non-self-sent tasks return `422`; other-owner or missing tasks
+  return `404`.
+- The backend chooses the customer WebDAV source through the existing
+  server-authoritative account lookup and returns intent metadata only:
+  `target_path`, `server_url`, `requires_if_match`, `provenance`,
+  `provider_write_executed=false`, and the audit event name.
+- Actual DAV `PUT`, ETag negotiation, Notes object synthesis, and provider
+  writeback remain future connector execution work.
+
+## Implementation
+
+- Add `POST /api/webdav/knowledge-materialization-intent` behind
+  `get_auth_context`.
+- Add backend tests for successful intent, required task id, other-owner 404,
+  non-self-sent 422, no WebDAV account 422, signed bearer acceptance, and service
+  source-type rejection.
+- Add a Tasks workspace subsection for self-sent knowledge tasks. It calls the
+  intent endpoint with the stored `naruon_session_token` bearer path through
+  `apiClient`, and displays the planned target without claiming execution.
+- Extend Playwright mocks and screenshots for desktop/mobile/mobile-scroll
+  evidence.
+
+## Verification
+
+```bash
+python3 -m pytest backend/tests/test_webdav_api.py -q
+```
+
+```bash
+cd frontend
+npm test -- --run src/app/tasks/page.test.tsx
+```
+
+Browser evidence to inspect:
+
+- `self-sent-knowledge-webdav-intent-desktop.png`
+- `self-sent-knowledge-webdav-intent-mobile.png`
+- `self-sent-knowledge-webdav-intent-mobile-scroll.png`
+
+## Governance
+
+- Strix remains OpenAI Platform direct-only through `STRIX_OPENAI_API_KEY`.
+- GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini/Vertex fallback,
+  GPT-4o, and GPT-4.1 are not valid Strix routes.

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -161,6 +161,84 @@ describe("TasksPage", () => {
     expect(doneButton?.getAttribute("aria-pressed")).toBe("true");
   });
 
+  it("creates self-sent knowledge WebDAV materialization intent with signed headers", async () => {
+    localStorage.setItem("naruon_session_token", "signed.knowledge.intent");
+    const publicIdentityHeaders = [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/webdav/knowledge-materialization-intent") {
+        const headers = init?.headers as Record<string, string>;
+        expect(init?.method).toBe("POST");
+        expect(headers.Authorization).toBe("Bearer signed.knowledge.intent");
+        expect(headers["Content-Type"]).toBe("application/json");
+        for (const headerName of publicIdentityHeaders) {
+          expect(Object.keys(headers).some((key) => key.toLowerCase() === headerName)).toBe(false);
+        }
+        expect(JSON.parse(String(init?.body))).toEqual({ source_task_id: "task-self-knowledge" });
+        return jsonResponse({
+          intent: "knowledge_materialization",
+          status: "intent_ready",
+          task_id: "task-self-knowledge",
+          source_type: "self_sent_knowledge",
+          source_email_id: "<self-note@example.com>",
+          source_thread_id: "thread-self-note",
+          source_id: 1,
+          server_url: "https://webdav.naruon.net",
+          target_path: "/Naruon/Notes/task-self-knowledge.md",
+          requires_if_match: true,
+          provenance: "server-authoritative",
+          provider_write_executed: false,
+          audit_event: "webdav.self_sent_knowledge_intent.created",
+        });
+      }
+      return jsonResponse([
+        {
+          id: "task-self-knowledge",
+          title: "나에게 보낸 지식 메모 정리",
+          status: "open",
+          priority: "normal",
+          source_type: "self_sent_knowledge",
+          source_email_id: "<self-note@example.com>",
+          related_thread_id: "thread-self-note",
+          updated_at: "2026-05-26T09:00:00.000Z",
+        },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<TasksPage />);
+    });
+    await flushAsyncWork();
+
+    const intentButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="나에게 보낸 지식 메모 정리 WebDAV 지식 노트 intent 생성"]',
+    );
+    expect(intentButton).not.toBeNull();
+    await act(async () => {
+      intentButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/webdav/knowledge-materialization-intent", expect.objectContaining({
+      method: "POST",
+    }));
+    expect(container.textContent).toContain("/Naruon/Notes/task-self-knowledge.md");
+    expect(container.textContent).toContain("https://webdav.naruon.net");
+    expect(container.textContent).toContain("provider_write_executed=false");
+    expect(container.textContent).toContain("webdav.self_sent_knowledge_intent.created");
+  });
+
   it("distinguishes signed-session authorization failures from generic task API errors", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ detail: "forbidden" }, false, 403)));
     container = document.createElement("div");

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -32,6 +32,22 @@ type TicketTask = {
   updated_at: string;
 };
 
+type KnowledgeMaterializationIntent = {
+  intent: 'knowledge_materialization';
+  status: 'intent_ready';
+  task_id: string;
+  source_type: 'self_sent_knowledge';
+  source_email_id: string | null;
+  source_thread_id: string | null;
+  source_id: number | null;
+  server_url: string | null;
+  target_path: string;
+  requires_if_match: boolean;
+  provenance: string;
+  provider_write_executed: boolean;
+  audit_event: string;
+};
+
 const taskStatusLabels: Record<TicketTask['status'], string> = {
   open: '접수',
   in_progress: '진행',
@@ -72,6 +88,11 @@ export function TasksLayout() {
   const [ticketTasks, setTicketTasks] = useState<TicketTask[]>([]);
   const [ticketStatus, setTicketStatus] = useState<TicketStatus>('loading');
   const [ticketActionStatus, setTicketActionStatus] = useState<string | null>(null);
+  const [knowledgeIntentStatus, setKnowledgeIntentStatus] = useState<{
+    state: 'idle' | 'loading' | 'ready' | 'error';
+    taskId: string | null;
+    result: KnowledgeMaterializationIntent | null;
+  }>({ state: 'idle', taskId: null, result: null });
 
   useEffect(() => {
     let cancelled = false;
@@ -141,6 +162,19 @@ export function TasksLayout() {
     }
   };
 
+  const handleKnowledgeIntentCreate = async (taskId: string) => {
+    setKnowledgeIntentStatus({ state: 'loading', taskId, result: null });
+    try {
+      const result = await apiClient.post<KnowledgeMaterializationIntent>(
+        '/api/webdav/knowledge-materialization-intent',
+        { source_task_id: taskId },
+      );
+      setKnowledgeIntentStatus({ state: 'ready', taskId, result });
+    } catch {
+      setKnowledgeIntentStatus({ state: 'error', taskId, result: null });
+    }
+  };
+
   const currentColumns = [
     { id: 'open', title: '접수', count: tasks.open.length, color: 'bg-blue-100 text-blue-700' },
     { id: 'in_progress', title: '진행', count: tasks.in_progress.length, color: 'bg-orange-100 text-orange-700' },
@@ -157,6 +191,11 @@ export function TasksLayout() {
       { open: 0, in_progress: 0, blocked: 0, done: 0 },
     );
   }, [ticketTasks]);
+
+  const selfSentKnowledgeTasks = useMemo(
+    () => ticketTasks.filter((task) => task.source_type === 'self_sent_knowledge'),
+    [ticketTasks],
+  );
 
   return (
     <div className="flex h-full min-h-0 bg-background text-foreground flex-col">
@@ -192,7 +231,7 @@ export function TasksLayout() {
       </header>
 
       {/* Kanban Board Area */}
-      <main className="flex-1 overflow-x-auto overflow-y-auto p-6 bg-secondary/20">
+      <main className="flex-1 overflow-x-auto overflow-y-auto bg-secondary/20 px-4 py-4 pb-28 sm:p-6">
         <section aria-label="source-linked ticket status board" className="mb-6 rounded-xl border border-border bg-card p-4 shadow-sm">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
@@ -264,6 +303,77 @@ export function TasksLayout() {
                 </article>
               ))}
             </div>
+          ) : null}
+
+          {ticketStatus === 'ready' && selfSentKnowledgeTasks.length > 0 ? (
+            <section aria-label="self-sent knowledge WebDAV materialization" className="mt-4 border-t border-border pt-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-bold text-foreground">나에게 보낸 지식 노트</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    self-sent 메일 task를 고객 WebDAV/Notes target intent로만 준비하고 provider write는 실행하지 않습니다.
+                  </p>
+                </div>
+                <span className="rounded-full bg-secondary px-3 py-1 text-xs font-bold text-secondary-foreground">
+                  {selfSentKnowledgeTasks.length}개 self-sent task
+                </span>
+              </div>
+              <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                {selfSentKnowledgeTasks.map((task) => {
+                  const isActiveTask = knowledgeIntentStatus.taskId === task.id;
+                  const currentIntent = isActiveTask ? knowledgeIntentStatus.result : null;
+                  return (
+                    <article key={task.id} className="rounded-lg border border-border bg-background/75 p-3 text-sm">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          <h4 className="font-bold text-foreground">{task.title}</h4>
+                          <p className="mt-1 text-xs text-muted-foreground">{task.source_email_id ?? 'self-sent source'} · {task.related_thread_id ?? 'thread pending'}</p>
+                        </div>
+                        <button
+                          type="button"
+                          aria-label={`${task.title} WebDAV 지식 노트 intent 생성`}
+                          disabled={knowledgeIntentStatus.state === 'loading' && isActiveTask}
+                          onClick={() => void handleKnowledgeIntentCreate(task.id)}
+                          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+                        >
+                          <Plus className="size-3.5" />
+                          {knowledgeIntentStatus.state === 'loading' && isActiveTask ? '준비 중' : 'intent 생성'}
+                        </button>
+                      </div>
+                      {knowledgeIntentStatus.state === 'error' && isActiveTask ? (
+                        <p role="status" className="mt-3 rounded-md border border-red-300 bg-red-50 p-2 text-xs font-semibold text-red-900">
+                          WebDAV/Notes intent를 만들지 못했습니다.
+                        </p>
+                      ) : null}
+                      {currentIntent ? (
+                        <dl className="mt-3 grid gap-2 rounded-md border border-border bg-card p-3 text-xs sm:grid-cols-2">
+                          <div>
+                            <dt className="font-bold text-foreground">target_path</dt>
+                            <dd className="break-all text-muted-foreground">{currentIntent.target_path}</dd>
+                          </div>
+                          <div>
+                            <dt className="font-bold text-foreground">server_url</dt>
+                            <dd className="break-all text-muted-foreground">{currentIntent.server_url ?? 'unassigned'}</dd>
+                          </div>
+                          <div>
+                            <dt className="font-bold text-foreground">write policy</dt>
+                            <dd className="text-muted-foreground">requires_if_match={String(currentIntent.requires_if_match)}</dd>
+                          </div>
+                          <div>
+                            <dt className="font-bold text-foreground">execution</dt>
+                            <dd className="text-muted-foreground">provider_write_executed={String(currentIntent.provider_write_executed)}</dd>
+                          </div>
+                          <div className="sm:col-span-2">
+                            <dt className="font-bold text-foreground">audit_event</dt>
+                            <dd className="break-all text-muted-foreground">{currentIntent.audit_event}</dd>
+                          </div>
+                        </dl>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
           ) : null}
 
           {ticketActionStatus ? (

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -48,6 +48,11 @@ type KnowledgeMaterializationIntent = {
   audit_event: string;
 };
 
+type KnowledgeIntentEntry = {
+  state: 'idle' | 'loading' | 'ready' | 'error';
+  result: KnowledgeMaterializationIntent | null;
+};
+
 const taskStatusLabels: Record<TicketTask['status'], string> = {
   open: '접수',
   in_progress: '진행',
@@ -88,11 +93,7 @@ export function TasksLayout() {
   const [ticketTasks, setTicketTasks] = useState<TicketTask[]>([]);
   const [ticketStatus, setTicketStatus] = useState<TicketStatus>('loading');
   const [ticketActionStatus, setTicketActionStatus] = useState<string | null>(null);
-  const [knowledgeIntentStatus, setKnowledgeIntentStatus] = useState<{
-    state: 'idle' | 'loading' | 'ready' | 'error';
-    taskId: string | null;
-    result: KnowledgeMaterializationIntent | null;
-  }>({ state: 'idle', taskId: null, result: null });
+  const [knowledgeIntentByTask, setKnowledgeIntentByTask] = useState<Record<string, KnowledgeIntentEntry>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -163,15 +164,24 @@ export function TasksLayout() {
   };
 
   const handleKnowledgeIntentCreate = async (taskId: string) => {
-    setKnowledgeIntentStatus({ state: 'loading', taskId, result: null });
+    setKnowledgeIntentByTask((current) => ({
+      ...current,
+      [taskId]: { state: 'loading', result: null },
+    }));
     try {
       const result = await apiClient.post<KnowledgeMaterializationIntent>(
         '/api/webdav/knowledge-materialization-intent',
         { source_task_id: taskId },
       );
-      setKnowledgeIntentStatus({ state: 'ready', taskId, result });
+      setKnowledgeIntentByTask((current) => ({
+        ...current,
+        [taskId]: { state: 'ready', result },
+      }));
     } catch {
-      setKnowledgeIntentStatus({ state: 'error', taskId, result: null });
+      setKnowledgeIntentByTask((current) => ({
+        ...current,
+        [taskId]: { state: 'error', result: null },
+      }));
     }
   };
 
@@ -320,8 +330,11 @@ export function TasksLayout() {
               </div>
               <div className="mt-3 grid gap-3 lg:grid-cols-2">
                 {selfSentKnowledgeTasks.map((task) => {
-                  const isActiveTask = knowledgeIntentStatus.taskId === task.id;
-                  const currentIntent = isActiveTask ? knowledgeIntentStatus.result : null;
+                  const currentKnowledgeIntent = knowledgeIntentByTask[task.id] ?? {
+                    state: 'idle',
+                    result: null,
+                  };
+                  const currentIntent = currentKnowledgeIntent.result;
                   return (
                     <article key={task.id} className="rounded-lg border border-border bg-background/75 p-3 text-sm">
                       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -332,15 +345,15 @@ export function TasksLayout() {
                         <button
                           type="button"
                           aria-label={`${task.title} WebDAV 지식 노트 intent 생성`}
-                          disabled={knowledgeIntentStatus.state === 'loading' && isActiveTask}
+                          disabled={currentKnowledgeIntent.state === 'loading'}
                           onClick={() => void handleKnowledgeIntentCreate(task.id)}
                           className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
                         >
                           <Plus className="size-3.5" />
-                          {knowledgeIntentStatus.state === 'loading' && isActiveTask ? '준비 중' : 'intent 생성'}
+                          {currentKnowledgeIntent.state === 'loading' ? '준비 중' : 'intent 생성'}
                         </button>
                       </div>
-                      {knowledgeIntentStatus.state === 'error' && isActiveTask ? (
+                      {currentKnowledgeIntent.state === 'error' ? (
                         <p role="status" className="mt-3 rounded-md border border-red-300 bg-red-50 p-2 text-xs font-semibold text-red-900">
                           WebDAV/Notes intent를 만들지 못했습니다.
                         </p>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -301,7 +301,7 @@ test('updates source-linked task ticket status with signed API headers', async (
   await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
   await expect(page.getByRole('region', { name: 'source-linked ticket status board' })).toBeVisible();
   await expect(page.getByText('실제 티켓 큐')).toBeVisible();
-  await expect(page.getByText('4개 티켓 연결')).toBeVisible();
+  await expect(page.getByText('5개 티켓 연결')).toBeVisible();
   const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(mobileOverflow).toBeLessThanOrEqual(1);
   await page.screenshot({ path: testInfo.outputPath('task-ticket-status-mobile.png'), fullPage: false });
@@ -318,6 +318,79 @@ test('updates source-linked task ticket status with signed API headers', async (
   expect(taskScrollMetrics.maxScroll).toBeGreaterThan(0);
   expect(taskScrollMetrics.after).toBeGreaterThan(taskScrollMetrics.before);
   await page.screenshot({ path: testInfo.outputPath('task-ticket-status-mobile-scroll.png'), fullPage: false });
+});
+
+test('creates self-sent knowledge WebDAV intent with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-self-sent-knowledge-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  const desktopIntentRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/webdav/knowledge-materialization-intent' && request.method() === 'POST';
+  });
+
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'self-sent knowledge WebDAV materialization' })).toBeVisible();
+  await page.getByRole('button', { name: '나에게 보낸 지식 메모 정리 WebDAV 지식 노트 intent 생성' }).click();
+  const request = await desktopIntentRequest;
+  const requestHeaders = request.headers();
+  expect(requestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(requestHeaders[headerName]).toBeUndefined();
+  }
+  expect(request.postDataJSON()).toEqual({ source_task_id: 'task-self-knowledge' });
+
+  await expect(page.getByText('/Naruon/Notes/task-self-knowledge.md')).toBeVisible();
+  await expect(page.getByText('provider_write_executed=false')).toBeVisible();
+  await expect(page.getByText('webdav.self_sent_knowledge_intent.created')).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('self-sent-knowledge-webdav-intent-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileIntentRequest = page.waitForRequest((mobileRequest) => {
+    const url = new URL(mobileRequest.url());
+    return url.pathname === '/api/webdav/knowledge-materialization-intent' && mobileRequest.method() === 'POST';
+  });
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await page.getByRole('button', { name: '나에게 보낸 지식 메모 정리 WebDAV 지식 노트 intent 생성' }).click();
+  const mobileRequest = await mobileIntentRequest;
+  expect(mobileRequest.headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  await expect(page.getByText('/Naruon/Notes/task-self-knowledge.md')).toBeVisible();
+  await page.getByText('webdav.self_sent_knowledge_intent.created').scrollIntoViewIfNeeded();
+  await page.locator('main').nth(1).evaluate((scroller) => {
+    scroller.scrollTop += 96;
+  });
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('self-sent-knowledge-webdav-intent-mobile.png'), fullPage: false });
+  const taskScrollMetrics = await page.locator('main').nth(1).evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(taskScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(taskScrollMetrics.after).toBeGreaterThan(taskScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('self-sent-knowledge-webdav-intent-mobile-scroll.png'), fullPage: false });
 });
 
 test('renders the settings self-hosted connector manifest with mobile scrolling', async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -302,6 +302,25 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
       return;
     }
 
+    if (path === '/api/webdav/knowledge-materialization-intent' && request.method() === 'POST') {
+      await fulfillJson(route, {
+        intent: 'knowledge_materialization',
+        status: 'intent_ready',
+        task_id: 'task-self-knowledge',
+        source_type: 'self_sent_knowledge',
+        source_email_id: '<self-note@example.com>',
+        source_thread_id: 'thread-self-note',
+        source_id: 1,
+        server_url: 'https://webdav.naruon.net',
+        target_path: '/Naruon/Notes/task-self-knowledge.md',
+        requires_if_match: true,
+        provenance: 'server-authoritative',
+        provider_write_executed: false,
+        audit_event: 'webdav.self_sent_knowledge_intent.created',
+      });
+      return;
+    }
+
     if (path === '/api/tasks' && request.method() === 'GET') {
       await fulfillJson(route, [
         {
@@ -347,6 +366,17 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
           related_thread_id: 'thread-q2',
           created_at: '2026-05-19T00:00:00Z',
           updated_at: '2026-05-24T00:00:00Z',
+        },
+        {
+          id: 'task-self-knowledge',
+          title: '나에게 보낸 지식 메모 정리',
+          status: 'open',
+          priority: 'normal',
+          source_type: 'self_sent_knowledge',
+          source_email_id: '<self-note@example.com>',
+          related_thread_id: 'thread-self-note',
+          created_at: '2026-05-19T00:00:00Z',
+          updated_at: '2026-05-25T00:00:00Z',
         },
       ]);
       return;


### PR DESCRIPTION
## Summary

- Add signed `POST /api/webdav/knowledge-materialization-intent` for self-sent knowledge task WebDAV/Notes materialization intent.
- Wire Tasks UI to call the endpoint through `apiClient` bearer session, without public identity headers or provider writes.
- Document the intent-only source-of-truth contract and keep Strix governance OpenAI Platform direct-only, with no GitHub Models route.

## Verification

- `python3 -m pytest backend/tests/test_tasks_api.py backend/tests/test_webdav_api.py -q`
- `cd frontend && npm test -- --run src/app/tasks/page.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run build`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18134 LIVE_BASE_URL=http://127.0.0.1:18134 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=desktop -g "self-sent knowledge WebDAV intent"`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18134 LIVE_BASE_URL=http://127.0.0.1:18134 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=desktop -g "updates source-linked task ticket status"`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18134 LIVE_BASE_URL=http://127.0.0.1:18134 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=mobile mobile-hamburger.spec.ts`

## Browser evidence inspected

- `self-sent-knowledge-webdav-intent-desktop.png`
- `self-sent-knowledge-webdav-intent-mobile.png`
- `self-sent-knowledge-webdav-intent-mobile-scroll.png`
- `task-ticket-status-mobile.png`
- `task-ticket-status-mobile-scroll.png`
- `mobile-hamburger-open.png`

## Governance

- Current head: `78114739d1f2125033834515b7b8f8e8138a5409`
- Provider rule: Strix must remain `STRIX_OPENAI_API_KEY` OpenAI Platform direct-only. Do not route through GitHub Models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create WebDAV/Notes knowledge materialization intents for self-sent knowledge items; shows planned target location and metadata without performing provider writes.
  * Tasks workspace: new "나에게 보낸 지식 노트" section with per-task intent creation controls, loading/error states, and rendered intent details.

* **Documentation**
  * Updated operational and planning docs and README to clarify the self-sent knowledge materialization workflow, intent contract, and governance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->