### PR TITLE
Wire calendar source registry intent UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@
   server-authoritative source selection and provenance. Do not wire browser
   actions back to legacy `/api/calendar/sync` unless a trusted backend credential
   dependency and source-owner contract are explicitly in scope.
+- Calendar writeback UI must fail closed while the signed source registry is
+  loading or errored; do not emit intent POSTs without a confirmed opaque
+  `target_source_id`, and keep tests covering the loading/error boundary.
 - Calendar and WebDAV writeback source selection must resolve through opaque
   `source_uid` values, signed-session organization scope, and persisted
   writeback eligibility, not sequential CalDAV or WebDAV account ids.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
   OpenAI Platform credential with an OpenAI GPT-5.4-or-newer model. Do not route
   Strix through GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini,
   Google/Vertex, GPT-4o, or GPT-4.1; record direct-provider evidence in the PR.
+  Keep architecture docs and reusable Strix gate tests aligned with this rule so
+  stale GitHub Models examples cannot re-enter copied workflow guidance.
 
 ## PR automation and review defaults
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,9 +158,10 @@ it must never fall back to scanning trusted-base content for a modified PR path.
 Pull request scans split scoped changed files into small bounded batches before
 the timeout-driven rebalance path, so large PRs do not spend the whole required
 check budget on one oversized Strix invocation. Strix remains a required
-Medium-or-higher gate. The workflow uses GitHub Models through `models: read`,
-the OpenAI-compatible GitHub Models endpoint, and an OpenAI GPT-5-or-newer
-model; non-GPT-5 provider fallbacks are not valid PR evidence for this gate.
+Medium-or-higher gate. The workflow uses only the explicit
+`STRIX_OPENAI_API_KEY` OpenAI Platform credential with an OpenAI
+GPT-5.4-or-newer model, rejects GitHub Models routing and `github.token` LLM
+credentials, and fails closed when direct credentials are missing or exhausted.
 Merge-gate governance for Strix, CodeRabbit, and required review evidence is
 documented in `docs/development/merge-gate-policy.md`.
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,12 @@ curl -s -X POST http://localhost:8000/api/tasks/from-email \
 
 # Request a customer-owned calendar writeback intent. This selects a trusted
 # server-side source and returns no provider secret or direct write proof.
+curl -s http://localhost:8000/api/calendar/writeback-sources \
+  -H "Authorization: Bearer $NARUON_DEV_BEARER"
 curl -s -X POST http://localhost:8000/api/calendar/writeback-intent \
   -H "Authorization: Bearer $NARUON_DEV_BEARER" \
   -H 'content-type: application/json' \
