### PR TITLE
Wire settings mail account config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@
   no-op. Do not place sensitive credential values, secret-derived values, or
   password-shaped field names in logs or raised exception text; use static
   non-secret labels such as "credential secret" instead.
+- Settings account screens must be source-backed by signed-session APIs rather
+  than static provider examples. Display only masked secret presence flags, keep
+  blank secret fields out of save payloads so stored values are preserved, and
+  do not reintroduce public identity headers in frontend account mocks.
 - New database tables and columns must use at least two-word `snake_case` names;
   avoid single-token columns such as `id`, `title`, `status`, or `priority` on
   newly introduced objects.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ mail/calendar/file systems.
 
 - **Sender ontology**: The backend classifies sender relationships and returns a
   deterministic next-action hint, such as reply/task tracking for colleagues or
-  summary-first handling for newsletters. Source-id filtered graph persistence is
-  still an episode task.
+  summary-first handling for newsletters. Relationship graph reads can be
+  filtered by source message/thread ids so the Search workspace can show the
+  sender DAG beside the originating mail context.
 - **Self-sent knowledge capture**: IMAP-imported emails sent from a user to the
   same address now create one idempotent, source-linked `self_sent_knowledge`
   ticket task with a plain-text memo title. The Tasks workspace can request a
@@ -245,6 +246,11 @@ exist. Browser writes to signed backend routes use the stored
 API client strips public identity headers such as `X-User-Id` and
 `X-Organization-Id`, including group and dev-token variants, rather than
 forwarding development identity fallbacks.
+Settings connected-account workflow reads and saves `/api/accounts/config`
+through the same signed-session path. It displays SMTP, IMAP, POP3, and OAuth
+provider state from masked response fields, preserves stored credential secrets
+when the user leaves replacement fields blank, and keeps Naruon framed as a web
+client/relay proxy rather than an email host.
 
 Email-derived work is tracked through `/api/tasks/from-email`. Created ticket
 tasks retain an internal source-email foreign key, expose source message/thread

