### PR TITLE
Scope provider connection onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@
   generic inbox fixtures or static copy. Tests and E2E mocks must verify the
   stored `naruon_session_token` bearer path and must not add public identity
   headers.
+- TenantConfig/provider account settings must be scoped by signed-session
+  `user_id` and `organization_id`; do not query provider credentials or API keys
+  by `user_id` only. Frontend Settings onboarding must use bearer-session API
+  calls for account config, CalDAV/WebDAV source readiness, and runner token
+  rotation, and mocks must not reintroduce public identity headers.
 - Reply-wait task escalation must reuse the server-authoritative pending reply
   path, create or update source-linked `reply_sla` ticket tasks by opaque task
   id, and sanitize generated task titles from email subjects before persistence.

--- a/README.md
+++ b/README.md
@@ -257,10 +257,15 @@ API client strips public identity headers such as `X-User-Id` and
 `X-Organization-Id`, including group and dev-token variants, rather than
 forwarding development identity fallbacks.
 Settings connected-account workflow reads and saves `/api/accounts/config`
-through the same signed-session path. It displays SMTP, IMAP, POP3, and OAuth
-provider state from masked response fields, preserves stored credential secrets
-when the user leaves replacement fields blank, and keeps Naruon framed as a web
-client/relay proxy rather than an email host.
+through the same signed-session path and scopes provider settings by the signed
+`user_id + organization_id` owner. It displays SMTP, IMAP, POP3, OAuth,
+CalDAV/CardDAV, and WebDAV readiness from masked account fields and source
+registry APIs, preserves stored credential secrets when the user leaves
+replacement fields blank, and keeps Naruon framed as a web client/relay proxy
+rather than an email host. Settings also exposes organization-admin
+self-hosted connector token rotation through `/api/runner-config/rotate`; the
+one-time token is shown only after rotation and is not included in the connector
+manifest.
 
 Email-derived work is tracked through `/api/tasks/from-email`. Created ticket
 tasks retain an internal source-email foreign key, expose source message/thread

--- a/backend/api/accounts.py
+++ b/backend/api/accounts.py
@@ -1,12 +1,14 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
 
 from db.session import get_db
-from db.models import TenantConfig
 from api.auth import AuthContext, get_auth_context
 from api.tenant_config import validate_mail_config_update
+from services.tenant_config_scope import (
+    get_scoped_tenant_config,
+    new_scoped_tenant_config,
+)
 
 router = APIRouter(prefix="/api/accounts", tags=["accounts"])
 
@@ -46,21 +48,8 @@ class TenantConfigResponse(BaseModel):
     oauth_redirect_uri: str | None
     has_oauth_client_secret: bool
 
