### PR TITLE
Harden DAV registry writeback contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,14 @@
   must not reveal or be deterministically derived from account primary keys, and
   provider mutations remain future work until connector execution can enforce
   capability, consent, and ETag/If-Match checks.
+- DAV/WebDAV folder and write paths must not expose sequential folder primary
+  keys or claim provider write success from skeleton endpoints. Browser-visible
+  project folders use opaque `folder_uid` values, and `/dav` mutation methods
+  must fail closed until source, capability, credential, and ETag/If-Match
+  execution exists.
+- WebDAV folder listings must stay tenant-scoped by both `user_id` and signed
+  session `organization_id`; do not reintroduce user-only folder queries because
+  the same principal can exist in multiple B2B tenants.
 - Mobile workspace drawers must lock background body scroll while open and keep
   the drawer itself scrollable; responsive E2E screenshots should cover the open
   hamburger state after scrolling the drawer.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,10 @@ eligibility, reject legacy `target_account_id` payloads, and keep sequential
 `account_id` values internal-only. The Data workspace exposes the WebDAV source
 as an explicit selected target and treats `409` If-Match/ETag responses as
 conflicts instead of generic failures, so UI copy never implies a provider write
-overwrote customer-owned files.
+overwrote customer-owned files. Project folder listings are scoped by the signed
+session organization and expose opaque `project_folders.folder_uid` values
+instead of sequential `folder_id` values, and the `/dav` PUT skeleton fails
+closed until provider-backed source, capability, and ETag/If-Match checks exist.
 
 ## Operations and release docs
 

--- a/backend/api/dav.py
+++ b/backend/api/dav.py
@@ -59,6 +59,14 @@ async def dav_handler(request: Request, path: str):
         body = await request.body()
         safe_path = path.replace("\n", "").replace("\r", "")
         logger.info("DAV PUT received %s bytes at /%s", len(body), safe_path)
-        return Response(status_code=201)  # Created
+        return Response(
+            content=(
+                "Provider-backed DAV writeback is not implemented; use signed "
+                "writeback-intent APIs until source, capability, and "
+                "ETag/If-Match checks are enforced."
+            ),
+            media_type="text/plain",
+            status_code=501,
+        )
 
     return Response(content="Not Implemented", status_code=501)

--- a/backend/api/webdav.py
+++ b/backend/api/webdav.py
@@ -23,7 +23,7 @@ class WebdavAccountResponse(BaseModel):
     writeback_enabled: bool
 
 class ProjectFolderResponse(BaseModel):
-    folder_id: int
+    folder_uid: str
     project_name: str
     webdav_path: str
 
@@ -80,7 +80,11 @@ async def get_project_folders(
     db: AsyncSession = Depends(get_db),
 ):
     user_id = auth_context.user_id
