### PR TITLE
Escalate pending replies into SLA tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@
   generic inbox fixtures or static copy. Tests and E2E mocks must verify the
   stored `naruon_session_token` bearer path and must not add public identity
   headers.
+- Reply-wait task escalation must reuse the server-authoritative pending reply
+  path, create or update source-linked `reply_sla` ticket tasks by opaque task
+  id, and sanitize generated task titles from email subjects before persistence.
+  Do not create duplicate reminder tasks for the same pending sent-mail message.
 - Mail connection updates and workers must validate server-side SMTP, POP3,
   IMAP, and relay destinations before persistence or network connection. POP3
   credentials are required for POP3 sync;

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ mail/calendar/file systems.
   Home KPIs and judgment points. Pending replies are calculated from
   customer-owned mailbox metadata; Naruon does not host the mailbox or fabricate
   provider writes.
+- **Reply SLA ticket escalation**: Home and Tasks can call signed
+  `POST /api/tasks/reply-sla-escalations` to convert overdue pending sent-mail
+  replies into opaque, source-linked `reply_sla` ticket tasks. Escalation reuses
+  server-side reply tracking, keeps generated titles plain text, and does not
+  mutate the customer's email provider.
 
 ## Five-minute local path
 

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -4,6 +4,7 @@ from typing import Literal, cast
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import AuthContext, get_auth_context
@@ -148,48 +149,50 @@ async def create_reply_sla_escalations(
 
     created_count = 0
     escalated_tasks: list[tuple[TicketTask, str | None]] = []
-    needs_commit = False
 
     for email in overdue_replies:
-        existing_result = await db.execute(
-            select(TicketTask)
-            .where(
-                TicketTask.user_id == auth_context.user_id,
-                TicketTask.organization_id == auth_context.organization_id,
-                TicketTask.related_email_id == email.id,
-                TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-            )
-            .order_by(TicketTask.updated_at.desc())
+        task = TicketTask(
+            user_id=auth_context.user_id,
+            organization_id=auth_context.organization_id,
+            title=_reply_sla_task_title(email),
+            status="blocked",
+            priority="urgent",
+            source_type=REPLY_SLA_SOURCE_TYPE,
+            related_email_id=email.id,
+            related_thread_id=canonical_thread_key(email),
         )
-        existing_tasks = existing_result.scalars().all()
-        task = existing_tasks[0] if existing_tasks else None
-        if task is None:
-            task = TicketTask(
-                user_id=auth_context.user_id,
-                organization_id=auth_context.organization_id,
-                title=_reply_sla_task_title(email),
-                status="blocked",
-                priority="urgent",
-                source_type=REPLY_SLA_SOURCE_TYPE,
-                related_email_id=email.id,
-                related_thread_id=canonical_thread_key(email),
-            )
+        try:
             db.add(task)
-            created_count += 1
-            needs_commit = True
-        elif task.status != "done":
-            task.title = _reply_sla_task_title(email)
-            task.status = "blocked"
-            task.priority = "urgent"
-            task.related_thread_id = canonical_thread_key(email)
-            task.updated_at = now
-            needs_commit = True
-        escalated_tasks.append((task, email.message_id))
-
-    if needs_commit:
-        await db.commit()
-        for task, _source_email_id in escalated_tasks:
+            await db.commit()
             await db.refresh(task)
+            created_count += 1
+        except IntegrityError:
+            await db.rollback()
+            existing_result = await db.execute(
+                select(TicketTask)
+                .where(
+                    TicketTask.user_id == auth_context.user_id,
+                    TicketTask.organization_id == auth_context.organization_id,
+                    TicketTask.related_email_id == email.id,
+                    TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
+                )
+                .order_by(TicketTask.updated_at.desc())
+            )
+            existing_tasks = existing_result.scalars().all()
+            if not existing_tasks:
+                raise HTTPException(
+                    status_code=409, detail="Reply SLA task conflict"
+                ) from None
+            task = existing_tasks[0]
+            if task.status != "done":
+                task.title = _reply_sla_task_title(email)
+                task.status = "blocked"
+                task.priority = "urgent"
+                task.related_thread_id = canonical_thread_key(email)
+                task.updated_at = now
+                await db.commit()
+                await db.refresh(task)
+        escalated_tasks.append((task, email.message_id))
 
     return ReplySlaEscalationResponse(
         evaluated=len(pending_replies),

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,6 +10,7 @@ from api.auth import AuthContext, get_auth_context
 from api.emails import canonical_thread_key
 from db.models import Email, TicketTask
 from db.session import get_db
+from services.reply_tracking_service import check_missing_replies
 from services.text_safety import contains_html_markup
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
@@ -17,6 +18,7 @@ router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 TaskStatus = Literal["open", "in_progress", "blocked", "done"]
 TaskPriority = Literal["low", "normal", "high", "urgent"]
+REPLY_SLA_SOURCE_TYPE = "reply_sla"
 
 
 class CreateTasksFromEmailRequest(BaseModel):
@@ -43,6 +45,24 @@ class TicketTaskResponse(BaseModel):
 
 class CreateTasksFromEmailResponse(BaseModel):
     created: int
+    tasks: list[TicketTaskResponse]
+
+
+class ReplySlaEscalationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    overdue_hours: int = Field(default=48, ge=1, le=720)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class ReplySlaPolicyResponse(BaseModel):
+    overdue_hours: int
+
+
+class ReplySlaEscalationResponse(BaseModel):
+    evaluated: int
+    created: int
+    policy: ReplySlaPolicyResponse
     tasks: list[TicketTaskResponse]
 
 
@@ -73,6 +93,24 @@ def _email_matches_auth(email: Email, auth_context: AuthContext) -> bool:
     )
 
 
+def _safe_email_subject(subject: str | None) -> str:
+    trimmed = (subject or "제목 없음").replace("\x00", " ").strip()
+    if not trimmed or contains_html_markup(trimmed):
+        return "제목 정리 필요"
+    return " ".join(trimmed.split())[:120]
+
+
+def _reply_sla_task_title(email: Email) -> str:
+    return f"답변 SLA 확인: {_safe_email_subject(email.subject)}"
+
+
+def _email_date_utc(email: Email) -> datetime.datetime:
+    message_date = email.date
+    if message_date.tzinfo is None:
+        return message_date.replace(tzinfo=datetime.timezone.utc)
+    return message_date
+
+
 def _task_response(task: TicketTask, source_email_id: str | None) -> TicketTaskResponse:
     scoped_thread_id = task.related_thread_id if source_email_id is not None else None
     return TicketTaskResponse(
@@ -85,6 +123,82 @@ def _task_response(task: TicketTask, source_email_id: str | None) -> TicketTaskR
         related_thread_id=scoped_thread_id,
         created_at=task.created_at,
         updated_at=task.updated_at,
+    )
+
+
+@router.post("/reply-sla-escalations", response_model=ReplySlaEscalationResponse)
+async def create_reply_sla_escalations(
+    request: ReplySlaEscalationRequest,
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> ReplySlaEscalationResponse:
+    pending_replies = await check_missing_replies(
+        db, auth_context.user_id, auth_context.organization_id
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    overdue_cutoff = now - datetime.timedelta(hours=request.overdue_hours)
+    overdue_replies = sorted(
+        [
+            email
+            for email in pending_replies
+            if _email_date_utc(email) <= overdue_cutoff
+        ],
+        key=_email_date_utc,
+    )[: request.limit]
+
+    created_count = 0
+    escalated_tasks: list[tuple[TicketTask, str | None]] = []
+    needs_commit = False
+
+    for email in overdue_replies:
+        existing_result = await db.execute(
+            select(TicketTask)
+            .where(
+                TicketTask.user_id == auth_context.user_id,
+                TicketTask.organization_id == auth_context.organization_id,
+                TicketTask.related_email_id == email.id,
+                TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
+            )
+            .order_by(TicketTask.updated_at.desc())
+        )
+        existing_tasks = existing_result.scalars().all()
+        task = existing_tasks[0] if existing_tasks else None
+        if task is None:
+            task = TicketTask(
+                user_id=auth_context.user_id,
+                organization_id=auth_context.organization_id,
+                title=_reply_sla_task_title(email),
+                status="blocked",
+                priority="urgent",
+                source_type=REPLY_SLA_SOURCE_TYPE,
+                related_email_id=email.id,
+                related_thread_id=canonical_thread_key(email),
+            )
+            db.add(task)
+            created_count += 1
+            needs_commit = True
+        elif task.status != "done":
+            task.title = _reply_sla_task_title(email)
+            task.status = "blocked"
+            task.priority = "urgent"
+            task.related_thread_id = canonical_thread_key(email)
+            task.updated_at = now
+            needs_commit = True
+        escalated_tasks.append((task, email.message_id))
+
+    if needs_commit:
+        await db.commit()
+        for task, _source_email_id in escalated_tasks:
+            await db.refresh(task)
+
+    return ReplySlaEscalationResponse(
+        evaluated=len(pending_replies),
+        created=created_count,
+        policy=ReplySlaPolicyResponse(overdue_hours=request.overdue_hours),
+        tasks=[
+            _task_response(task, source_email_id)
+            for task, source_email_id in escalated_tasks
+        ],
     )
 
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -298,6 +298,20 @@ class TicketTask(Base):
     related_email: Mapped["Email | None"] = relationship(back_populates="ticket_tasks")
 
 
+Index(
+    "uq_ticket_tasks_reply_sla_email",
+    TicketTask.user_id,
+    func.coalesce(TicketTask.organization_id, ""),
+    TicketTask.source_type,
+    TicketTask.related_email_id,
+    unique=True,
+    postgresql_where=(
+        (TicketTask.source_type == "reply_sla")
+        & (TicketTask.related_email_id.is_not(None))
+    ),
+)
+
+
 class Attachment(Base):
     __tablename__ = "attachments"
 

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -209,6 +209,29 @@ def schema_backfill_sql():
                 "(user_id, coalesce(organization_id, ''), sender_email, "
                 "coalesce(source_message_id, ''), coalesce(source_thread_id, ''))"
             ),
+            text(
+                "WITH ranked_tasks AS ("
+                "SELECT ctid, row_number() OVER ("
+                "PARTITION BY user_id, coalesce(organization_id, ''), "
+                "source_type, email_id "
+                "ORDER BY updated_at DESC NULLS LAST, "
+                "created_at DESC NULLS LAST, task_id DESC"
+                ") AS row_rank "
+                "FROM ticket_tasks "
+                "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
+                ") "
+                "DELETE FROM ticket_tasks "
+                "USING ranked_tasks "
+                "WHERE ticket_tasks.ctid = ranked_tasks.ctid "
+                "AND ranked_tasks.row_rank > 1"
+            ),
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "uq_ticket_tasks_reply_sla_email "
+                "ON ticket_tasks "
+                "(user_id, coalesce(organization_id, ''), source_type, email_id) "
+                "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
+            ),
         ]
     )
     return statements

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -11,6 +11,7 @@ from db.models import (
     CalendarWritebackSource,
     ConnectorSignalEvent,
     SenderRelationship,
+    TicketTask,
     WebdavAccount,
 )
 