-@router.get("/config", response_model=TenantConfigResponse)
-async def get_tenant_config(
-    db: AsyncSession = Depends(get_db),
-    auth_ctx: AuthContext = Depends(get_auth_context)
-):
-    stmt = select(TenantConfig).where(TenantConfig.user_id == auth_ctx.user_id)
-    result = await db.execute(stmt)
-    config = result.scalar_one_or_none()
-    
-    if not config:
-        config = TenantConfig(user_id=auth_ctx.user_id)
-        db.add(config)
-        await db.commit()
-        await db.refresh(config)
-        
+
+def _tenant_config_response(config) -> TenantConfigResponse:
     return TenantConfigResponse(
         user_id=config.user_id,
         smtp_server=config.smtp_server,
@@ -80,18 +69,42 @@ async def get_tenant_config(
         has_oauth_client_secret=bool(config.oauth_client_secret),
     )
 
+
+def _empty_tenant_config_response(user_id: str) -> TenantConfigResponse:
+    config = new_scoped_tenant_config(user_id=user_id, organization_id=None)
+    return _tenant_config_response(config)
+
+@router.get("/config", response_model=TenantConfigResponse)
+async def get_tenant_config(
+    db: AsyncSession = Depends(get_db),
+    auth_ctx: AuthContext = Depends(get_auth_context)
+):
+    config = await get_scoped_tenant_config(
+        db,
+        auth_ctx.user_id,
+        auth_ctx.organization_id,
+    )
+    if not config:
+        return _empty_tenant_config_response(auth_ctx.user_id)
+
+    return _tenant_config_response(config)
+
 @router.put("/config", response_model=TenantConfigResponse)
 async def update_tenant_config(
     update_data: TenantConfigUpdate,
     db: AsyncSession = Depends(get_db),
     auth_ctx: AuthContext = Depends(get_auth_context)
 ):
-    stmt = select(TenantConfig).where(TenantConfig.user_id == auth_ctx.user_id)
-    result = await db.execute(stmt)
-    config = result.scalar_one_or_none()
-    
+    config = await get_scoped_tenant_config(
+        db,
+        auth_ctx.user_id,
+        auth_ctx.organization_id,
+    )
     if not config:
-        config = TenantConfig(user_id=auth_ctx.user_id)
+        config = new_scoped_tenant_config(
+            user_id=auth_ctx.user_id,
+            organization_id=auth_ctx.organization_id,
+        )
         db.add(config)
         
     update_dict = update_data.model_dump(exclude_unset=True)
@@ -101,22 +114,5 @@ async def update_tenant_config(
         
     await db.commit()
     await db.refresh(config)
-    
-    return TenantConfigResponse(
-        user_id=config.user_id,
-        smtp_server=config.smtp_server,
-        smtp_port=config.smtp_port,
-        smtp_username=config.smtp_username,
-        has_smtp_password=bool(config.smtp_password),
-        imap_server=config.imap_server,
-        imap_port=config.imap_port,
-        imap_username=config.imap_username,
-        has_imap_password=bool(config.imap_password),
-        pop3_server=config.pop3_server,
-        pop3_port=config.pop3_port,
-        pop3_username=config.pop3_username,
-        has_pop3_password=bool(config.pop3_password),
-        oauth_client_id=config.oauth_client_id,
-        oauth_redirect_uri=config.oauth_redirect_uri,
-        has_oauth_client_secret=bool(config.oauth_client_secret),
-    )
+
+    return _tenant_config_response(config)

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import or_, select
 from db.session import get_db
-from db.models import Email, TenantConfig
+from db.models import Email
 from pydantic import BaseModel, EmailStr, Field
 import datetime
 from typing import Literal
@@ -22,7 +22,8 @@ from services.email_dedupe_service import (
     email_strong_fingerprint,
 )
 import logging
-from api.auth import AuthContext, get_auth_context, get_current_user
+from api.auth import AuthContext, get_auth_context
+from services.tenant_config_scope import get_scoped_tenant_config
 
 logger = logging.getLogger(__name__)
 
@@ -158,8 +159,10 @@ async def get_emails(
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(get_auth_context),
 ):
-    tenant_config = await db.scalar(
-        select(TenantConfig).where(TenantConfig.user_id == auth_context.user_id)
+    tenant_config = await get_scoped_tenant_config(
+        db,
+        auth_context.user_id,
+        auth_context.organization_id,
     )
     user_addresses = configured_email_addresses(tenant_config)
     candidate_window = min(max(limit * 10, 200), 2000)
@@ -415,13 +418,13 @@ class SendEmailRequest(BaseModel):
 async def send_email_endpoint(
     request: SendEmailRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(get_current_user),
+    auth_context: AuthContext = Depends(get_auth_context),
 ):
-    target_user_id = current_user
-
     try:
-        tenant_config = await db.scalar(
-            select(TenantConfig).where(TenantConfig.user_id == target_user_id)
+        tenant_config = await get_scoped_tenant_config(
+            db,
+            auth_context.user_id,
+            auth_context.organization_id,
         )
 
         if (

--- a/backend/api/llm.py
+++ b/backend/api/llm.py
@@ -1,17 +1,16 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
 from fastapi import Depends
 from db.session import get_db
-from db.models import TenantConfig, LLMProvider
-from api.auth import get_current_user
+from api.auth import AuthContext, get_auth_context
 from services.llm_service import (
     extract_todos_and_summary,
     draft_reply,
     ExtractionResult,
 )
 from core.exceptions import LLMServiceError
+from services.tenant_config_scope import get_scoped_tenant_config
 
 router = APIRouter(prefix="/api/llm")
 
@@ -26,16 +25,25 @@ class DraftRequest(BaseModel):
 
 
 @router.post("/summarize", response_model=ExtractionResult)
-async def summarize_endpoint(request: SummarizeRequest, user_id: str | None = None, db: AsyncSession = Depends(get_db), current_user: str = Depends(get_current_user)):
-    if user_id and user_id != current_user:
+async def summarize_endpoint(
+    request: SummarizeRequest,
+    user_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+):
+    if user_id and user_id != auth_context.user_id:
         raise HTTPException(status_code=403, detail="Not authorized")
-    target_user_id = user_id or current_user
+    target_user_id = user_id or auth_context.user_id
 
     try:
-        tenant_config = await db.scalar(select(TenantConfig).where(TenantConfig.user_id == target_user_id))
+        tenant_config = await get_scoped_tenant_config(
+            db,
+            target_user_id,
+            auth_context.organization_id,
+        )
         if not tenant_config or not tenant_config.openai_api_key:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")
-            
+
         openai_api_key = tenant_config.openai_api_key
         return await extract_todos_and_summary(request.email_body, openai_api_key)
     except LLMServiceError:
@@ -53,16 +61,25 @@ async def summarize_endpoint(request: SummarizeRequest, user_id: str | None = No
 
 
 @router.post("/draft")
-async def draft_endpoint(request: DraftRequest, user_id: str | None = None, db: AsyncSession = Depends(get_db), current_user: str = Depends(get_current_user)):
-    if user_id and user_id != current_user:
+async def draft_endpoint(
+    request: DraftRequest,
+    user_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+):
+    if user_id and user_id != auth_context.user_id:
         raise HTTPException(status_code=403, detail="Not authorized")
-    target_user_id = user_id or current_user
+    target_user_id = user_id or auth_context.user_id
 
     try:
-        tenant_config = await db.scalar(select(TenantConfig).where(TenantConfig.user_id == target_user_id))
+        tenant_config = await get_scoped_tenant_config(
+            db,
+            target_user_id,
+            auth_context.organization_id,
+        )
         if not tenant_config or not tenant_config.openai_api_key:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")
-            
+
         openai_api_key = tenant_config.openai_api_key
         reply = await draft_reply(request.email_body, request.instruction, openai_api_key)
         return {"draft": reply}

--- a/backend/api/prompts.py
+++ b/backend/api/prompts.py
@@ -10,9 +10,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import AuthContext, get_auth_context, get_current_user
-from db.models import LLMProvider, PromptTemplate, TenantConfig
+from db.models import LLMProvider, PromptTemplate
 from db.session import get_db
 from services.llm_provider_urls import validate_llm_provider_base_url_async
+from services.tenant_config_scope import get_scoped_tenant_config
 
 router = APIRouter(prefix="/api/prompts", tags=["prompts"])
 
@@ -185,10 +186,11 @@ async def test_prompt(
         api_key = active_provider.api_key
         base_url = active_provider.base_url
     else:
-        tenant_result = await db.execute(
-            select(TenantConfig).where(TenantConfig.user_id == user_id)
+        tenant_config = await get_scoped_tenant_config(
+            db,
+            user_id,
+            auth_context.organization_id,
         )
-        tenant_config = tenant_result.scalars().first()
         if tenant_config and tenant_config.openai_api_key:
             api_key = tenant_config.openai_api_key
 

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -5,9 +5,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, union_all
 from db.session import get_db
-from db.models import Email, Attachment, TenantConfig
+from db.models import Email, Attachment
 from services.embedding import generate_embeddings
 from api.auth import AuthContext, get_auth_context
+from services.tenant_config_scope import get_scoped_tenant_config
 
 router = APIRouter(prefix="/api")
 logger = logging.getLogger(__name__)
@@ -81,8 +82,10 @@ async def hybrid_search(
         return SearchResponse(results=[])
 
     try:
-        tenant_config = await db.scalar(
-            select(TenantConfig).where(TenantConfig.user_id == target_user_id)
+        tenant_config = await get_scoped_tenant_config(
+            db,
+            target_user_id,
+            auth_context.organization_id,
         )
         if not tenant_config or not tenant_config.openai_api_key:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")

--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -1,12 +1,20 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
 from pydantic import BaseModel, ConfigDict
 from typing import Optional
 
 from db.models import TenantConfig
 from db.session import get_db
-from api.auth import get_current_user, get_current_user_role, is_admin_role
+from api.auth import (
+    AuthContext,
+    get_auth_context,
+    get_current_user_role,
+    is_admin_role,
+)
+from services.tenant_config_scope import (
+    get_scoped_tenant_config,
+    new_scoped_tenant_config,
+)
 from services.email_client import (
     validate_imap_destination,
     validate_imap_port,
@@ -150,15 +158,16 @@ def validate_mail_config_update(
 async def create_or_update_config(
     config: TenantConfigCreate,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(get_current_user),
+    auth_context: AuthContext = Depends(get_auth_context),
 ):
-    if config.user_id != current_user:
+    if config.user_id != auth_context.user_id:
         raise HTTPException(status_code=403, detail=MAILBOX_MANAGE_FORBIDDEN)
 
-    result = await db.execute(
-        select(TenantConfig).where(TenantConfig.user_id == config.user_id)
+    db_config = await get_scoped_tenant_config(
+        db,
+        auth_context.user_id,
+        auth_context.organization_id,
     )
-    db_config = result.scalar_one_or_none()
 
     config_data = config.model_dump(exclude_unset=True)
     validate_mail_config_update(config_data, db_config)
@@ -172,7 +181,12 @@ async def create_or_update_config(
         for key in SECRET_FIELDS:
             if key in config_data and config_data[key] == "********":
                 config_data[key] = None
-        db_config = TenantConfig(**config_data)
+        db_config = new_scoped_tenant_config(
+            user_id=auth_context.user_id,
+            organization_id=auth_context.organization_id,
+        )
+        for key, value in config_data.items():
+            setattr(db_config, key, value)
         db.add(db_config)
 
     try:
@@ -191,15 +205,16 @@ async def create_or_update_config(
 async def get_config(
     user_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(get_current_user),
+    auth_context: AuthContext = Depends(get_auth_context),
 ):
-    if user_id != current_user:
+    if user_id != auth_context.user_id:
         raise HTTPException(status_code=403, detail=MAILBOX_VIEW_FORBIDDEN)
 
-    result = await db.execute(
-        select(TenantConfig).where(TenantConfig.user_id == user_id)
+    db_config = await get_scoped_tenant_config(
+        db,
+        auth_context.user_id,
+        auth_context.organization_id,
     )
-    db_config = result.scalar_one_or_none()
 
     if not db_config:
         return TenantConfigResponse(user_id=user_id)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -328,7 +328,12 @@ class TenantConfig(Base):
     __tablename__ = "tenant_configs"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[str] = mapped_column(String, unique=True, index=True)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+    organization_id: Mapped[str | None] = mapped_column(
+        String,
+        index=True,
+        nullable=True,
+    )
 
     # Email settings
     smtp_server: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -360,6 +365,7 @@ class TenantConfig(Base):
     def __repr__(self) -> str:
         return (
             f"<TenantConfig(id={self.id}, user_id='{self.user_id}', "
+            f"organization_id='{self.organization_id}', "
             f"smtp_server='{self.smtp_server}', imap_server='{self.imap_server}', "
             f"has_smtp_password={self.smtp_password is not None}, "
             f"has_imap_password={self.imap_password is not None}, "
@@ -368,6 +374,14 @@ class TenantConfig(Base):
             f"has_openai_key={self.openai_api_key is not None}, "
             f"has_google_secret={self.google_client_secret is not None})>"
         )
+
+
+Index(
+    "uq_tenant_configs_owner_scope",
+    TenantConfig.user_id,
+    func.coalesce(TenantConfig.organization_id, ""),
+    unique=True,
+)
 
 
 class SenderRelationship(Base):

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -70,6 +70,10 @@ def schema_backfill_sql():
             "ALTER TABLE project_folders "
             "ADD COLUMN IF NOT EXISTS organization_id varchar"
         ),
+        text(
+            "ALTER TABLE tenant_configs "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
         text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_username varchar"),
         text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_password varchar"),
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
@@ -147,6 +151,10 @@ def schema_backfill_sql():
         ),
         text("ALTER TABLE emails DROP CONSTRAINT IF EXISTS emails_message_id_key"),
         text(
+            "ALTER TABLE tenant_configs "
+            "DROP CONSTRAINT IF EXISTS tenant_configs_user_id_key"
+        ),
+        text(
             "ALTER TABLE sender_relationships "
             "DROP CONSTRAINT IF EXISTS uq_sender_relationships_user_email"
         ),
@@ -154,8 +162,21 @@ def schema_backfill_sql():
             "ALTER TABLE llm_providers DROP CONSTRAINT IF EXISTS llm_providers_name_key"
         ),
         text("DROP INDEX IF EXISTS ix_llm_providers_name"),
+        text("DROP INDEX IF EXISTS ix_tenant_configs_user_id"),
         text("DROP INDEX IF EXISTS ix_emails_message_id"),
         text("CREATE INDEX IF NOT EXISTS ix_emails_message_id ON emails (message_id)"),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_tenant_configs_user_id "
+            "ON tenant_configs (user_id)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_tenant_configs_owner_scope "
+            "ON tenant_configs (user_id, organization_id)"
+        ),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_configs_owner_scope "
+            "ON tenant_configs (user_id, coalesce(organization_id, ''))"
+        ),
     ]
     if backfill_user_id is not None and backfill_organization_id is not None:
         statements.extend(
@@ -180,6 +201,14 @@ def schema_backfill_sql():
                 ),
                 text(
                     "UPDATE project_folders "
+                    "SET organization_id = :organization_id "
+                    "WHERE user_id = :user_id AND organization_id IS NULL"
+                ).bindparams(
+                    user_id=backfill_user_id,
+                    organization_id=backfill_organization_id,
+                ),
+                text(
+                    "UPDATE tenant_configs "
                     "SET organization_id = :organization_id "
                     "WHERE user_id = :user_id AND organization_id IS NULL"
                 ).bindparams(

--- a/backend/scripts/import_fixtures.py
+++ b/backend/scripts/import_fixtures.py
@@ -17,6 +17,7 @@ from services.threading_service import assign_thread_id
 from db.session import AsyncSessionLocal
 from db.models import Email, TenantConfig
 from sqlalchemy import select
+from services.tenant_config_scope import tenant_config_owner_filters
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -45,7 +46,10 @@ async def process_zip_file(zip_path: str | Path, session: AsyncSession):
                 try:
                     tenant_config = await session.scalar(
                         select(TenantConfig).where(
-                            TenantConfig.user_id == IMPORT_USER_ID
+                            *tenant_config_owner_filters(
+                                IMPORT_USER_ID,
+                                IMPORT_ORGANIZATION_ID,
+                            )
                         )
                     )
                     api_key = (

--- a/backend/services/reply_tracking_service.py
+++ b/backend/services/reply_tracking_service.py
@@ -2,6 +2,7 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from db.models import Email, TenantConfig
+from services.tenant_config_scope import get_scoped_tenant_config
 from services.email_service import detect_reply_tracking
 from services.threading_service import normalize_message_id
 import datetime
@@ -97,10 +98,11 @@ async def check_missing_replies(
     Returns a list of such emails.
     """
     # Find user's own email address
-    tenant_config = await session.execute(
-        select(TenantConfig).where(TenantConfig.user_id == user_id)
+    config = await get_scoped_tenant_config(
+        session,
+        user_id,
+        organization_id,
     )
-    config = tenant_config.scalar_one_or_none()
     user_addresses = configured_email_addresses(config)
 
     if not user_addresses:

--- a/backend/services/tenant_config_scope.py
+++ b/backend/services/tenant_config_scope.py
@@ -1,0 +1,33 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import TenantConfig
+
+
+def tenant_config_owner_filters(user_id: str, organization_id: str | None):
+    organization_filter = (
+        TenantConfig.organization_id == organization_id
+        if organization_id is not None
+        else TenantConfig.organization_id.is_(None)
+    )
+    return (TenantConfig.user_id == user_id, organization_filter)
+
+
+async def get_scoped_tenant_config(
+    session: AsyncSession,
+    user_id: str,
+    organization_id: str | None,
+) -> TenantConfig | None:
+    result = await session.execute(
+        select(TenantConfig).where(
+            *tenant_config_owner_filters(user_id, organization_id)
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def new_scoped_tenant_config(
+    user_id: str,
+    organization_id: str | None,
+) -> TenantConfig:
+    return TenantConfig(user_id=user_id, organization_id=organization_id)

--- a/backend/tests/test_accounts_api.py
+++ b/backend/tests/test_accounts_api.py
@@ -6,8 +6,9 @@ from db.session import get_db
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
 class MockTenantConfig:
-    def __init__(self, user_id):
+    def __init__(self, user_id, organization_id=None):
         self.user_id = user_id
+        self.organization_id = organization_id
         self.smtp_server = None
         self.smtp_port = None
         self.smtp_username = None
@@ -32,16 +33,23 @@ class MockResult:
 
 class MockSession:
     def __init__(self):
-        self.config = None
-        
+        self.configs = {}
+        self.commits = 0
+
+    def _query_key(self, stmt):
+        params = dict(stmt.compile().params)
+        user_id = params.get("user_id_1")
+        organization_id = params.get("organization_id_1")
+        return user_id, organization_id
+
     async def execute(self, stmt):
-        return MockResult(self.config)
+        return MockResult(self.configs.get(self._query_key(stmt)))
 
     def add(self, obj):
-        self.config = obj
+        self.configs[(obj.user_id, obj.organization_id)] = obj
 
     async def commit(self):
-        pass
+        self.commits += 1
 
     async def refresh(self, obj):
         pass
@@ -70,11 +78,12 @@ def test_get_and_update_tenant_config(client: TestClient, monkeypatch):
         lambda host, port, *, resolve_host=True: (host, port),
     )
 
-    # Get config (should create empty one)
+    # Get config returns an empty response without creating a row.
     response = client.get("/api/accounts/config")
     assert response.status_code == 200
     data = response.json()
     assert data["smtp_server"] is None
+    assert data["user_id"] == "testuser"
 
     # Update config
     update_data = {
@@ -96,6 +105,52 @@ def test_get_and_update_tenant_config(client: TestClient, monkeypatch):
     assert data["pop3_port"] == 995
     assert data["pop3_username"] == "pop3-user"
     assert data["has_pop3_password"] is True
+
+
+def test_accounts_config_uses_signed_session_organization_scope(monkeypatch):
+    monkeypatch.setattr(
+        "api.tenant_config.validate_smtp_host",
+        lambda host, *, resolve_host=True: host,
+    )
+    monkeypatch.setattr(
+        "api.tenant_config.validate_smtp_destination",
+        lambda host, port, *, resolve_host=True: (host, port),
+    )
+    session = MockSession()
+
+    async def scoped_db():
+        yield session
+
+    app.dependency_overrides[get_db] = scoped_db
+    try:
+        with TestClient(app, headers={"X-User-Id": "shared-user"}) as c:
+            first = c.put(
+                "/api/accounts/config",
+                json={"smtp_server": "smtp.example.com", "smtp_port": 587},
+                headers={"X-Organization-Id": "org-acme"},
+            )
+            second = c.put(
+                "/api/accounts/config",
+                json={"smtp_server": "smtp.other.com", "smtp_port": 587},
+                headers={"X-Organization-Id": "org-rival"},
+            )
+            acme_read = c.get(
+                "/api/accounts/config",
+                headers={"X-Organization-Id": "org-acme"},
+            )
+            rival_read = c.get(
+                "/api/accounts/config",
+                headers={"X-Organization-Id": "org-rival"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert acme_read.json()["smtp_server"] == "smtp.example.com"
+    assert rival_read.json()["smtp_server"] == "smtp.other.com"
+    assert ("shared-user", "org-acme") in session.configs
+    assert ("shared-user", "org-rival") in session.configs
 
 
 def test_accounts_config_rejects_private_imap_host(client: TestClient):

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -12,6 +12,7 @@ from db.models import (
     ConnectorSignalEvent,
     ProjectFolder,
     SenderRelationship,
+    TenantConfig,
     TicketTask,
     WebdavAccount,
 )
@@ -230,6 +231,31 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
         in statement
         for statement in statements
     )
+    assert any(
+        "alter table tenant_configs add column if not exists organization_id"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table tenant_configs drop constraint if exists tenant_configs_user_id_key"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "drop index if exists ix_tenant_configs_user_id" in statement
+        for statement in statements
+    )
+    assert any(
+        "create index if not exists ix_tenant_configs_owner_scope" in statement
+        and "user_id, organization_id" in statement
+        for statement in statements
+    )
+    assert any(
+        "create unique index if not exists uq_tenant_configs_owner_scope"
+        in statement
+        and "coalesce(organization_id, '')" in statement
+        for statement in statements
+    )
 
 
 def test_schema_backfill_uses_only_explicit_non_default_owner_ids(monkeypatch):
@@ -254,6 +280,13 @@ def test_schema_backfill_uses_only_explicit_non_default_owner_ids(monkeypatch):
         for statement in statements
     )
     assert sum("update llm_providers" in statement for statement in statements) == 1
+    assert any(
+        "update tenant_configs" in statement
+        and "set organization_id = :organization_id" in statement
+        and "where user_id = :user_id and organization_id is null" in statement
+        for statement in statements
+    )
+    assert sum("update tenant_configs" in statement for statement in statements) == 1
 
 
 def test_schema_backfill_stops_partially_owned_legacy_rows(monkeypatch):
@@ -299,6 +332,20 @@ def test_sender_relationship_model_declares_source_unique_index():
     assert "sender_email" in expression_text
     assert "source_message_id" in expression_text
     assert "source_thread_id" in expression_text
+
+
+def test_tenant_config_model_declares_owner_scope_unique_index():
+    indexes = {index.name: index for index in TenantConfig.__table__.indexes}
+
+    source_index = indexes["uq_tenant_configs_owner_scope"]
+
+    assert source_index.unique is True
+    expression_text = " ".join(
+        str(expression).lower() for expression in source_index.expressions
+    )
+    assert "user_id" in expression_text
+    assert "coalesce" in expression_text
+    assert "organization_id" in expression_text
 
 
 def test_ticket_task_reply_sla_unique_index_is_bootstrapped():

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -153,7 +153,12 @@ class QueryCapturingSession(MockSession):
 class ScalarQueryCapturingSession(MockSession):
     def __init__(self, items, tenant_config=_DEFAULT_TENANT_CONFIG):
         super().__init__(items, tenant_config=tenant_config)
+        self.queries = []
         self.scalar_queries = []
+
+    async def execute(self, query):
+        self.queries.append(query)
+        return await super().execute(query)
 
     async def scalar(self, query):
         self.scalar_queries.append(query)
@@ -981,7 +986,10 @@ def test_send_email_endpoint_ignores_user_id_query_and_uses_authenticated_user_c
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert compiled_query_params(session.scalar_queries[-1])["user_id_1"] == "testuser"
+    tenant_query = next(
+        query for query in session.queries if "tenant_configs" in compiled_query_text(query)
+    )
+    assert compiled_query_params(tenant_query)["user_id_1"] == "testuser"
     mock_send_email.assert_called_once()
 
 

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -12,9 +12,20 @@ class MockTenantConfig:
         self.openai_api_key = openai_api_key
 
 
+class MockTenantConfigResult:
+    def __init__(self, tenant_config):
+        self.tenant_config = tenant_config
+
+    def scalar_one_or_none(self):
+        return self.tenant_config
+
+
 class MockSession:
     def __init__(self, tenant_config=None):
         self.tenant_config = tenant_config or MockTenantConfig()
+
+    async def execute(self, stmt):
+        return MockTenantConfigResult(self.tenant_config)
 
     async def scalar(self, stmt):
         return self.tenant_config

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -47,6 +47,9 @@ class MockSession:
             def scalars(self):
                 return MockScalars(self._rows)
 
+            def scalar_one_or_none(self):
+                return self._rows[0] if self._rows else None
+
         return MockResult(items)
 
     def add(self, obj):

--- a/backend/tests/test_reply_tracking.py
+++ b/backend/tests/test_reply_tracking.py
@@ -161,6 +161,14 @@ async def test_missing_reply_tracking_scopes_email_query_to_user_and_org():
 
     await check_missing_replies(session, "user_1", "org_1")
 
+    config_query = session.queries[0]
+    config_query_text = compiled_query_text(config_query)
+    config_query_params = compiled_query_params(config_query)
+    assert "tenant_configs.user_id = :user_id_1" in config_query_text
+    assert "tenant_configs.organization_id = :organization_id_1" in config_query_text
+    assert config_query_params["user_id_1"] == "user_1"
+    assert config_query_params["organization_id_1"] == "org_1"
+
     email_query = session.queries[-1]
     query_text = compiled_query_text(email_query)
     query_params = compiled_query_params(email_query)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -26,6 +26,14 @@ class MockResult:
         return [MockRow(1, "Test Subject", "test@test.com", "Test Body", 1.0)]
 
 
+class MockTenantConfigResult:
+    def __init__(self, config):
+        self.config = config
+
+    def scalar_one_or_none(self):
+        return self.config
+
+
 class MockTenantConfig:
     def __init__(self):
         self.openai_api_key = "test-key"
@@ -33,6 +41,8 @@ class MockTenantConfig:
 
 class MockSession:
     async def execute(self, stmt):
+        if "tenant_configs" in str(stmt).lower():
+            return MockTenantConfigResult(MockTenantConfig())
         return MockResult()
 
     async def scalar(self, stmt):

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -22,11 +22,15 @@ class MockAsyncSession:
     def __init__(self):
         self.objects = {}
 
+    def _query_key(self, query):
+        params = dict(query.compile().params)
+        return params.get("user_id_1"), params.get("organization_id_1")
+
     async def execute(self, query):
-        return MockResult(self.objects.get("test_user"))
+        return MockResult(self.objects.get(self._query_key(query)))
 
     def add(self, obj):
-        self.objects[obj.user_id] = obj
+        self.objects[(obj.user_id, obj.organization_id)] = obj
 
     async def commit(self):
         pass
@@ -112,7 +116,7 @@ def test_tenant_config_endpoint(client, mock_db, monkeypatch):
     assert imap_destination_calls == [("imap.example.com", 993, True)]
     assert pop3_destination_calls == [("pop3.example.com", 995, True)]
 
-    assert "test_user" in mock_db.objects
+    assert ("test_user", None) in mock_db.objects
 
     get_response = client.get(
         "/api/config",
@@ -137,6 +141,56 @@ def test_tenant_config_endpoint(client, mock_db, monkeypatch):
     assert data["pop3_port"] == 995
     assert data["pop3_username"] == "pop3-user"
     assert data["google_client_secret"] is None
+
+
+def test_legacy_tenant_config_endpoint_keeps_organization_scope(
+    client, mock_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "api.tenant_config.validate_smtp_host",
+        lambda host, *, resolve_host=True: host,
+    )
+    monkeypatch.setattr(
+        "api.tenant_config.validate_smtp_destination",
+        lambda host, port, *, resolve_host=True: (host, port),
+    )
+
+    acme_response = client.post(
+        "/api/config",
+        json={
+            "user_id": "shared_user",
+            "smtp_server": "smtp.example.com",
+            "smtp_port": 587,
+        },
+        headers={"X-User-Id": "shared_user", "X-Organization-Id": "org-acme"},
+    )
+    rival_response = client.post(
+        "/api/config",
+        json={
+            "user_id": "shared_user",
+            "smtp_server": "smtp.other.com",
+            "smtp_port": 587,
+        },
+        headers={"X-User-Id": "shared_user", "X-Organization-Id": "org-rival"},
+    )
+
+    acme_get = client.get(
+        "/api/config",
+        params={"user_id": "shared_user"},
+        headers={"X-User-Id": "shared_user", "X-Organization-Id": "org-acme"},
+    )
+    rival_get = client.get(
+        "/api/config",
+        params={"user_id": "shared_user"},
+        headers={"X-User-Id": "shared_user", "X-Organization-Id": "org-rival"},
+    )
+
+    assert acme_response.status_code == 200
+    assert rival_response.status_code == 200
+    assert acme_get.json()["smtp_server"] == "smtp.example.com"
+    assert rival_get.json()["smtp_server"] == "smtp.other.com"
+    assert ("shared_user", "org-acme") in mock_db.objects
+    assert ("shared_user", "org-rival") in mock_db.objects
 
 
 def test_tenant_config_stays_user_owned_even_for_admin_headers(client):

--- a/backend/tests/test_tenant_config_model.py
+++ b/backend/tests/test_tenant_config_model.py
@@ -32,9 +32,41 @@ def db_session():
 
 
 def test_tenant_config_model_exists():
-    config = TenantConfig(user_id="test_user", openai_api_key="test_key")
+    config = TenantConfig(
+        user_id="test_user",
+        organization_id="org_acme",
+        openai_api_key="test_key",
+    )
     assert config.user_id == "test_user"
+    assert config.organization_id == "org_acme"
     assert config.openai_api_key == "test_key"
+
+
+def test_tenant_config_allows_same_user_in_different_organizations(db_session):
+    db_session.add(
+        TenantConfig(
+            user_id="shared_user",
+            organization_id="org_acme",
+            smtp_server="smtp.example.com",
+        )
+    )
+    db_session.add(
+        TenantConfig(
+            user_id="shared_user",
+            organization_id="org_rival",
+            smtp_server="smtp.other.com",
+        )
+    )
+    db_session.commit()
+
+    rows = (
+        db_session.query(TenantConfig)
+        .filter_by(user_id="shared_user")
+        .order_by(TenantConfig.organization_id)
+        .all()
+    )
+
+    assert [row.organization_id for row in rows] == ["org_acme", "org_rival"]
 
 
 def test_get_fernet_requires_encryption_key_even_when_debug_enabled():

--- a/docs/plans/2026-05-28-provider-connection-onboarding.md
+++ b/docs/plans/2026-05-28-provider-connection-onboarding.md
@@ -1,0 +1,58 @@
+# Provider Connection Onboarding Slice
+
+## Goal
+
+Turn the remaining Settings connection gap into an API-wired onboarding surface
+without changing Naruon into an SMTP, IMAP, CalDAV, or WebDAV host. Customer
+data remains in member-selected providers; Naruon stores connection metadata,
+masked secrets, source registry intent, and connector control-plane state.
+
+## Confirmed Gaps
+
+- `frontend/branding` and the Settings roadmap expect users to choose and
+  operate connected providers from Settings, but the previous surface only
+  showed SMTP/IMAP/POP3/OAuth fields.
+- `TenantConfig` was unique by `user_id`, so the same person could not maintain
+  separate account configuration for two organizations.
+- Legacy `/api/config` and runtime consumers still queried provider settings by
+  user only, which would leak or select the wrong provider row after scoped rows
+  are introduced.
+- Self-hosted connector token rotation existed in the backend but was not
+  exposed in Settings. The manifest must keep the role outbound-only and must
+  not imply SMTP/IMAP/MX hosting.
+- CalDAV/CardDAV/WebDAV readiness existed in Calendar/Data surfaces but was not
+  visible where provider onboarding is managed.
+
+## Implementation Scope
+
+- Add `tenant_configs.organization_id` and scoped uniqueness over
+  `user_id + organization_id` while preserving personal rows as
+  `organization_id IS NULL`.
+- Route `/api/accounts/config`, legacy `/api/config`, LLM/search/email runtime
+  consumers, and reply tracking through a shared scoped lookup helper.
+- Make `/api/accounts/config` GET return an empty response without creating a DB
+  row; only PUT creates or updates connection settings.
+- Extend Settings `연결 계정` to load signed-session CalDAV/CardDAV and WebDAV
+  source readiness from `/api/calendar/writeback-sources` and
+  `/api/webdav/accounts`.
+- Show OAuth app readiness truthfully as app-configured/consent-pending; actual
+  provider-specific token exchange remains a future connector/auth slice.
+- Expose `/api/runner-config/rotate` in Settings for organization admins as a
+  one-time token action, keeping the token outside the connector manifest.
+
+## Non-Goals
+
+- No provider write execution in the browser.
+- No Naruon-hosted mailbox, SMTP server, IMAP server, MX host, CalDAV host, or
+  WebDAV storage capacity.
+- No provider-specific OAuth authorization-code exchange in this slice.
+
+## Verification
+
+- Backend tests must prove same `user_id` can hold different provider settings
+  per organization and that legacy `/api/config` is not a user-only bypass.
+- Frontend unit tests must prove signed-session bearer usage for account config,
+  CalDAV/WebDAV readiness, and runner token rotation, with no public identity
+  headers.
+- Responsive browser evidence must cover desktop, tablet, and mobile Settings
+  connection screens, including scroll and mobile navigation sanity.

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -51,6 +51,20 @@ describe("SettingsLayout", () => {
             },
           });
         }
+        if (String(input) === "/api/runner-config/rotate" && init?.method === "POST") {
+          return jsonResponse({
+            workspace_id: "workspace-org-acme",
+            registration_token: "nrn_one_time_connector_token",
+            connector_manifest: {
+              role: "self-hosted_connector",
+              network_mode: "outbound_only",
+              control_plane_domain: "naruon.net",
+              local_protocols: ["imap", "pop3", "smtp", "caldav", "carddav", "webdav"],
+              prohibited_roles: ["smtp_server", "imap_server", "mx_host"],
+              runner_usage: "ci_smoke_only",
+            },
+          });
+        }
         if (String(input) === "/api/observability/operational-signals") {
           return jsonResponse({
             workspace_id: "workspace-org-acme",
@@ -109,6 +123,30 @@ describe("SettingsLayout", () => {
               },
             ],
           });
+        }
+        if (String(input) === "/api/calendar/writeback-sources") {
+          return jsonResponse([
+            {
+              source_id: "caldav_src_fastmail_primary",
+              provider: "Fastmail",
+              protocol: "caldav",
+              owner_id: "default",
+              organization_id: "org-acme",
+              capabilities: ["read", "write", "etag"],
+              writeback_enabled: true,
+              etag: "etag-caldav-primary",
+            },
+          ]);
+        }
+        if (String(input) === "/api/webdav/accounts") {
+          return jsonResponse([
+            {
+              source_id: "webdav_src_primary",
+              server_url: "https://files.example.com/dav",
+              username: "files@example.com",
+              writeback_enabled: true,
+            },
+          ]);
         }
         if (String(input) === "/api/accounts/config" && init?.method === "PUT") {
           const body = JSON.parse(String(init.body));
@@ -230,6 +268,24 @@ describe("SettingsLayout", () => {
     expect(container.textContent).not.toContain("nrn_registered-token");
     expect(container.textContent).toContain("Connector heartbeat");
     expect(container.textContent).toContain("instrumentation_pending");
+
+    const rotateButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("등록 토큰 회전"));
+    expect(rotateButton).toBeTruthy();
+    await act(async () => {
+      rotateButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const rotateCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/runner-config/rotate" && init?.method === "POST");
+    expect(rotateCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    expect(rotateCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(rotateCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(rotateCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+    expect(container.textContent).toContain("One-time connector registration token");
+    expect(container.textContent).toContain("nrn_one_time_connector_token");
   });
 
   it("loads and saves source-backed mail account settings without public identity headers or secret replay", async () => {
@@ -267,12 +323,33 @@ describe("SettingsLayout", () => {
     expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Group-Ids");
     expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
     expect(configGetCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+    const calendarSourcesCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === "/api/calendar/writeback-sources");
+    const webdavAccountsCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === "/api/webdav/accounts");
+    expect(calendarSourcesCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    expect(webdavAccountsCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    for (const sourceCall of [calendarSourcesCall, webdavAccountsCall]) {
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-Group-Id");
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-Group-Ids");
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
+      expect(sourceCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+    }
 
     expect(container.textContent).toContain("고객 지정 Provider");
     expect(container.textContent).toContain("smtp.example.com:587");
     expect(container.textContent).toContain("imap.example.com:993");
     expect(container.textContent).toContain("pop3.example.com:995");
     expect(container.textContent).toContain("OAuth 로그인");
+    expect(container.textContent).toContain("앱 설정 완료, 사용자 consent 대기");
+    expect(container.textContent).toContain("Source readiness");
+    expect(container.textContent).toContain("caldav_src_fastmail_primary");
+    expect(container.textContent).toContain("webdav_src_primary");
+    expect(container.textContent).toContain("writeback intent enabled");
     expect(container.textContent).toContain("저장된 secret 유지");
     expect(container.textContent).toContain("Naruon은 메일함 용량이나 SMTP/IMAP 서버를 제공하지 않습니다");
 

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -22,6 +22,12 @@ interface RunnerConfig {
   };
 }
 
+interface RunnerRotateResponse {
+  workspace_id: string;
+  registration_token: string;
+  connector_manifest: RunnerConfig['connector_manifest'];
+}
+
 interface OperationalSignal {
   signal_key: string;
   display_name: string;
@@ -100,6 +106,24 @@ interface AccountConfigUpdate {
   oauth_client_id: string | null;
   oauth_client_secret?: string;
   oauth_redirect_uri: string | null;
+}
+
+interface CalendarWritebackSource {
+  source_id: string;
+  provider: string;
+  protocol: string;
+  owner_id: string;
+  organization_id: string | null;
+  capabilities: string[];
+  writeback_enabled: boolean;
+  etag: string | null;
+}
+
+interface WebdavAccount {
+  source_id: string;
+  server_url: string;
+  username: string;
+  writeback_enabled: boolean;
 }
 
 interface AccountFormState {
@@ -261,6 +285,9 @@ export function SettingsLayout() {
   const [runnerConfig, setRunnerConfig] = useState<RunnerConfig | null>(null);
   const [runnerError, setRunnerError] = useState<string | null>(null);
   const [runnerLoading, setRunnerLoading] = useState(true);
+  const [runnerRotating, setRunnerRotating] = useState(false);
+  const [runnerRotateError, setRunnerRotateError] = useState<string | null>(null);
+  const [oneTimeRunnerToken, setOneTimeRunnerToken] = useState<string | null>(null);
   const [operationalSignals, setOperationalSignals] = useState<OperationalSignalsResponse | null>(null);
   const [operationalError, setOperationalError] = useState<string | null>(null);
   const [operationalLoading, setOperationalLoading] = useState(true);
@@ -270,11 +297,21 @@ export function SettingsLayout() {
   const [accountStatus, setAccountStatus] = useState<string | null>(null);
   const [accountLoading, setAccountLoading] = useState(true);
   const [accountSaving, setAccountSaving] = useState(false);
+  const [calendarSources, setCalendarSources] = useState<CalendarWritebackSource[]>([]);
+  const [webdavAccounts, setWebdavAccounts] = useState<WebdavAccount[]>([]);
+  const [sourceReadinessLoading, setSourceReadinessLoading] = useState(true);
+  const [sourceReadinessError, setSourceReadinessError] = useState<string | null>(null);
   const startupView = useWorkspaceStartupView();
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
   const connectorEvents = operationalSignals?.connector.recent_events ?? [];
   const accountReady = !accountLoading && !accountError && accountConfig !== null;
+  const oauthAppConfigured = Boolean(
+    accountConfig?.oauth_client_id
+      && accountConfig?.oauth_redirect_uri
+      && accountConfig?.has_oauth_client_secret,
+  );
+  const oauthConsentState = oauthAppConfigured ? '앱 설정 완료, 사용자 consent 대기' : '앱 설정 미완료';
   const accountProtocols = [
     {
       label: 'SMTP 송신',
@@ -302,7 +339,7 @@ export function SettingsLayout() {
       endpoint: accountConfig?.oauth_client_id ?? '미설정',
       identity: accountConfig?.oauth_redirect_uri ?? 'redirect URI 미설정',
       secretReady: accountConfig?.has_oauth_client_secret ?? false,
-      detail: '지원 provider에서는 비밀번호 대신 OAuth consent를 사용합니다.',
+      detail: `지원 provider에서는 비밀번호 대신 OAuth consent를 사용합니다. ${oauthConsentState}`,
     },
   ];
 
@@ -328,6 +365,30 @@ export function SettingsLayout() {
       setAccountError(message);
     } finally {
       setAccountSaving(false);
+    }
+  };
+
+  const handleRunnerTokenRotate = async () => {
+    setRunnerRotating(true);
+    setRunnerRotateError(null);
+    setOneTimeRunnerToken(null);
+
+    try {
+      const rotated = await apiClient.post<RunnerRotateResponse>('/api/runner-config/rotate', {});
+      setOneTimeRunnerToken(rotated.registration_token);
+      setRunnerConfig({
+        workspace_id: rotated.workspace_id,
+        configured: true,
+        fingerprint: null,
+        updated_at: null,
+        connector_manifest: rotated.connector_manifest,
+      });
+      setRunnerError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '등록 토큰을 회전할 수 없습니다.';
+      setRunnerRotateError(message);
+    } finally {
+      setRunnerRotating(false);
     }
   };
 
@@ -378,6 +439,24 @@ export function SettingsLayout() {
       })
       .finally(() => {
         if (!cancelled) setAccountLoading(false);
+      });
+
+    void Promise.all([
+      apiClient.get<CalendarWritebackSource[]>('/api/calendar/writeback-sources'),
+      apiClient.get<WebdavAccount[]>('/api/webdav/accounts'),
+    ])
+      .then(([calendarSourceRows, webdavAccountRows]) => {
+        if (cancelled) return;
+        setCalendarSources(calendarSourceRows);
+        setWebdavAccounts(webdavAccountRows);
+        setSourceReadinessError(null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setSourceReadinessError(error.message || 'Source readiness를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setSourceReadinessLoading(false);
       });
 
     return () => {
@@ -499,9 +578,9 @@ export function SettingsLayout() {
                   <p className="rounded-xl border border-emerald-300 bg-emerald-50 p-3 text-sm font-semibold text-emerald-900">{accountStatus}</p>
                 ) : null}
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  {accountProtocols.map((protocol) => (
-                    <article key={protocol.label} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {accountProtocols.map((protocol) => (
+                      <article key={protocol.label} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
                       <div className="flex items-start gap-3">
                         <div className="grid size-10 shrink-0 place-items-center rounded-full bg-secondary">
                           <Mail className="size-5 text-primary" />
@@ -518,11 +597,87 @@ export function SettingsLayout() {
                           <p className="mt-3 text-sm leading-6 text-muted-foreground">{protocol.detail}</p>
                         </div>
                       </div>
-                    </article>
-                  ))}
-                </div>
+                      </article>
+                    ))}
+                  </div>
 
-                <form onSubmit={handleAccountSave} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <section aria-label="Provider source readiness" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-bold text-lg">Source readiness</h3>
+                        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                          CalDAV/CardDAV/WebDAV source registry와 writeback intent 상태를 확인합니다. 이 화면은 provider write를 실행하지 않습니다.
+                        </p>
+                      </div>
+                      <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-xs font-bold text-foreground">
+                        OAuth: {oauthConsentState}
+                      </span>
+                    </div>
+
+                    {sourceReadinessLoading ? (
+                      <p className="mt-4 rounded-xl bg-secondary/60 p-3 text-sm font-semibold text-muted-foreground">source readiness를 불러오는 중입니다.</p>
+                    ) : null}
+                    {sourceReadinessError ? (
+                      <p className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{sourceReadinessError}</p>
+                    ) : null}
+
+                    {!sourceReadinessLoading && !sourceReadinessError ? (
+                      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between gap-3">
+                            <h4 className="text-sm font-bold">CalDAV/CardDAV sources</h4>
+                            <span className="rounded-full bg-secondary px-2.5 py-1 font-mono text-xs font-semibold text-foreground">{calendarSources.length} sources</span>
+                          </div>
+                          {calendarSources.length > 0 ? (
+                            <ul className="divide-y divide-border rounded-xl border border-border bg-background">
+                              {calendarSources.map((source) => (
+                                <li key={source.source_id} className="p-3">
+                                  <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <p className="font-mono text-xs font-bold text-foreground">{source.source_id}</p>
+                                    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${source.writeback_enabled ? 'bg-emerald-100 text-emerald-800' : 'bg-secondary text-muted-foreground'}`}>
+                                      {source.writeback_enabled ? 'writeback intent enabled' : 'read-only intent'}
+                                    </span>
+                                  </div>
+                                  <p className="mt-2 break-all text-sm text-foreground">{source.provider} / {source.protocol}</p>
+                                  <p className="mt-1 break-all text-xs text-muted-foreground">{source.capabilities.join(', ')}</p>
+                                  <p className="mt-1 break-all font-mono text-xs text-muted-foreground">etag {source.etag ?? 'none'}</p>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className="rounded-xl border border-dashed border-border p-3 text-sm font-semibold text-muted-foreground">등록된 CalDAV/CardDAV source가 없습니다.</p>
+                          )}
+                        </div>
+
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between gap-3">
+                            <h4 className="text-sm font-bold">WebDAV repositories</h4>
+                            <span className="rounded-full bg-secondary px-2.5 py-1 font-mono text-xs font-semibold text-foreground">{webdavAccounts.length} sources</span>
+                          </div>
+                          {webdavAccounts.length > 0 ? (
+                            <ul className="divide-y divide-border rounded-xl border border-border bg-background">
+                              {webdavAccounts.map((account) => (
+                                <li key={account.source_id} className="p-3">
+                                  <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <p className="font-mono text-xs font-bold text-foreground">{account.source_id}</p>
+                                    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${account.writeback_enabled ? 'bg-emerald-100 text-emerald-800' : 'bg-secondary text-muted-foreground'}`}>
+                                      {account.writeback_enabled ? 'writeback intent enabled' : 'read-only intent'}
+                                    </span>
+                                  </div>
+                                  <p className="mt-2 break-all text-sm text-foreground">{account.server_url}</p>
+                                  <p className="mt-1 break-all text-xs text-muted-foreground">{account.username}</p>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className="rounded-xl border border-dashed border-border p-3 text-sm font-semibold text-muted-foreground">등록된 WebDAV repository가 없습니다.</p>
+                          )}
+                        </div>
+                      </div>
+                    ) : null}
+                  </section>
+
+                  <form onSubmit={handleAccountSave} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <h3 className="font-bold text-lg">Source-backed 계정 설정</h3>
@@ -646,6 +801,41 @@ export function SettingsLayout() {
                   ) : null}
                   {runnerError ? (
                     <p className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{runnerError}</p>
+                  ) : null}
+                  <div className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <dl className="grid gap-3 sm:grid-cols-3">
+                      <div>
+                        <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">workspace_id</dt>
+                        <dd className="mt-1 break-all font-mono text-sm text-foreground">{runnerConfig?.workspace_id ?? 'none'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">registration</dt>
+                        <dd className="mt-1 font-mono text-sm text-foreground">{runnerConfig?.configured ? 'configured' : 'not_configured'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">fingerprint</dt>
+                        <dd className="mt-1 break-all font-mono text-sm text-foreground">{runnerConfig?.fingerprint ?? 'none'}</dd>
+                      </div>
+                    </dl>
+                    <button
+                      type="button"
+                      onClick={handleRunnerTokenRotate}
+                      disabled={runnerRotating}
+                      aria-disabled={runnerRotating}
+                      className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <RefreshCw className={`size-4 ${runnerRotating ? 'animate-spin' : ''}`} />
+                      {runnerRotating ? '회전 중' : '등록 토큰 회전'}
+                    </button>
+                  </div>
+                  {runnerRotateError ? (
+                    <p className="mt-3 rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{runnerRotateError}</p>
+                  ) : null}
+                  {oneTimeRunnerToken ? (
+                    <div className="mt-3 rounded-xl border border-emerald-300 bg-emerald-50 p-3">
+                      <p className="text-sm font-bold text-emerald-900">One-time connector registration token</p>
+                      <p className="mt-2 break-all font-mono text-xs text-emerald-950">{oneTimeRunnerToken}</p>
+                    </div>
                   ) : null}
                   {connectorManifest ? (
                     <div className="mt-5 space-y-4">

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -659,6 +659,9 @@ test('renders source-backed mail account settings across desktop tablet and mobi
     await expect(page.getByText('imap.example.com:993')).toBeVisible();
     await expect(page.getByText('pop3.example.com:995')).toBeVisible();
     await expect(page.getByText('OAuth 로그인')).toBeVisible();
+    await expect(page.getByText('Source readiness')).toBeVisible();
+    await expect(page.getByText('caldav-primary', { exact: true })).toBeVisible();
+    await expect(page.getByText('webdav_src_primary')).toBeVisible();
     await expect(page.getByText('저장된 secret 유지').first()).toBeVisible();
 
     if (viewport.name === 'desktop') {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -291,6 +291,15 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
       return;
     }
 
+    if (path === '/api/runner-config/rotate' && request.method() === 'POST') {
+      await fulfillJson(route, {
+        workspace_id: 'workspace-org-acme',
+        registration_token: 'nrn_e2e_one_time_connector_token',
+        connector_manifest: runnerConfig.connector_manifest,
+      });
+      return;
+    }
+
     if (path === '/api/observability/operational-signals' && request.method() === 'GET') {
       await fulfillJson(route, operationalSignals);
       return;


### PR DESCRIPTION
## Summary
- scope TenantConfig/provider settings by signed-session user_id + organization_id and route legacy/runtime consumers through a shared lookup helper
- extend Settings connected-account onboarding with CalDAV/CardDAV and WebDAV source readiness plus self-hosted connector token rotation
- document the provider onboarding slice, Naruon relay boundary, and the review bug pattern in README/AGENTS

## Verification
- PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests -q
- npm test -- src/components/SettingsLayout.test.tsx
- npm run typecheck
- npm run lint
- NEXT_TELEMETRY_DISABLED=1 NEXT_PRIVATE_MAX_WORKERS=2 npm run build
- npm test
- env -u FORCE_COLOR -u NO_COLOR PLAYWRIGHT_PORT=18081 npx playwright test tests/e2e/dashboard-branding.spec.ts -g "renders source-backed mail account settings across desktop tablet and mobile|validates mobile hamburger composition" --project=desktop

## Browser evidence
- settings-mail-account-desktop.png
- settings-mail-account-tablet.png
- settings-mail-account-mobile.png
- settings-mail-account-mobile-scroll.png
- mobile-workspace-menu.png

## Notes
- Naruon remains a web client/control-plane relay. This PR does not add SMTP, IMAP, CalDAV, or WebDAV hosting capacity.
- Strix must use direct OpenAI Platform configuration; no GitHub Models routing is introduced.