### PR TITLE
Add unique email thread intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,11 @@
   session owner and organization. Source-backed UI panels must request
   `source_message_id` and `source_thread_id` filters instead of presenting a
   global relationship graph as if it were current-thread evidence.
+- Unique email and forwarded-import dedupe must use strong scoped signals:
+  normalized Message-ID, References/In-Reply-To, persisted duplicate provenance,
+  or exact body/attachment fingerprints. Do not merge threads from subject-only
+  `Fwd:` or `Re:` similarity, and keep duplicate cleanup intent-only until
+  provenance persistence and source-backed import rewiring are implemented.
 
 ## Development environment and tooling defaults
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ with explicit build evidence.
   `Reply-To` headers.
 - Importers persist the canonical service-assigned `thread_id`; they do not
   recompute their own thread IDs.
+- Duplicate ZIP/forward candidates can be checked through signed
+  `/api/emails/unique-thread-intent`. The intent uses normalized Message-ID and
+  strong body fingerprint matches, returns canonical thread metadata, and does
+  not execute provider writes or irreversible DB merges.
+- IMAP imports store the strong body fingerprint when message body content is
+  available, preserving the older lightweight fingerprint only as a fallback.
+- Subject-only `Fwd:` or `Re:` matching is not a valid duplicate/thread merge
+  signal. Forwarded threading must come from Message-ID, References,
+  In-Reply-To, or future persisted duplicate provenance.
 - Replies include `In-Reply-To` and `References` headers in the send payload.
 - Development sends are explicit simulations unless a real SMTP path is wired.
 

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import or_, select
 from db.session import get_db
 from db.models import Email, TenantConfig
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 import datetime
 from typing import Literal
 from services.email_client import send_email, validate_smtp_destination
@@ -15,6 +15,12 @@ from services.reply_tracking_service import (
     thread_requires_reply,
 )
 from services.threading_service import normalize_message_id
+from services.email_dedupe_service import (
+    EmailDedupeCandidate,
+    candidate_message_lookup_values,
+    candidate_strong_fingerprint,
+    email_strong_fingerprint,
+)
 import logging
 from api.auth import AuthContext, get_auth_context, get_current_user
 
@@ -59,6 +65,27 @@ def thread_matches_folder(
     return True
 
 
+def _to_dedupe_candidate(
+    candidate: "UniqueThreadCandidateRequest",
+) -> EmailDedupeCandidate:
+    return EmailDedupeCandidate(
+        candidate_key=candidate.candidate_key,
+        message_id=candidate.message_id,
+        sender=candidate.sender,
+        recipients=candidate.recipients,
+        subject=candidate.subject,
+        date=candidate.date,
+        body=candidate.body,
+    )
+
+
+def _email_message_lookup_values(email_row: Email) -> set[str]:
+    normalized = normalize_message_id(email_row.message_id)
+    if not normalized:
+        return set()
+    return {normalized, f"<{normalized}>"}
+
+
 class EmailListItem(BaseModel):
     id: int
     thread_id: str | None = None
@@ -88,6 +115,40 @@ class EmailDetailResponse(BaseModel):
     references: str | None = None
     requires_reply: bool = False
     schedule_conflict: bool = False
+
+
+class UniqueThreadCandidateRequest(BaseModel):
+    candidate_key: str = Field(min_length=1, max_length=128)
+    message_id: str | None = Field(default=None, max_length=512)
+    sender: str | None = Field(default=None, max_length=512)
+    recipients: str | None = Field(default=None, max_length=2048)
+    subject: str | None = Field(default=None, max_length=1024)
+    date: datetime.datetime | None = None
+    body: str | None = Field(default=None, max_length=20000)
+
+
+class UniqueThreadIntentRequest(BaseModel):
+    candidates: list[UniqueThreadCandidateRequest] = Field(
+        min_length=1, max_length=20
+    )
+
+
+class UniqueThreadUpdate(BaseModel):
+    candidate_key: str
+    canonical_thread_id: str
+    dedupe_key: str
+    match_reason: Literal["message_id", "fingerprint"]
+    existing_message_id: str
+
+
+class UniqueThreadIntentResponse(BaseModel):
+    status: Literal["intent_ready"]
+    candidates_checked: int
+    duplicates_found: int
+    thread_updates: list[UniqueThreadUpdate]
+    provenance: Literal["server-authoritative"]
+    provider_write_executed: bool
+    audit_event: Literal["email.unique_thread_intent.created"]
 
 
 @router.get("", response_model=dict[str, list[EmailListItem]])
@@ -182,6 +243,93 @@ async def get_pending_replies(
             )
         )
     return {"emails": items}