-    return await webdav_service.get_project_folders_from_db(db, user_id)
+    return await webdav_service.get_project_folders_from_db(
+        db,
+        user_id,
+        auth_context.organization_id,
+    )
 
 @router.post("/writeback-intent", response_model=WritebackIntentResponse)
 async def get_webdav_writeback_intent(

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -375,7 +375,11 @@ class SenderRelationship(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
-    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    organization_id: Mapped[str | None] = mapped_column(
+        String,
+        index=True,
+        nullable=True,
+    )
     sender_email: Mapped[str] = mapped_column(String, index=True, nullable=False)
     parent_sender_email: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     source_message_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
@@ -491,7 +495,15 @@ class ProjectFolder(Base):
     __tablename__ = "project_folders"
 
     id: Mapped[int] = mapped_column("folder_id", primary_key=True)
+    folder_uid: Mapped[str] = mapped_column(
+        String,
+        unique=True,
+        index=True,
+        default=lambda: f"webdav_folder_{uuid.uuid4().hex}",
+        nullable=False,
+    )
     user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     project_name: Mapped[str] = mapped_column(String, index=True, nullable=False)
     webdav_path: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -65,6 +65,11 @@ def schema_backfill_sql():
             "ALTER TABLE webdav_accounts "
             "ADD COLUMN IF NOT EXISTS writeback_enabled boolean NOT NULL DEFAULT false"
         ),
+        text("ALTER TABLE project_folders ADD COLUMN IF NOT EXISTS folder_uid varchar"),
+        text(
+            "ALTER TABLE project_folders "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
         text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_username varchar"),
         text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_password varchar"),
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
@@ -123,6 +128,23 @@ def schema_backfill_sql():
             "CREATE INDEX IF NOT EXISTS ix_webdav_accounts_organization_id "
             "ON webdav_accounts (organization_id)"
         ),
+        text(
+            "UPDATE project_folders "
+            "SET folder_uid = 'webdav_folder_' || md5("
+            "random()::text || ':' || clock_timestamp()::text || ':' || "
+            "user_id || ':' || project_name || ':' || webdav_path"
+            ") "
+            "WHERE folder_uid IS NULL OR folder_uid = ''"
+        ),
+        text("ALTER TABLE project_folders ALTER COLUMN folder_uid SET NOT NULL"),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_project_folders_folder_uid "
+            "ON project_folders (folder_uid)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_project_folders_owner_scope "
+            "ON project_folders (user_id, organization_id)"
+        ),
         text("ALTER TABLE emails DROP CONSTRAINT IF EXISTS emails_message_id_key"),
         text(
             "ALTER TABLE sender_relationships "
@@ -152,6 +174,14 @@ def schema_backfill_sql():
                     "SET user_id = :user_id, "
                     "organization_id = :organization_id "
                     "WHERE user_id IS NULL AND organization_id IS NULL"
+                ).bindparams(
+                    user_id=backfill_user_id,
+                    organization_id=backfill_organization_id,
+                ),
+                text(
+                    "UPDATE project_folders "
+                    "SET organization_id = :organization_id "
+                    "WHERE user_id = :user_id AND organization_id IS NULL"
                 ).bindparams(
                     user_id=backfill_user_id,
                     organization_id=backfill_organization_id,

--- a/backend/services/caldav_service.py
+++ b/backend/services/caldav_service.py
@@ -41,23 +41,31 @@ class CalDavService:
     def __init__(self):
         pass
         
-    def determine_writeback_target(self, task_context: Dict[str, Any], connected_accounts: list) -> str:
+    def determine_writeback_target(
+        self,
+        task_context: Dict[str, Any],
+        connected_accounts: list,
+    ) -> str | None:
         """
-        Determines the most appropriate CalDav account to write back to,
-        based on the context of the task (e.g., if it originated from a company email).
+        Determine the opaque customer-owned CalDAV source to write back to.
         """
-        # Basic ontology/context mock logic
+        eligible_sources = [
+            account
+            for account in connected_accounts
+            if account.get("writeback_enabled") is True
+            and isinstance(account.get("source_id"), str)
+            and account.get("source_id")
+        ]
         source_email = task_context.get("source_email", "")
         if isinstance(source_email, str) and "@" in source_email:
             source_domain = source_email.strip().lower().rsplit("@", 1)[-1]
-            for account in connected_accounts:
+            for account in eligible_sources:
                 account_domain = str(account.get("domain", "")).lower().strip()
                 if account_domain and source_domain == account_domain:
-                    return account.get("account_id")
+                    return account["source_id"]
                 
-        # Fallback to the primary account
-        if connected_accounts:
-            return connected_accounts[0].get("account_id")
-        return "default_system_caldav"
+        if eligible_sources:
+            return eligible_sources[0]["source_id"]
+        return None
 
 caldav_service = CalDavService()

--- a/backend/services/webdav_service.py
+++ b/backend/services/webdav_service.py
@@ -39,12 +39,12 @@ class WebDavService:
         self._mock_folders = {
             "demo_user": [
                 {
-                    "folder_id": 1,
+                    "folder_uid": "webdav_folder_demo_roadmap",
                     "project_name": "Naruon Roadmap 2026",
                     "webdav_path": "/Projects/Naruon_Roadmap_2026"
                 },
                 {
-                    "folder_id": 2,
+                    "folder_uid": "webdav_folder_demo_marketing",
                     "project_name": "Marketing Assets",
                     "webdav_path": "/Projects/Marketing_Assets"
                 }
@@ -96,12 +96,18 @@ class WebDavService:
         self,
         session: AsyncSession,
         user_id: str,
+        organization_id: str | None,
     ) -> List[Dict[str, Any]]:
-        stmt = select(ProjectFolder).where(ProjectFolder.user_id == user_id)
+        stmt = select(ProjectFolder).where(
+            ProjectFolder.user_id == user_id,
+            ProjectFolder.organization_id == organization_id
+            if organization_id is not None
+            else ProjectFolder.organization_id.is_(None),
+        )
         result = await session.execute(stmt)
         return [
             {
-                "folder_id": folder.id,
+                "folder_uid": folder.folder_uid,
                 "project_name": folder.project_name,
                 "webdav_path": folder.webdav_path,
             }

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -10,6 +10,7 @@ from scripts.bootstrap_db import schema_backfill_sql
 from db.models import (
     CalendarWritebackSource,
     ConnectorSignalEvent,
+    ProjectFolder,
     SenderRelationship,
     TicketTask,
     WebdavAccount,
@@ -147,6 +148,16 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
         for statement in statements
     )
     assert any(
+        "alter table project_folders add column if not exists folder_uid"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table project_folders add column if not exists organization_id"
+        in statement
+        for statement in statements
+    )
+    assert any(
         "update webdav_accounts set source_uid" in statement
         and "webdav_src_" in statement
         and "md5" in statement
@@ -168,6 +179,29 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
     assert any(
         "create index if not exists ix_webdav_accounts_organization_id"
         in statement
+        for statement in statements
+    )
+    assert any(
+        "update project_folders set folder_uid" in statement
+        and "webdav_folder_" in statement
+        and "md5" in statement
+        and "random()::text" in statement
+        and "clock_timestamp()::text" in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table project_folders alter column folder_uid set not null"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "create unique index if not exists uq_project_folders_folder_uid"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "create index if not exists ix_project_folders_owner_scope" in statement
+        and "user_id, organization_id" in statement
         for statement in statements
     )
     assert any(
@@ -326,6 +360,15 @@ def test_webdav_account_model_exposes_opaque_source_uid():
     assert WebdavAccount.__table__.c.source_uid.nullable is False
     assert WebdavAccount.__table__.c.source_uid.unique is True
     assert WebdavAccount.__table__.c.writeback_enabled.nullable is False
+
+
+def test_project_folder_model_exposes_opaque_folder_uid():
+    column_names = {column.name for column in ProjectFolder.__table__.columns}
+
+    assert "folder_uid" in column_names
+    assert "organization_id" in column_names
+    assert ProjectFolder.__table__.c.folder_uid.nullable is False
+    assert ProjectFolder.__table__.c.folder_uid.unique is True
 
 
 def test_connector_signal_event_model_uses_two_word_names():

--- a/backend/tests/test_caldav.py
+++ b/backend/tests/test_caldav.py
@@ -3,26 +3,64 @@ from services.caldav_service import caldav_service
 
 def test_determine_writeback_target():
     connected_accounts = [
-        {"account_id": "account1", "domain": "company.com"},
-        {"account_id": "account2", "domain": "personal.com"}
+        {
+            "source_id": "caldav_src_company",
+            "domain": "company.com",
+            "writeback_enabled": True,
+        },
+        {
+            "source_id": "caldav_src_personal",
+            "domain": "personal.com",
+            "writeback_enabled": True,
+        },
     ]
     
     # Should match company.com
     task_context_1 = {"source_email": "boss@company.com"}
     target_1 = caldav_service.determine_writeback_target(task_context_1, connected_accounts)
-    assert target_1 == "account1"
+    assert target_1 == "caldav_src_company"
     
     # Should fallback to primary
     task_context_2 = {"source_email": "friend@other.com"}
     target_2 = caldav_service.determine_writeback_target(task_context_2, connected_accounts)
-    assert target_2 == "account1"
+    assert target_2 == "caldav_src_company"
 
     # Should not match substring domain collisions
     task_context_3 = {"source_email": "attacker@evilcompany.com"}
     target_3 = caldav_service.determine_writeback_target(task_context_3, connected_accounts)
-    assert target_3 == "account1"  # fallback, not domain match
+    assert target_3 == "caldav_src_company"  # fallback, not domain match
 
 def test_determine_writeback_target_no_accounts():
     task_context = {"source_email": "boss@company.com"}
     target = caldav_service.determine_writeback_target(task_context, [])
-    assert target == "default_system_caldav"
+    assert target is None
+
+
+def test_determine_writeback_target_ignores_internal_account_ids():
+    task_context = {"source_email": "boss@company.com"}
+    connected_accounts = [
+        {
+            "account_id": "account1",
+            "domain": "company.com",
+            "writeback_enabled": True,
+        },
+    ]
+
+    target = caldav_service.determine_writeback_target(task_context, connected_accounts)
+
+    assert target is None
+
+
+def test_determine_writeback_target_requires_writeback_eligibility():
+    task_context = {"source_email": "boss@company.com"}
+    connected_accounts = [
+        {
+            "source_id": "caldav_src_company",
+            "domain": "company.com",
+            "writeback_enabled": False,
+        },
+    ]
+
+    target = caldav_service.determine_writeback_target(task_context, connected_accounts)
+
+    assert target is None

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -65,4 +65,6 @@ def test_dav_put(dev_auth_dependency_overrides):
             content=b"BEGIN:VCALENDAR\r\nEND:VCALENDAR",
             headers=AUTH_HEADERS,
         )
-        assert response.status_code == 201
+        assert response.status_code == 501
+        assert "Provider-backed DAV writeback is not implemented" in response.text
+        assert "etag" not in {header.lower() for header in response.headers}

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -73,11 +73,19 @@ def stub_webdav_service(monkeypatch):
             }
         ] if user_id == "alice" else []
 
-    async def fake_folders(db, user_id):
+    async def fake_folders(db, user_id, organization_id=None):
         return [
-            {"folder_id": 1, "project_name": "Naruon Roadmap 2026", "webdav_path": "/Projects/Naruon_Roadmap_2026"},
-            {"folder_id": 2, "project_name": "Marketing Assets", "webdav_path": "/Projects/Marketing_Assets"}
-        ] if user_id == "alice" else []
+            {
+                "folder_uid": "webdav_folder_demo_roadmap",
+                "project_name": "Naruon Roadmap 2026",
+                "webdav_path": "/Projects/Naruon_Roadmap_2026",
+            },
+            {
+                "folder_uid": "webdav_folder_demo_marketing",
+                "project_name": "Marketing Assets",
+                "webdav_path": "/Projects/Marketing_Assets",
+            },
+        ] if user_id == "alice" and organization_id == "org-acme" else []
 
     async def fake_intent(db, user_id, organization_id=None, target_source_id=None):
         return webdav_service.determine_webdav_writeback_intent_from_accounts(
@@ -228,8 +236,10 @@ def test_get_project_folders(auth_client):
     assert response.status_code == 200, response.text
     body = response.json()
     assert len(body) == 2
+    assert body[0]["folder_uid"] == "webdav_folder_demo_roadmap"
     assert body[0]["project_name"] == "Naruon Roadmap 2026"
     assert body[1]["project_name"] == "Marketing Assets"
+    assert "folder_id" not in body[0]
 
 def test_get_webdav_writeback_intent(auth_client):
     response = auth_client.post("/api/webdav/writeback-intent", json={})
@@ -671,6 +681,195 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
     assert body["server_url"] == "https://real-webdav.naruon.net"
     assert body["provenance"] == "server-authoritative"
     assert "account_id" not in body
+
+
+@pytest.mark.asyncio
+async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
+    folder_uid = f"webdav_folder_{uuid.uuid4().hex[:24]}"
+    rival_folder_uid = f"webdav_folder_{uuid.uuid4().hex[:24]}"
+    folder_id = 10_000 + (uuid.uuid4().int % 1_000_000)
+    rival_folder_id = 10_000 + (uuid.uuid4().int % 1_000_000)
+    user_id = f"webdav-folder-{uuid.uuid4().hex[:12]}"
+    monkeypatch.setattr(
+        webdav_service,
+        "get_project_folders_from_db",
+        WebDavService.get_project_folders_from_db.__get__(
+            webdav_service,
+            WebDavService,
+        ),
+    )
+
+    engine = create_async_engine(settings.DATABASE_URL)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS project_folders (
+                        folder_id INTEGER PRIMARY KEY,
+                        folder_uid VARCHAR UNIQUE NOT NULL,
+                        user_id VARCHAR NOT NULL,
+                        organization_id VARCHAR,
+                        project_name VARCHAR NOT NULL,
+                        webdav_path VARCHAR NOT NULL,
+                        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    "ALTER TABLE project_folders "
+                    "ADD COLUMN IF NOT EXISTS folder_uid VARCHAR"
+                )
+            )
+            await conn.execute(
+                text(
+                    "ALTER TABLE project_folders "
+                    "ADD COLUMN IF NOT EXISTS organization_id VARCHAR"
+                )
+            )
+            await conn.execute(
+                text(
+                    "DELETE FROM project_folders "
+                    "WHERE folder_uid IN (:folder_uid, :rival_folder_uid) "
+                    "OR folder_id IN (:folder_id, :rival_folder_id)"
+                ),
+                {
+                    "folder_uid": folder_uid,
+                    "rival_folder_uid": rival_folder_uid,
+                    "folder_id": folder_id,
+                    "rival_folder_id": rival_folder_id,
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO project_folders (
+                        folder_id,
+                        folder_uid,
+                        user_id,
+                        organization_id,
+                        project_name,
+                        webdav_path
+                    )
+                    VALUES (
+                        :folder_id,
+                        :folder_uid,
+                        :user_id,
+                        :organization_id,
+                        :project_name,
+                        :webdav_path
+                    )
+                    """
+                ),
+                {
+                    "folder_id": folder_id,
+                    "folder_uid": folder_uid,
+                    "user_id": user_id,
+                    "organization_id": "org-acme",
+                    "project_name": "Source-backed Folder",
+                    "webdav_path": "/Projects/Source_Backed_Folder",
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO project_folders (
+                        folder_id,
+                        folder_uid,
+                        user_id,
+                        organization_id,
+                        project_name,
+                        webdav_path
+                    )
+                    VALUES (
+                        :folder_id,
+                        :folder_uid,
+                        :user_id,
+                        :organization_id,
+                        :project_name,
+                        :webdav_path
+                    )
+                    """
+                ),
+                {
+                    "folder_id": rival_folder_id,
+                    "folder_uid": rival_folder_uid,
+                    "user_id": user_id,
+                    "organization_id": "org-rival",
+                    "project_name": "Rival Folder",
+                    "webdav_path": "/Projects/Rival_Folder",
+                },
+            )
+    except (
+        ConnectionRefusedError,
+        OSError,
+        OperationalError,
+        asyncpg.CannotConnectNowError,
+        asyncpg.InvalidAuthorizationSpecificationError,
+        asyncpg.InvalidCatalogNameError,
+        asyncpg.InvalidPasswordError,
+    ):
+        await engine.dispose()
+        pytest.skip("PostgreSQL smoke path unavailable")
+    except Exception:
+        await engine.dispose()
+        raise
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_real_db():
+        async with session_factory() as session:
+            yield session
+
+    previous_override = app.dependency_overrides.pop(get_auth_context, None)
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    app.dependency_overrides[get_db] = override_real_db
+    token = _signed_session_token(
+        _valid_session_payload(sub=user_id, org="org-acme", workspace="workspace-org-acme")
+    )
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as client:
+            response = await client.get("/api/webdav/folders")
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        if previous_override is not None:
+            app.dependency_overrides[get_auth_context] = previous_override
+        app.dependency_overrides.pop(get_db, None)
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "DELETE FROM project_folders "
+                    "WHERE folder_uid IN (:folder_uid, :rival_folder_uid) "
+                    "OR folder_id IN (:folder_id, :rival_folder_id)"
+                ),
+                {
+                    "folder_uid": folder_uid,
+                    "rival_folder_uid": rival_folder_uid,
+                    "folder_id": folder_id,
+                    "rival_folder_id": rival_folder_id,
+                },
+            )
+        await engine.dispose()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body == [
+        {
+            "folder_uid": folder_uid,
+            "project_name": "Source-backed Folder",
+            "webdav_path": "/Projects/Source_Backed_Folder",
+        }
+    ]
+    assert "folder_id" not in body[0]
 
 
 @pytest.mark.asyncio