-  -d '{"action":"create","summary":"담당자 확인 회의"}'
+  -d '{"action":"create","summary":"담당자 확인 회의","target_source_id":"caldav-primary"}'
 ```
 
 ## Error-message contract
@@ -255,9 +257,11 @@ Calendar actions in `EmailDetail` now request `/api/calendar/writeback-intent`
 for each extracted execution item and display the selected trusted source
 provenance. Calendar source selection now reads opaque
 `calendar_writeback_sources.source_uid` rows instead of exposing sequential
-CalDAV account ids. The browser no longer claims `/api/calendar/sync` success
-from the mail-detail action path; direct provider writes stay deferred until
-connector execution can enforce ETag/If-Match and owner capability checks.
+CalDAV account ids, and the Calendar workspace loads those rows through signed
+`/api/calendar/writeback-sources` before posting an opaque `target_source_id`.
+The browser no longer claims `/api/calendar/sync` success from the mail-detail
+action path; direct provider writes stay deferred until connector execution can
+enforce ETag/If-Match and owner capability checks.
 WebDAV writeback and self-sent knowledge materialization use
 `webdav_accounts.source_uid` as the browser-visible source id, scope lookup by
 the signed session organization, honor persisted `writeback_enabled`

--- a/backend/api/calendar.py
+++ b/backend/api/calendar.py
@@ -131,6 +131,13 @@ async def get_writeback_sources(
     )
 
 
+@router.get("/writeback-sources", response_model=tuple[WritebackSource, ...])
+async def list_writeback_sources(
+    available_sources: tuple[WritebackSource, ...] = Depends(get_writeback_sources),
+) -> tuple[WritebackSource, ...]:
+    return available_sources
+
+
 async def get_calendar_user_token(
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> dict | None:

--- a/backend/tests/test_calendar_api.py
+++ b/backend/tests/test_calendar_api.py
@@ -259,6 +259,41 @@ def test_calendar_writeback_intent_uses_customer_owned_caldav_account(
     }
 
 
+def test_calendar_writeback_sources_endpoint_lists_authoritative_sources(
+    writeback_source_override,
+):
+    writeback_source_override(
+        [
+            WritebackSource(
+                source_id="calendar-primary",
+                provider="fastmail",
+                protocol="caldav",
+                owner_id="testuser",
+                organization_id="org-acme",
+                capabilities=["read", "write", "etag"],
+                writeback_enabled=True,
+                etag="abc123",
+            )
+        ]
+    )
+
+    response = workspace_client.get("/api/calendar/writeback-sources")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "source_id": "calendar-primary",
+            "provider": "fastmail",
+            "protocol": "caldav",
+            "owner_id": "testuser",
+            "organization_id": "org-acme",
+            "capabilities": ["read", "write", "etag"],
+            "writeback_enabled": True,
+            "etag": "abc123",
+        }
+    ]
+
+
 def test_calendar_writeback_update_requires_etag_if_match(writeback_source_override):
     writeback_source_override(
         [

--- a/docs/operations/source-of-truth-and-writeback-sovereignty.md
+++ b/docs/operations/source-of-truth-and-writeback-sovereignty.md
@@ -44,7 +44,8 @@ contracts, source-linked ticket tasks, self-sent knowledge capture into
 idempotent ticket tasks, deterministic sender ontology action hints, generic
 WebDAV writeback intent, self-sent knowledge WebDAV/Notes materialization
 intent, DB-backed CalDAV intent source selection through opaque
-`calendar_writeback_sources.source_uid` rows, and WebDAV intent selection through
+`calendar_writeback_sources.source_uid` rows exposed to the Calendar workspace
+through a signed source-registry read, and WebDAV intent selection through
 opaque, organization-scoped `webdav_accounts.source_uid` rows with persisted
 writeback eligibility. Real CalDAV/WebDAV mutation,
 ETag-aware WebDAV/Notes provider execution for synthesized knowledge, POP3

--- a/docs/plans/2026-05-27-calendar-writeback-intent-ui.md
+++ b/docs/plans/2026-05-27-calendar-writeback-intent-ui.md
@@ -13,6 +13,9 @@ is the calendar server or directly writing provider data from the browser.
 - Customer CalDAV/CardDAV/WebDAV accounts remain the source of truth.
 - Calendar actions create server-authoritative intent through
   `POST /api/calendar/writeback-intent`.
+- The Calendar workspace first loads server-owned source registry rows through
+  `GET /api/calendar/writeback-sources`; the browser may pass only the opaque
+  `target_source_id`, never owner or capability claims.
 - The UI must show `writeback_mode`, `protocol`, `target_source_id`,
   `if_match`, and `audit_event` when the intent is accepted.
 - `422` means no customer-owned source is available.
@@ -23,6 +26,8 @@ is the calendar server or directly writing provider data from the browser.
 ## Implemented Slice
 
 - `/calendar` now exposes a CalDAV/CardDAV/WebDAV intent check panel.
+- The intent panel lists signed-session CalDAV registry sources and chooses an
+  eligible write-capable customer source before posting intent.
 - The monthly, weekly, detail, coordination, and candidate calendar tabs all
   render concrete surfaces instead of an inert "under implementation" state.
 - Mobile layout keeps the header and monthly grid bounded, and adds bottom safe
@@ -34,6 +39,7 @@ is the calendar server or directly writing provider data from the browser.
 
 ```bash
 npm test -- src/app/calendar/page.test.tsx src/components/EmailDetail.test.tsx src/lib/api-client.test.ts
+PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_calendar_api.py -q
 npm test -- src/components/mobile-workspace-panels.test.tsx
 npm run typecheck
 npm run build

--- a/frontend/src/app/calendar/page.test.tsx
+++ b/frontend/src/app/calendar/page.test.tsx
@@ -39,6 +39,19 @@ async function flushAsyncWork() {
   });
 }
 
+const calendarSourceList = [
+  {
+    source_id: "caldav-primary",
+    provider: "Customer CalDAV",
+    protocol: "caldav",
+    owner_id: "user-1",
+    organization_id: "org-acme",
+    capabilities: ["read", "write", "etag"],
+    writeback_enabled: true,
+    etag: "etag-caldav-1",
+  },
+];
+
 describe("CalendarPage", () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
@@ -53,6 +66,7 @@ describe("CalendarPage", () => {
   });
 
   it("renders monthly weekly detail coordination candidate and CalDAV writeback workspaces", () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(calendarSourceList)));
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -69,6 +83,14 @@ describe("CalendarPage", () => {
   it("creates a signed customer-owned calendar writeback intent", async () => {
     localStorage.setItem("naruon_session_token", "signed-calendar-session");
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/calendar/writeback-sources") {
+        expect(init?.method).toBeUndefined();
+        expect(init?.headers).toEqual(expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer signed-calendar-session",
+        }));
+        return jsonResponse(calendarSourceList);
+      }
       expect(String(input)).toBe("/api/calendar/writeback-intent");
       expect(init?.method).toBe("POST");
       expect(init?.headers).toEqual(expect.objectContaining({
@@ -90,6 +112,7 @@ describe("CalendarPage", () => {
       expect(JSON.parse(String(init?.body))).toEqual({
         action: "create",
         summary: "Naruon 일정 후보 writeback intent 점검",
+        target_source_id: "caldav-primary",
       });
       return jsonResponse({
         workspace_id: "workspace-org-acme",
@@ -114,6 +137,8 @@ describe("CalendarPage", () => {
     act(() => {
       root?.render(<CalendarPage />);
     });
+    await flushAsyncWork();
+    expect(container.textContent).toContain("Customer CalDAV");
 
     const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("새 일정 intent 점검"));
     expect(button).toBeTruthy();
@@ -148,6 +173,7 @@ describe("CalendarPage", () => {
 
   it("distinguishes no-source and ETag conflict writeback errors", async () => {
     const responses = [
+      jsonResponse(calendarSourceList),
       jsonResponse({ detail: "No customer-owned writeback source is available" }, false, 422),
       jsonResponse({ detail: "ETag is required for writeback updates" }, false, 409),
     ];
@@ -159,6 +185,7 @@ describe("CalendarPage", () => {
     act(() => {
       root?.render(<CalendarPage />);
     });
+    await flushAsyncWork();
 
     const createButton = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("새 일정 intent 점검"));
     await act(async () => {

--- a/frontend/src/app/calendar/page.test.tsx
+++ b/frontend/src/app/calendar/page.test.tsx
@@ -153,8 +153,12 @@ describe("CalendarPage", () => {
     expect(container.textContent).toContain("calendar.writeback_intent.created");
   });
 
-  it("shows a loading state while writeback intent is pending", async () => {
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => undefined)));
+  it("does not post writeback intent before source registry readiness", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      expect(String(input)).toBe("/api/calendar/writeback-sources");
+      return new Promise<Response>(() => undefined);
+    });
+    vi.stubGlobal("fetch", fetchMock);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -168,6 +172,35 @@ describe("CalendarPage", () => {
       button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("/api/calendar/writeback-sources");
+    expect(container.textContent).toContain("CalDAV source registry 확인 중입니다.");
+  });
+
+  it("shows a loading state while writeback intent is pending", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/calendar/writeback-sources") {
+        return Promise.resolve(jsonResponse(calendarSourceList));
+      }
+      return new Promise(() => undefined);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(<CalendarPage />);
+    });
+    await flushAsyncWork();
+
+    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent?.includes("새 일정 intent 점검"));
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe("/api/calendar/writeback-intent");
     expect(container.textContent).toContain("writeback intent 요청 중입니다.");
   });
 

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -70,9 +70,15 @@ export function CalendarLayout() {
     )) ?? null,
     [writebackSources],
   );
+  const isSourceRegistryReady = sourceLoadStatus === 'ready';
 
   const requestWritebackIntent = useCallback(async (action: 'create' | 'update') => {
-    if (sourceLoadStatus === 'ready' && selectedWritebackSource === null) {
+    if (!isSourceRegistryReady) {
+      setWritebackResult(null);
+      setWritebackStatus(sourceLoadStatus === 'error' ? 'error' : 'loading');
+      return;
+    }
+    if (selectedWritebackSource === null) {
       setWritebackResult(null);
       setWritebackStatus('no_source');
       return;
@@ -101,9 +107,10 @@ export function CalendarLayout() {
         setWritebackStatus('error');
       }
     }
-  }, [selectedWritebackSource, sourceLoadStatus]);
+  }, [isSourceRegistryReady, selectedWritebackSource, sourceLoadStatus]);
 
   const isWritebackLoading = writebackStatus === 'loading';
+  const isWritebackActionDisabled = isWritebackLoading || !isSourceRegistryReady;
 
   return (
     <div className="flex h-full min-h-0 bg-background text-foreground">
@@ -184,7 +191,7 @@ export function CalendarLayout() {
                 <button
                   type="button"
                   onClick={() => void requestWritebackIntent('create')}
-                  disabled={isWritebackLoading}
+                  disabled={isWritebackActionDisabled}
                   className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60"
                 >
                   새 일정 intent 점검
@@ -192,7 +199,7 @@ export function CalendarLayout() {
                 <button
                   type="button"
                   onClick={() => void requestWritebackIntent('update')}
-                  disabled={isWritebackLoading}
+                  disabled={isWritebackActionDisabled}
                   className="rounded-xl border border-border bg-background px-4 py-2 text-sm font-bold hover:bg-secondary disabled:cursor-wait disabled:opacity-60"
                 >
                   ETag 업데이트 점검

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, Settings, Plus, Users, Video, Paperclip, Clock, CalendarDays, X } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
@@ -16,6 +16,17 @@ type CalendarWritebackIntentResponse = {
   audit_event: string;
 };
 
+type CalendarWritebackSource = {
+  source_id: string;
+  provider: string;
+  protocol: 'caldav' | 'carddav' | 'webdav' | 'local';
+  owner_id: string;
+  organization_id: string | null;
+  capabilities: string[];
+  writeback_enabled: boolean;
+  etag: string | null;
+};
+
 type WritebackStatus = 'idle' | 'loading' | 'success' | 'no_source' | 'conflict' | 'auth' | 'error';
 
 function getApiErrorStatus(error: unknown) {
@@ -29,8 +40,43 @@ export function CalendarLayout() {
   const [viewMode, setViewMode] = useState<'월간 캘린더' | '주간 캘린더' | '일정 상세' | '회의 조율' | '일정 후보'>('월간 캘린더');
   const [writebackStatus, setWritebackStatus] = useState<WritebackStatus>('idle');
   const [writebackResult, setWritebackResult] = useState<CalendarWritebackIntentResponse | null>(null);
+  const [writebackSources, setWritebackSources] = useState<CalendarWritebackSource[]>([]);
+  const [sourceLoadStatus, setSourceLoadStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    let isMounted = true;
+    void apiClient.get<CalendarWritebackSource[]>('/api/calendar/writeback-sources')
+      .then((sources) => {
+        if (!isMounted) return;
+        setWritebackSources(sources);
+        setSourceLoadStatus('ready');
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setWritebackSources([]);
+        setSourceLoadStatus('error');
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const selectedWritebackSource = useMemo(
+    () => writebackSources.find((source) => (
+      source.writeback_enabled
+      && source.protocol !== 'local'
+      && source.capabilities.includes('write')
+    )) ?? null,
+    [writebackSources],
+  );
 
   const requestWritebackIntent = useCallback(async (action: 'create' | 'update') => {
+    if (sourceLoadStatus === 'ready' && selectedWritebackSource === null) {
+      setWritebackResult(null);
+      setWritebackStatus('no_source');
+      return;
+    }
     setWritebackStatus('loading');
     setWritebackResult(null);
     try {
@@ -39,6 +85,7 @@ export function CalendarLayout() {
         summary: action === 'create'
           ? 'Naruon 일정 후보 writeback intent 점검'
           : 'Naruon 기존 일정 ETag/If-Match 충돌 점검',
+        ...(selectedWritebackSource ? { target_source_id: selectedWritebackSource.source_id } : {}),
       });
       setWritebackResult(result);
       setWritebackStatus('success');
@@ -54,7 +101,7 @@ export function CalendarLayout() {
         setWritebackStatus('error');
       }
     }
-  }, []);
+  }, [selectedWritebackSource, sourceLoadStatus]);
 
   const isWritebackLoading = writebackStatus === 'loading';
 
@@ -151,6 +198,38 @@ export function CalendarLayout() {
                   ETag 업데이트 점검
                 </button>
               </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              {writebackSources.map((source) => (
+                <article
+                  key={source.source_id}
+                  className="rounded-xl border border-border bg-background/70 p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="font-mono text-xs font-bold text-primary">{source.source_id}</p>
+                      <p className="mt-1 break-words text-sm font-bold">{source.provider}</p>
+                    </div>
+                    <span className={`rounded-full px-2 py-1 text-xs font-black ${source.writeback_enabled ? 'bg-green-100 text-green-700' : 'bg-secondary text-muted-foreground'}`}>
+                      {source.writeback_enabled ? 'write' : 'read_only'}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs font-semibold text-muted-foreground">
+                    {source.protocol} · {source.capabilities.join(', ')}
+                  </p>
+                </article>
+              ))}
+              {sourceLoadStatus === 'loading' && (
+                <p className="rounded-xl border border-border bg-background/70 p-3 text-sm font-bold text-primary">
+                  CalDAV source registry 확인 중입니다.
+                </p>
+              )}
+              {sourceLoadStatus === 'error' && (
+                <p className="rounded-xl border border-border bg-background/70 p-3 text-sm font-bold text-amber-700">
+                  signed session으로 CalDAV source registry를 확인할 수 없습니다.
+                </p>
+              )}
             </div>
 
             <div role="status" aria-live="polite" className="mt-4 rounded-xl border border-border bg-background/70 p-4 text-sm">

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -471,20 +471,27 @@ test('renders calendar writeback intent status without direct provider writes', 
   }, expectedNaruonToken);
 
   await page.goto('/calendar');
+  await expect(page.getByText('Customer CalDAV').first()).toBeVisible();
   const desktopWritebackRequest = page.waitForRequest((request) => {
     const url = new URL(request.url());
     return url.pathname === '/api/calendar/writeback-intent' && request.method() === 'POST';
   });
   await page.getByRole('button', { name: '새 일정 intent 점검' }).click();
-  const desktopRequestHeaders = (await desktopWritebackRequest).headers();
+  const desktopWritebackCall = await desktopWritebackRequest;
+  const desktopRequestHeaders = desktopWritebackCall.headers();
   expect(desktopRequestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  expect(desktopWritebackCall.postDataJSON()).toEqual({
+    action: 'create',
+    summary: 'Naruon 일정 후보 writeback intent 점검',
+    target_source_id: 'caldav-primary',
+  });
   for (const headerName of publicIdentityHeaders) {
     expect(desktopRequestHeaders[headerName]).toBeUndefined();
   }
 
   await expect(page.getByText('customer_owned')).toBeVisible();
   await expect(page.getByText('caldav', { exact: true })).toBeVisible();
-  await expect(page.getByText('caldav-primary')).toBeVisible();
+  await expect(page.getByRole('status').getByText('caldav-primary')).toBeVisible();
   await expect(page.getByText('calendar.writeback_intent.created')).toBeVisible();
   await expect(page.getByText('동기화 완료')).toHaveCount(0);
   const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
@@ -494,13 +501,20 @@ test('renders calendar writeback intent status without direct provider writes', 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/calendar');
   await expect(page.getByRole('heading', { name: '일정 관리' })).toBeVisible();
+  await expect(page.getByText('caldav-primary').first()).toBeVisible();
   const mobileWritebackRequest = page.waitForRequest((request) => {
     const url = new URL(request.url());
     return url.pathname === '/api/calendar/writeback-intent' && request.method() === 'POST';
   });
   await page.getByRole('button', { name: '새 일정 intent 점검' }).click();
-  const mobileRequestHeaders = (await mobileWritebackRequest).headers();
+  const mobileWritebackCall = await mobileWritebackRequest;
+  const mobileRequestHeaders = mobileWritebackCall.headers();
   expect(mobileRequestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  expect(mobileWritebackCall.postDataJSON()).toEqual({
+    action: 'create',
+    summary: 'Naruon 일정 후보 writeback intent 점검',
+    target_source_id: 'caldav-primary',
+  });
   for (const headerName of publicIdentityHeaders) {
     expect(mobileRequestHeaders[headerName]).toBeUndefined();
   }

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -301,6 +301,22 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
       return;
     }
 
+    if (path === '/api/calendar/writeback-sources' && request.method() === 'GET') {
+      await fulfillJson(route, [
+        {
+          source_id: 'caldav-primary',
+          provider: 'Customer CalDAV',
+          protocol: 'caldav',
+          owner_id: 'default',
+          organization_id: 'org-acme',
+          capabilities: ['read', 'write', 'etag'],
+          writeback_enabled: true,
+          etag: 'etag-caldav-primary',
+        },
+      ]);
+      return;
+    }
+
     if (path === '/api/calendar/writeback-intent' && request.method() === 'POST') {
       await fulfillJson(route, {
         workspace_id: 'default',

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -477,6 +477,29 @@ is_preexisting_report_dir() {
 	return 1
 }
 
+is_github_models_model() {
+	case "$1" in
+	openai/openai/* | github_models/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+is_github_models_api_base() {
+	local api_base="$1"
+	case "$api_base" in
+	https://models.github.ai | https://models.github.ai/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 # shellcheck disable=SC2034  # consumed indirectly by sourced model helper functions
 if DEFAULT_PROVIDER_SANITIZED="$(sanitize_provider_name "$DEFAULT_PROVIDER_RAW")"; then
 	DEFAULT_PROVIDER="$DEFAULT_PROVIDER_SANITIZED"
@@ -494,6 +517,10 @@ fi
 PRIMARY_MODEL="$(normalize_model "$STRIX_LLM")"
 if [ "$PRIMARY_MODEL" != "$STRIX_LLM" ]; then
 	echo "Normalized STRIX_LLM to provider-qualified model '$PRIMARY_MODEL'."
+fi
+if is_github_models_model "$PRIMARY_MODEL"; then
+	echo "ERROR: STRIX_LLM must not use GitHub Models model prefixes; use direct OpenAI Platform model names such as openai/gpt-5.4." >&2
+	exit 2
 fi
 
 require_non_negative_integer "$STRIX_TRANSIENT_RETRY_PER_MODEL" "STRIX_TRANSIENT_RETRY_PER_MODEL"
@@ -1799,6 +1826,10 @@ resolved_llm_api_base_for_model() {
 		echo "ERROR: LLM_API_BASE must be an https URL when configured." >&2
 		return 2
 	fi
+	if is_github_models_api_base "$llm_api_base_value"; then
+		echo "ERROR: LLM_API_BASE must not route Strix through GitHub Models; use direct OpenAI Platform routing." >&2
+		return 2
+	fi
 	printf '%s\n' "$llm_api_base_value"
 }
 
@@ -2760,6 +2791,10 @@ run_current_target_scan() {
 	fallback_tried=0
 	for candidate_raw in "${FALLBACK_MODELS[@]}"; do
 		candidate="$(normalize_model "$candidate_raw")"
+		if is_github_models_model "$candidate"; then
+			echo "ERROR: Strix fallback models must not use GitHub Models model prefixes; use direct OpenAI Platform model names." >&2
+			return 2
+		fi
 		if [ -z "$candidate" ] || [ "$candidate" = "$PRIMARY_MODEL" ]; then
 			if [ -n "$candidate" ]; then
 				echo "Skipping fallback model '$candidate' — same as primary model." >&2

--- a/scripts/ci/test_pr_governance_gate.sh
+++ b/scripts/ci/test_pr_governance_gate.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
 
 head_sha="0123456789abcdef0123456789abcdef01234567"
+args="$*"
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   case "${GH_SCENARIO:-pass}" in
@@ -27,7 +28,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
 fi
 
 if [ "$1" = "api" ] && [[ "$2" == repos/*/pulls/42 ]]; then
-  if printf '%s\n' "$*" | grep -q -- '.base.sha'; then
+  if [[ "$args" == *".base.sha"* ]]; then
     printf 'abcdefabcdefabcdefabcdefabcdefabcdefabcd'
   else
     printf '%s' "$head_sha"
@@ -90,14 +91,14 @@ if [ "$1" = "api" ] && [[ "$2" == repos/*/commits/*/check-runs ]]; then
   exit 0
 fi
 
-if [ "$1" = "api" ] && printf '%s\n' "$*" | grep -q 'repos/.*/issues/42/comments'; then
-  if printf '%s\n' "$*" | grep -q -- '--jq'; then
+if [ "$1" = "api" ] && [[ "$args" == *repos/*/issues/42/comments* ]]; then
+  if [[ "$args" == *"--jq"* ]]; then
     if [ "${GH_SCENARIO:-pass}" = "failed_existing" ]; then
       printf '555\n'
     fi
     exit 0
   fi
-  if printf '%s\n' "$*" | grep -q -- '--paginate'; then
+  if [[ "$args" == *"--paginate"* ]]; then
     case "${GH_SCENARIO:-pass}" in
       coderabbit_blocking_comment)
         printf '[{"id":777,"user":{"login":"coderabbitai[bot]"},"created_at":"2026-05-19T00:01:00Z","body":"Pre-merge warning for 0123456789abcdef0123456789abcdef01234567"}]'
@@ -115,7 +116,7 @@ if [ "$1" = "api" ] && printf '%s\n' "$*" | grep -q 'repos/.*/issues/42/comments
   exit 0
 fi
 
-if [ "$1" = "api" ] && printf '%s\n' "$*" | grep -q 'repos/.*/pulls/42/comments'; then
+if [ "$1" = "api" ] && [[ "$args" == *repos/*/pulls/42/comments* ]]; then
   case "${GH_SCENARIO:-pass}" in
     coderabbit_current_review_comment)
       printf '[{"id":888,"user":{"login":"coderabbitai[bot]"},"commit_id":"0123456789abcdef0123456789abcdef01234567","original_commit_id":"old","created_at":"2026-05-19T00:01:00Z","body":"Potential issue on current head"}]'

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -293,7 +293,7 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 		echo "scan ok with timeout disabled"
 		exit 0
 		;;
-	vertex-primary-notfound-fallback-success)
+	vertex-primary-notfound-fallback-success|github-models-fallback-model-prefix-rejected)
 		case "${STRIX_LLM:-}" in
 		vertex_ai/missing-primary)
 			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
@@ -6312,6 +6312,33 @@ assert_model_requires_vertex_auth "nonvertex-provider" "gemini/gemini-2.5-pro" "
 assert_vertex_path "space-in-project" "projects/my proj/locations/us/models/foo" 1
 assert_vertex_path "tab-in-model-id" $'models/gemini\t2.5' 1
 assert_vertex_path "space-in-model-id" "models/my model" 1
+
+run_gate_case "github-models-model-prefix-rejected" \
+	"openai/openai/gpt-5.4" \
+	"" \
+	"2" \
+	"STRIX_LLM must not use GitHub Models model prefixes" \
+	"0"
+
+run_gate_case "github-models-api-base-rejected" \
+	"openai/gpt-5.4" \
+	"" \
+	"2" \
+	"LLM_API_BASE must not route Strix through GitHub Models" \
+	"0" \
+	"" \
+	"" \
+	"openai" \
+	"https://models.github.ai/inference"
+
+run_gate_case "github-models-fallback-model-prefix-rejected" \
+	"vertex_ai/missing-primary" \
+	"openai/openai/gpt-5.4" \
+	"2" \
+	"Strix fallback models must not use GitHub Models model prefixes" \
+	"1" \
+	"vertex_ai/missing-primary" \
+	"<unset>"
 
 # Endpoint only exists in excluded directories (.git/, node_modules/).
 # The grep --exclude-dir patterns must prevent matching, so the finding


### PR DESCRIPTION
## Summary
- expose signed `/api/calendar/writeback-sources` and test server-authoritative CalDAV source registry reads
- wire the Calendar workspace to load write-capable opaque `target_source_id` values before posting writeback intent
- update E2E mocks/docs and harden Strix reusable gate/tests so GitHub Models routing stays rejected

## Verification
- `env -u NO_COLOR -u FORCE_COLOR npm test -- --run src/app/calendar/page.test.tsx`
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_calendar_api.py backend/tests/test_release_governance.py -q`
- `env -u NO_COLOR -u FORCE_COLOR npm run typecheck`
- `env -u NO_COLOR -u FORCE_COLOR npm run lint`
- `env -u NO_COLOR -u FORCE_COLOR NEXT_TELEMETRY_DISABLED=1 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 npm run build`
- `env -u NO_COLOR -u FORCE_COLOR LIVE_BASE_URL=http://127.0.0.1:18141 npm run test:e2e -- --project=desktop --project=mobile -g "calendar writeback|validates mobile hamburger composition"`
- inspected latest desktop/mobile Calendar writeback, mobile scroll, and mobile hamburger screenshots under `frontend/test-results`
- `bash scripts/ci/test_pr_governance_gate.sh`
- `env -u NO_COLOR -u FORCE_COLOR bash scripts/ci/test_strix_quick_gate.sh`

## Security/Governance
- Strix remains direct OpenAI Platform only through explicit `STRIX_OPENAI_API_KEY`; no GitHub Models path, no `models: read`, and no `github.token` LLM key.
- Browser Calendar writeback posts only bearer-session requests with opaque source ids; public identity headers stay absent in E2E assertions.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar source selection interface, allowing users to view and select available calendar sources before creating writeback intents.

* **Documentation**
  * Updated workflow and architecture documentation to reflect the calendar source selection process and security requirements.

* **Tests**
  * Added test coverage for the calendar writeback sources endpoint and end-to-end workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->