@@ -263,6 +264,36 @@ def test_sender_relationship_model_declares_source_unique_index():
     assert "source_thread_id" in expression_text
 
 
+def test_ticket_task_reply_sla_unique_index_is_bootstrapped():
+    statements = [str(statement).lower() for statement in schema_backfill_sql()]
+    indexes = {index.name: index for index in TicketTask.__table__.indexes}
+    dedupe_statement_index = next(
+        index
+        for index, statement in enumerate(statements)
+        if "with ranked_tasks as" in statement
+        and "delete from ticket_tasks" in statement
+        and "source_type = 'reply_sla'" in statement
+        and "task_id desc" in statement
+        and "row_rank > 1" in statement
+    )
+    unique_index_statement_index = next(
+        index
+        for index, statement in enumerate(statements)
+        if "create unique index if not exists uq_ticket_tasks_reply_sla_email"
+        in statement
+    )
+
+    assert "uq_ticket_tasks_reply_sla_email" in indexes
+    assert indexes["uq_ticket_tasks_reply_sla_email"].unique is True
+    assert dedupe_statement_index < unique_index_statement_index
+    assert any(
+        "create unique index if not exists uq_ticket_tasks_reply_sla_email"
+        in statement
+        and "where source_type = 'reply_sla'" in statement
+        for statement in statements
+    )
+
+
 def test_calendar_writeback_source_model_uses_two_word_names():
     assert CalendarWritebackSource.__tablename__ == "calendar_writeback_sources"
     column_names = {column.name for column in CalendarWritebackSource.__table__.columns}
@@ -327,11 +358,80 @@ def test_schema_backfill_creates_connector_signal_events():
 @pytest.mark.postgres
 async def test_connector_signal_events_real_postgres_bootstrap_smoke():
     engine = create_async_engine(settings.DATABASE_URL)
+    duplicate_count = 0
+    kept_title = ""
+    smoke_user_id = "reply-sla-bootstrap-smoke-user"
+    smoke_organization_id = "reply-sla-bootstrap-smoke-org"
     try:
         async with engine.begin() as conn:
             await conn.execute(text("SELECT 1"))
             await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
             await conn.run_sync(Base.metadata.create_all)
+            await conn.execute(
+                text("DROP INDEX IF EXISTS uq_ticket_tasks_reply_sla_email")
+            )
+            await conn.execute(
+                text("DELETE FROM ticket_tasks WHERE user_id = :user_id"),
+                {"user_id": smoke_user_id},
+            )
+            await conn.execute(
+                text("DELETE FROM emails WHERE user_id = :user_id"),
+                {"user_id": smoke_user_id},
+            )
+            email_result = await conn.execute(
+                text(
+                    """
+                    INSERT INTO emails (
+                        user_id, organization_id, message_id, sender, recipients,
+                        subject, "date", body
+                    )
+                    VALUES (
+                        :user_id, :organization_id, :message_id, :sender,
+                        :recipients, :subject, now(), :body
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "user_id": smoke_user_id,
+                    "organization_id": smoke_organization_id,
+                    "message_id": "<reply-sla-bootstrap-smoke@example.com>",
+                    "sender": "smoke@example.com",
+                    "recipients": "owner@example.com",
+                    "subject": "Bootstrap duplicate reply SLA",
+                    "body": "bootstrap duplicate smoke",
+                },
+            )
+            email_id = email_result.scalar_one()
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO ticket_tasks (
+                        task_uid, user_id, organization_id, task_title,
+                        status_code, priority_code, source_type, email_id,
+                        thread_id, created_at, updated_at
+                    )
+                    VALUES
+                    (
+                        'reply_sla_bootstrap_old', :user_id, :organization_id,
+                        'old duplicate', 'blocked', 'urgent', 'reply_sla',
+                        :email_id, 'thread-bootstrap-smoke',
+                        now() - interval '2 hours', now() - interval '2 hours'
+                    ),
+                    (
+                        'reply_sla_bootstrap_new', :user_id, :organization_id,
+                        'new duplicate', 'blocked', 'urgent', 'reply_sla',
+                        :email_id, 'thread-bootstrap-smoke',
+                        now() - interval '1 hour', now() - interval '1 hour'
+                    )
+                    """
+                ),
+                {
+                    "user_id": smoke_user_id,
+                    "organization_id": smoke_organization_id,
+                    "email_id": email_id,
+                },
+            )
             for statement in schema_backfill_sql():
                 await conn.execute(statement)
             result = await conn.execute(
@@ -344,6 +444,36 @@ async def test_connector_signal_events_real_postgres_bootstrap_smoke():
                 )
             )
             column_names = {row[0] for row in result.fetchall()}
