### PR TITLE
Add connector APM operational signals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,11 @@
   or exact body/attachment fingerprints. Do not merge threads from subject-only
   `Fwd:` or `Re:` similarity, and keep duplicate cleanup intent-only until
   provenance persistence and source-backed import rewiring are implemented.
+- Operational dashboards must distinguish live server-observed state from
+  planned instrumentation. Show connector registration and active outbound
+  runner socket state when available, but label sync lag, provider throttling,
+  queue depth, and writeback conflict dashboards as pending until source-backed
+  connector events exist.
 
 ## Development environment and tooling defaults
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,11 @@ source registry work can enforce ETag/If-Match and owner capability checks.
 - `docs/operations/release-deployment-architecture.md`: release, CI, GHCR, and
   live E2E evidence path.
 - `docs/operations/open-source-apm.md`: OpenTelemetry, Prometheus, Grafana, Loki,
-  Tempo/Jaeger adoption plan.
+  Tempo/Jaeger adoption plan. Settings calls signed
+  `/api/observability/operational-signals` to show server-observed connector
+  registration, active runner connection state, Prometheus, and OpenTelemetry
+  configuration while durable heartbeat history and provider execution remain
+  future connector work.
 - `docs/operations/email-relay-proxy-boundary.md`: Naruon is a web client
   relay/proxy, not an email server.
 - `docs/operations/source-of-truth-and-writeback-sovereignty.md`: customer-owned

--- a/backend/api/observability.py
+++ b/backend/api/observability.py
@@ -82,11 +82,29 @@ def _endpoint_host(endpoint: str | None) -> str | None:
 
 def _check_org_admin(auth_context: AuthContext = Depends(get_auth_context)) -> AuthContext:
     if not is_admin_role(auth_context.role):
-        raise HTTPException(status_code=403, detail="Organization admin access required")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error_code": "ORG_ADMIN_REQUIRED",
+                "message": "Organization admin access required",
+            },
+        )
     if is_tenant_admin_role(auth_context.role) and not auth_context.organization_id:
-        raise HTTPException(status_code=403, detail="Organization scope is required")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error_code": "ORG_SCOPE_REQUIRED",
+                "message": "Organization scope is required",
+            },
+        )
     if not auth_context.organization_id:
-        raise HTTPException(status_code=403, detail="Organization scope is required")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error_code": "ORG_SCOPE_REQUIRED",
+                "message": "Organization scope is required",
+            },
+        )
     return auth_context
 
 
@@ -214,9 +232,15 @@ async def get_operational_signals(
 ):
     organization_id = auth_context.organization_id
     if organization_id is None:
-        raise HTTPException(status_code=403, detail="Organization scope is required")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error_code": "ORG_SCOPE_REQUIRED",
+                "message": "Organization scope is required",
+            },
+        )
 
-    workspace_id = f"workspace-{organization_id}"
+    workspace_id = auth_context.workspace_id
     config = await _get_runner_config(db, organization_id)
     telemetry = _telemetry_runtime()
     connector = _connector_state(organization_id, workspace_id, config)