--- a/docs/operations/source-of-truth-and-writeback-sovereignty.md
+++ b/docs/operations/source-of-truth-and-writeback-sovereignty.md
@@ -50,9 +50,13 @@ ticket tasks, DB-backed CalDAV intent source selection through opaque
 through a signed source-registry read, and WebDAV intent selection through
 opaque, organization-scoped `webdav_accounts.source_uid` rows with persisted
 writeback eligibility; sequential `webdav_accounts.account_id` values remain
-internal and are not browser-visible source identifiers. Real CalDAV/WebDAV
-mutation, ETag-aware WebDAV/Notes provider execution for synthesized knowledge,
-POP3 runtime sync, durable
+internal and are not browser-visible source identifiers. WebDAV project folders
+now expose opaque `project_folders.folder_uid` values, scope listing by the
+signed-session `user_id` and `organization_id`, and keep sequential folder
+primary keys internal. `/dav` mutation methods fail closed until provider
+execution can enforce source, capability, credential, and ETag/If-Match checks.
+Real CalDAV/WebDAV mutation, ETag-aware WebDAV/Notes provider execution for
+synthesized knowledge, POP3 runtime sync, durable
 reply-tracking notifications, configurable SLA policy storage, and source-id
 filtered sender graph views remain episode work and must preserve this registry
 boundary.