+            duplicate_result = await conn.execute(
+                text(
+                    """
+                    SELECT
+                        count(*) OVER () AS task_count,
+                        task_title
+                    FROM ticket_tasks
+                    WHERE user_id = :user_id
+                        AND organization_id = :organization_id
+                        AND source_type = 'reply_sla'
+                        AND email_id = :email_id
+                    ORDER BY updated_at DESC, task_id DESC
+                    LIMIT 1
+                    """
+                ),
+                {
+                    "user_id": smoke_user_id,
+                    "organization_id": smoke_organization_id,
+                    "email_id": email_id,
+                },
+            )
+            duplicate_count, kept_title = duplicate_result.one()
+            await conn.execute(
+                text("DELETE FROM ticket_tasks WHERE user_id = :user_id"),
+                {"user_id": smoke_user_id},
+            )
+            await conn.execute(
+                text("DELETE FROM emails WHERE user_id = :user_id"),
+                {"user_id": smoke_user_id},
+            )
     except (
         ConnectionRefusedError,
         OSError,
@@ -370,3 +500,5 @@ async def test_connector_signal_events_real_postgres_bootstrap_smoke():
         "detail_text",
         "observed_at",
     }.issubset(column_names)
+    assert duplicate_count == 1
+    assert kept_title == "new duplicate"

--- a/backend/tests/test_tasks_api.py
+++ b/backend/tests/test_tasks_api.py
@@ -9,11 +9,12 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from pydantic import SecretStr
 
 from api.auth import get_auth_context
 from core.config import settings
-from db.models import Email, TicketTask
+from db.models import Email, TenantConfig, TicketTask
 from db.session import get_db
 from main import app
 
@@ -63,6 +64,11 @@ class MockTaskSession:
     def __init__(self) -> None:
         self.emails: dict[int, Email] = {}
         self.tasks: list[TicketTask] = []
+        self.tenant_config: TenantConfig | None = TenantConfig(
+            user_id="alice",
+            smtp_username="alice@example.com",
+            imap_username=None,
+        )
 
     async def get(self, model, primary_key):
         if model is Email:
@@ -99,18 +105,34 @@ class MockTaskSession:
             def one_or_none(self):
                 return self.scalar_one_or_none()
 
+        if descriptions and descriptions[0].get("entity") is TenantConfig:
+            return MockResult([] if self.tenant_config is None else [self.tenant_config])
+
         if descriptions and descriptions[0].get("entity") is Email:
             params = stmt.compile().params
             source_email_id = params.get("message_id_1")
             user_id = params.get("user_id_1")
             organization_id = params.get("organization_id_1")
+            minimum_date = next(
+                (
+                    value
+                    for key, value in params.items()
+                    if key.startswith("date_")
+                    and isinstance(value, datetime.datetime)
+                ),
+                None,
+            )
             return MockResult(
                 [
                     email
                     for email in self.emails.values()
-                    if email.message_id == source_email_id
-                    and email.user_id == user_id
-                    and email.organization_id == organization_id
+                    if (source_email_id is None or email.message_id == source_email_id)
+                    and (user_id is None or email.user_id == user_id)
+                    and (
+                        organization_id is None
+                        or email.organization_id == organization_id
+                    )
+                    and (minimum_date is None or email.date > minimum_date)
                 ]
             )
 
@@ -120,6 +142,9 @@ class MockTaskSession:
             task_uid = params.get("task_uid_1")
             user_id = params.get("user_id_1")
             organization_id = params.get("organization_id_1")