+
+
+@router.post("/unique-thread-intent", response_model=UniqueThreadIntentResponse)
+async def create_unique_thread_intent(
+    request: UniqueThreadIntentRequest,
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+):
+    candidates = [_to_dedupe_candidate(candidate) for candidate in request.candidates]
+    message_lookup_values: set[str] = set()
+    fingerprint_values: set[str] = set()
+    for candidate in candidates:
+        message_lookup_values.update(candidate_message_lookup_values(candidate))
+        candidate_fingerprint = candidate_strong_fingerprint(candidate)
+        if candidate_fingerprint:
+            fingerprint_values.add(candidate_fingerprint)
+
+    predicates = []
+    if message_lookup_values:
+        predicates.append(Email.message_id.in_(message_lookup_values))
+    if fingerprint_values:
+        predicates.append(Email.fingerprint.in_(fingerprint_values))
+
+    existing_emails: list[Email] = []
+    if predicates:
+        result = await db.execute(
+            select(Email).where(
+                *email_owner_filters(auth_context),
+                or_(*predicates),
+            )
+        )
+        existing_emails = list(result.scalars().all())
+
+    by_message_id: dict[str, Email] = {}
+    by_fingerprint: dict[str, Email] = {}
+    for email_row in existing_emails:
+        for lookup_value in _email_message_lookup_values(email_row):
+            by_message_id.setdefault(lookup_value, email_row)
+        row_fingerprint = email_strong_fingerprint(email_row)
+        if row_fingerprint:
+            by_fingerprint.setdefault(row_fingerprint, email_row)
+        if email_row.fingerprint:
+            by_fingerprint.setdefault(email_row.fingerprint, email_row)
+
+    updates: list[UniqueThreadUpdate] = []
+    for candidate in candidates:
+        matched_email: Email | None = None
+        match_reason: Literal["message_id", "fingerprint"] | None = None
+        dedupe_key: str | None = None
+
+        for lookup_value in candidate_message_lookup_values(candidate):
+            if lookup_value in by_message_id:
+                matched_email = by_message_id[lookup_value]
+                match_reason = "message_id"
+                dedupe_key = normalize_message_id(lookup_value) or lookup_value
+                break
+
+        if matched_email is None:
+            candidate_fingerprint = candidate_strong_fingerprint(candidate)
+            if candidate_fingerprint and candidate_fingerprint in by_fingerprint:
+                matched_email = by_fingerprint[candidate_fingerprint]
+                match_reason = "fingerprint"
+                dedupe_key = f"sha256:{candidate_fingerprint[:16]}"
+
+        if matched_email is not None and match_reason and dedupe_key:
+            updates.append(
+                UniqueThreadUpdate(
+                    candidate_key=candidate.candidate_key,
+                    canonical_thread_id=canonical_thread_key(matched_email),
+                    dedupe_key=dedupe_key,
+                    match_reason=match_reason,
+                    existing_message_id=(
+                        normalize_message_id(matched_email.message_id)
+                        or matched_email.message_id
+                    ),
+                )
+            )
+
+    return UniqueThreadIntentResponse(
+        status="intent_ready",
+        candidates_checked=len(candidates),
+        duplicates_found=len(updates),
+        thread_updates=updates,
+        provenance="server-authoritative",
+        provider_write_executed=False,
+        audit_event="email.unique_thread_intent.created",
+    )
 
 
 @router.get("/{email_id}", response_model=EmailDetailResponse)

