### PR TITLE
Wire Today pending reply dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@
   storing user-supplied tags for later UI rendering. Parsed email display fields
   must not persist active HTML/script markup; preserve message/thread identifiers
   separately from UI-safe subject/body, address, and attachment display text.
+- Home/Today dashboard reply-wait surfaces must read signed
+  `/api/emails/pending-replies` data instead of inferring pending replies from
+  generic inbox fixtures or static copy. Tests and E2E mocks must verify the
+  stored `naruon_session_token` bearer path and must not add public identity
+  headers.
 - Mail connection updates and workers must validate server-side SMTP, POP3,
   IMAP, and relay destinations before persistence or network connection. POP3
   credentials are required for POP3 sync;

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ mail/calendar/file systems.
   signed WebDAV/Notes materialization intent for that task and shows the planned
   customer-owned target with `provider_write_executed=false`; actual provider
   mutation remains connector execution work.
+- **Pending reply dashboard**: the Today dashboard reads signed
+  `/api/emails/pending-replies?limit=3` data and shows sent-mail reply waits in
+  Home KPIs and judgment points. Pending replies are calculated from
+  customer-owned mailbox metadata; Naruon does not host the mailbox or fabricate
+  provider writes.
 
 ## Five-minute local path
 

--- a/docs/operations/source-of-truth-and-writeback-sovereignty.md
+++ b/docs/operations/source-of-truth-and-writeback-sovereignty.md
@@ -42,15 +42,16 @@ claims.
 Implemented slices currently cover signed task/mail provenance, dedupe/threading
 contracts, source-linked ticket tasks, self-sent knowledge capture into
 idempotent ticket tasks, deterministic sender ontology action hints, generic
-WebDAV writeback intent, self-sent knowledge WebDAV/Notes materialization
+WebDAV writeback intent, source-backed Today dashboard pending reply reads from
+`/api/emails/pending-replies`, self-sent knowledge WebDAV/Notes materialization
 intent, DB-backed CalDAV intent source selection through opaque
 `calendar_writeback_sources.source_uid` rows exposed to the Calendar workspace
 through a signed source-registry read, and WebDAV intent selection through
 opaque, organization-scoped `webdav_accounts.source_uid` rows with persisted
-writeback eligibility. Real CalDAV/WebDAV mutation,
-ETag-aware WebDAV/Notes provider execution for synthesized knowledge, POP3
-runtime sync, durable reply-tracking notifications, and source-id filtered
-sender graph views remain episode work and must preserve this registry
+writeback eligibility. Real CalDAV/WebDAV mutation, ETag-aware WebDAV/Notes
+provider execution for synthesized knowledge, POP3 runtime sync, durable
+reply-tracking notifications, pending-reply SLA escalation, and source-id
+filtered sender graph views remain episode work and must preserve this registry
 boundary.
 
 ## Policy and audit requirements

--- a/docs/plans/2026-05-27-today-pending-replies-dashboard.md
+++ b/docs/plans/2026-05-27-today-pending-replies-dashboard.md
@@ -1,0 +1,46 @@
+# Today Pending Replies Dashboard
+
+Date: 2026-05-27
+
+## Scope
+
+Wire the Today dashboard to the existing source-backed sent-mail reply tracking
+API. This slice does not add database objects and does not execute provider
+writes; it surfaces the server-authoritative pending reply lane already exposed
+by `/api/emails/pending-replies`.
+
+## Confirmed Inputs
+
+- `docs/plans/2026-05-27-sent-mail-reply-tracking-route.md` made
+  `/mail?folder=sent` source-backed.
+- `backend/api/emails.py` exposes `GET /api/emails/pending-replies` with
+  `get_auth_context`, owner/organization scope, configured SMTP/IMAP address
+  detection, self-sent exclusion, and later external-reply exclusion.
+- `frontend/branding` and the GNB plan require Home to show judgment points,
+  pending work, calendar conflicts, and recent mail instead of inert copy.
+- The gap before this slice was frontend-only: the Today dashboard read
+  `/api/emails` and `/api/tasks`, but did not read pending replies.
+
+## Implementation Plan
+
+1. Add pending reply loading to `WorkspaceHome` through
+   `/api/emails/pending-replies?limit=3` using the shared `apiClient`.
+2. Surface the count in Home KPI cards and the first summary lane.
+3. Replace static judgment-point filler with the source-backed pending reply
+   list, preserving safe React text rendering.
+4. Add focused JSDOM coverage proving the signed `Authorization: Bearer`
+   session header is used and public identity headers are not emitted.
+5. Add Playwright coverage for desktop and mobile screenshots, horizontal
+   overflow, and mobile dashboard scrolling.
+
+## Verification Targets
+
+- `npx vitest run src/components/WorkspaceHome.dashboard.test.tsx`
+- `npm run lint -- src/components/WorkspaceHome.tsx src/components/WorkspaceHome.dashboard.test.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts`
+- `npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts -g "pending reply lane" --project=desktop`
+
+## Deferred Work
+
+- Durable reminder scheduling and notification policy for pending replies.
+- Provider-side sent-folder sync completeness for all IMAP/SMTP/OAuth adapters.
+- Task-board escalation when pending replies exceed workspace SLA policy.