--- a/backend/api/observability.py
+++ b/backend/api/observability.py
@@ -1,0 +1,229 @@
+import os
+from typing import Literal
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import AuthContext, get_auth_context, is_admin_role, is_tenant_admin_role
+from api.runner_config import _connector_manifest
+from api.runner_ws import manager as runner_connection_manager
+from core.config import settings
+from db.models import WorkspaceRunnerConfig
+from db.session import get_db
+
+router = APIRouter(prefix="/api/observability", tags=["observability"])
+
+SignalState = Literal[
+    "enabled",
+    "not_configured",
+    "intent_only",
+    "instrumentation_pending",
+    "registration_configured",
+    "not_registered",
+]
+
+
+class TelemetryRuntime(BaseModel):
+    prometheus_metrics_enabled: bool
+    otel_traces_enabled: bool
+    otel_endpoint_configured: bool
+    otel_endpoint_host: str | None
+
+
+class ConnectorOperationalState(BaseModel):
+    workspace_id: str
+    registration_state: Literal["registration_configured", "not_registered"]
+    connection_state: Literal["connected", "not_connected"]
+    active_connection_count: int
+    control_plane_domain: str
+    network_mode: str
+    runner_usage: str
+    local_protocols: list[str]
+    last_heartbeat_at: str | None
+    last_disconnect_at: str | None
+    queue_depth_state: Literal["not_reported"]
+
+
+class OperationalSignal(BaseModel):
+    signal_key: str
+    display_name: str
+    state: SignalState
+    evidence_source: str
+    detail: str
+    provider_write_executed: bool = False
+
+
+class OperationalSignalsResponse(BaseModel):
+    workspace_id: str
+    audit_event: Literal["observability.operational_signals.viewed"]
+    telemetry: TelemetryRuntime
+    connector: ConnectorOperationalState
+    signals: list[OperationalSignal]
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _endpoint_host(endpoint: str | None) -> str | None:
+    if not endpoint or not endpoint.strip():
+        return None
+    parsed = urlparse(endpoint.strip())
+    if not parsed.netloc:
+        return None
+    return parsed.netloc.rsplit("@", 1)[-1]
+
+
+def _check_org_admin(auth_context: AuthContext = Depends(get_auth_context)) -> AuthContext:
+    if not is_admin_role(auth_context.role):
+        raise HTTPException(status_code=403, detail="Organization admin access required")
+    if is_tenant_admin_role(auth_context.role) and not auth_context.organization_id:
+        raise HTTPException(status_code=403, detail="Organization scope is required")
+    if not auth_context.organization_id:
+        raise HTTPException(status_code=403, detail="Organization scope is required")
+    return auth_context
+
+
+async def _get_runner_config(
+    db: AsyncSession, organization_id: str
+) -> WorkspaceRunnerConfig | None:
+    result = await db.execute(
+        select(WorkspaceRunnerConfig).where(
+            WorkspaceRunnerConfig.organization_id == organization_id
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def _telemetry_runtime() -> TelemetryRuntime:
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    otel_endpoint_configured = bool(otel_endpoint and otel_endpoint.strip())
+    return TelemetryRuntime(
+        prometheus_metrics_enabled=settings.ENABLE_PROMETHEUS_METRICS,
+        otel_traces_enabled=_env_flag("ENABLE_OTEL") and otel_endpoint_configured,
+        otel_endpoint_configured=otel_endpoint_configured,
+        otel_endpoint_host=_endpoint_host(otel_endpoint),
+    )
+
+
+def _connector_state(
+    organization_id: str, workspace_id: str, config: WorkspaceRunnerConfig | None
+) -> ConnectorOperationalState:
+    manifest = _connector_manifest()
+    connection_snapshot = runner_connection_manager.snapshot(
+        organization_id=organization_id,
+        workspace_id=config.workspace_id if config is not None else workspace_id,
+    )
+    connection_state: Literal["connected", "not_connected"] = (
+        "connected"
+        if connection_snapshot.connection_state == "connected"
+        else "not_connected"
+    )
+    registration_state: Literal["registration_configured", "not_registered"] = (
+        "registration_configured"
+        if config is not None and bool(config.registration_token)
+        else "not_registered"
+    )
+    return ConnectorOperationalState(
+        workspace_id=config.workspace_id if config is not None else workspace_id,
+        registration_state=registration_state,
+        connection_state=connection_state,
+        active_connection_count=connection_snapshot.active_connection_count,
+        control_plane_domain=str(manifest["control_plane_domain"]),
+        network_mode=str(manifest["network_mode"]),
+        runner_usage=str(manifest["runner_usage"]),
+        local_protocols=list(manifest["local_protocols"]),
+        last_heartbeat_at=connection_snapshot.last_seen_at,
+        last_disconnect_at=connection_snapshot.last_disconnect_at,
+        queue_depth_state="not_reported",
+    )
+
+
+def _operational_signals(
+    telemetry: TelemetryRuntime, connector: ConnectorOperationalState
+) -> list[OperationalSignal]:
+    metrics_state: SignalState = (
+        "enabled" if telemetry.prometheus_metrics_enabled else "not_configured"
+    )
+    traces_state: SignalState = (
+        "enabled" if telemetry.otel_traces_enabled else "not_configured"
+    )
+    return [
+        OperationalSignal(
+            signal_key="prometheus_metrics",
+            display_name="Prometheus metrics",
+            state=metrics_state,
+            evidence_source="ENABLE_PROMETHEUS_METRICS",
+            detail="Prometheus /metrics exposure is opt-in and remains behind a trusted scrape path.",
+        ),
+        OperationalSignal(
+            signal_key="otel_traces",
+            display_name="OpenTelemetry traces",
+            state=traces_state,
+            evidence_source="ENABLE_OTEL and OTEL_EXPORTER_OTLP_ENDPOINT",
+            detail="Trace export starts only when the OpenTelemetry flag and OTLP endpoint are both configured.",
+        ),
+        OperationalSignal(
+            signal_key="connector_heartbeat",
+            display_name="Connector heartbeat",
+            state="enabled" if connector.connection_state == "connected" else connector.registration_state,
+            evidence_source="runner WebSocket manager and workspace_runner_configs.registration_token",
+            detail="Live heartbeat uses active outbound runner sockets; persistent heartbeat history is still planned.",
+        ),
+        OperationalSignal(
+            signal_key="sync_lag",
+            display_name="Sync lag",
+            state="instrumentation_pending",
+            evidence_source="IMAP, POP3, CalDAV, CardDAV, WebDAV workers",
+            detail="Provider sync lag will be emitted by source-backed connector jobs, not inferred in the browser.",
+        ),
+        OperationalSignal(
+            signal_key="provider_throttling",
+            display_name="Provider throttling",
+            state="instrumentation_pending",
+            evidence_source="provider adapters",
+            detail="Throttle and retry budgets require provider adapter events before dashboard claims are enabled.",
+        ),
+        OperationalSignal(
+            signal_key="writeback_conflicts",
+            display_name="Writeback conflicts",
+            state="intent_only",
+            evidence_source="calendar and WebDAV writeback-intent APIs",
+            detail="Conflict handling is surfaced at intent boundaries until connector write execution records ETags.",
+        ),
+        OperationalSignal(
+            signal_key="ai_action_audit",
+            display_name="AI action audit",
+            state="instrumentation_pending",
+            evidence_source="task, mail, ontology, and WebDAV intent APIs",
+            detail="Audit event names are returned by intent APIs; centralized trace correlation is still planned.",
+        ),
+    ]
+
+
+@router.get("/operational-signals", response_model=OperationalSignalsResponse)
+async def get_operational_signals(
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(_check_org_admin),
+):
+    organization_id = auth_context.organization_id
+    if organization_id is None:
+        raise HTTPException(status_code=403, detail="Organization scope is required")
+
+    workspace_id = f"workspace-{organization_id}"
+    config = await _get_runner_config(db, organization_id)
+    telemetry = _telemetry_runtime()
+    connector = _connector_state(organization_id, workspace_id, config)
+    return OperationalSignalsResponse(
+        workspace_id=connector.workspace_id,
+        audit_event="observability.operational_signals.viewed",
+        telemetry=telemetry,
+        connector=connector,
+        signals=_operational_signals(telemetry, connector),
+    )

--- a/backend/api/runner_ws.py
+++ b/backend/api/runner_ws.py
@@ -1,6 +1,8 @@
 import hashlib
 import hmac
 import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from fastapi import (
     APIRouter,
@@ -21,9 +23,33 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["runner"])
 
 
+@dataclass(frozen=True)
+class RunnerConnectionRecord:
+    organization_id: str
+    workspace_id: str
+    connected_at: str
+
+
+@dataclass(frozen=True)
+class RunnerConnectionSnapshot:
+    organization_id: str
+    workspace_id: str
+    connection_state: str
+    active_connection_count: int
+    last_seen_at: str | None
+    last_disconnect_at: str | None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 class ConnectionManager:
     def __init__(self):
         self.active_connections: dict[str, WebSocket] = {}
+        self.connection_records: dict[str, RunnerConnectionRecord] = {}
+        self.last_seen_by_org: dict[str, str] = {}
+        self.last_disconnect_by_org: dict[str, str] = {}
 
     async def connect(
         self,
@@ -32,17 +58,66 @@ class ConnectionManager:
         auth_context: AuthContext,
     ):
         await ws.accept()
+        organization_id = auth_context.organization_id
+        if not organization_id:
+            raise _policy_violation()
+        now = _utc_now_iso()
         self.active_connections[connection_key] = ws
+        self.connection_records[connection_key] = RunnerConnectionRecord(
+            organization_id=organization_id,
+            workspace_id=auth_context.workspace_id,
+            connected_at=now,
+        )
+        self.last_seen_by_org[organization_id] = now
         logger.info(
             "Runner connected for organization %s workspace %s",
-            auth_context.organization_id,
+            organization_id,
             auth_context.workspace_id,
         )
 
     def disconnect(self, connection_key: str):
+        record = self.connection_records.pop(connection_key, None)
         if connection_key in self.active_connections:
             del self.active_connections[connection_key]
-            logger.info("Runner disconnected: %s", connection_key)
+        if record:
+            self.last_disconnect_by_org[record.organization_id] = _utc_now_iso()
+            logger.info(
+                "Runner disconnected for organization %s workspace %s",
+                record.organization_id,
+                record.workspace_id,
+            )
+
+    def touch(self, connection_key: str):
+        record = self.connection_records.get(connection_key)
+        if record:
+            self.last_seen_by_org[record.organization_id] = _utc_now_iso()
+
+    def snapshot(
+        self, organization_id: str, workspace_id: str
+    ) -> RunnerConnectionSnapshot:
+        active_records = [
+            record
+            for record in self.connection_records.values()
+            if record.organization_id == organization_id
+        ]
+        active_count = len(active_records)
+        last_seen_at = self.last_seen_by_org.get(organization_id)
+        if active_records:
+            last_seen_at = max(record.connected_at for record in active_records)
+        return RunnerConnectionSnapshot(
+            organization_id=organization_id,
+            workspace_id=active_records[0].workspace_id if active_records else workspace_id,
+            connection_state="connected" if active_count else "not_connected",
+            active_connection_count=active_count,
+            last_seen_at=last_seen_at,
+            last_disconnect_at=self.last_disconnect_by_org.get(organization_id),
+        )
+
+    def reset(self):
+        self.active_connections.clear()
+        self.connection_records.clear()
+        self.last_seen_by_org.clear()
+        self.last_disconnect_by_org.clear()
 
 
 manager = ConnectionManager()
@@ -89,6 +164,7 @@ async def runner_endpoint(websocket: WebSocket, token: str):
     try:
         while True:
             data = await websocket.receive_text()
+            manager.touch(connection_key)
             # Echo back or process intents
             await websocket.send_text(f"Naruon ack: {data}")
     except WebSocketDisconnect:

--- a/backend/api/runner_ws.py
+++ b/backend/api/runner_ws.py
@@ -101,9 +101,14 @@ class ConnectionManager:
             if record.organization_id == organization_id
         ]
         active_count = len(active_records)
-        last_seen_at = self.last_seen_by_org.get(organization_id)
+        last_seen_candidates = [
+            candidate
+            for candidate in [self.last_seen_by_org.get(organization_id)]
+            if candidate
+        ]
         if active_records:
-            last_seen_at = max(record.connected_at for record in active_records)
+            last_seen_candidates.extend(record.connected_at for record in active_records)
+        last_seen_at = max(last_seen_candidates) if last_seen_candidates else None
         return RunnerConnectionSnapshot(
             organization_id=organization_id,
             workspace_id=active_records[0].workspace_id if active_records else workspace_id,
@@ -168,4 +173,6 @@ async def runner_endpoint(websocket: WebSocket, token: str):
             # Echo back or process intents
             await websocket.send_text(f"Naruon ack: {data}")
     except WebSocketDisconnect:
+        pass
+    finally:
         manager.disconnect(connection_key)

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from api.llm_providers import router as llm_providers_router
 from api.prompts import router as prompts_router
 from api.tasks import router as tasks_router
 from api.ontology import router as ontology_router
+from api.observability import router as observability_router
 from api.runner_ws import router as runner_ws_router
 from api.dav import router as dav_router
 from api.accounts import router as accounts_router
@@ -80,6 +81,7 @@ app.include_router(llm_providers_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(prompts_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(tasks_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(ontology_router, dependencies=PRIVATE_API_DEPENDENCIES)
+app.include_router(observability_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(runner_ws_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(dav_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(accounts_router, dependencies=PRIVATE_API_DEPENDENCIES)

--- a/backend/tests/test_observability_api.py
+++ b/backend/tests/test_observability_api.py
@@ -77,6 +77,28 @@ def test_member_cannot_read_operational_signals(member_client):
     response = member_client.get("/api/observability/operational-signals")
 
     assert response.status_code == 403
+    assert response.json()["detail"]["error_code"] == "ORG_ADMIN_REQUIRED"
+
+
+def test_admin_without_org_scope_gets_deterministic_error(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "admin",
+                "X-User-Role": "tenant_admin",
+            },
+        ) as client:
+            response = client.get("/api/observability/operational-signals")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error_code"] == "ORG_SCOPE_REQUIRED"
 
 
 def test_operational_signals_are_truthful_when_unconfigured(admin_client):

--- a/backend/tests/test_observability_api.py
+++ b/backend/tests/test_observability_api.py
@@ -1,0 +1,147 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from api import runner_ws
+from core.config import settings
+from db.models import WorkspaceRunnerConfig
+from db.session import get_db
+from main import app
+
+pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
+
+
+class MockResult:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def scalar_one_or_none(self):
+        return self.obj
+
+
+class MockAsyncSession:
+    def __init__(self):
+        self.runner = None
+
+    async def execute(self, query):
+        return MockResult(self.runner)
+
+
+@pytest.fixture(autouse=True)
+def reset_runner_connections():
+    runner_ws.manager.reset()
+    yield
+    runner_ws.manager.reset()
+
+
+@pytest.fixture
+def mock_db():
+    return MockAsyncSession()
+
+
+@pytest.fixture
+def member_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app, headers={"X-User-Id": "member", "X-Organization-Id": "org-acme"}
+        ) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def admin_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "admin",
+                "X-User-Role": "tenant_admin",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_member_cannot_read_operational_signals(member_client):
+    response = member_client.get("/api/observability/operational-signals")
+
+    assert response.status_code == 403
+
+
+def test_operational_signals_are_truthful_when_unconfigured(admin_client):
+    response = admin_client.get("/api/observability/operational-signals")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["workspace_id"] == "workspace-org-acme"
+    assert data["audit_event"] == "observability.operational_signals.viewed"
+    assert data["telemetry"] == {
+        "prometheus_metrics_enabled": False,
+        "otel_traces_enabled": False,
+        "otel_endpoint_configured": False,
+        "otel_endpoint_host": None,
+    }
+    assert data["connector"]["registration_state"] == "not_registered"
+    assert data["connector"]["connection_state"] == "not_connected"
+    assert data["connector"]["active_connection_count"] == 0
+    assert data["connector"]["last_heartbeat_at"] is None
+    assert data["connector"]["queue_depth_state"] == "not_reported"
+    assert data["connector"]["control_plane_domain"] == "naruon.net"
+    signals = {signal["signal_key"]: signal for signal in data["signals"]}
+    assert signals["prometheus_metrics"]["state"] == "not_configured"
+    assert signals["otel_traces"]["state"] == "not_configured"
+    assert signals["connector_heartbeat"]["state"] == "not_registered"
+    assert signals["sync_lag"]["state"] == "instrumentation_pending"
+    assert signals["writeback_conflicts"]["state"] == "intent_only"
+    assert all(signal["provider_write_executed"] is False for signal in data["signals"])
+
+
+def test_operational_signals_reflect_registered_connector_and_otel(
+    admin_client, mock_db, monkeypatch
+):
+    previous_metrics = settings.ENABLE_PROMETHEUS_METRICS
+    settings.ENABLE_PROMETHEUS_METRICS = True
+    monkeypatch.setenv("ENABLE_OTEL", "true")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
+    mock_db.runner = WorkspaceRunnerConfig(
+        organization_id="org-acme",
+        workspace_id="workspace-org-acme",
+        registration_token="nrn_registered-token",
+    )
+    runner_ws.manager.connection_records["org-acme:token-fingerprint"] = (
+        runner_ws.RunnerConnectionRecord(
+            organization_id="org-acme",
+            workspace_id="workspace-org-acme",
+            connected_at="2026-05-27T12:00:00Z",
+        )
+    )
+    try:
+        response = admin_client.get("/api/observability/operational-signals")
+    finally:
+        settings.ENABLE_PROMETHEUS_METRICS = previous_metrics
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["telemetry"]["prometheus_metrics_enabled"] is True
+    assert data["telemetry"]["otel_traces_enabled"] is True
+    assert data["telemetry"]["otel_endpoint_host"] == "otel-collector:4317"
+    assert data["connector"]["registration_state"] == "registration_configured"
+    assert data["connector"]["connection_state"] == "connected"
+    assert data["connector"]["active_connection_count"] == 1
+    assert data["connector"]["last_heartbeat_at"] == "2026-05-27T12:00:00Z"
+    assert "nrn_registered-token" not in str(data)
+    signals = {signal["signal_key"]: signal for signal in data["signals"]}
+    assert signals["prometheus_metrics"]["state"] == "enabled"
+    assert signals["otel_traces"]["state"] == "enabled"
+    assert signals["connector_heartbeat"]["state"] == "enabled"

--- a/backend/tests/test_runner_ws_api.py
+++ b/backend/tests/test_runner_ws_api.py
@@ -97,7 +97,9 @@ def _auth_context() -> AuthContext:
 @pytest.fixture(autouse=True)
 def restore_session_secret():
     previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    runner_ws.manager.reset()
     yield
+    runner_ws.manager.reset()
     settings.AUTH_SESSION_HMAC_SECRET = previous_secret
 
 
@@ -164,3 +166,14 @@ def test_runner_ws_accepts_signed_session_and_registered_token(monkeypatch):
         ) as websocket:
             websocket.send_text("ping")
             assert websocket.receive_text() == "Naruon ack: ping"
+            snapshot = runner_ws.manager.snapshot("org-acme", "workspace-org-acme")
+            assert snapshot.connection_state == "connected"
+            assert snapshot.active_connection_count == 1
+            assert snapshot.last_seen_at is not None
+            assert snapshot.last_disconnect_at is None
+            assert "nrn_registered-token" not in str(runner_ws.manager.connection_records)
+
+    snapshot = runner_ws.manager.snapshot("org-acme", "workspace-org-acme")
+    assert snapshot.connection_state == "not_connected"
+    assert snapshot.active_connection_count == 0
+    assert snapshot.last_disconnect_at is not None

--- a/backend/tests/test_runner_ws_api.py
+++ b/backend/tests/test_runner_ws_api.py
@@ -42,6 +42,23 @@ class _MockRunnerSession:
         return _MockResult(self.token)
 
 
+class _FailingSendWebSocket:
+    headers: dict[str, str]
+
+    def __init__(self):
+        authorization = _valid_session_headers()["Authorization"]
+        self.headers = {"authorization": authorization}
+
+    async def accept(self):
+        return None
+
+    async def receive_text(self):
+        return "ping"
+
+    async def send_text(self, text: str):
+        raise RuntimeError("simulated runner send failure")
+
+
 def _base64url_encode(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
@@ -172,6 +189,39 @@ def test_runner_ws_accepts_signed_session_and_registered_token(monkeypatch):
             assert snapshot.last_seen_at is not None
             assert snapshot.last_disconnect_at is None
             assert "nrn_registered-token" not in str(runner_ws.manager.connection_records)
+
+    snapshot = runner_ws.manager.snapshot("org-acme", "workspace-org-acme")
+    assert snapshot.connection_state == "not_connected"
+    assert snapshot.active_connection_count == 0
+    assert snapshot.last_disconnect_at is not None
+
+
+def test_runner_snapshot_keeps_latest_touch_after_connected_at():
+    runner_ws.manager.connection_records["org-acme:token-fingerprint"] = (
+        runner_ws.RunnerConnectionRecord(
+            organization_id="org-acme",
+            workspace_id="workspace-org-acme",
+            connected_at="2026-05-27T12:00:00Z",
+        )
+    )
+    runner_ws.manager.last_seen_by_org["org-acme"] = "2026-05-27T12:01:00Z"
+
+    snapshot = runner_ws.manager.snapshot("org-acme", "workspace-org-acme")
+
+    assert snapshot.last_seen_at == "2026-05-27T12:01:00Z"
+
+
+@pytest.mark.asyncio
+async def test_runner_endpoint_disconnects_on_send_errors(monkeypatch):
+    async def registered_key(token: str, auth_context: AuthContext) -> str:
+        assert token == "nrn_registered-token"
+        assert auth_context.organization_id == "org-acme"
+        return "org-acme:registered"
+
+    monkeypatch.setattr(runner_ws, "_runner_connection_key", registered_key)
+
+    with pytest.raises(RuntimeError, match="simulated runner send failure"):
+        await runner_ws.runner_endpoint(_FailingSendWebSocket(), "nrn_registered-token")
 
     snapshot = runner_ws.manager.snapshot("org-acme", "workspace-org-acme")
     assert snapshot.connection_state == "not_connected"

--- a/docs/architecture/self-hosted-runner-design.md
+++ b/docs/architecture/self-hosted-runner-design.md
@@ -15,6 +15,11 @@ To connect to these private network mail servers without exposing them to the pu
 - Maintains WebSocket connections with registered runners.
 - Holds the configuration for each tenant (e.g., Target Internal IP, Port).
 - Manages AI capabilities, deduplication, threading, and user sessions.
+- Exposes organization-admin operational state through
+  `/api/observability/operational-signals`, including connector registration,
+  active outbound connection count, last in-process heartbeat, and APM
+  configuration. Persistent heartbeat history and queue depth remain connector
+  execution work.
 
 ### 2. The Self-Hosted Runner (Customer Network)
 - Distributed as a lightweight Docker container.
@@ -31,3 +36,5 @@ To connect to these private network mail servers without exposing them to the pu
 1. Create a `RunnerAgent` CLI application.
 2. Expose WebSocket or HTTP polling endpoints on the Naruon backend.
 3. Update `WorkspaceRunnerConfig` in `backend/db/models.py` to manage runner lifecycle.
+4. Persist connector heartbeat and queue depth events so the APM dashboard can
+   move from in-process status to durable operational history.

--- a/docs/operations/open-source-apm.md
+++ b/docs/operations/open-source-apm.md
@@ -4,6 +4,11 @@
 
 - `backend/main.py` wires optional OpenTelemetry FastAPI instrumentation and
   exposes Prometheus `/metrics` only when `ENABLE_PROMETHEUS_METRICS=true`.
+- `backend/api/observability.py` exposes signed-session
+  `/api/observability/operational-signals` for organization admins. It reports
+  Prometheus/OTel configuration, self-hosted connector registration, active
+  outbound runner connection state, and the remaining instrumentation gaps
+  without executing provider writes.
 - `backend/requirements.txt` includes `prometheus-fastapi-instrumentator` and
   OpenTelemetry dependencies used by the FastAPI app.
 - `docker-compose.observability.yml`, `docker-compose.apm.yml`, and
@@ -43,7 +48,9 @@
 
 ## Remaining gaps
 
-- Add connector heartbeat, sync lag, writeback conflict, and AI action audit
-  dashboards.
+- Persist connector heartbeat history and queue depth beyond the in-process
+  runner WebSocket manager.
+- Add sync lag, writeback conflict, and AI action audit dashboards fed by
+  source-backed connector/provider events.
 - Add log and trace redaction tests for email bodies, provider tokens, DSNs, and
   calendar/file descriptions.

--- a/docs/plans/2026-05-27-apm-connector-operational-signals.md
+++ b/docs/plans/2026-05-27-apm-connector-operational-signals.md
@@ -1,0 +1,39 @@
+# APM Connector Operational Signals Slice
+
+## Goal
+
+Wire the Settings developer surface to server-authoritative open-source APM and
+self-hosted connector state without claiming provider execution that does not
+exist yet.
+
+## Scope
+
+- Add signed `GET /api/observability/operational-signals` for organization
+  admins.
+- Return Prometheus and OpenTelemetry runtime configuration from server
+  settings/environment.
+- Return self-hosted connector registration and active outbound runner
+  connection state from the existing runner config table and WebSocket manager.
+- Keep sync lag, provider throttling, writeback conflict, and AI action audit
+  signals explicit as `instrumentation_pending` or `intent_only` until
+  source-backed events exist.
+- Render the signals in Settings with signed bearer API calls and no public
+  identity headers.
+
+## Non-Goals
+
+- No IMAP/SMTP/CalDAV/WebDAV provider execution.
+- No Naruon-hosted mailbox/storage claim.
+- No GitHub Models routing for Strix or security scans.
+- No new database objects in this slice.
+
+## Verification
+
+- Backend mocked API tests cover admin/member authorization, unconfigured state,
+  configured telemetry, connected runner state, and token non-disclosure.
+- Runner WebSocket tests cover manager connect/disconnect metadata without raw
+  token leakage.
+- Frontend unit tests cover signed API wiring and no client-controlled identity
+  headers.
+- Browser E2E captures Settings desktop/mobile scroll screenshots for the
+  connector/APM panel.

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -146,13 +146,9 @@ describe("SettingsLayout", () => {
       }),
     );
     const operationalCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === "/api/observability/operational-signals");
-    expect(operationalCall?.[1]?.headers).not.toEqual(
-      expect.objectContaining({
-        "X-User-Id": expect.any(String),
-        "X-Organization-Id": expect.any(String),
-        "X-User-Role": expect.any(String),
-      }),
-    );
+    expect(operationalCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(operationalCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(operationalCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
     expect(container.textContent).toContain("Self-hosted connector manifest");
     expect(container.textContent).toContain("Naruon은 이메일 서버가 아닙니다");
     expect(container.textContent).toContain("self-hosted_connector");

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("lucide-react", () => ({
+  Activity: () => <svg aria-hidden="true" />,
   AlertCircle: () => <svg aria-hidden="true" />,
   Bell: () => <svg aria-hidden="true" />,
   Mail: () => <svg aria-hidden="true" />,
@@ -50,6 +51,49 @@ describe("SettingsLayout", () => {
             },
           });
         }
+        if (String(input) === "/api/observability/operational-signals") {
+          return jsonResponse({
+            workspace_id: "workspace-org-acme",
+            audit_event: "observability.operational_signals.viewed",
+            telemetry: {
+              prometheus_metrics_enabled: true,
+              otel_traces_enabled: true,
+              otel_endpoint_configured: true,
+              otel_endpoint_host: "otel-collector:4317",
+            },
+            connector: {
+              workspace_id: "workspace-org-acme",
+              registration_state: "registration_configured",
+              connection_state: "connected",
+              active_connection_count: 1,
+              control_plane_domain: "naruon.net",
+              network_mode: "outbound_only",
+              runner_usage: "ci_smoke_only",
+              local_protocols: ["imap", "pop3", "smtp", "caldav", "carddav", "webdav"],
+              last_heartbeat_at: "2026-05-27T12:00:00Z",
+              last_disconnect_at: null,
+              queue_depth_state: "not_reported",
+            },
+            signals: [
+              {
+                signal_key: "connector_heartbeat",
+                display_name: "Connector heartbeat",
+                state: "enabled",
+                evidence_source: "runner WebSocket manager",
+                detail: "Live heartbeat uses active outbound runner sockets.",
+                provider_write_executed: false,
+              },
+              {
+                signal_key: "sync_lag",
+                display_name: "Sync lag",
+                state: "instrumentation_pending",
+                evidence_source: "provider adapters",
+                detail: "Provider sync lag will be emitted by source-backed connector jobs.",
+                provider_write_executed: false,
+              },
+            ],
+          });
+        }
         return jsonResponse({});
       }),
     );
@@ -72,6 +116,7 @@ describe("SettingsLayout", () => {
     await act(async () => {
       root?.render(<SettingsLayout />);
       await Promise.resolve();
+      await Promise.resolve();
     });
 
     const mobileSettingsNav = container.querySelector('nav[aria-label="설정 섹션"]');
@@ -92,6 +137,22 @@ describe("SettingsLayout", () => {
         }),
       }),
     );
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/observability/operational-signals",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer signed-runner-session-token",
+        }),
+      }),
+    );
+    const operationalCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === "/api/observability/operational-signals");
+    expect(operationalCall?.[1]?.headers).not.toEqual(
+      expect.objectContaining({
+        "X-User-Id": expect.any(String),
+        "X-Organization-Id": expect.any(String),
+        "X-User-Role": expect.any(String),
+      }),
+    );
     expect(container.textContent).toContain("Self-hosted connector manifest");
     expect(container.textContent).toContain("Naruon은 이메일 서버가 아닙니다");
     expect(container.textContent).toContain("self-hosted_connector");