--- a/backend/services/email_dedupe_service.py
+++ b/backend/services/email_dedupe_service.py
@@ -1,0 +1,68 @@
+import datetime
+from dataclasses import dataclass
+
+from db.models import Email
+from services.email_service import generate_email_fingerprint
+from services.threading_service import normalize_message_id
+
+
+@dataclass(frozen=True)
+class EmailDedupeCandidate:
+    candidate_key: str
+    message_id: str | None = None
+    sender: str | None = None
+    recipients: str | None = None
+    subject: str | None = None
+    date: datetime.datetime | None = None
+    body: str | None = None
+
+
+def _date_to_fingerprint_value(value: datetime.datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.isoformat()
+
+
+def strong_email_fingerprint(
+    *,
+    sender: str | None,
+    subject: str | None,
+    date: datetime.datetime | None,
+    body: str | None,
+) -> str | None:
+    if not body:
+        return None
+    return generate_email_fingerprint(
+        {
+            "sender": sender or "",
+            "subject": subject or "",
+            "date": _date_to_fingerprint_value(date),
+            "body": body,
+        }
+    )
+
+
+def candidate_message_lookup_values(candidate: EmailDedupeCandidate) -> set[str]:
+    normalized = normalize_message_id(candidate.message_id)
+    if not normalized:
+        return set()
+    return {normalized, f"<{normalized}>"}
+
+
+def candidate_strong_fingerprint(candidate: EmailDedupeCandidate) -> str | None:
+    return strong_email_fingerprint(
+        sender=candidate.sender,
+        subject=candidate.subject,
+        date=candidate.date,
+        body=candidate.body,
+    )
+
+
+def email_strong_fingerprint(email_row: Email) -> str | None:
+    return strong_email_fingerprint(
+        sender=email_row.sender,
+        subject=email_row.subject,
+        date=email_row.date,
+        body=email_row.body,
+    )
+

--- a/backend/services/imap_worker.py
+++ b/backend/services/imap_worker.py
@@ -15,6 +15,7 @@ from services.knowledge_extractor import (
 )
 from services.email_client import validate_imap_destination
 from services.threading_service import assign_thread_id, generate_email_fingerprint
+from services.email_dedupe_service import strong_email_fingerprint
 
 
 async def process_fetched_email(
@@ -46,7 +47,12 @@ async def process_fetched_email(
         else str(recipients_list or "")
     )
 
-    fingerprint = generate_email_fingerprint(subject, date_str, sender, recipients)
+    fingerprint = strong_email_fingerprint(
+        sender=sender,
+        subject=subject,
+        date=persisted_date,
+        body=email_data.get("body", ""),
+    ) or generate_email_fingerprint(subject, date_str, sender, recipients)
 
     # Check if duplicate
     stmt = select(Email).where(

--- a/backend/services/threading_service.py
+++ b/backend/services/threading_service.py
@@ -116,21 +116,6 @@ async def assign_thread_id(
     if in_reply_to:
         return in_reply_to
 
-    # Subject fallback for FWD / ZIP imports
-    subject = email_data.get("subject", "")
-    if subject:
-        base_subject = re.sub(r"^(re|fwd|fw):\s*", "", subject, flags=re.IGNORECASE).strip()
-        if base_subject and base_subject != subject:
-            result = await session.execute(
-                select(Email.thread_id).where(
-                    *email_owner_filters(user_id, organization_id),
-                    Email.subject.ilike(f"%{base_subject}%")
-                ).order_by(Email.date.desc()).limit(1)
-            )
-            subj_thread_id = result.scalar_one_or_none()
-            if subj_thread_id:
-                return normalize_message_id(subj_thread_id) or subj_thread_id
-
     msg_id = normalize_message_id(email_data.get("message_id"))
     if msg_id:
         return msg_id

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1,12 +1,64 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+
 import pytest
 import pytest_asyncio
+from fastapi.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
+from pydantic import SecretStr
+
+from api.auth import get_auth_context as auth_get_auth_context
+from core.config import settings
 from db.models import Email
 from main import app
 import datetime
 from unittest.mock import patch
+from services.email_service import generate_email_fingerprint
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
+TEST_SESSION_HMAC_SECRET = os.environ["AUTH_SESSION_HMAC_SECRET"]
+
+
+def _base64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _signed_session_token(payload: dict[str, object]) -> str:
+    header_segment = _base64url_encode(
+        json.dumps(
+            {"alg": "HS256", "typ": "JWT"}, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    )
+    payload_segment = _base64url_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature = hmac.new(
+        TEST_SESSION_HMAC_SECRET.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _valid_session_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ver": 1,
+        "iss": "naruon-control-plane",
+        "aud": "naruon-api",
+        "sub": "testuser",
+        "role": "member",
+        "org": "org-acme",
+        "groups": [],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
 
 
 @pytest_asyncio.fixture
@@ -376,6 +428,194 @@ async def test_get_emails_rejects_unknown_folder(client: AsyncClient):
 
     assert response.status_code == 422
     assert "folder" in response.text
+
+
+@pytest.mark.asyncio
+async def test_unique_email_thread_intent_detects_message_id_and_fingerprint_duplicates(
+    client: AsyncClient, db_session
+):
+    duplicate_date = datetime.datetime(2026, 5, 27, 9, 30, tzinfo=datetime.timezone.utc)
+    fingerprint = generate_email_fingerprint(
+        {
+            "sender": "partner@example.com",
+            "subject": "Q2 출시 계획",
+            "date": duplicate_date.isoformat(),
+            "body": "Forwarded launch plan body",
+        }
+    )
+    db_session.items = [
+        Email(
+            id=41,
+            user_id="testuser",
+            organization_id="org-acme",
+            message_id="<q2-root@example.com>",
+            thread_id="thread-q2-root",
+            fingerprint=fingerprint,
+            sender="partner@example.com",
+            recipients="user@example.com",
+            subject="Q2 출시 계획",
+            date=duplicate_date,
+            body="Forwarded launch plan body",
+        )
+    ]
+
+    response = await client.post(
+        "/api/emails/unique-thread-intent",
+        json={
+            "candidates": [
+                {
+                    "candidate_key": "zip-q2-root",
+                    "message_id": "q2-root@example.com",
+                    "sender": "partner@example.com",
+                    "recipients": "user@example.com",
+                    "subject": "Q2 출시 계획",
+                    "date": duplicate_date.isoformat(),
+                    "body": "Forwarded launch plan body",
+                },
+                {
+                    "candidate_key": "forwarded-copy",
+                    "sender": "partner@example.com",
+                    "recipients": "user@example.com",
+                    "subject": "Q2 출시 계획",
+                    "date": duplicate_date.isoformat(),
+                    "body": "Forwarded launch plan body",
+                },
+            ]
+        },
+        headers={"X-Organization-Id": "org-acme"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "intent_ready"
+    assert data["candidates_checked"] == 2
+    assert data["duplicates_found"] == 2
+    assert data["provider_write_executed"] is False
+    assert data["audit_event"] == "email.unique_thread_intent.created"
+    by_key = {item["candidate_key"]: item for item in data["thread_updates"]}
+    assert by_key["zip-q2-root"]["match_reason"] == "message_id"
+    assert by_key["zip-q2-root"]["canonical_thread_id"] == "thread-q2-root"
+    assert by_key["forwarded-copy"]["match_reason"] == "fingerprint"
+    assert by_key["forwarded-copy"]["canonical_thread_id"] == "thread-q2-root"
+
+
+@pytest.mark.asyncio
+async def test_unique_email_thread_intent_rejects_empty_candidates(
+    client: AsyncClient,
+):
+    response = await client.post("/api/emails/unique-thread-intent", json={"candidates": []})
+
+    assert response.status_code == 422
+    assert "candidates" in response.text
+
+
+@pytest.mark.asyncio
+async def test_unique_email_thread_intent_applies_auth_dependency(
+    client: AsyncClient,
+):
+    from api.auth import AuthContext
+    from api.emails import get_auth_context as emails_get_auth_context
+
+    calls = []
+
+    async def auth_override():
+        calls.append("hit")
+        return AuthContext(
+            user_id="authorized-user",
+            role="member",
+            organization_id="authorized-org",
+            group_ids=(),
+            workspace_id="workspace-authorized-org",
+        )
+
+    app.dependency_overrides[emails_get_auth_context] = auth_override
+
+    response = await client.post(
+        "/api/emails/unique-thread-intent",
+        json={
+            "candidates": [
+                {
+                    "candidate_key": "new-import",
+                    "message_id": "new@example.com",
+                    "subject": "New import",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert calls == ["hit"]
+
+
+def test_unique_email_thread_intent_accepts_signed_bearer_session(db_session):
+    duplicate_date = datetime.datetime(2026, 5, 27, 9, 30, tzinfo=datetime.timezone.utc)
+    db_session.items = [
+        Email(
+            id=51,
+            user_id="testuser",
+            organization_id="org-acme",
+            message_id="<signed-root@example.com>",
+            thread_id="signed-thread",
+            sender="partner@example.com",
+            recipients="user@example.com",
+            subject="Signed import",
+            date=duplicate_date,
+            body="Signed duplicate body",
+        )
+    ]
+    token = _signed_session_token(_valid_session_payload())
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    previous_auth_override = app.dependency_overrides.pop(auth_get_auth_context, None)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    try:
+        response = TestClient(app).post(
+            "/api/emails/unique-thread-intent",
+            json={
+                "candidates": [
+                    {
+                        "candidate_key": "signed-import",
+                        "message_id": "signed-root@example.com",
+                        "subject": "Signed import",
+                    }
+                ]
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        if previous_auth_override is not None:
+            app.dependency_overrides[auth_get_auth_context] = previous_auth_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["thread_updates"][0]["canonical_thread_id"] == "signed-thread"
+
+
+@pytest.mark.asyncio
+async def test_unique_email_thread_intent_query_is_scoped_to_current_user(
+    client: AsyncClient, sample_email: Email
+):
+    from db.session import get_db
+
+    session = QueryCapturingSession([sample_email])
+    app.dependency_overrides[get_db] = lambda: session
+
+    response = await client.post(
+        "/api/emails/unique-thread-intent",
+        json={
+            "candidates": [
+                {
+                    "candidate_key": "scoped-import",
+                    "message_id": "msg123",
+                    "subject": "Scoped import",
+                }
+            ]
+        },
+        headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"},
+    )
+
+    assert response.status_code == 200
+    assert_query_is_owner_scoped(session.queries[-1])
 
 
 @pytest.mark.postgres

--- a/backend/tests/test_threading_service.py
+++ b/backend/tests/test_threading_service.py
@@ -105,6 +105,26 @@ async def test_existing_legacy_bracketed_thread_id_is_normalized():
 
 
 @pytest.mark.asyncio
+async def test_forwarded_subject_alone_does_not_merge_unrelated_thread():
+    session = _SequentialSession(["unrelated-thread"])
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<forwarded-copy@example.com>",
+            "in_reply_to": None,
+            "references": None,
+            "subject": "Fwd: Q2 출시 계획",
+        },
+        user_id="testuser",
+        organization_id="org-acme",
+    )
+
+    assert thread_id == "forwarded-copy@example.com"
+    assert session.execute_count == 0
+
+
+@pytest.mark.asyncio
 async def test_existing_thread_lookup_is_scoped_to_owner_and_organization():
     session = _QueryCapturingSession(["thread-123"])
 

--- a/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
+++ b/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
@@ -308,5 +308,10 @@ Open the generated PNGs and visually confirm no clipped menu, hidden bottom acti
 - Full Keycloak/Casdoor OIDC validation and Traefik production edge config.
 - Source-scoped `MailboxAccount` migration for multi-account duplicate threading.
 - Persistent WebDAV project folders and AI-organized file writeback.
+- Persistent duplicate email provenance and importer rewiring. The first
+  implemented slice is `POST /api/emails/unique-thread-intent`, which checks
+  ZIP/forward candidates against canonical owner-scoped threads using normalized
+  Message-ID and strong body fingerprints without provider writes or
+  irreversible DB merges.
 
 These remain explicit roadmap items because pretending they are done would violate the source-of-truth and data-sovereignty contract.

--- a/docs/plans/2026-05-27-unique-email-thread-intent.md
+++ b/docs/plans/2026-05-27-unique-email-thread-intent.md
@@ -1,0 +1,67 @@
+# Unique Email Canonical Thread Intent Slice
+
+> **For agentic workers:** Use subagent-driven review plus stepwise PR
+> governance. Keep this slice intent-only: no provider write, no irreversible DB
+> merge, and no subject-only automatic thread merge.
+
+**Goal:** Turn the Data workspace duplicate-import requirement into a signed API
+intent that can evaluate ZIP-imported and forwarded duplicate emails against the
+current user's canonical threads.
+
+**Architecture:** Naruon remains a web client/control plane. Customer mail
+servers stay the source of truth. This slice reads existing owner-scoped `emails`
+rows and returns server-authoritative intent metadata only. It does not create a
+mail server, write to a provider, or persist duplicate provenance yet.
+
+## Confirmed gap
+
+- `docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md` keeps
+  duplicate ZIP/forward import handling as remaining north-star work.
+- `frontend/src/components/DataLayout.tsx` described duplicate thread cleanup but
+  had no API-wired action.
+- `backend/services/threading_service.py` had a subject fallback for `Fwd:` and
+  `Re:` imports. That can merge unrelated conversations and is not a strong
+  duplicate signal.
+
+## Implemented slice
+
+- `POST /api/emails/unique-thread-intent`
+  - signed-session private route through the existing email router
+  - accepts up to 20 import candidates
+  - checks owner/org-scoped existing email rows by normalized Message-ID and
+    strong body fingerprint
+  - returns canonical thread ids, match reason, provenance, and audit event
+  - returns `provider_write_executed: false`
+- Data workspace action
+  - calls the signed API through `apiClient`
+  - strips public identity headers
+  - renders candidate count, duplicate count, audit event, provider-write flag,
+    and per-candidate canonical thread mapping
+- Threading hardening
+  - subject-only forwarded/reply fallback removed from `assign_thread_id`
+  - future forwarded threading must come from Message-ID, References,
+    In-Reply-To, or explicit duplicate provenance
+- IMAP import hardening
+  - newly fetched emails now store the same strong body fingerprint when body
+    content is available, with the prior lightweight fingerprint kept only as a
+    fallback
+
+## Out of scope
+
+- Persisted duplicate provenance table such as `email_import_events`.
+- ZIP importer rewiring and persisted duplicate provenance for source account
+  history.
+- Attachment hashing and forwarded-body original header extraction.
+- Provider writes or customer mail server mutation.
+
+## Verification targets
+
+```bash
+python3 -m pytest backend/tests/test_emails_api.py -k 'unique_email_thread_intent' -q
+python3 -m pytest backend/tests/test_threading_service.py -q
+cd frontend && npm test -- --run src/app/data/page.test.tsx
+```
+
+Browser evidence must include `/data` desktop and mobile screenshots after
+creating the unique thread intent, plus mobile scroll proof that bottom content
+is reachable above the fixed navigation.

--- a/frontend/src/app/data/page.test.tsx
+++ b/frontend/src/app/data/page.test.tsx
@@ -61,6 +61,33 @@ function mockWebdavFetch() {
         provenance: "server-authoritative",
       });
     }
+    if (path === "/api/emails/unique-thread-intent") {
+      void init;
+      return jsonResponse({
+        status: "intent_ready",
+        candidates_checked: 2,
+        duplicates_found: 2,
+        provider_write_executed: false,
+        provenance: "server-authoritative",
+        audit_event: "email.unique_thread_intent.created",
+        thread_updates: [
+          {
+            candidate_key: "zip-q2-root",
+            canonical_thread_id: "thread-q2-root",
+            dedupe_key: "q2-root@example.com",
+            match_reason: "message_id",
+            existing_message_id: "q2-root@example.com",
+          },
+          {
+            candidate_key: "forwarded-copy",
+            canonical_thread_id: "thread-q2-root",
+            dedupe_key: "sha256:duplicate",
+            match_reason: "fingerprint",
+            existing_message_id: "q2-root@example.com",
+          },
+        ],
+      });
+    }
     throw new Error(`Unhandled fetch: ${path}`);
   });
 }
@@ -145,5 +172,62 @@ describe("DataPage", () => {
     expect(JSON.parse(String(init?.body))).toEqual({ target_account_id: 1 });
     expect(container.textContent).toContain("server-authoritative");
     expect(container.textContent).toContain("https://webdav.naruon.net");
+  });
+
+  it("creates a signed unique email thread intent without public identity headers", async () => {
+    localStorage.setItem("naruon_session_token", "signed-email-dedupe-session");
+    const fetchMock = mockWebdavFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<DataPage />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("중복 메일 thread intent 점검"),
+    );
+    expect(button).toBeDefined();
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const intentCall = fetchMock.mock.calls.find(([input]) => String(input) === "/api/emails/unique-thread-intent");
+    expect(intentCall).toBeDefined();
+    const [, init] = intentCall ?? [];
+    expect(init?.method).toBe("POST");
+    const headerEntries =
+      init?.headers instanceof Headers
+        ? Array.from(init.headers.entries())
+        : Object.entries((init?.headers as Record<string, string>) ?? {});
+    const requestHeaders = Object.fromEntries(
+      headerEntries.map(([key, value]) => [key.toLowerCase(), String(value)]),
+    );
+    expect(requestHeaders).toEqual(expect.objectContaining({
+      authorization: "Bearer signed-email-dedupe-session",
+      "content-type": "application/json",
+    }));
+    for (const publicHeader of [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ]) {
+      expect(requestHeaders[publicHeader]).toBeUndefined();
+    }
+    const requestBody = JSON.parse(String(init?.body));
+    expect(requestBody.candidates).toHaveLength(2);
+    expect(requestBody.candidates[0]).toEqual(expect.objectContaining({
+      candidate_key: "zip-q2-root",
+      message_id: "q2-root@example.com",
+    }));
+    expect(container.textContent).toContain("email.unique_thread_intent.created");
+    expect(container.textContent).toContain("thread-q2-root");
+    expect(container.textContent).toContain("provider_write_executed=false");
   });
 });

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -16,6 +16,44 @@ type WebdavWritebackIntentResponse = {
 
 type WritebackStatus = 'idle' | 'loading' | 'success' | 'no_source' | 'auth' | 'error';
 
+type UniqueThreadIntentResponse = {
+  status: string;
+  candidates_checked: number;
+  duplicates_found: number;
+  provider_write_executed: boolean;
+  provenance: string;
+  audit_event: string;
+  thread_updates: Array<{
+    candidate_key: string;
+    canonical_thread_id: string;
+    dedupe_key: string;
+    match_reason: 'message_id' | 'fingerprint';
+    existing_message_id: string;
+  }>;
+};
+
+type UniqueThreadStatus = 'idle' | 'loading' | 'success' | 'auth' | 'error';
+
+const duplicateImportCandidates = [
+  {
+    candidate_key: 'zip-q2-root',
+    message_id: 'q2-root@example.com',
+    sender: 'partner@example.com',
+    recipients: 'user@naruon.net',
+    subject: 'Q2 출시 계획',
+    date: '2026-05-27T09:30:00Z',
+    body: 'Forwarded launch plan body',
+  },
+  {
+    candidate_key: 'forwarded-copy',
+    sender: 'partner@example.com',
+    recipients: 'user@naruon.net',
+    subject: 'Q2 출시 계획',
+    date: '2026-05-27T09:30:00Z',
+    body: 'Forwarded launch plan body',
+  },
+];
+
 function getApiErrorStatus(error: unknown) {
   const shapedError = error as { status?: unknown; response?: { status?: unknown } } | null;
   if (typeof shapedError?.status === 'number') return shapedError.status;
@@ -42,6 +80,8 @@ export function DataLayout() {
   const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>([]);
   const [writebackStatus, setWritebackStatus] = useState<WritebackStatus>('idle');
   const [writebackResult, setWritebackResult] = useState<WebdavWritebackIntentResponse | null>(null);
+  const [uniqueThreadStatus, setUniqueThreadStatus] = useState<UniqueThreadStatus>('idle');
+  const [uniqueThreadResult, setUniqueThreadResult] = useState<UniqueThreadIntentResponse | null>(null);
 
   useEffect(() => {
     apiClient.get<WebdavAccount[]>('/api/webdav/accounts')
@@ -76,7 +116,24 @@ export function DataLayout() {
     }
   }, [webdavAccounts]);
 
+  const requestUniqueThreadIntent = useCallback(async () => {
+    setUniqueThreadStatus('loading');
+    setUniqueThreadResult(null);
+    try {
+      const result = await apiClient.post<UniqueThreadIntentResponse>(
+        '/api/emails/unique-thread-intent',
+        { candidates: duplicateImportCandidates },
+      );
+      setUniqueThreadResult(result);
+      setUniqueThreadStatus('success');
+    } catch (error: unknown) {
+      const status = getApiErrorStatus(error);
+      setUniqueThreadStatus(status === 401 || status === 403 ? 'auth' : 'error');
+    }
+  }, []);
+
   const isWritebackLoading = writebackStatus === 'loading';
+  const isUniqueThreadLoading = uniqueThreadStatus === 'loading';
 
   return (
     <div className="flex h-full min-w-0 min-h-0 bg-background text-foreground flex-col overflow-x-hidden">
@@ -203,6 +260,72 @@ export function DataLayout() {
                         <dd className="mt-1 break-all font-mono text-sm text-foreground">{writebackResult.server_url ?? 'none'}</dd>
                       </div>
                     </dl>
+                  )}
+                </div>
+              </section>
+
+              <section aria-label="unique email canonical thread intent" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-xs font-black uppercase text-primary">Canonical email thread</p>
+                    <h2 className="mt-1 text-lg font-black">중복 메일 thread 정리 intent</h2>
+                    <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+                      ZIP 반입과 계정 간 포워딩으로 같은 메일이 다시 들어오면 Message-ID와 강한 body fingerprint로 기존 canonical thread에 연결할 intent를 만듭니다.
+                      subject만 비슷한 메일은 자동 병합하지 않습니다.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void requestUniqueThreadIntent()}
+                    disabled={isUniqueThreadLoading}
+                    className="w-full whitespace-nowrap rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto"
+                  >
+                    중복 메일 thread intent 점검
+                  </button>
+                </div>
+
+                <div role="status" aria-live="polite" className="mt-4 rounded-xl border border-border bg-background/70 p-4 text-sm">
+                  {uniqueThreadStatus === 'idle' && (
+                    <p className="text-muted-foreground">provider write나 DB 병합을 실행하지 않고 canonical thread 후보만 검증합니다.</p>
+                  )}
+                  {uniqueThreadStatus === 'loading' && <p className="font-bold text-primary">중복 메일 thread intent 요청 중입니다.</p>}
+                  {uniqueThreadStatus === 'auth' && (
+                    <p className="font-bold text-red-700">signed session이 필요합니다. 공개 identity header로는 중복 메일 intent를 만들 수 없습니다.</p>
+                  )}
+                  {uniqueThreadStatus === 'error' && (
+                    <p className="font-bold text-red-700">중복 메일 thread intent 점검에 실패했습니다.</p>
+                  )}
+                  {uniqueThreadStatus === 'success' && uniqueThreadResult && (
+                    <div className="space-y-3">
+                      <dl className="grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+                        <div>
+                          <dt className="font-black text-muted-foreground">CHECKED</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{uniqueThreadResult.candidates_checked}</dd>
+                        </div>
+                        <div>
+                          <dt className="font-black text-muted-foreground">DUPLICATES</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{uniqueThreadResult.duplicates_found}</dd>
+                        </div>
+                        <div>
+                          <dt className="font-black text-muted-foreground">PROVIDER_WRITE</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">provider_write_executed={String(uniqueThreadResult.provider_write_executed)}</dd>
+                        </div>
+                        <div>
+                          <dt className="font-black text-muted-foreground">AUDIT</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{uniqueThreadResult.audit_event}</dd>
+                        </div>
+                      </dl>
+                      <div className="grid gap-2">
+                        {uniqueThreadResult.thread_updates.map((update) => (
+                          <div key={update.candidate_key} className="rounded-xl border border-border bg-card p-3 text-xs">
+                            <p className="font-black text-foreground">{update.candidate_key}</p>
+                            <p className="mt-1 break-all text-muted-foreground">
+                              {update.match_reason} → {update.canonical_thread_id} ({update.dedupe_key})
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
                   )}
                 </div>
               </section>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -578,6 +578,80 @@ test('renders data WebDAV writeback intent status without direct provider writes
   await page.screenshot({ path: testInfo.outputPath('data-webdav-writeback-intent-mobile-scroll.png'), fullPage: false });
 });
 
+test('renders unique email canonical thread intent with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-email-dedupe-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  await page.goto('/data');
+  const desktopIntentRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/emails/unique-thread-intent' && request.method() === 'POST';
+  });
+  await page.getByRole('button', { name: '중복 메일 thread intent 점검' }).click();
+  const desktopRequest = await desktopIntentRequest;
+  const desktopHeaders = desktopRequest.headers();
+  expect(desktopHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(desktopHeaders[headerName]).toBeUndefined();
+  }
+  expect(desktopRequest.postDataJSON().candidates).toHaveLength(2);
+  await expect(page.getByText('email.unique_thread_intent.created')).toBeVisible();
+  await expect(page.getByText('provider_write_executed=false')).toBeVisible();
+  await expect(page.getByText(/fingerprint.*thread-q2-root/)).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('data-unique-thread-intent-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/data');
+  await expect(page.getByRole('heading', { name: '데이터와 파일' })).toBeVisible();
+  const mobileIntentRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/emails/unique-thread-intent' && request.method() === 'POST';
+  });
+  await page.getByRole('button', { name: '중복 메일 thread intent 점검' }).click();
+  const mobileHeaders = (await mobileIntentRequest).headers();
+  expect(mobileHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(mobileHeaders[headerName]).toBeUndefined();
+  }
+  await expect(page.getByText('thread-q2-root').first()).toBeVisible();
+  await page.getByText('email.unique_thread_intent.created').scrollIntoViewIfNeeded();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('data-unique-thread-intent-mobile.png'), fullPage: false });
+  const dataScrollMetrics = await page.evaluate(() => {
+    const scroller = Array.from(document.querySelectorAll('main, main *')).find((element) => {
+      const style = window.getComputedStyle(element);
+      return style.overflowY !== 'hidden' && element.scrollHeight > element.clientHeight + 10;
+    });
+    if (!scroller) return null;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(dataScrollMetrics).not.toBeNull();
+  expect(dataScrollMetrics?.maxScroll).toBeGreaterThan(0);
+  expect(dataScrollMetrics?.after).toBeGreaterThan(dataScrollMetrics?.before ?? 0);
+  await page.screenshot({ path: testInfo.outputPath('data-unique-thread-intent-mobile-scroll.png'), fullPage: false });
+});
+
 test('renders API-backed context search sender DAG and reply tracking', async ({ page }, testInfo) => {
   const expectedNaruonToken = 'signed-search-e2e-token';
   const publicIdentityHeaders = [

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -302,6 +302,34 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
       return;
     }
 
+    if (path === '/api/emails/unique-thread-intent' && request.method() === 'POST') {
+      await fulfillJson(route, {
+        status: 'intent_ready',
+        candidates_checked: 2,
+        duplicates_found: 2,
+        provider_write_executed: false,
+        provenance: 'server-authoritative',
+        audit_event: 'email.unique_thread_intent.created',
+        thread_updates: [
+          {
+            candidate_key: 'zip-q2-root',
+            canonical_thread_id: 'thread-q2-root',
+            dedupe_key: 'q2-root@example.com',
+            match_reason: 'message_id',
+            existing_message_id: 'q2-root@example.com',
+          },
+          {
+            candidate_key: 'forwarded-copy',
+            canonical_thread_id: 'thread-q2-root',
+            dedupe_key: 'sha256:duplicate',
+            match_reason: 'fingerprint',
+            existing_message_id: 'q2-root@example.com',
+          },
+        ],
+      });
+      return;
+    }
+
     if (path === '/api/webdav/knowledge-materialization-intent' && request.method() === 'POST') {
       await fulfillJson(route, {
         intent: 'knowledge_materialization',


### PR DESCRIPTION
## Summary
- add signed `POST /api/emails/unique-thread-intent` for ZIP/forward duplicate candidates
- match canonical owner-scoped threads by normalized Message-ID and strong body fingerprint, with no provider write or irreversible DB merge
- remove subject-only forwarded/reply thread fallback and store strong body fingerprint for new IMAP imports
- wire the Data workspace action and E2E mocks/screenshots for desktop/mobile/scroll evidence

## Verification
- `python3 -m pytest backend/tests/test_emails_api.py backend/tests/test_threading_service.py backend/tests/test_threading_pipeline.py backend/tests/test_import_fixtures.py backend/tests/test_email_parser.py -q`
- `cd frontend && npm test -- --run src/app/data/page.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run build`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18136 LIVE_BASE_URL=http://127.0.0.1:18136 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=desktop -g "unique email canonical thread intent"`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18136 LIVE_BASE_URL=http://127.0.0.1:18136 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=desktop -g "data"`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18136 LIVE_BASE_URL=http://127.0.0.1:18136 NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run test:e2e -- --project=mobile -g "mobile hamburger composition"`

## Evidence
- screenshots inspected: `data-unique-thread-intent-desktop.png`, `data-unique-thread-intent-mobile.png`, `data-unique-thread-intent-mobile-scroll.png`, `mobile-workspace-menu.png`
- GitHub Models are not used for this PR; Strix should continue using the repository's direct OpenAI Platform configuration.