--- a/frontend/src/components/WorkspaceHome.dashboard.test.tsx
+++ b/frontend/src/components/WorkspaceHome.dashboard.test.tsx
@@ -1,0 +1,146 @@
+/* @vitest-environment jsdom */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/EmailList", () => ({
+  EmailList: () => <section aria-label="mock email list">mock email list</section>,
+}));
+
+vi.mock("@/components/EmailDetail", () => ({
+  EmailDetail: () => <section aria-label="mock email detail">mock email detail</section>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+
+vi.mock("@/components/mobile-workspace-panels", () => ({
+  MobileCalendarPanel: () => <section>mock calendar</section>,
+  MobileSearchPanel: () => <section>mock search</section>,
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => function MockDynamic() {
+    return <div>mock graph</div>;
+  },
+}));
+
+vi.mock("lucide-react", () => ({
+  CalendarDays: () => <svg aria-hidden="true" />,
+  CheckCircle2: () => <svg aria-hidden="true" />,
+  Inbox: () => <svg aria-hidden="true" />,
+  Network: () => <svg aria-hidden="true" />,
+  Send: () => <svg aria-hidden="true" />,
+  Settings: () => <svg aria-hidden="true" />,
+}));
+
+import { WorkspaceHome } from "./WorkspaceHome";
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function waitForCondition(condition: () => boolean) {
+  for (let index = 0; index < 20; index += 1) {
+    if (condition()) return;
+    await flushAsyncWork();
+  }
+  throw new Error("waitForCondition timed out after 20 attempts");
+}
+
+describe("WorkspaceHome Today dashboard", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    const mountedRoot = root;
+    if (mountedRoot) {
+      act(() => mountedRoot.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads pending sent-mail replies through signed session headers", async () => {
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })));
+    localStorage.setItem("naruon_session_token", "signed-dashboard-token");
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchCalls.push({ url, init });
+      if (url.endsWith("/api/emails/pending-replies?limit=3")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            emails: [
+              {
+                id: 301,
+                subject: "벤더 계약 답변 요청",
+                sender: "Seongho <user@naruon.ai>",
+                date: "2026-05-17T09:00:00Z",
+                snippet: "계약 검토 회신 SLA가 지나 작업 보드와 연결해야 합니다.",
+                requires_reply: true,
+              },
+            ],
+          }),
+        });
+      }
+      if (url.endsWith("/api/emails")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            emails: [
+              {
+                id: 101,
+                subject: "고객 계약 승인 대기",
+                sender: "legal@example.com",
+                date: "2026-05-17T09:00:00Z",
+                snippet: "오늘 승인해야 하는 계약 검토 요청",
+                unread: true,
+              },
+            ],
+          }),
+        });
+      }
+      if (url.endsWith("/api/tasks")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ([]),
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<WorkspaceHome forcedStartupView="dashboard" />);
+    });
+    await waitForCondition(() => container?.textContent?.includes("벤더 계약 답변 요청") ?? false);
+
+    expect(container.textContent).toContain("답변 대기 메일");
+    expect(container.textContent).toContain("계약 검토 회신 SLA");
+    const pendingCall = fetchCalls.find((call) => call.url.endsWith("/api/emails/pending-replies?limit=3"));
+    expect(pendingCall).toBeDefined();
+    const headers = pendingCall?.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer signed-dashboard-token");
+    expect(headers["X-User-Id"]).toBeUndefined();
+    expect(headers["X-Organization-Id"]).toBeUndefined();
+    expect(headers["X-Dev-Auth-Token"]).toBeUndefined();
+  });
+});