@@ -103,6 +164,12 @@ describe("SettingsLayout", () => {
     expect(container.textContent).toContain("smtp_server");
     expect(container.textContent).toContain("imap_server");
     expect(container.textContent).toContain("mx_host");
+    expect(container.textContent).toContain("Connector health & APM signals");
+    expect(container.textContent).toContain("observability.operational_signals.viewed");
+    expect(container.textContent).toContain("connected");
+    expect(container.textContent).toContain("otel-collector:4317");
+    expect(container.textContent).toContain("Connector heartbeat");
+    expect(container.textContent).toContain("instrumentation_pending");
   });
 
   it("renders settings tabs as detail surfaces instead of placeholder dead space", async () => {
@@ -112,6 +179,7 @@ describe("SettingsLayout", () => {
 
     await act(async () => {
       root?.render(<SettingsLayout />);
+      await Promise.resolve();
       await Promise.resolve();
     });
 

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings, User, Mail, Bell, Shield, Smartphone, Plus, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
+import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Plus, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { useWorkspaceStartupView, setWorkspaceStartupView } from '@/lib/workspace-preferences';
 import { useEffect, useState } from 'react';
@@ -20,6 +20,40 @@ interface RunnerConfig {
     prohibited_roles: string[];
     runner_usage: string;
   };
+}
+
+interface OperationalSignal {
+  signal_key: string;
+  display_name: string;
+  state: string;
+  evidence_source: string;
+  detail: string;
+  provider_write_executed: boolean;
+}
+
+interface OperationalSignalsResponse {
+  workspace_id: string;
+  audit_event: string;
+  telemetry: {
+    prometheus_metrics_enabled: boolean;
+    otel_traces_enabled: boolean;
+    otel_endpoint_configured: boolean;
+    otel_endpoint_host: string | null;
+  };
+  connector: {
+    workspace_id: string;
+    registration_state: 'registration_configured' | 'not_registered';
+    connection_state: 'connected' | 'not_connected';
+    active_connection_count: number;
+    control_plane_domain: string;
+    network_mode: string;
+    runner_usage: string;
+    local_protocols: string[];
+    last_heartbeat_at: string | null;
+    last_disconnect_at: string | null;
+    queue_depth_state: 'not_reported';
+  };
+  signals: OperationalSignal[];
 }
 
 const settingsTabs: { id: SettingsTab; icon: typeof Monitor }[] = [
@@ -80,6 +114,9 @@ export function SettingsLayout() {
   const [runnerConfig, setRunnerConfig] = useState<RunnerConfig | null>(null);
   const [runnerError, setRunnerError] = useState<string | null>(null);
   const [runnerLoading, setRunnerLoading] = useState(true);
+  const [operationalSignals, setOperationalSignals] = useState<OperationalSignalsResponse | null>(null);
+  const [operationalError, setOperationalError] = useState<string | null>(null);
+  const [operationalLoading, setOperationalLoading] = useState(true);
   const startupView = useWorkspaceStartupView();
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
@@ -100,6 +137,21 @@ export function SettingsLayout() {
       })
       .finally(() => {
         if (!cancelled) setRunnerLoading(false);
+      });
+
+    void apiClient
+      .get<OperationalSignalsResponse>('/api/observability/operational-signals')
+      .then((signals) => {
+        if (cancelled) return;
+        setOperationalSignals(signals);
+        setOperationalError(null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setOperationalError(error.message || '운영 신호를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setOperationalLoading(false);
       });
 
     return () => {
@@ -320,6 +372,82 @@ export function SettingsLayout() {
                             ))}
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  ) : null}
+                </section>
+
+                <section aria-label="Open-source APM operational signals" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="flex items-center gap-2 font-bold text-lg">
+                        <Activity className="size-5 text-teal-600" />
+                        Connector health & APM signals
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        서버가 확인한 self-hosted connector 연결, OpenTelemetry, Prometheus 상태만 표시합니다. Provider write 실행은 여기서 수행하지 않습니다.
+                      </p>
+                    </div>
+                    {operationalSignals ? (
+                      <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-xs font-bold text-foreground">
+                        {operationalSignals.audit_event}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {operationalLoading ? (
+                    <p className="mt-4 rounded-xl bg-secondary/60 p-3 text-sm font-semibold text-muted-foreground">운영 신호를 불러오는 중입니다.</p>
+                  ) : null}
+                  {operationalError ? (
+                    <p className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{operationalError}</p>
+                  ) : null}
+                  {operationalSignals ? (
+                    <div className="mt-5 space-y-5">
+                      <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                        <div className="rounded-xl border border-border bg-background p-3">
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">connection_state</dt>
+                          <dd className="mt-1 font-mono text-sm font-bold text-foreground">{operationalSignals.connector.connection_state}</dd>
+                        </div>
+                        <div className="rounded-xl border border-border bg-background p-3">
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">active_connections</dt>
+                          <dd className="mt-1 font-mono text-sm font-bold text-foreground">{operationalSignals.connector.active_connection_count}</dd>
+                        </div>
+                        <div className="rounded-xl border border-border bg-background p-3">
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">prometheus</dt>
+                          <dd className="mt-1 font-mono text-sm font-bold text-foreground">{operationalSignals.telemetry.prometheus_metrics_enabled ? 'enabled' : 'not_configured'}</dd>
+                        </div>
+                        <div className="rounded-xl border border-border bg-background p-3">
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">otel_traces</dt>
+                          <dd className="mt-1 font-mono text-sm font-bold text-foreground">{operationalSignals.telemetry.otel_traces_enabled ? 'enabled' : 'not_configured'}</dd>
+                        </div>
+                      </dl>
+
+                      <dl className="grid gap-3 border-t border-border pt-4 sm:grid-cols-3">
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">last_heartbeat_at</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{operationalSignals.connector.last_heartbeat_at ?? 'none'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">last_disconnect_at</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{operationalSignals.connector.last_disconnect_at ?? 'none'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">otel_endpoint_host</dt>
+                          <dd className="mt-1 font-mono text-sm text-foreground">{operationalSignals.telemetry.otel_endpoint_host ?? 'none'}</dd>
+                        </div>
+                      </dl>
+
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {operationalSignals.signals.map((signal) => (
+                          <article key={signal.signal_key} className="rounded-xl border border-border bg-background p-4">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <h4 className="font-bold text-sm">{signal.display_name}</h4>
+                              <span className="rounded-full bg-secondary px-2.5 py-1 font-mono text-xs font-semibold text-foreground">{signal.state}</span>
+                            </div>
+                            <p className="mt-2 text-sm leading-6 text-muted-foreground">{signal.detail}</p>
+                            <p className="mt-3 break-all font-mono text-xs text-muted-foreground">{signal.evidence_source}</p>
+                          </article>
+                        ))}
                       </div>
                     </div>
                   ) : null}

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -405,9 +405,13 @@ test('renders the settings self-hosted connector manifest with mobile scrolling'
   await expect(page.getByText('naruon.net', { exact: true })).toBeVisible();
   await expect(page.getByText('ci_smoke_only')).toBeVisible();
   await expect(page.getByText('smtp_server')).toBeVisible();
+  await expect(page.getByText('Connector health & APM signals')).toBeVisible();
+  await expect(page.getByText('observability.operational_signals.viewed')).toBeVisible();
+  await expect(page.getByText('otel-collector:4317')).toBeVisible();
+  await expect(page.getByText('instrumentation_pending')).toBeVisible();
   const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(overflow).toBeLessThanOrEqual(1);
-  await page.screenshot({ path: testInfo.outputPath('settings-runner-mobile-manifest.png'), fullPage: false });
+  await page.screenshot({ path: testInfo.outputPath('settings-connector-apm-mobile.png'), fullPage: false });
 
   const scrollMetrics = await page.evaluate(() => {
     const scroller = Array.from(document.querySelectorAll('body, body *')).find((element) => {
@@ -426,7 +430,28 @@ test('renders the settings self-hosted connector manifest with mobile scrolling'
   expect(scrollMetrics).not.toBeNull();
   expect(scrollMetrics?.maxScroll).toBeGreaterThan(0);
   expect(scrollMetrics?.after).toBeGreaterThan(scrollMetrics?.before ?? 0);
-  await page.screenshot({ path: testInfo.outputPath('settings-runner-mobile-scroll.png'), fullPage: false });
+  await page.screenshot({ path: testInfo.outputPath('settings-connector-apm-mobile-scroll.png'), fullPage: false });
+});
+
+test('renders settings connector APM signals across desktop and tablet', async ({ page }, testInfo) => {
+  await mockDashboardApi(page);
+
+  for (const viewport of [
+    { name: 'desktop', width: 1280, height: 1024 },
+    { name: 'tablet', width: 1024, height: 768 },
+  ] as const) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/settings');
+    await page.getByRole('button', { name: '개발자' }).first().click();
+
+    await expect(page.getByText('Connector health & APM signals')).toBeVisible();
+    await expect(page.getByText('observability.operational_signals.viewed')).toBeVisible();
+    await expect(page.getByText('otel-collector:4317')).toBeVisible();
+    await expect(page.getByText('Connector heartbeat')).toBeVisible();
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+    await page.screenshot({ path: testInfo.outputPath(`settings-connector-apm-${viewport.name}.png`), fullPage: false });
+  }
 });
 
 test('renders calendar writeback intent status without direct provider writes', async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -152,6 +152,56 @@ const runnerConfig = {
   },
 };
 
+const operationalSignals = {
+  workspace_id: 'workspace-org-acme',
+  audit_event: 'observability.operational_signals.viewed',
+  telemetry: {
+    prometheus_metrics_enabled: true,
+    otel_traces_enabled: true,
+    otel_endpoint_configured: true,
+    otel_endpoint_host: 'otel-collector:4317',
+  },
+  connector: {
+    workspace_id: 'workspace-org-acme',
+    registration_state: 'registration_configured',
+    connection_state: 'connected',
+    active_connection_count: 1,
+    control_plane_domain: 'naruon.net',
+    network_mode: 'outbound_only',
+    runner_usage: 'ci_smoke_only',
+    local_protocols: ['imap', 'pop3', 'smtp', 'caldav', 'carddav', 'webdav'],
+    last_heartbeat_at: '2026-05-27T12:00:00Z',
+    last_disconnect_at: null,
+    queue_depth_state: 'not_reported',
+  },
+  signals: [
+    {
+      signal_key: 'connector_heartbeat',
+      display_name: 'Connector heartbeat',
+      state: 'enabled',
+      evidence_source: 'runner WebSocket manager',
+      detail: 'Live heartbeat uses active outbound runner sockets.',
+      provider_write_executed: false,
+    },
+    {
+      signal_key: 'sync_lag',
+      display_name: 'Sync lag',
+      state: 'instrumentation_pending',
+      evidence_source: 'provider adapters',
+      detail: 'Provider sync lag will be emitted by source-backed connector jobs.',
+      provider_write_executed: false,
+    },
+    {
+      signal_key: 'writeback_conflicts',
+      display_name: 'Writeback conflicts',
+      state: 'intent_only',
+      evidence_source: 'calendar and WebDAV writeback-intent APIs',
+      detail: 'Conflict handling is surfaced at intent boundaries.',
+      provider_write_executed: false,
+    },
+  ],
+};
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
@@ -198,6 +248,11 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
 
     if (path === '/api/runner-config' && request.method() === 'GET') {
       await fulfillJson(route, runnerConfig);
+      return;
+    }
+
+    if (path === '/api/observability/operational-signals' && request.method() === 'GET') {
+      await fulfillJson(route, operationalSignals);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Supersedes #244 to avoid a stale old-head CodeRabbit review object after the review fixes were pushed.
- Add signed organization-admin `/api/observability/operational-signals` for open-source APM and self-hosted connector operational state.
- Track active outbound runner WebSocket connection metadata without exposing raw registration tokens.
- Wire Settings developer surface to the API with signed bearer auth, no public identity headers, and responsive screenshot coverage.
- Document the implemented slice and keep provider execution, durable heartbeat history, sync lag, throttling, and queue depth as source-backed future work.

## Verification
- `python3 -m pytest backend/tests/test_observability_api.py backend/tests/test_runner_ws_api.py backend/tests/test_runner_config_api.py backend/tests/test_apm_observability.py -q`
- `python3 -m pytest backend/tests/test_observability_api.py backend/tests/test_runner_ws_api.py backend/tests/test_runner_config_api.py backend/tests/test_apm_observability.py backend/tests/test_release_governance.py -q`
- `cd frontend && npm test -- --run src/components/SettingsLayout.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run build`
- `bash scripts/ci/test_strix_quick_gate.sh`
- `bash scripts/ci/test_pr_governance_gate.sh`
- `cd frontend && env -u NO_COLOR -u FORCE_COLOR LIVE_BASE_URL=http://127.0.0.1:18137 npm run test:e2e -- --project=desktop --project=mobile -g "settings self-hosted connector manifest|settings connector APM signals|validates mobile hamburger composition"`

## Screenshots inspected
- `settings-connector-apm-desktop.png`
- `settings-connector-apm-tablet.png`
- `settings-connector-apm-mobile.png`
- `settings-connector-apm-mobile-scroll.png`
- `mobile-workspace-menu.png`

## Strix/GitHub Models
- Strix remains OpenAI Platform direct-only through `STRIX_OPENAI_API_KEY` and GPT-5.4+ model guard.
- No GitHub Models routing, `models: read`, `models.github.ai`, or `github.token` as LLM key is introduced.