+            source_type = params.get("source_type_1")
+            related_email_id = params.get("email_id_1")
+            returns_joined_email = len(descriptions) > 1
             scoped_email_join = (
                 "emails.user_id" in statement_text
                 and "emails.organization_id" in statement_text
@@ -138,18 +163,25 @@ class MockTaskSession:
                     return None
                 return source_email.message_id
 
-            return MockResult(
-                [
-                    (task, source_message_id(task))
-                    for task in self.tasks
-                    if (task_uid is None or task.task_uid == task_uid)
-                    and (user_id is None or task.user_id == user_id)
-                    and (
-                        organization_id is None
-                        or task.organization_id == organization_id
-                    )
-                ]
-            )
+            matching_tasks = [
+                task
+                for task in self.tasks
+                if (task_uid is None or task.task_uid == task_uid)
+                and (user_id is None or task.user_id == user_id)
+                and (
+                    organization_id is None or task.organization_id == organization_id
+                )
+                and (source_type is None or task.source_type == source_type)
+                and (
+                    related_email_id is None
+                    or task.related_email_id == related_email_id
+                )
+            ]
+            if returns_joined_email:
+                return MockResult(
+                    [(task, source_message_id(task)) for task in matching_tasks]
+                )
+            return MockResult(matching_tasks)
 
         return MockResult(self.tasks)
 
@@ -180,6 +212,11 @@ def override_get_db():
     app.dependency_overrides.pop(get_db, None)
     mock_session.emails = {}
     mock_session.tasks = []
+    mock_session.tenant_config = TenantConfig(
+        user_id="alice",
+        smtp_username="alice@example.com",
+        imap_username=None,
+    )
 
 
 @pytest.fixture
@@ -219,6 +256,285 @@ def test_create_ticket_tasks_accepts_signed_bearer_session():
     assert body["tasks"][0]["source_email_id"] == "<message-14@example.com>"
     assert "user_id" not in body["tasks"][0]
     assert "organization_id" not in body["tasks"][0]
+
+
+def test_reply_sla_escalation_accepts_signed_bearer_session():
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mock_session.emails[21] = make_email(
+        email_id=21,
+        message_id="<sent-sla-signed@example.com>",
+        thread_id="<thread-sla-signed>",
+        sender="alice@example.com",
+        recipients="vendor@example.com",
+        subject="Vendor reply",
+        body="Please reply by Friday.",
+        date=now - datetime.timedelta(days=3),
+    )
+    app.dependency_overrides.pop(get_auth_context, None)
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(_valid_session_payload())
+
+    try:
+        with TestClient(
+            app,
+            headers={"Authorization": f"Bearer {token}"},
+        ) as client:
+            response = client.post(
+                "/api/tasks/reply-sla-escalations",
+                json={"overdue_hours": 48},
+            )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["created"] == 1
+    assert body["tasks"][0]["source_type"] == "reply_sla"
+    assert body["tasks"][0]["source_email_id"] == "<sent-sla-signed@example.com>"
+    assert "user_id" not in body["tasks"][0]
+    assert "organization_id" not in body["tasks"][0]
+
+
+def test_reply_sla_escalation_creates_source_linked_overdue_task(auth_client):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mock_session.emails[21] = make_email(
+        email_id=21,
+        message_id="<sent-sla@example.com>",
+        thread_id="<thread-sla>",
+        sender="alice@example.com",
+        recipients="vendor@example.com",
+        subject="<script>alert('x')</script>",
+        body="Please reply by Friday.",
+        date=now - datetime.timedelta(days=3),
+    )
+    mock_session.emails[22] = make_email(
+        email_id=22,
+        message_id="<sent-recent@example.com>",
+        thread_id="thread-recent",
+        sender="alice@example.com",
+        recipients="vendor@example.com",
+        subject="Recent follow-up",
+        body="Please reply when you can.",
+        date=now - datetime.timedelta(hours=2),
+    )
+    mock_session.emails[23] = make_email(
+        email_id=23,
+        message_id="<sent-answered@example.com>",
+        thread_id="<thread-answered>",
+        sender="alice@example.com",
+        recipients="vendor@example.com",
+        subject="Answered follow-up",
+        body="Please reply when you can.",
+        date=now - datetime.timedelta(days=3),
+    )
+    mock_session.emails[24] = make_email(
+        email_id=24,
+        message_id="<reply-answered@example.com>",
+        thread_id="thread-answered",
+        sender="vendor@example.com",
+        recipients="alice@example.com",
+        subject="Re: Answered follow-up",
+        body="Confirmed.",
+        date=now - datetime.timedelta(days=2),
+    )
+    mock_session.emails[25] = make_email(
+        email_id=25,
+        message_id="<self-note@example.com>",
+        thread_id="thread-self",
+        sender="alice@example.com",
+        recipients="alice@example.com",
+        subject="Self note",
+        body="Please reply is not external work.",
+        date=now - datetime.timedelta(days=3),
+    )
+
+    response = auth_client.post(
+        "/api/tasks/reply-sla-escalations",
+        json={"overdue_hours": 48},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["evaluated"] == 2
+    assert body["created"] == 1
+    assert body["policy"] == {"overdue_hours": 48}
+    assert len(body["tasks"]) == 1
+    task = body["tasks"][0]
+    assert task["title"] == "답변 SLA 확인: 제목 정리 필요"
+    assert task["status"] == "blocked"
+    assert task["priority"] == "urgent"
+    assert task["source_type"] == "reply_sla"
+    assert task["source_email_id"] == "<sent-sla@example.com>"
+    assert task["related_thread_id"] == "thread-sla"
+    assert "related_email_id" not in task
+    assert "user_id" not in task
+    assert "organization_id" not in task
+    assert len(mock_session.tasks) == 1
+    assert mock_session.tasks[0].related_email_id == 21
+    assert "<script>" not in mock_session.tasks[0].title
+
+
+def test_reply_sla_escalation_is_idempotent_for_existing_task(auth_client):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    previous_update = now - datetime.timedelta(days=1)
+    mock_session.emails[31] = make_email(
+        email_id=31,
+        message_id="<existing-sla@example.com>",
+        thread_id="<thread-existing-sla>",
+        sender="alice@example.com",
+        recipients="vendor@example.com",
+        subject="Existing SLA follow-up",
+        body="Please reply by tomorrow.",
+        date=now - datetime.timedelta(days=4),
+    )
+    mock_session.tasks.append(
+        TicketTask(
+            id=1,
+            task_uid="opaque-existing-sla",
+            user_id="alice",
+            organization_id="org-acme",
+            title="예전 SLA 작업",
+            status="open",
+            priority="normal",
+            source_type="reply_sla",
+            related_email_id=31,
+            related_thread_id="old-thread",
+            created_at=previous_update,
+            updated_at=previous_update,
+        )
+    )
+
+    response = auth_client.post(
+        "/api/tasks/reply-sla-escalations",
+        json={"overdue_hours": 48},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["created"] == 0
+    assert len(body["tasks"]) == 1
+    assert body["tasks"][0]["id"] == "opaque-existing-sla"
+    assert body["tasks"][0]["status"] == "blocked"
+    assert body["tasks"][0]["priority"] == "urgent"
+    assert body["tasks"][0]["related_thread_id"] == "thread-existing-sla"
+    assert len(mock_session.tasks) == 1
+    assert mock_session.tasks[0].title == "답변 SLA 확인: Existing SLA follow-up"
+    assert mock_session.tasks[0].updated_at > previous_update
+
+
+@pytest.mark.postgres
+@pytest.mark.asyncio
+async def test_reply_sla_escalation_real_postgres_smoke():
+    from asyncpg.exceptions import InvalidAuthorizationSpecificationError
+    from asyncpg.exceptions import InvalidPasswordError
+    from db.models import Base
+    from sqlalchemy import delete, select, text
+    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(settings.DATABASE_URL)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            await conn.run_sync(Base.metadata.create_all)
+    except (
+        InvalidAuthorizationSpecificationError,
+        InvalidPasswordError,
+        OperationalError,
+        OSError,
+    ) as exc:
+        await engine.dispose()
+        pytest.skip(f"PostgreSQL smoke database unavailable: {exc}")
+
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    user_id = "reply-sla-smoke-user"
+    organization_id = "reply-sla-smoke-org"
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    async def cleanup_seed_rows():
+        async with Session() as session:
+            await session.execute(
+                delete(TicketTask).where(TicketTask.user_id == user_id)
+            )
+            await session.execute(delete(Email).where(Email.user_id == user_id))
+            await session.execute(
+                delete(TenantConfig).where(TenantConfig.user_id == user_id)
+            )
+            await session.commit()
+
+    await cleanup_seed_rows()
+    async with Session() as session:
+        session.add(
+            TenantConfig(
+                user_id=user_id,
+                smtp_username="reply-sla-smoke@example.com",
+                imap_username=None,
+            )
+        )
+        session.add(
+            Email(
+                user_id=user_id,
+                organization_id=organization_id,
+                message_id="<reply-sla-smoke@example.com>",
+                thread_id="<reply-sla-smoke-thread>",
+                sender="reply-sla-smoke@example.com",
+                recipients="vendor@example.com",
+                subject="<img src=x onerror=alert(1)>",
+                date=now - datetime.timedelta(days=3),
+                body="Please reply by tomorrow.",
+            )
+        )
+        await session.commit()
+
+    async def real_db_override():
+        async with Session() as session:
+            yield session
+
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = real_db_override
+    persisted_task: TicketTask | None = None
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            headers={
+                "X-User-Id": user_id,
+                "X-Organization-Id": organization_id,
+            },
+            base_url="http://test",
+        ) as real_client:
+            response = await real_client.post(
+                "/api/tasks/reply-sla-escalations",
+                json={"overdue_hours": 48},
+            )
+        async with Session() as session:
+            task_result = await session.execute(
+                select(TicketTask).where(
+                    TicketTask.user_id == user_id,
+                    TicketTask.organization_id == organization_id,
+                    TicketTask.source_type == "reply_sla",
+                )
+            )
+            persisted_task = task_result.scalar_one()
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+        await cleanup_seed_rows()
+        await engine.dispose()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["created"] == 1
+    assert body["tasks"][0]["source_email_id"] == "<reply-sla-smoke@example.com>"
+    assert body["tasks"][0]["related_thread_id"] == "reply-sla-smoke-thread"
+    assert body["tasks"][0]["title"] == "답변 SLA 확인: 제목 정리 필요"
+    assert persisted_task is not None
+    assert persisted_task.status == "blocked"
+    assert persisted_task.priority == "urgent"
+    assert persisted_task.related_thread_id == "reply-sla-smoke-thread"
 
 
 def test_list_ticket_tasks_does_not_leak_cross_tenant_source_email(auth_client):
@@ -335,18 +651,24 @@ def make_email(
     user_id: str = "alice",
     organization_id: str | None = "org-acme",
     thread_id: str | None = "thread-123",
+    message_id: str | None = None,
+    sender: str = "pm@example.com",
+    recipients: str = "alice@example.com",
+    subject: str | None = "Task source email",
+    body: str = "Please create tracked work items.",
+    date: datetime.datetime | None = None,
 ) -> Email:
     return Email(
         id=email_id,
         user_id=user_id,
         organization_id=organization_id,
-        message_id=f"<message-{email_id}@example.com>",
+        message_id=message_id or f"<message-{email_id}@example.com>",
         thread_id=thread_id,
-        sender="pm@example.com",
-        recipients="alice@example.com",
-        subject="Task source email",
-        date=datetime.datetime(2026, 5, 19, tzinfo=datetime.timezone.utc),
-        body="Please create tracked work items.",
+        sender=sender,
+        recipients=recipients,
+        subject=subject,
+        date=date or datetime.datetime(2026, 5, 19, tzinfo=datetime.timezone.utc),
+        body=body,
     )
 
 

--- a/backend/tests/test_tasks_api.py
+++ b/backend/tests/test_tasks_api.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from pydantic import SecretStr
+from sqlalchemy.exc import IntegrityError
 
 from api.auth import get_auth_context
 from core.config import settings
@@ -187,6 +188,14 @@ class MockTaskSession:
 
     def add(self, obj):
         if isinstance(obj, TicketTask):
+            if obj.source_type == "reply_sla" and any(
+                task.user_id == obj.user_id
+                and task.organization_id == obj.organization_id
+                and task.source_type == obj.source_type
+                and task.related_email_id == obj.related_email_id
+                for task in self.tasks
+            ):
+                raise IntegrityError("duplicate reply_sla task", {}, None)
             obj.id = len(self.tasks) + 1
             if not getattr(obj, "task_uid", None):
                 obj.task_uid = uuid.uuid4().hex
@@ -196,6 +205,9 @@ class MockTaskSession:
             self.tasks.append(obj)
 
     async def commit(self):
+        pass
+
+    async def rollback(self):
         pass
 
     async def refresh(self, obj):
@@ -690,6 +702,22 @@ def test_ticket_task_database_columns_use_two_word_snake_case():
         "updated_at",
     }
     assert all("_" in column_name for column_name in column_names)
+
+
+def test_ticket_task_model_declares_reply_sla_unique_index():
+    indexes = {index.name: index for index in TicketTask.__table__.indexes}
+
+    reply_sla_index = indexes["uq_ticket_tasks_reply_sla_email"]
+
+    assert reply_sla_index.unique is True
+    expression_text = " ".join(
+        str(expression).lower() for expression in reply_sla_index.expressions
+    )
+    assert "user_id" in expression_text
+    assert "coalesce" in expression_text
+    assert "organization_id" in expression_text
+    assert "source_type" in expression_text
+    assert "email_id" in expression_text
 
 
 def test_create_ticket_tasks_from_email_links_source_email_and_thread(auth_client):

--- a/docs/operations/source-of-truth-and-writeback-sovereignty.md
+++ b/docs/operations/source-of-truth-and-writeback-sovereignty.md
@@ -44,13 +44,14 @@ contracts, source-linked ticket tasks, self-sent knowledge capture into
 idempotent ticket tasks, deterministic sender ontology action hints, generic
 WebDAV writeback intent, source-backed Today dashboard pending reply reads from
 `/api/emails/pending-replies`, self-sent knowledge WebDAV/Notes materialization
-intent, DB-backed CalDAV intent source selection through opaque
+intent, pending-reply SLA escalation into idempotent source-linked `reply_sla`
+ticket tasks, DB-backed CalDAV intent source selection through opaque
 `calendar_writeback_sources.source_uid` rows exposed to the Calendar workspace
 through a signed source-registry read, and WebDAV intent selection through
 opaque, organization-scoped `webdav_accounts.source_uid` rows with persisted
 writeback eligibility. Real CalDAV/WebDAV mutation, ETag-aware WebDAV/Notes
 provider execution for synthesized knowledge, POP3 runtime sync, durable
-reply-tracking notifications, pending-reply SLA escalation, and source-id
+reply-tracking notifications, configurable SLA policy storage, and source-id
 filtered sender graph views remain episode work and must preserve this registry
 boundary.
 

--- a/docs/plans/2026-05-28-pending-reply-sla-task-escalation.md
+++ b/docs/plans/2026-05-28-pending-reply-sla-task-escalation.md
@@ -1,0 +1,51 @@
+# Pending Reply SLA Task Escalation
+
+Date: 2026-05-28
+
+## Scope
+
+Connect source-backed pending sent-mail replies to ticket-style task escalation.
+This slice does not add database objects, does not host email, and does not
+execute provider writes. It converts customer-mailbox reply waits that exceed a
+workspace SLA threshold into source-linked `reply_sla` tasks.
+
+## Confirmed Inputs
+
+- `docs/plans/2026-05-27-today-pending-replies-dashboard.md` left
+  task-board escalation for pending replies as deferred work.
+- `backend/api/emails.py` and `services.reply_tracking_service` already compute
+  pending replies from configured user mailbox addresses, exclude self-sent
+  notes, and exclude threads with later external replies.
+- `frontend/branding` and workspace navigation require Tasks to be actionable,
+  not placeholder-only.
+- `AGENTS.md` requires signed-session task APIs, no public identity headers,
+  opaque task ids, source-linked email/thread scope, and plain-text task titles.
+
+## Implementation Plan
+
+1. Add `POST /api/tasks/reply-sla-escalations` with a default 48-hour SLA and a
+   bounded limit.
+2. Reuse server-authoritative pending reply detection instead of inferring waits
+   in the browser.
+3. Create or update one source-linked `reply_sla` task per overdue pending
+   sent-mail message, using `blocked` and `urgent` for escalated work.
+4. Keep generated task titles plain text and replace active HTML-like subjects
+   with a safe fallback label.
+5. Add Home and Tasks workspace controls that call the endpoint with the stored
+   `naruon_session_token` bearer session and show the updated board/status.
+6. Verify desktop and mobile screenshots, horizontal overflow, and mobile scroll.
+
+## Verification Targets
+
+- `python3 -m pytest backend/tests/test_tasks_api.py -q -k reply_sla`
+- `npx vitest run src/app/tasks/page.test.tsx src/components/WorkspaceHome.dashboard.test.tsx`
+- `npm run lint -- src/components/TasksLayout.tsx src/components/WorkspaceHome.tsx src/app/tasks/page.test.tsx src/components/WorkspaceHome.dashboard.test.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts`
+- `npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts -g "pending reply SLA task escalation" --project=desktop`
+
+## Deferred Work
+
+- Durable reminder notifications and workspace-configurable SLA policy storage.
+- Provider-specific sent-folder sync completeness for OAuth, SMTP, POP3, and
+  IMAP adapters.
+- Calendar/task writeback execution after source-backed provider connectors are
+  ready.

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -161,6 +161,75 @@ describe("TasksPage", () => {
     expect(doneButton?.getAttribute("aria-pressed")).toBe("true");
   });
 
+  it("creates reply SLA ticket escalations with signed headers", async () => {
+    localStorage.setItem("naruon_session_token", "signed.reply.sla");
+    const publicIdentityHeaders = [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/tasks/reply-sla-escalations") {
+        const headers = init?.headers as Record<string, string>;
+        expect(init?.method).toBe("POST");
+        expect(headers.Authorization).toBe("Bearer signed.reply.sla");
+        expect(headers["Content-Type"]).toBe("application/json");
+        for (const headerName of publicIdentityHeaders) {
+          expect(Object.keys(headers).some((key) => key.toLowerCase() === headerName)).toBe(false);
+        }
+        expect(JSON.parse(String(init?.body))).toEqual({ overdue_hours: 48 });
+        return jsonResponse({
+          evaluated: 2,
+          created: 1,
+          policy: { overdue_hours: 48 },
+          tasks: [
+            {
+              id: "task-reply-sla-urgent",
+              title: "답변 SLA 확인: 벤더 계약 답변 요청",
+              status: "blocked",
+              priority: "urgent",
+              source_type: "reply_sla",
+              source_email_id: "<sent-q2@example.com>",
+              related_thread_id: "thread-sent-q2",
+              updated_at: "2026-05-26T11:00:00.000Z",
+            },
+          ],
+        });
+      }
+      return jsonResponse([]);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<TasksPage />);
+    });
+    await flushAsyncWork();
+
+    const escalationButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="보낸 메일 답변 SLA 티켓 생성"]',
+    );
+    expect(escalationButton).not.toBeNull();
+    await act(async () => {
+      escalationButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks/reply-sla-escalations", expect.objectContaining({
+      method: "POST",
+    }));
+    expect(container.textContent).toContain("1개 답변 SLA 티켓을 생성했습니다. 2개 대기 메일을 48시간 기준으로 확인했습니다.");
+    expect(container.textContent).toContain("답변 SLA 확인: 벤더 계약 답변 요청");
+    expect(container.textContent).toContain("<sent-q2@example.com>");
+    expect(container.textContent).toContain("thread-sent-q2");
+  });
+
   it("creates self-sent knowledge WebDAV materialization intent with signed headers", async () => {
     localStorage.setItem("naruon_session_token", "signed.knowledge.intent");
     const publicIdentityHeaders = [

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -211,8 +211,10 @@ export function TasksLayout() {
       });
       if (result.tasks.length > 0) {
         setTicketStatus('ready');
-      } else if (ticketStatus === 'loading' || ticketStatus === 'error') {
-        setTicketStatus('empty');
+      } else {
+        setTicketStatus((currentStatus) => (
+          currentStatus === 'loading' || currentStatus === 'error' ? 'empty' : currentStatus
+        ));
       }
       setReplySlaStatus('ready');
       setTicketActionStatus(`${result.created}개 답변 SLA 티켓을 생성했습니다. ${result.evaluated}개 대기 메일을 ${result.policy.overdue_hours}시간 기준으로 확인했습니다.`);

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -53,6 +53,15 @@ type KnowledgeIntentEntry = {
   result: KnowledgeMaterializationIntent | null;
 };
 
+type ReplySlaEscalationResponse = {
+  evaluated: number;
+  created: number;
+  policy: {
+    overdue_hours: number;
+  };
+  tasks: TicketTask[];
+};
+
 const taskStatusLabels: Record<TicketTask['status'], string> = {
   open: '접수',
   in_progress: '진행',
@@ -77,6 +86,7 @@ const taskPriorityLabels: Record<TicketTask['priority'], string> = {
 };
 
 type TicketStatus = 'loading' | 'ready' | 'empty' | 'auth' | 'error';
+type ReplySlaStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 function getApiErrorStatus(error: unknown) {
   const shapedError = error as { status?: unknown; response?: { status?: unknown } } | null;
@@ -93,6 +103,7 @@ export function TasksLayout() {
   const [ticketTasks, setTicketTasks] = useState<TicketTask[]>([]);
   const [ticketStatus, setTicketStatus] = useState<TicketStatus>('loading');
   const [ticketActionStatus, setTicketActionStatus] = useState<string | null>(null);
+  const [replySlaStatus, setReplySlaStatus] = useState<ReplySlaStatus>('idle');
   const [knowledgeIntentByTask, setKnowledgeIntentByTask] = useState<Record<string, KnowledgeIntentEntry>>({});
 
   useEffect(() => {
@@ -185,6 +196,32 @@ export function TasksLayout() {
     }
   };
 
+  const handleReplySlaEscalation = async () => {
+    setReplySlaStatus('loading');
+    setTicketActionStatus(null);
+    try {
+      const result = await apiClient.post<ReplySlaEscalationResponse>(
+        '/api/tasks/reply-sla-escalations',
+        { overdue_hours: 48 },
+      );
+      setTicketTasks((currentTasks) => {
+        const mergedTasks = new Map(currentTasks.map((task) => [task.id, task]));
+        result.tasks.forEach((task) => mergedTasks.set(task.id, task));
+        return Array.from(mergedTasks.values());
+      });
+      if (result.tasks.length > 0) {
+        setTicketStatus('ready');
+      } else if (ticketStatus === 'loading' || ticketStatus === 'error') {
+        setTicketStatus('empty');
+      }
+      setReplySlaStatus('ready');
+      setTicketActionStatus(`${result.created}개 답변 SLA 티켓을 생성했습니다. ${result.evaluated}개 대기 메일을 ${result.policy.overdue_hours}시간 기준으로 확인했습니다.`);
+    } catch {
+      setReplySlaStatus('error');
+      setTicketActionStatus('답변 SLA 티켓 생성에 실패했습니다.');
+    }
+  };
+
   const currentColumns = [
     { id: 'open', title: '접수', count: tasks.open.length, color: 'bg-blue-100 text-blue-700' },
     { id: 'in_progress', title: '진행', count: tasks.in_progress.length, color: 'bg-orange-100 text-orange-700' },
@@ -267,6 +304,37 @@ export function TasksLayout() {
               </div>
             ))}
           </div>
+
+          <section aria-label="pending reply SLA escalation" className="mt-4 border-t border-border pt-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-bold text-foreground">보낸 메일 SLA 승격</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  48시간 넘게 답변이 없는 보낸 메일을 원본 메일과 스레드가 연결된 티켓으로 올립니다.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="보낸 메일 답변 SLA 티켓 생성"
+                disabled={replySlaStatus === 'loading'}
+                onClick={() => void handleReplySlaEscalation()}
+                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+              >
+                <Plus className="size-3.5" />
+                {replySlaStatus === 'loading' ? '확인 중' : 'SLA 티켓 생성'}
+              </button>
+            </div>
+            {replySlaStatus === 'ready' ? (
+              <p role="status" className="mt-3 text-xs font-semibold text-muted-foreground">
+                답변 SLA 티켓 승격 결과가 보드에 반영되었습니다.
+              </p>
+            ) : null}
+            {replySlaStatus === 'error' ? (
+              <p role="status" className="mt-3 text-xs font-semibold text-red-700">
+                답변 SLA 티켓 승격 API를 완료하지 못했습니다.
+              </p>
+            ) : null}
+          </section>
 
           {ticketStatus === 'ready' ? (
             <div aria-label="source-linked ticket list" className="mt-4 grid gap-3 lg:grid-cols-2">

--- a/frontend/src/components/WorkspaceHome.dashboard.test.tsx
+++ b/frontend/src/components/WorkspaceHome.dashboard.test.tsx
@@ -143,4 +143,96 @@ describe("WorkspaceHome Today dashboard", () => {
     expect(headers["X-Organization-Id"]).toBeUndefined();
     expect(headers["X-Dev-Auth-Token"]).toBeUndefined();
   });
+
+  it("creates reply SLA ticket escalation from the Today dashboard with signed headers", async () => {
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })));
+    localStorage.setItem("naruon_session_token", "signed-home-reply-sla");
+    const publicIdentityHeaders = [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ];
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchCalls.push({ url, init });
+      if (url.endsWith("/api/tasks/reply-sla-escalations")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            evaluated: 2,
+            created: 1,
+            policy: { overdue_hours: 48 },
+            tasks: [],
+          }),
+        });
+      }
+      if (url.endsWith("/api/emails/pending-replies?limit=3")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            emails: [
+              {
+                id: 301,
+                subject: "벤더 계약 답변 요청",
+                sender: "Seongho <user@naruon.ai>",
+                date: "2026-05-17T09:00:00Z",
+                snippet: "계약 검토 회신 SLA가 지나 작업 보드와 연결해야 합니다.",
+                requires_reply: true,
+              },
+            ],
+          }),
+        });
+      }
+      if (url.endsWith("/api/emails")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ emails: [] }),
+        });
+      }
+      if (url.endsWith("/api/tasks")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ([]),
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<WorkspaceHome forcedStartupView="dashboard" />);
+    });
+    await waitForCondition(() => container?.textContent?.includes("벤더 계약 답변 요청") ?? false);
+
+    const escalationButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="홈에서 보낸 메일 답변 SLA 티켓 생성"]',
+    );
+    expect(escalationButton).not.toBeNull();
+    await act(async () => {
+      escalationButton?.click();
+    });
+    await waitForCondition(() => container?.textContent?.includes("1개 SLA 티켓 생성") ?? false);
+
+    const escalationCall = fetchCalls.find((call) => call.url.endsWith("/api/tasks/reply-sla-escalations"));
+    expect(escalationCall).toBeDefined();
+    expect(escalationCall?.init?.method).toBe("POST");
+    expect(JSON.parse(String(escalationCall?.init?.body))).toEqual({ overdue_hours: 48 });
+    const headers = escalationCall?.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer signed-home-reply-sla");
+    for (const headerName of publicIdentityHeaders) {
+      expect(Object.keys(headers).some((key) => key.toLowerCase() === headerName)).toBe(false);
+    }
+    expect(container.textContent).toContain("1개 SLA 티켓 생성, 2개 답변 대기 확인");
+  });
 });