--- a/docs/plans/2026-05-28-dav-registry-hardening.md
+++ b/docs/plans/2026-05-28-dav-registry-hardening.md
@@ -1,0 +1,43 @@
+# DAV Registry Hardening Phase
+
+## Goal
+
+Stop legacy DAV paths from implying that Naruon owns customer calendar or file
+state. Naruon remains a signed client/control plane over customer-owned
+CalDAV/CardDAV/WebDAV sources.
+
+## Implemented Slice
+
+- Legacy `CalDavService.determine_writeback_target()` now returns only opaque,
+  writeback-eligible `source_id` values and returns `None` when no eligible
+  customer source exists. It no longer returns sequential `account_id` values or
+  the synthetic `default_system_caldav` fallback.
+- `project_folders.folder_uid` is added as the browser-visible WebDAV folder
+  identifier. `/api/webdav/folders`, backend mocks, frontend Data types, unit
+  mocks, and E2E mocks now use `folder_uid` and stop exposing `folder_id`.
+- `project_folders.organization_id` is added and folder lookup is scoped by both
+  signed-session `user_id` and `organization_id`, closing the Strix-confirmed
+  cross-tenant folder listing finding for principals reused across B2B tenants.
+- `/dav` `PUT` now fails closed with `501` until provider-backed source
+  selection, capability checks, credential execution, and ETag/If-Match
+  semantics exist. It does not fabricate `201 Created` or ETag headers.
+- README, AGENTS, and source-of-truth docs record the regression guardrail so
+  copied examples do not reintroduce internal id leaks or fake DAV writes.
+
+## Verification
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest \
+  backend/tests/test_caldav.py \
+  backend/tests/test_dav_api.py \
+  backend/tests/test_webdav_api.py \
+  backend/tests/test_bootstrap_db.py -q
+
+npm test -- src/app/data/page.test.tsx
+npm run lint -- src/components/DataLayout.tsx src/app/data/page.test.tsx tests/e2e/helpers.ts
+npm run typecheck
+```
+
+The WebDAV folder smoke test includes a real PostgreSQL path when the configured
+database is reachable; otherwise it skips with the existing PostgreSQL-unavailable
+guard used by other WebDAV smoke tests.

--- a/docs/plans/2026-05-28-dav-source-selection-conflict-ui.md
+++ b/docs/plans/2026-05-28-dav-source-selection-conflict-ui.md
@@ -45,11 +45,11 @@ workspace/control plane over customer-owned CalDAV/CardDAV/WebDAV providers.
 - Real connector/provider write execution remains out of scope until the
   connector can enforce consent, capability, credential reference, remote href,
   and ETag/If-Match checks server-side.
-- `CaldavAccount` and `/dav` still need deeper registry consolidation so legacy
-  account ids and skeleton PUT behavior cannot be mistaken for a complete
-  provider write path.
-- WebDAV project folder responses still need opaque folder ids in a backend
-  slice; this UI phase did not change that API contract.
+- `CaldavAccount` still needs deeper credential/account registry consolidation
+  with `calendar_writeback_sources`; this UI phase did not add provider
+  execution.
+- WebDAV project folder opaque ids and `/dav` fail-closed mutation behavior are
+  handled in `2026-05-28-dav-registry-hardening.md`.
 
 ## Verification
 

--- a/frontend/src/app/data/page.test.tsx
+++ b/frontend/src/app/data/page.test.tsx
@@ -56,7 +56,7 @@ function mockWebdavFetch() {
     if (path === "/api/webdav/folders") {
       return jsonResponse([
         {
-          folder_id: 1,
+          folder_uid: "webdav_folder_roadmap",
           project_name: "Naruon Roadmap 2026",
           webdav_path: "/Projects/Naruon_Roadmap_2026",
         },
@@ -134,6 +134,7 @@ describe("DataPage", () => {
     expect(container.textContent).toContain("로컬 캐시");
     expect(container.textContent).toContain("WebDAV writeback intent 승인");
     expect(container.textContent).toContain("etag=etag-webdav-primary");
+    expect(container.textContent).toContain("webdav_folder_roadmap");
   });
 
   it("creates a signed customer-owned WebDAV writeback intent", async () => {

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -81,7 +81,7 @@ export function DataLayout() {
   }
   
   interface ProjectFolder {
-    folder_id: number;
+    folder_uid: string;
     project_name: string;
     webdav_path: string;
   }
@@ -404,11 +404,12 @@ export function DataLayout() {
                 </div>
                 <div className="p-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
                   {projectFolders.length > 0 ? projectFolders.map(folder => (
-                    <div key={folder.folder_id} className="border border-border rounded-xl p-4 bg-background hover:bg-secondary/20 transition-colors">
+                    <div key={folder.folder_uid} className="border border-border rounded-xl p-4 bg-background hover:bg-secondary/20 transition-colors">
                       <div className="flex items-center gap-3 mb-2">
                         <FolderOpen className="size-5 text-primary" />
                         <span className="font-bold truncate">{folder.project_name}</span>
                       </div>
+                      <p className="mb-2 break-all font-mono text-[11px] font-semibold text-primary">{folder.folder_uid}</p>
                       <p className="text-xs text-muted-foreground break-all">{folder.webdav_path}</p>
                     </div>
                   )) : (

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -415,12 +415,12 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
     if (path === '/api/webdav/folders' && request.method() === 'GET') {
       await fulfillJson(route, [
         {
-          folder_id: 1,
+          folder_uid: 'webdav_folder_roadmap',
           project_name: 'Naruon Roadmap 2026',
           webdav_path: '/Projects/Naruon_Roadmap_2026',
         },
         {
-          folder_id: 2,
+          folder_uid: 'webdav_folder_marketing',
           project_name: 'Marketing Assets',
           webdav_path: '/Projects/Marketing_Assets',
         },


### PR DESCRIPTION
## Summary
- return only opaque, writeback-eligible CalDAV `source_id` values and remove legacy `account_id` / `default_system_caldav` fallback selection
- expose WebDAV project folders with browser-visible `folder_uid` values instead of sequential `folder_id` values across API, Data UI, unit mocks, and E2E mocks
- make raw `/dav` `PUT` fail closed with `501` until provider source, capability, credential, and ETag/If-Match execution exists
- update README, AGENTS, operations docs, and plans with the DAV/WebDAV regression guardrail

## Verification
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_caldav.py backend/tests/test_dav_api.py backend/tests/test_webdav_api.py backend/tests/test_bootstrap_db.py -q` -> 41 passed, 4 skipped
- `npm test -- src/app/data/page.test.tsx` -> 5 passed
- `npm run lint -- src/components/DataLayout.tsx src/app/data/page.test.tsx tests/e2e/helpers.ts`
- `npm run typecheck`
- `POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build` -> build passed; static generation used 11 workers
- production `next start -p 18208` + `env -u NO_COLOR -u FORCE_COLOR LIVE_BASE_URL=http://127.0.0.1:18208 PLAYWRIGHT_PORT=18208 npm run test:e2e -- tests/e2e/dashboard-branding.spec.ts --project=desktop -g "data WebDAV"` -> 1 passed
- production `next start -p 18208` + `env -u NO_COLOR -u FORCE_COLOR LIVE_BASE_URL=http://127.0.0.1:18208 PLAYWRIGHT_PORT=18208 npm run test:e2e -- tests/e2e/mobile-hamburger.spec.ts --project=desktop` -> 1 passed
- manually inspected screenshots: Data WebDAV desktop, Data WebDAV mobile, Data WebDAV mobile scroll, mobile hamburger open, mobile hamburger scrolled
- `git diff --check`

## Notes
Naruon remains a signed client/control plane over customer-owned CalDAV/WebDAV providers. This PR does not add provider-backed DAV writes; it prevents legacy paths from implying successful provider writes before source, capability, and conflict checks exist.