--- a/frontend/src/components/WorkspaceHome.tsx
+++ b/frontend/src/components/WorkspaceHome.tsx
@@ -7,7 +7,7 @@ import type { MailFolder } from '@/components/EmailList';
 import { EmailDetail } from '@/components/EmailDetail';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import dynamic from 'next/dynamic';
-import { CalendarDays, CheckCircle2, Inbox, Network, Settings } from 'lucide-react';
+import { CalendarDays, CheckCircle2, Inbox, Network, Send, Settings } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { setMobileWorkspaceView, useMobileWorkspaceView } from '@/lib/mobile-workspace';
 import { toSafeReactText } from '@/lib/safe-text';
@@ -74,6 +74,7 @@ interface EmailItem {
 
 function useDashboardData() {
   const [emails, setEmails] = useState<EmailItem[]>([]);
+  const [pendingReplies, setPendingReplies] = useState<EmailItem[]>([]);
   const [tasks, setTasks] = useState<TaskItem[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -81,10 +82,12 @@ function useDashboardData() {
     let cancelled = false;
     Promise.all([
       apiClient.get<{ emails: EmailItem[] }>('/api/emails').catch(() => ({ emails: [] })),
+      apiClient.get<{ emails: EmailItem[] }>('/api/emails/pending-replies?limit=3').catch(() => ({ emails: [] })),
       apiClient.get<TaskItem[]>('/api/tasks').catch(() => [])
-    ]).then(([emailRes, tasksRes]) => {
+    ]).then(([emailRes, pendingReplyRes, tasksRes]) => {
       if (cancelled) return;
       setEmails(emailRes.emails || []);
+      setPendingReplies(pendingReplyRes.emails || []);
       setTasks(tasksRes || []);
       setLoading(false);
     });
@@ -94,7 +97,7 @@ function useDashboardData() {
     };
   }, []);
 
-  return { emails, tasks, loading };
+  return { emails, pendingReplies, tasks, loading };
 }
 
 function formatStartupDate(value: string) {
@@ -137,11 +140,12 @@ function StartupResultList({ results }: { results: StartupSearchResult[] }) {
 }
 
 function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupView) => void }) {
-  const { emails, tasks, loading } = useDashboardData();
+  const { emails, pendingReplies, tasks, loading } = useDashboardData();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [currentTimestamp, setCurrentTimestamp] = useState('');
   const settingsMenuId = 'workspace-startup-settings-menu';
   const unreadCount = emails.filter((e) => e.unread).length;
+  const pendingReplyCount = pendingReplies.length;
   const pendingTasks = tasks.filter((t) => t.status !== 'done');
 
   useEffect(() => {
@@ -201,9 +205,10 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
         </div>
 
         {/* KPI Cards */}
-        <div aria-label="홈 지표" className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-5">
+        <div aria-label="홈 지표" className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
           {[
             { title: '받은 메일', value: loading ? '-' : emails.length.toString(), diff: unreadCount > 0 ? `+${unreadCount}` : '-', diffText: '안 읽음', icon: Inbox, color: 'text-primary' },
+            { title: '답변 대기', value: loading ? '-' : pendingReplyCount.toString(), diff: pendingReplyCount > 0 ? `${pendingReplyCount}건` : '-', diffText: '보낸 메일', icon: Send, color: 'text-rose-500' },
             { title: '오늘 일정', value: '5', diff: '+1', diffText: '어제 대비', icon: CalendarDays, color: 'text-blue-500' },
             { title: '대기 중 작업', value: loading ? '-' : pendingTasks.length.toString(), diff: '-', diffText: '변동 없음', icon: CheckCircle2, color: 'text-green-500' },
             { title: '진행 중 프로젝트', value: '7', diff: '-', diffText: '변동 없음', icon: Network, color: 'text-purple-500' },
@@ -227,11 +232,11 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
           <h2 className="text-lg font-bold">오늘의 핵심 요약</h2>
           <div className="mt-4 grid grid-cols-1 gap-4 divide-y divide-border md:grid-cols-3 md:gap-6 md:divide-x md:divide-y-0">
             <div className="flex gap-4">
-              <div className="grid size-10 shrink-0 place-items-center rounded-full bg-purple-100 text-purple-600"><Inbox className="size-5" /></div>
+              <div className="grid size-10 shrink-0 place-items-center rounded-full bg-rose-100 text-rose-600"><Send className="size-5" /></div>
               <div>
-                <p className="break-keep font-bold">중요 메일 {loading ? '-' : unreadCount}건</p>
-                <p className="text-xs text-muted-foreground mt-1">오늘 확인이 필요한 메일이 있어요.</p>
-                <button onClick={() => onOpenView('email')} className="mt-2 text-xs font-semibold text-primary hover:underline">메일 바로가기</button>
+                <p className="break-keep font-bold">답변 대기 {loading ? '-' : pendingReplyCount}건</p>
+                <p className="text-xs text-muted-foreground mt-1">보낸 메일 중 회신 확인이 필요한 항목입니다.</p>
+                <a href="/mail?folder=sent" className="mt-2 inline-flex text-xs font-semibold text-primary hover:underline">보낸 메일 보기</a>
               </div>
             </div>
             <div className="flex gap-4 pt-4 md:pl-6 md:pt-0">
@@ -260,28 +265,29 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
               <h2 className="text-base font-bold">오늘의 판단 포인트</h2>
             </div>
             <div className="space-y-3">
-              <div className="flex flex-col gap-2 rounded-lg bg-secondary/50 p-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <span className="w-fit shrink-0 rounded bg-purple-100 px-2 py-0.5 text-[10px] font-bold text-purple-700">우선 검토 필요</span>
-                  <div>
-                    <p className="text-sm font-bold">출시 회의 (Naruon 2.0)</p>
-                    <p className="text-[11px] text-muted-foreground">주요 의사결정이 필요한 회의입니다.</p>
+              <div className="text-xs font-bold text-muted-foreground">답변 대기 메일</div>
+              {loading ? (
+                <div className="text-sm text-muted-foreground p-2">답변 대기 메일을 불러오는 중...</div>
+              ) : pendingReplies.length === 0 ? (
+                <div className="text-sm text-muted-foreground p-2">답변 대기 중인 보낸 메일이 없습니다.</div>
+              ) : pendingReplies.map((reply) => {
+                const safeSubject = toSafeReactText(reply.subject?.trim() || null, '(제목 없음)');
+                const safeSnippet = toSafeReactText(reply.snippet);
+                return (
+                  <div key={reply.id} className="flex flex-col gap-2 rounded-lg bg-secondary/50 p-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                      <span className="w-fit shrink-0 rounded bg-rose-100 px-2 py-0.5 text-[10px] font-bold text-rose-700">답변 대기</span>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-bold">{safeSubject}</p>
+                        <p className="line-clamp-2 text-[11px] text-muted-foreground">{safeSnippet}</p>
+                      </div>
+                    </div>
+                    <span suppressHydrationWarning className="shrink-0 text-xs text-muted-foreground">{formatStartupDate(reply.date || '')}</span>
                   </div>
-                </div>
-                <span className="shrink-0 text-xs text-muted-foreground">오늘 10:30</span>
-              </div>
-              <div className="flex flex-col gap-2 rounded-lg bg-secondary/50 p-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <span className="w-fit shrink-0 rounded bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-700">데이터 검토</span>
-                  <div>
-                    <p className="text-sm font-bold">5월 리포트 분석</p>
-                    <p className="text-[11px] text-muted-foreground">핵심 지표 변동사항을 확인하세요.</p>
-                  </div>
-                </div>
-                <span className="shrink-0 text-xs text-muted-foreground">오늘 11:00</span>
-              </div>
+                );
+              })}
             </div>
-            <button className="mt-4 w-full text-center text-sm font-semibold text-primary hover:underline">오늘 전체 보기</button>
+            <a href="/mail?folder=sent" className="mt-4 block w-full text-center text-sm font-semibold text-primary hover:underline">보낸 메일 전체 보기</a>
           </div>
 
           <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -58,6 +58,74 @@ test('renders the desktop Naruon shell with local brand assets', async ({ page }
   await expect(page.locator('link[rel="preload"][href="/brand/naruon-logo.svg"]')).toHaveCount(0);
 });
 
+test('renders Today dashboard pending reply lane with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-dashboard-pending-replies-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  const desktopPendingRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/emails/pending-replies' && request.method() === 'GET';
+  });
+
+  await page.goto('/');
+  const desktopHeaders = (await desktopPendingRequest).headers();
+  expect(desktopHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(desktopHeaders[headerName]).toBeUndefined();
+  }
+
+  const desktopDashboard = page.locator('section[aria-label="홈 개요 대시보드"]:visible').first();
+  await expect(desktopDashboard).toBeVisible();
+  await expect(page.getByRole('article', { name: '답변 대기' }).first()).toBeVisible();
+  await expect(desktopDashboard.getByText('답변 대기 메일')).toBeVisible();
+  await expect(desktopDashboard.getByText('벤더 계약 답변 요청')).toBeVisible();
+  await expect(desktopDashboard.getByText('예산 승인 후속 확인')).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('today-pending-replies-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobilePendingRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/emails/pending-replies' && request.method() === 'GET';
+  });
+  await page.goto('/');
+  expect((await mobilePendingRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  const mobileDashboard = page.locator('section[aria-label="홈 개요 대시보드"]:visible').first();
+  await expect(mobileDashboard).toBeVisible();
+  await mobileDashboard.getByText('답변 대기 메일').scrollIntoViewIfNeeded();
+  await expect(mobileDashboard.getByText('답변 대기 메일')).toBeVisible();
+  await expect(mobileDashboard.getByText('벤더 계약 답변 요청')).toBeVisible();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('today-pending-replies-mobile-pending-list.png'), fullPage: false });
+  const dashboardScrollMetrics = await mobileDashboard.evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(dashboardScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(dashboardScrollMetrics.after).toBeGreaterThan(dashboardScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('today-pending-replies-mobile-scroll.png'), fullPage: false });
+});
+
 test('keeps the short mobile AI quick action menu inside the viewport with scrollable actions', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 640 });
   await mockDashboardApi(page);

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -276,6 +276,11 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
       return;
     }
 