--- a/frontend/src/components/WorkspaceHome.tsx
+++ b/frontend/src/components/WorkspaceHome.tsx
@@ -63,6 +63,14 @@ type TaskItem = {
   updated_at: string;
 };
 
+type ReplySlaEscalationResponse = {
+  evaluated: number;
+  created: number;
+  policy: {
+    overdue_hours: number;
+  };
+};
+
 interface EmailItem {
   id: number;
   subject: string | null;
@@ -143,6 +151,8 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
   const { emails, pendingReplies, tasks, loading } = useDashboardData();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [currentTimestamp, setCurrentTimestamp] = useState('');
+  const [replySlaStatus, setReplySlaStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [replySlaMessage, setReplySlaMessage] = useState<string | null>(null);
   const settingsMenuId = 'workspace-startup-settings-menu';
   const unreadCount = emails.filter((e) => e.unread).length;
   const pendingReplyCount = pendingReplies.length;
@@ -164,6 +174,23 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
       default: return p;
     }
   };
+
+  const handleReplySlaEscalation = async () => {
+    setReplySlaStatus('loading');
+    setReplySlaMessage(null);
+    try {
+      const result = await apiClient.post<ReplySlaEscalationResponse>(
+        '/api/tasks/reply-sla-escalations',
+        { overdue_hours: 48 },
+      );
+      setReplySlaStatus('ready');
+      setReplySlaMessage(`${result.created}개 SLA 티켓 생성, ${result.evaluated}개 답변 대기 확인`);
+    } catch {
+      setReplySlaStatus('error');
+      setReplySlaMessage('답변 SLA 티켓 생성 실패');
+    }
+  };
+
   return (
     <section role="region" aria-label="홈 개요 대시보드" className="h-full overflow-y-auto bg-background p-4 sm:p-6">
       <div className="mx-auto max-w-7xl space-y-6">
@@ -236,7 +263,23 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
               <div>
                 <p className="break-keep font-bold">답변 대기 {loading ? '-' : pendingReplyCount}건</p>
                 <p className="text-xs text-muted-foreground mt-1">보낸 메일 중 회신 확인이 필요한 항목입니다.</p>
-                <a href="/mail?folder=sent" className="mt-2 inline-flex text-xs font-semibold text-primary hover:underline">보낸 메일 보기</a>
+                <div className="mt-2 flex flex-wrap items-center gap-3">
+                  <a href="/mail?folder=sent" className="inline-flex text-xs font-semibold text-primary hover:underline">보낸 메일 보기</a>
+                  <button
+                    type="button"
+                    aria-label="홈에서 보낸 메일 답변 SLA 티켓 생성"
+                    disabled={loading || pendingReplyCount === 0 || replySlaStatus === 'loading'}
+                    onClick={() => void handleReplySlaEscalation()}
+                    className="text-xs font-semibold text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground disabled:no-underline"
+                  >
+                    {replySlaStatus === 'loading' ? 'SLA 확인 중' : 'SLA 티켓 생성'}
+                  </button>
+                </div>
+                {replySlaMessage ? (
+                  <p role="status" className={`mt-2 text-xs font-semibold ${replySlaStatus === 'error' ? 'text-red-600' : 'text-muted-foreground'}`}>
+                    {replySlaMessage}
+                  </p>
+                ) : null}
               </div>
             </div>
             <div className="flex gap-4 pt-4 md:pl-6 md:pt-0">

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -124,7 +124,11 @@ test('renders Today dashboard pending reply lane with signed API headers', async
     return url.pathname === '/api/tasks/reply-sla-escalations' && request.method() === 'POST';
   });
   await mobileDashboard.getByRole('button', { name: '홈에서 보낸 메일 답변 SLA 티켓 생성' }).click();