--- a/docs/plans/2026-05-27-settings-mail-account-source-wiring.md
+++ b/docs/plans/2026-05-27-settings-mail-account-source-wiring.md
@@ -1,0 +1,54 @@
+# Settings Mail Account Source Wiring
+
+## Goal
+
+Close the Settings gap where the `연결 계정` tab still showed static provider
+examples even though `/api/accounts/config` already exposes signed-session
+SMTP, IMAP, POP3, and OAuth configuration with masked secrets.
+
+## Implementation Slice
+
+- Replace static Google/iCloud cards with source-backed protocol status cards.
+- Load `/api/accounts/config` through the shared browser `apiClient` so the
+  stored `naruon_session_token` is sent as `Authorization: Bearer`.
+- Keep public identity headers such as `X-User-Id`, `X-Organization-Id`, and
+  dev-token variants out of frontend mocks and requests.
+- Render SMTP, IMAP, POP3, and OAuth fields in one responsive form.
+- Preserve existing credential secrets when replacement fields are blank; do not
+  replay masked secret placeholders to the backend.
+- Keep copy explicit that Naruon is a web client/relay proxy, not an email
+  server, mailbox-capacity provider, IMAP server, SMTP server, or MX host.
+
+## Research Notes
+
+- Google OAuth web-server guidance requires a client id, client secret, and
+  redirect URI, and recommends keeping auth endpoints from exposing
+  authorization codes to unrelated page resources:
+  https://developers.google.com/identity/protocols/oauth2/web-server
+- Microsoft identity platform recommends authorization code flow with PKCE for
+  supported app types, and states client secrets belong to confidential web apps
+  that can store them server-side:
+  https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
+- RFC 7628 defines SASL OAuth mechanisms with IMAP and SMTP examples, so OAuth
+  account setup must remain a provider/client adapter concern rather than a
+  Naruon-hosted mailbox role:
+  https://datatracker.ietf.org/doc/html/rfc7628
+- RFC 8314 makes cleartext submission/access obsolete and establishes TLS as
+  the baseline for email submission and access protocols:
+  https://www.rfc-editor.org/rfc/rfc8314
+
+## Verification Targets
+
+- Frontend unit test covers account config load, signed-session headers, save
+  payload shape, and no secret replay.
+- Browser screenshots cover desktop, tablet, and mobile Settings scroll with the
+  connected account form visible.
+- Existing backend account tests remain the contract for server-side host/port
+  validation and masked secret response fields.
+
+## Deferred Connector Work
+
+- Actual provider connection tests and provider writes remain self-hosted
+  connector execution work.
+- OAuth provider-specific consent flows remain an auth/connector slice after the
+  generic account configuration contract is source-backed in the UI.

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -286,6 +286,12 @@ describe("SettingsLayout", () => {
 
     const putCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/accounts/config" && init?.method === "PUT");
     expect(putCall).toBeTruthy();
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-Group-Id");
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-Group-Ids");
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
+    expect(putCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
     const putBody = JSON.parse(String(putCall?.[1]?.body));
     expect(putBody).toMatchObject({
       smtp_server: "smtp.example.com",

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -34,7 +34,7 @@ describe("SettingsLayout", () => {
     localStorage.setItem("naruon_session_token", "signed-runner-session-token");
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         if (String(input) === "/api/runner-config") {
           return jsonResponse({
             workspace_id: "workspace-org-acme",
@@ -108,6 +108,47 @@ describe("SettingsLayout", () => {
                 provider_write_executed: false,
               },
             ],
+          });
+        }
+        if (String(input) === "/api/accounts/config" && init?.method === "PUT") {
+          const body = JSON.parse(String(init.body));
+          return jsonResponse({
+            user_id: "default",
+            smtp_server: body.smtp_server,
+            smtp_port: body.smtp_port,
+            smtp_username: body.smtp_username,
+            has_smtp_password: false,
+            imap_server: body.imap_server,
+            imap_port: body.imap_port,
+            imap_username: body.imap_username,
+            has_imap_password: true,
+            pop3_server: body.pop3_server,
+            pop3_port: body.pop3_port,
+            pop3_username: body.pop3_username,
+            has_pop3_password: false,
+            oauth_client_id: body.oauth_client_id,
+            oauth_redirect_uri: body.oauth_redirect_uri,
+            has_oauth_client_secret: true,
+          });
+        }
+        if (String(input) === "/api/accounts/config") {
+          return jsonResponse({
+            user_id: "default",
+            smtp_server: "smtp.example.com",
+            smtp_port: 587,
+            smtp_username: "sender@example.com",
+            has_smtp_password: true,
+            imap_server: "imap.example.com",
+            imap_port: 993,
+            imap_username: "inbox@example.com",
+            has_imap_password: true,
+            pop3_server: "pop3.example.com",
+            pop3_port: 995,
+            pop3_username: "archive@example.com",
+            has_pop3_password: false,
+            oauth_client_id: "oauth-client-id",
+            oauth_redirect_uri: "https://naruon.net/oauth/mail/callback",
+            has_oauth_client_secret: true,
           });
         }
         return jsonResponse({});
@@ -189,6 +230,81 @@ describe("SettingsLayout", () => {
     expect(container.textContent).not.toContain("nrn_registered-token");
     expect(container.textContent).toContain("Connector heartbeat");
     expect(container.textContent).toContain("instrumentation_pending");
+  });
+
+  it("loads and saves source-backed mail account settings without public identity headers or secret replay", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const accountButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "연결 계정");
+    expect(accountButton).toBeTruthy();
+    await act(async () => {
+      accountButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/accounts/config",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer signed-runner-session-token",
+        }),
+      }),
+    );
+    const configGetCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/accounts/config" && init?.method !== "PUT");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Group-Id");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Group-Ids");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
+    expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+
+    expect(container.textContent).toContain("고객 지정 Provider");
+    expect(container.textContent).toContain("smtp.example.com:587");
+    expect(container.textContent).toContain("imap.example.com:993");
+    expect(container.textContent).toContain("pop3.example.com:995");
+    expect(container.textContent).toContain("OAuth 로그인");
+    expect(container.textContent).toContain("저장된 secret 유지");
+    expect(container.textContent).toContain("Naruon은 메일함 용량이나 SMTP/IMAP 서버를 제공하지 않습니다");
+
+    const saveButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "계정 설정 저장");
+    expect(saveButton).toBeTruthy();
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const putCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/accounts/config" && init?.method === "PUT");
+    expect(putCall).toBeTruthy();
+    const putBody = JSON.parse(String(putCall?.[1]?.body));
+    expect(putBody).toMatchObject({
+      smtp_server: "smtp.example.com",
+      smtp_port: 587,
+      smtp_username: "sender@example.com",
+      imap_server: "imap.example.com",
+      imap_port: 993,
+      imap_username: "inbox@example.com",
+      pop3_server: "pop3.example.com",
+      pop3_port: 995,
+      pop3_username: "archive@example.com",
+      oauth_client_id: "oauth-client-id",
+      oauth_redirect_uri: "https://naruon.net/oauth/mail/callback",
+    });
+    expect(putBody).not.toHaveProperty("smtp_password");
+    expect(putBody).not.toHaveProperty("imap_password");
+    expect(putBody).not.toHaveProperty("pop3_password");
+    expect(putBody).not.toHaveProperty("oauth_client_secret");
+    expect(container.textContent).toContain("계정 설정을 저장했습니다");
   });
 
   it("renders settings tabs as detail surfaces instead of placeholder dead space", async () => {

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -166,8 +166,9 @@ function optionalText(value: string) {
 function optionalPort(value: string) {
   const trimmed = value.trim();
   if (!trimmed) return null;
+  if (!/^\d+$/.test(trimmed)) return null;
   const parsed = Number.parseInt(trimmed, 10);
-  return Number.isFinite(parsed) ? parsed : null;
+  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : null;
 }
 
 function buildAccountUpdate(form: AccountFormState): AccountConfigUpdate {
@@ -273,6 +274,7 @@ export function SettingsLayout() {
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
   const connectorEvents = operationalSignals?.connector.recent_events ?? [];
+  const accountReady = !accountLoading && !accountError && accountConfig !== null;
   const accountProtocols = [
     {
       label: 'SMTP 송신',
@@ -311,6 +313,7 @@ export function SettingsLayout() {
 
   const handleAccountSave = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!accountReady) return;
     setAccountSaving(true);
     setAccountError(null);
     setAccountStatus(null);
@@ -529,7 +532,8 @@ export function SettingsLayout() {
                     </div>
                     <button
                       type="submit"
-                      disabled={accountSaving}
+                      disabled={accountSaving || !accountReady}
+                      aria-disabled={accountSaving || !accountReady}
                       className="rounded-lg bg-foreground px-5 py-2 text-sm font-bold text-background hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {accountSaving ? '저장 중' : '계정 설정 저장'}

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Plus, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
+import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { useWorkspaceStartupView, setWorkspaceStartupView } from '@/lib/workspace-preferences';
 import { useEffect, useState } from 'react';
@@ -65,6 +65,143 @@ interface OperationalSignalsResponse {
   signals: OperationalSignal[];
 }
 
+interface AccountConfig {
+  user_id: string;
+  smtp_server: string | null;
+  smtp_port: number | null;
+  smtp_username: string | null;
+  has_smtp_password: boolean;
+  imap_server: string | null;
+  imap_port: number | null;
+  imap_username: string | null;
+  has_imap_password: boolean;
+  pop3_server: string | null;
+  pop3_port: number | null;
+  pop3_username: string | null;
+  has_pop3_password: boolean;
+  oauth_client_id: string | null;
+  oauth_redirect_uri: string | null;
+  has_oauth_client_secret: boolean;
+}
+
+interface AccountConfigUpdate {
+  smtp_server: string | null;
+  smtp_port: number | null;
+  smtp_username: string | null;
+  smtp_password?: string;
+  imap_server: string | null;
+  imap_port: number | null;
+  imap_username: string | null;
+  imap_password?: string;
+  pop3_server: string | null;
+  pop3_port: number | null;
+  pop3_username: string | null;
+  pop3_password?: string;
+  oauth_client_id: string | null;
+  oauth_client_secret?: string;
+  oauth_redirect_uri: string | null;
+}
+
+interface AccountFormState {
+  smtpServer: string;
+  smtpPort: string;
+  smtpUsername: string;
+  smtpPassword: string;
+  imapServer: string;
+  imapPort: string;
+  imapUsername: string;
+  imapPassword: string;
+  pop3Server: string;
+  pop3Port: string;
+  pop3Username: string;
+  pop3Password: string;
+  oauthClientId: string;
+  oauthClientSecret: string;
+  oauthRedirectUri: string;
+}
+
+const emptyAccountForm: AccountFormState = {
+  smtpServer: '',
+  smtpPort: '',
+  smtpUsername: '',
+  smtpPassword: '',
+  imapServer: '',
+  imapPort: '',
+  imapUsername: '',
+  imapPassword: '',
+  pop3Server: '',
+  pop3Port: '',
+  pop3Username: '',
+  pop3Password: '',
+  oauthClientId: '',
+  oauthClientSecret: '',
+  oauthRedirectUri: '',
+};
+
+function toAccountForm(config: AccountConfig): AccountFormState {
+  return {
+    smtpServer: config.smtp_server ?? '',
+    smtpPort: config.smtp_port?.toString() ?? '',
+    smtpUsername: config.smtp_username ?? '',
+    smtpPassword: '',
+    imapServer: config.imap_server ?? '',
+    imapPort: config.imap_port?.toString() ?? '',
+    imapUsername: config.imap_username ?? '',
+    imapPassword: '',
+    pop3Server: config.pop3_server ?? '',
+    pop3Port: config.pop3_port?.toString() ?? '',
+    pop3Username: config.pop3_username ?? '',
+    pop3Password: '',
+    oauthClientId: config.oauth_client_id ?? '',
+    oauthClientSecret: '',
+    oauthRedirectUri: config.oauth_redirect_uri ?? '',
+  };
+}
+
+function optionalText(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function optionalPort(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function buildAccountUpdate(form: AccountFormState): AccountConfigUpdate {
+  const update: AccountConfigUpdate = {
+    smtp_server: optionalText(form.smtpServer),
+    smtp_port: optionalPort(form.smtpPort),
+    smtp_username: optionalText(form.smtpUsername),
+    imap_server: optionalText(form.imapServer),
+    imap_port: optionalPort(form.imapPort),
+    imap_username: optionalText(form.imapUsername),
+    pop3_server: optionalText(form.pop3Server),
+    pop3_port: optionalPort(form.pop3Port),
+    pop3_username: optionalText(form.pop3Username),
+    oauth_client_id: optionalText(form.oauthClientId),
+    oauth_redirect_uri: optionalText(form.oauthRedirectUri),
+  };
+
+  const smtpPassword = optionalText(form.smtpPassword);
+  if (smtpPassword) update.smtp_password = smtpPassword;
+  const imapPassword = optionalText(form.imapPassword);
+  if (imapPassword) update.imap_password = imapPassword;
+  const pop3Password = optionalText(form.pop3Password);
+  if (pop3Password) update.pop3_password = pop3Password;
+  const oauthClientSecret = optionalText(form.oauthClientSecret);
+  if (oauthClientSecret) update.oauth_client_secret = oauthClientSecret;
+
+  return update;
+}
+
+function formatEndpoint(host: string | null | undefined, port: number | null | undefined) {
+  if (!host) return '미설정';
+  return port ? `${host}:${port}` : host;
+}
+
 const settingsTabs: { id: SettingsTab; icon: typeof Monitor }[] = [
   { id: '워크스페이스', icon: Monitor },
   { id: '멤버', icon: User },
@@ -126,10 +263,70 @@ export function SettingsLayout() {
   const [operationalSignals, setOperationalSignals] = useState<OperationalSignalsResponse | null>(null);
   const [operationalError, setOperationalError] = useState<string | null>(null);
   const [operationalLoading, setOperationalLoading] = useState(true);
+  const [accountConfig, setAccountConfig] = useState<AccountConfig | null>(null);
+  const [accountForm, setAccountForm] = useState<AccountFormState>(emptyAccountForm);
+  const [accountError, setAccountError] = useState<string | null>(null);
+  const [accountStatus, setAccountStatus] = useState<string | null>(null);
+  const [accountLoading, setAccountLoading] = useState(true);
+  const [accountSaving, setAccountSaving] = useState(false);
   const startupView = useWorkspaceStartupView();
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
   const connectorEvents = operationalSignals?.connector.recent_events ?? [];
+  const accountProtocols = [
+    {
+      label: 'SMTP 송신',
+      endpoint: formatEndpoint(accountConfig?.smtp_server, accountConfig?.smtp_port),
+      identity: accountConfig?.smtp_username ?? '발신 계정 미설정',
+      secretReady: accountConfig?.has_smtp_password ?? false,
+      detail: '메일 발송과 보낸 메일 답변 추적에 사용합니다.',
+    },
+    {
+      label: 'IMAP 수신',
+      endpoint: formatEndpoint(accountConfig?.imap_server, accountConfig?.imap_port),
+      identity: accountConfig?.imap_username ?? '수신 계정 미설정',
+      secretReady: accountConfig?.has_imap_password ?? false,
+      detail: '받은편지함, 스레드, self-sent 지식 후보를 읽습니다.',
+    },
+    {
+      label: 'POP3 반입',
+      endpoint: formatEndpoint(accountConfig?.pop3_server, accountConfig?.pop3_port),
+      identity: accountConfig?.pop3_username ?? '반입 계정 미설정',
+      secretReady: accountConfig?.has_pop3_password ?? false,
+      detail: '레거시 메일함과 ZIP 반입 중복 정리에 사용합니다.',
+    },
+    {
+      label: 'OAuth 로그인',
+      endpoint: accountConfig?.oauth_client_id ?? '미설정',
+      identity: accountConfig?.oauth_redirect_uri ?? 'redirect URI 미설정',
+      secretReady: accountConfig?.has_oauth_client_secret ?? false,
+      detail: '지원 provider에서는 비밀번호 대신 OAuth consent를 사용합니다.',
+    },
+  ];
+
+  const updateAccountField = (field: keyof AccountFormState, value: string) => {
+    setAccountForm((current) => ({ ...current, [field]: value }));
+    setAccountStatus(null);
+  };
+
+  const handleAccountSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAccountSaving(true);
+    setAccountError(null);
+    setAccountStatus(null);
+
+    try {
+      const savedConfig = await apiClient.put<AccountConfig>('/api/accounts/config', buildAccountUpdate(accountForm));
+      setAccountConfig(savedConfig);
+      setAccountForm(toAccountForm(savedConfig));
+      setAccountStatus('계정 설정을 저장했습니다. 저장된 secret은 응답에 노출되지 않습니다.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '계정 설정을 저장할 수 없습니다.';
+      setAccountError(message);
+    } finally {
+      setAccountSaving(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -162,6 +359,22 @@ export function SettingsLayout() {
       })
       .finally(() => {
         if (!cancelled) setOperationalLoading(false);
+      });
+
+    void apiClient
+      .get<AccountConfig>('/api/accounts/config')
+      .then((config) => {
+        if (cancelled) return;
+        setAccountConfig(config);
+        setAccountForm(toAccountForm(config));
+        setAccountError(null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setAccountError(error.message || '계정 설정을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setAccountLoading(false);
       });
 
     return () => {
@@ -261,60 +474,142 @@ export function SettingsLayout() {
 
             {activeTab === '연결 계정' && (
               <div className="space-y-6">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-start justify-between gap-4">
                   <div>
                     <h2 className="font-bold text-xl">이메일 및 캘린더 커넥터</h2>
-                    <p className="text-sm text-muted-foreground mt-1">Naruon Relay Proxy를 통해 외부 계정의 데이터를 수집하고 연동합니다.</p>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      회원이 지정한 SMTP/IMAP/POP3/OAuth provider를 사용합니다. Naruon은 메일함 용량이나 SMTP/IMAP 서버를 제공하지 않습니다.
+                    </p>
                   </div>
-                  <button className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90">
-                    <Plus className="size-4" /> 커넥터 추가
-                  </button>
+                  <span className="rounded-full border border-border bg-card px-3 py-1 font-mono text-xs font-bold text-foreground">
+                    고객 지정 Provider
+                  </span>
                 </div>
 
-                <div className="space-y-4">
-                  {/* Connected Accounts */}
-                  <div className="rounded-2xl border border-border bg-card p-5 shadow-sm flex items-center justify-between">
-                    <div className="flex items-center gap-4">
-                      <div className="size-10 rounded-full bg-blue-100 grid place-items-center"><Mail className="size-5 text-blue-600" /></div>
-                      <div>
-                        <h3 className="font-bold text-base">Google Workspace (업무용)</h3>
-                        <p className="text-sm text-muted-foreground">seongho@naruon.com • IMAP, SMTP, CalDAV 연동됨</p>
+                {accountLoading ? (
+                  <p className="rounded-xl bg-secondary/60 p-3 text-sm font-semibold text-muted-foreground">계정 설정을 불러오는 중입니다.</p>
+                ) : null}
+                {accountError ? (
+                  <p className="rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{accountError}</p>
+                ) : null}
+                {accountStatus ? (
+                  <p className="rounded-xl border border-emerald-300 bg-emerald-50 p-3 text-sm font-semibold text-emerald-900">{accountStatus}</p>
+                ) : null}
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  {accountProtocols.map((protocol) => (
+                    <article key={protocol.label} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                      <div className="flex items-start gap-3">
+                        <div className="grid size-10 shrink-0 place-items-center rounded-full bg-secondary">
+                          <Mail className="size-5 text-primary" />
+                        </div>
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="font-bold text-base">{protocol.label}</h3>
+                            <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${protocol.secretReady ? 'bg-emerald-100 text-emerald-800' : 'bg-secondary text-muted-foreground'}`}>
+                              {protocol.secretReady ? '저장된 secret 유지' : 'secret 미설정'}
+                            </span>
+                          </div>
+                          <p className="mt-1 break-all font-mono text-sm text-foreground">{protocol.endpoint}</p>
+                          <p className="mt-1 break-all text-sm text-muted-foreground">{protocol.identity}</p>
+                          <p className="mt-3 text-sm leading-6 text-muted-foreground">{protocol.detail}</p>
+                        </div>
                       </div>
+                    </article>
+                  ))}
+                </div>
+
+                <form onSubmit={handleAccountSave} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-bold text-lg">Source-backed 계정 설정</h3>
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        빈 secret 입력은 기존 저장값을 유지합니다. 실제 연결과 provider write는 서버 검증과 self-hosted connector 정책을 통과한 뒤 별도 실행됩니다.
+                      </p>
                     </div>
-                    <button className="text-sm font-semibold border border-border px-4 py-2 rounded-lg hover:bg-secondary">설정 변경</button>
+                    <button
+                      type="submit"
+                      disabled={accountSaving}
+                      className="rounded-lg bg-foreground px-5 py-2 text-sm font-bold text-background hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {accountSaving ? '저장 중' : '계정 설정 저장'}
+                    </button>
                   </div>
 
-                  <div className="rounded-2xl border border-border bg-card p-5 shadow-sm flex items-center justify-between opacity-70">
-                    <div className="flex items-center gap-4">
-                      <div className="size-10 rounded-full bg-slate-100 grid place-items-center"><Mail className="size-5 text-slate-600" /></div>
-                      <div>
-                        <h3 className="font-bold text-base">개인 메일 (iCloud)</h3>
-                        <p className="text-sm text-muted-foreground">seongho.bae@icloud.com • IMAP 수집만 됨 (일정 연동 제외)</p>
+                  <div className="mt-6 grid gap-5">
+                    <section aria-label="SMTP 송신 설정" className="grid gap-3 border-t border-border pt-5 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label htmlFor="smtp-server" className="text-sm font-bold text-muted-foreground">SMTP 서버</label>
+                        <input id="smtp-server" name="smtp_server" value={accountForm.smtpServer} onChange={(event) => updateAccountField('smtpServer', event.target.value)} placeholder="smtp.example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
-                    </div>
-                    <button className="text-sm font-semibold border border-border px-4 py-2 rounded-lg hover:bg-secondary">설정 변경</button>
-                  </div>
-                </div>
+                      <div className="space-y-2">
+                        <label htmlFor="smtp-port" className="text-sm font-bold text-muted-foreground">SMTP 포트</label>
+                        <input id="smtp-port" name="smtp_port" type="number" inputMode="numeric" value={accountForm.smtpPort} onChange={(event) => updateAccountField('smtpPort', event.target.value)} placeholder="587" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="smtp-username" className="text-sm font-bold text-muted-foreground">SMTP 사용자</label>
+                        <input id="smtp-username" name="smtp_username" value={accountForm.smtpUsername} onChange={(event) => updateAccountField('smtpUsername', event.target.value)} placeholder="sender@example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="smtp-password" className="text-sm font-bold text-muted-foreground">SMTP secret</label>
+                        <input id="smtp-password" name="smtp_password" type="password" value={accountForm.smtpPassword} onChange={(event) => updateAccountField('smtpPassword', event.target.value)} placeholder={accountConfig?.has_smtp_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                    </section>
 
-                {/* Form Example */}
-                <div className="mt-8 rounded-2xl border border-border bg-card p-6 shadow-sm">
-                  <h3 className="font-bold text-lg mb-4">IMAP 수동 설정 (사내 메일)</h3>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <label className="text-sm font-bold text-muted-foreground">IMAP 서버 주소</label>
-                      <input type="text" placeholder="imap.example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm focus:border-primary focus:ring-1 focus:ring-primary outline-none" />
-                    </div>
-                    <div className="space-y-2">
-                      <label className="text-sm font-bold text-muted-foreground">포트 (SSL)</label>
-                      <input type="text" defaultValue="993" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm focus:border-primary focus:ring-1 focus:ring-primary outline-none" />
-                    </div>
-                    <div className="col-span-2 space-y-2">
-                      <label className="text-sm font-bold text-muted-foreground">사용자 계정</label>
-                      <input type="email" placeholder="user@company.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm focus:border-primary focus:ring-1 focus:ring-primary outline-none" />
-                    </div>
+                    <section aria-label="IMAP 수신 설정" className="grid gap-3 border-t border-border pt-5 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label htmlFor="imap-server" className="text-sm font-bold text-muted-foreground">IMAP 서버</label>
+                        <input id="imap-server" name="imap_server" value={accountForm.imapServer} onChange={(event) => updateAccountField('imapServer', event.target.value)} placeholder="imap.example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="imap-port" className="text-sm font-bold text-muted-foreground">IMAP 포트</label>
+                        <input id="imap-port" name="imap_port" type="number" inputMode="numeric" value={accountForm.imapPort} onChange={(event) => updateAccountField('imapPort', event.target.value)} placeholder="993" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="imap-username" className="text-sm font-bold text-muted-foreground">IMAP 사용자</label>
+                        <input id="imap-username" name="imap_username" value={accountForm.imapUsername} onChange={(event) => updateAccountField('imapUsername', event.target.value)} placeholder="inbox@example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="imap-password" className="text-sm font-bold text-muted-foreground">IMAP secret</label>
+                        <input id="imap-password" name="imap_password" type="password" value={accountForm.imapPassword} onChange={(event) => updateAccountField('imapPassword', event.target.value)} placeholder={accountConfig?.has_imap_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                    </section>
+
+                    <section aria-label="POP3 반입 설정" className="grid gap-3 border-t border-border pt-5 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label htmlFor="pop3-server" className="text-sm font-bold text-muted-foreground">POP3 서버</label>
+                        <input id="pop3-server" name="pop3_server" value={accountForm.pop3Server} onChange={(event) => updateAccountField('pop3Server', event.target.value)} placeholder="pop3.example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="pop3-port" className="text-sm font-bold text-muted-foreground">POP3 포트</label>
+                        <input id="pop3-port" name="pop3_port" type="number" inputMode="numeric" value={accountForm.pop3Port} onChange={(event) => updateAccountField('pop3Port', event.target.value)} placeholder="995" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="pop3-username" className="text-sm font-bold text-muted-foreground">POP3 사용자</label>
+                        <input id="pop3-username" name="pop3_username" value={accountForm.pop3Username} onChange={(event) => updateAccountField('pop3Username', event.target.value)} placeholder="archive@example.com" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="pop3-password" className="text-sm font-bold text-muted-foreground">POP3 secret</label>
+                        <input id="pop3-password" name="pop3_password" type="password" value={accountForm.pop3Password} onChange={(event) => updateAccountField('pop3Password', event.target.value)} placeholder={accountConfig?.has_pop3_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                    </section>
+
+                    <section aria-label="OAuth 앱 설정" className="grid gap-3 border-t border-border pt-5 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label htmlFor="oauth-client-id" className="text-sm font-bold text-muted-foreground">OAuth client ID</label>
+                        <input id="oauth-client-id" name="oauth_client_id" value={accountForm.oauthClientId} onChange={(event) => updateAccountField('oauthClientId', event.target.value)} placeholder="client-id" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="oauth-client-secret" className="text-sm font-bold text-muted-foreground">OAuth client secret</label>
+                        <input id="oauth-client-secret" name="oauth_client_secret" type="password" value={accountForm.oauthClientSecret} onChange={(event) => updateAccountField('oauthClientSecret', event.target.value)} placeholder={accountConfig?.has_oauth_client_secret ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2 sm:col-span-2">
+                        <label htmlFor="oauth-redirect-uri" className="text-sm font-bold text-muted-foreground">OAuth redirect URI</label>
+                        <input id="oauth-redirect-uri" name="oauth_redirect_uri" value={accountForm.oauthRedirectUri} onChange={(event) => updateAccountField('oauthRedirectUri', event.target.value)} placeholder="https://naruon.net/oauth/mail/callback" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                    </section>
                   </div>
-                  <button className="mt-6 rounded-lg bg-foreground text-background px-6 py-2 text-sm font-bold hover:bg-foreground/90">연결 테스트</button>
-                </div>
+                </form>
               </div>
             )}
 

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -423,6 +423,7 @@ test('renders the settings self-hosted connector manifest with mobile scrolling'
       return style.overflowY !== 'hidden' && element.scrollHeight > element.clientHeight + 10;
     });
     if (!scroller) return null;
+    scroller.scrollTop = 0;
     const before = scroller.scrollTop;
     scroller.scrollTop = scroller.scrollHeight;
     return {
@@ -458,6 +459,105 @@ test('renders settings connector APM signals across desktop and tablet', async (
     await page.getByText('outbound runner heartbeat received').scrollIntoViewIfNeeded();
     await page.screenshot({ path: testInfo.outputPath(`settings-connector-apm-${viewport.name}.png`), fullPage: false });
   }
+});
+
+test('renders source-backed mail account settings across desktop tablet and mobile', async ({ page }, testInfo) => {
+  const accountRequests: {
+    method: string;
+    headers: Record<string, string>;
+    postData: string | null;
+  }[] = [];
+
+  await page.addInitScript(() => {
+    localStorage.setItem('naruon_session_token', 'signed-settings-e2e-token');
+  });
+  await mockDashboardApi(page, (path, request) => {
+    if (path === '/api/accounts/config') {
+      accountRequests.push({
+        method: request.method(),
+        headers: request.headers(),
+        postData: request.postData(),
+      });
+    }
+  });
+
+  for (const viewport of [
+    { name: 'desktop', width: 1280, height: 1024 },
+    { name: 'tablet', width: 1024, height: 768 },
+    { name: 'mobile', width: 390, height: 844 },
+  ] as const) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/settings');
+    await page.getByRole('button', { name: '연결 계정' }).first().click();
+
+    await expect(page.getByText('고객 지정 Provider')).toBeVisible();
+    await expect(page.getByText('Naruon은 메일함 용량이나 SMTP/IMAP 서버를 제공하지 않습니다')).toBeVisible();
+    await expect(page.getByText('smtp.example.com:587')).toBeVisible();
+    await expect(page.getByText('imap.example.com:993')).toBeVisible();
+    await expect(page.getByText('pop3.example.com:995')).toBeVisible();
+    await expect(page.getByText('OAuth 로그인')).toBeVisible();
+    await expect(page.getByText('저장된 secret 유지').first()).toBeVisible();
+
+    if (viewport.name === 'desktop') {
+      await page.getByRole('button', { name: '계정 설정 저장' }).click();
+      await expect(page.getByText('계정 설정을 저장했습니다')).toBeVisible();
+    }
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+    await page.screenshot({ path: testInfo.outputPath(`settings-mail-account-${viewport.name}.png`), fullPage: false });
+  }
+
+  await page.setViewportSize({ width: 390, height: 640 });
+  await page.goto('/settings');
+  await page.getByRole('button', { name: '연결 계정' }).first().click();
+  await page.getByLabel('OAuth redirect URI').scrollIntoViewIfNeeded();
+  const mobileScrollMetrics = await page.evaluate(() => {
+    const scroller = Array.from(document.querySelectorAll('main, main *')).find((element) => {
+      const style = window.getComputedStyle(element);
+      return style.overflowY !== 'hidden' && element.scrollHeight > element.clientHeight + 10;
+    });
+    if (!scroller) return null;
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(mobileScrollMetrics).not.toBeNull();
+  expect(mobileScrollMetrics?.maxScroll).toBeGreaterThan(0);
+  expect(mobileScrollMetrics?.after).toBeGreaterThan(mobileScrollMetrics?.before ?? 0);
+  await page.screenshot({ path: testInfo.outputPath('settings-mail-account-mobile-scroll.png'), fullPage: false });
+
+  const getRequest = accountRequests.find((request) => request.method === 'GET');
+  expect(getRequest?.headers.authorization).toBe('Bearer signed-settings-e2e-token');
+  for (const header of ['x-user-id', 'x-organization-id', 'x-group-id', 'x-group-ids', 'x-user-role', 'x-dev-auth-token']) {
+    expect(getRequest?.headers[header]).toBeUndefined();
+  }
+
+  const putRequest = accountRequests.find((request) => request.method === 'PUT');
+  expect(putRequest?.headers.authorization).toBe('Bearer signed-settings-e2e-token');
+  const putBody = JSON.parse(putRequest?.postData || '{}') as Record<string, unknown>;
+  expect(putBody).toMatchObject({
+    smtp_server: 'smtp.example.com',
+    smtp_port: 587,
+    smtp_username: 'sender@example.com',
+    imap_server: 'imap.example.com',
+    imap_port: 993,
+    imap_username: 'inbox@example.com',
+    pop3_server: 'pop3.example.com',
+    pop3_port: 995,
+    pop3_username: 'archive@example.com',
+    oauth_client_id: 'oauth-client-id',
+    oauth_redirect_uri: 'https://naruon.net/oauth/mail/callback',
+  });
+  expect(putBody).not.toHaveProperty('smtp_password');
+  expect(putBody).not.toHaveProperty('imap_password');
+  expect(putBody).not.toHaveProperty('pop3_password');
+  expect(putBody).not.toHaveProperty('oauth_client_secret');
 });
 
 test('renders calendar writeback intent status without direct provider writes', async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import type { Page, Route } from '@playwright/test';
+import type { Page, Request, Route } from '@playwright/test';
 
 const email = {
   id: 7,
@@ -218,10 +218,29 @@ const operationalSignals = {
   ],
 };
 
+const accountConfig = {
+  user_id: 'default',
+  smtp_server: 'smtp.example.com',
+  smtp_port: 587,
+  smtp_username: 'sender@example.com',
+  has_smtp_password: true,
+  imap_server: 'imap.example.com',
+  imap_port: 993,
+  imap_username: 'inbox@example.com',
+  has_imap_password: true,
+  pop3_server: 'pop3.example.com',
+  pop3_port: 995,
+  pop3_username: 'archive@example.com',
+  has_pop3_password: false,
+  oauth_client_id: 'oauth-client-id',
+  oauth_redirect_uri: 'https://naruon.net/oauth/mail/callback',
+  has_oauth_client_secret: true,
+};
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, OPTIONS',
 };
 
 async function fulfillJson(route: Route, body: unknown) {
@@ -233,12 +252,12 @@ async function fulfillJson(route: Route, body: unknown) {
   });
 }
 
-export async function mockDashboardApi(page: Page, onApiRequest?: (path: string) => void) {
+export async function mockDashboardApi(page: Page, onApiRequest?: (path: string, request: Request) => void) {
   await page.route('**/api/**', async (route) => {
     const request = route.request();
     const url = new URL(request.url());
     const path = url.pathname;
-    onApiRequest?.(path);
+    onApiRequest?.(path, request);
 
     if (request.method() === 'OPTIONS') {
       await route.fulfill({
@@ -269,6 +288,30 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string)
 
     if (path === '/api/observability/operational-signals' && request.method() === 'GET') {
       await fulfillJson(route, operationalSignals);
+      return;
+    }
+
+    if (path === '/api/accounts/config' && request.method() === 'GET') {
+      await fulfillJson(route, accountConfig);
+      return;
+    }
+
+    if (path === '/api/accounts/config' && request.method() === 'PUT') {
+      const body = JSON.parse(request.postData() || '{}') as Record<string, unknown>;
+      await fulfillJson(route, {
+        ...accountConfig,
+        smtp_server: body.smtp_server,
+        smtp_port: body.smtp_port,
+        smtp_username: body.smtp_username,
+        imap_server: body.imap_server,
+        imap_port: body.imap_port,
+        imap_username: body.imap_username,
+        pop3_server: body.pop3_server,
+        pop3_port: body.pop3_port,
+        pop3_username: body.pop3_username,
+        oauth_client_id: body.oauth_client_id,
+        oauth_redirect_uri: body.oauth_redirect_uri,
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- replaces static Settings connected-account cards with a signed `/api/accounts/config` SMTP/IMAP/POP3/OAuth workflow
- preserves stored credential secrets when replacement fields are blank and keeps masked secret state out of browser-visible values
- adds responsive Playwright coverage and a plan doc for the source-backed Settings account slice
- keeps Strix governance direct OpenAI Platform only; no GitHub Models path is introduced

## Verification
- `npm test -- SettingsLayout.test.tsx`
- `npm run lint -- src/components/SettingsLayout.tsx src/components/SettingsLayout.test.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts`
- `npm run typecheck`
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_accounts_api.py -q`
- `env -u NO_COLOR -u FORCE_COLOR NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 PLAYWRIGHT_PORT=18183 npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts -g "settings" --project=desktop`
- `env -u NO_COLOR -u FORCE_COLOR NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build`
- `env -u NO_COLOR -u FORCE_COLOR bash scripts/ci/test_strix_quick_gate.sh`

## Browser Evidence
- `frontend/test-results/dashboard-branding-renders-2d3b3-s-desktop-tablet-and-mobile-desktop/settings-mail-account-desktop.png`
- `frontend/test-results/dashboard-branding-renders-2d3b3-s-desktop-tablet-and-mobile-desktop/settings-mail-account-tablet.png`
- `frontend/test-results/dashboard-branding-renders-2d3b3-s-desktop-tablet-and-mobile-desktop/settings-mail-account-mobile.png`
- `frontend/test-results/dashboard-branding-renders-2d3b3-s-desktop-tablet-and-mobile-desktop/settings-mail-account-mobile-scroll.png`

## Notes
- Next build reported static generation using 11 workers while respecting the configured experimental static-generation values. This is not a hundreds-of-process regression, but the next phase should separately tighten/measure build-worker count if CI process fanout reappears.
- Subagent audit recommends the next implementation slice as a Today dashboard pending-reply lane backed by `GET /api/emails/pending-replies`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings for connected email accounts (SMTP/IMAP/POP3/OAuth) now load and save account configuration.
  * Protocol status cards display account connection status across desktop, tablet, and mobile viewports.

* **Documentation**
  * Added guidance for account settings workflows and security best practices.
  * Updated documentation on sender relationship graphs and configuration contracts.

* **Tests**
  * Added end-to-end tests validating account settings behavior and security across all device types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->