+    if (path === '/api/emails/pending-replies' && request.method() === 'GET') {
+      await fulfillJson(route, { emails: [sentEmail, sentFollowUp] });
+      return;
+    }
+
     if (path === '/api/prompts' && request.method() === 'GET') {
       await fulfillJson(route, aiHubPrompts);
       return;


### PR DESCRIPTION
## Summary
- Wire the Today dashboard to signed `/api/emails/pending-replies?limit=3` data.
- Add source-backed pending reply KPI, summary, and judgment-point lane with sent-mail navigation.
- Add focused JSDOM coverage plus Playwright desktop/mobile/scroll screenshot coverage.
- Document the implemented dashboard slice and preserve durable scheduler/provider writes as future work.

## Verification
- `npx vitest run src/components/WorkspaceHome.dashboard.test.tsx`
- `npm run lint -- src/components/WorkspaceHome.tsx src/components/WorkspaceHome.dashboard.test.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts`
- `npm run typecheck`
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_emails_api.py -q -k pending_replies`
- `env -u NO_COLOR -u FORCE_COLOR NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 PLAYWRIGHT_PORT=18187 npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts -g "pending reply lane" --project=desktop`
- `env -u NO_COLOR -u FORCE_COLOR NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build`

## Browser Evidence
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-desktop.png`
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-mobile-pending-list.png`
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-mobile-scroll.png`

## Notes
- No new DB objects or columns.
- Naruon still reads customer-owned mailbox metadata; it is not an email server.
- Build still reports 11 static-generation workers under Next 16 even with constrained env values, but this is not a hundreds-of-process fan-out.
- Strix remains direct OpenAI Platform only through `STRIX_OPENAI_API_KEY`; GitHub Models are not used.