-  expect((await mobileEscalationRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  const mobileEscalationHeaders = (await mobileEscalationRequest).headers();
+  expect(mobileEscalationHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(mobileEscalationHeaders[headerName]).toBeUndefined();
+  }
   await expect(mobileDashboard.getByText('1개 SLA 티켓 생성, 2개 답변 대기 확인')).toBeVisible();
   const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(mobileOverflow).toBeLessThanOrEqual(1);
@@ -454,7 +458,11 @@ test('creates pending reply SLA task escalation with signed API headers', async 
   await page.goto('/tasks');
   await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
   await page.getByRole('button', { name: '보낸 메일 답변 SLA 티켓 생성' }).click();
-  expect((await mobileEscalationRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  const mobileRequestHeaders = (await mobileEscalationRequest).headers();
+  expect(mobileRequestHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(mobileRequestHeaders[headerName]).toBeUndefined();
+  }
   await expect(page.getByRole('heading', { name: '답변 SLA 확인: 벤더 계약 답변 요청' })).toBeVisible();
   await page.getByRole('heading', { name: '답변 SLA 확인: 벤더 계약 답변 요청' }).scrollIntoViewIfNeeded();
   const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -92,6 +92,17 @@ test('renders Today dashboard pending reply lane with signed API headers', async
   await expect(desktopDashboard.getByText('답변 대기 메일')).toBeVisible();
   await expect(desktopDashboard.getByText('벤더 계약 답변 요청')).toBeVisible();
   await expect(desktopDashboard.getByText('예산 승인 후속 확인')).toBeVisible();
+  const desktopEscalationRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks/reply-sla-escalations' && request.method() === 'POST';
+  });
+  await desktopDashboard.getByRole('button', { name: '홈에서 보낸 메일 답변 SLA 티켓 생성' }).click();
+  const desktopEscalationHeaders = (await desktopEscalationRequest).headers();
+  expect(desktopEscalationHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(desktopEscalationHeaders[headerName]).toBeUndefined();
+  }
+  await expect(desktopDashboard.getByText('1개 SLA 티켓 생성, 2개 답변 대기 확인')).toBeVisible();
   const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(desktopOverflow).toBeLessThanOrEqual(1);
   await page.screenshot({ path: testInfo.outputPath('today-pending-replies-desktop.png'), fullPage: false });
@@ -108,6 +119,13 @@ test('renders Today dashboard pending reply lane with signed API headers', async
   await mobileDashboard.getByText('답변 대기 메일').scrollIntoViewIfNeeded();
   await expect(mobileDashboard.getByText('답변 대기 메일')).toBeVisible();
   await expect(mobileDashboard.getByText('벤더 계약 답변 요청')).toBeVisible();
+  const mobileEscalationRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks/reply-sla-escalations' && request.method() === 'POST';
+  });
+  await mobileDashboard.getByRole('button', { name: '홈에서 보낸 메일 답변 SLA 티켓 생성' }).click();
+  expect((await mobileEscalationRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  await expect(mobileDashboard.getByText('1개 SLA 티켓 생성, 2개 답변 대기 확인')).toBeVisible();
   const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(mobileOverflow).toBeLessThanOrEqual(1);
   await page.screenshot({ path: testInfo.outputPath('today-pending-replies-mobile-pending-list.png'), fullPage: false });
@@ -386,6 +404,75 @@ test('updates source-linked task ticket status with signed API headers', async (
   expect(taskScrollMetrics.maxScroll).toBeGreaterThan(0);
   expect(taskScrollMetrics.after).toBeGreaterThan(taskScrollMetrics.before);
   await page.screenshot({ path: testInfo.outputPath('task-ticket-status-mobile-scroll.png'), fullPage: false });
+});
+
+test('creates pending reply SLA task escalation with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-reply-sla-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  const desktopEscalationRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks/reply-sla-escalations' && request.method() === 'POST';
+  });
+
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await page.getByRole('button', { name: '보낸 메일 답변 SLA 티켓 생성' }).click();
+  const desktopRequest = await desktopEscalationRequest;
+  const desktopHeaders = desktopRequest.headers();
+  expect(desktopHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(desktopHeaders[headerName]).toBeUndefined();
+  }
+  expect(desktopRequest.postDataJSON()).toEqual({ overdue_hours: 48 });
+
+  await expect(page.getByText('1개 답변 SLA 티켓을 생성했습니다. 2개 대기 메일을 48시간 기준으로 확인했습니다.')).toBeVisible();
+  await expect(page.getByRole('heading', { name: '답변 SLA 확인: 벤더 계약 답변 요청' })).toBeVisible();
+  const escalatedDesktopTask = page.getByRole('article').filter({ hasText: '답변 SLA 확인: 벤더 계약 답변 요청' });
+  await expect(escalatedDesktopTask.getByText('차단 · 긴급')).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('reply-sla-escalation-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileEscalationRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks/reply-sla-escalations' && request.method() === 'POST';
+  });
+  await page.goto('/tasks');
+  await expect(page.getByRole('heading', { name: '할 일 추적' })).toBeVisible();
+  await page.getByRole('button', { name: '보낸 메일 답변 SLA 티켓 생성' }).click();
+  expect((await mobileEscalationRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  await expect(page.getByRole('heading', { name: '답변 SLA 확인: 벤더 계약 답변 요청' })).toBeVisible();
+  await page.getByRole('heading', { name: '답변 SLA 확인: 벤더 계약 답변 요청' }).scrollIntoViewIfNeeded();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('reply-sla-escalation-mobile.png'), fullPage: false });
+  const taskScrollMetrics = await page.locator('main').nth(1).evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(taskScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(taskScrollMetrics.after).toBeGreaterThan(taskScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('reply-sla-escalation-mobile-scroll.png'), fullPage: false });
 });
 
 test('creates self-sent knowledge WebDAV intent with signed API headers', async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -577,6 +577,28 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
       return;
     }
 
+    if (path === '/api/tasks/reply-sla-escalations' && request.method() === 'POST') {
+      await fulfillJson(route, {
+        evaluated: 2,
+        created: 1,
+        policy: { overdue_hours: 48 },
+        tasks: [
+          {
+            id: 'task-reply-followup',
+            title: '답변 SLA 확인: 벤더 계약 답변 요청',
+            status: 'blocked',
+            priority: 'urgent',
+            source_type: 'reply_sla',
+            source_email_id: '<sent-q2@example.com>',
+            related_thread_id: 'thread-sent-q2',
+            created_at: '2026-05-19T00:00:00Z',
+            updated_at: '2026-05-27T08:30:00Z',
+          },
+        ],
+      });
+      return;
+    }
+
     if (path === '/api/tasks/task-q2-owner' && request.method() === 'PATCH') {
       await fulfillJson(route, {
         id: 'task-q2-owner',


### PR DESCRIPTION
## Summary
- add signed `POST /api/tasks/reply-sla-escalations` that reuses server-authoritative pending reply detection and creates/updates source-linked `reply_sla` ticket tasks
- add Home and Tasks CTAs that call the endpoint with the stored `naruon_session_token` bearer session and no public identity headers
- document the slice in plans, README, AGENTS, and source-of-truth/writeback sovereignty docs

## Verification
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_tasks_api.py -q`
- `npx vitest run src/app/tasks/page.test.tsx src/components/WorkspaceHome.dashboard.test.tsx`
- `npm run lint -- src/components/TasksLayout.tsx src/components/WorkspaceHome.tsx src/app/tasks/page.test.tsx src/components/WorkspaceHome.dashboard.test.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts`
- `npm run typecheck`
- `PLAYWRIGHT_PORT=18189 npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts -g "pending reply|pending reply SLA task escalation" --project=desktop`
- `NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build`

## Browser evidence
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-desktop.png`
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-mobile-pending-list.png`
- `frontend/test-results/dashboard-branding-renders-49cc0-ane-with-signed-API-headers-desktop/today-pending-replies-mobile-scroll.png`
- `frontend/test-results/dashboard-branding-creates-71b4c-ion-with-signed-API-headers-desktop/reply-sla-escalation-desktop.png`
- `frontend/test-results/dashboard-branding-creates-71b4c-ion-with-signed-API-headers-desktop/reply-sla-escalation-mobile.png`
- `frontend/test-results/dashboard-branding-creates-71b4c-ion-with-signed-API-headers-desktop/reply-sla-escalation-mobile-scroll.png`

## Notes
- No new database tables or columns were added.
- PostgreSQL smoke path is included in `backend/tests/test_tasks_api.py` and skips only when local PostgreSQL is unavailable.
- Build reported 11 static-generation workers, not hundreds; the configured Next static generation environment was applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reply SLA escalation capability to automatically convert overdue pending sent-mail replies into ticket tasks with blocked/urgent priority and clean titles, accessible via new UI buttons in both home and tasks views.

* **Documentation**
  * Updated documentation with operational scope and implementation details for the reply SLA escalation feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->