### PR TITLE
Wire Security governance access surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,11 @@
   runner socket state when available, but label sync lag, provider throttling,
   queue depth, and writeback conflict dashboards as pending until source-backed
   connector events exist.
+- Security governance screens must be source-backed by signed
+  `/api/security/access-surface` data. Do not ship static RBAC/ABAC rows, fake
+  blocked-login logs, unsupported TLS/TDE claims, or permanent Security tab
+  placeholders as implemented features. New Security mocks and E2E fixtures must
+  preserve bearer-session calls and omit public identity headers.
 - Self-hosted connector APM history must be persisted as scoped control-plane
   signal events before the UI claims durable heartbeat evidence. Do not expose
   runner registration tokens, path tokens, or raw provider credentials in event

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ mail/calendar/file systems.
   fails closed rather than falling back to GitHub Models, Google/Vertex/Gemini,
   `github.token`, or GPT-4-era models. Pending CodeRabbit or check evidence is
   a wait state, not a hard blocker.
+- Security governance is source-backed through signed
+  `/api/security/access-surface`. The endpoint reads scoped WebDAV, CalDAV, and
+  connector evidence, reuses the deny-first RBAC/ABAC policy engine, and returns
+  no sequential account ids, raw credentials, or fake security posture claims.
   
 ## Agentic Ontology & Auto-Organization
 
@@ -205,6 +209,11 @@ curl -s -X POST http://localhost:8000/api/calendar/writeback-intent \
   -H "Authorization: Bearer $NARUON_DEV_BEARER" \
   -H 'content-type: application/json' \
   -d '{"action":"create","summary":"담당자 확인 회의","target_source_id":"caldav-primary"}'
+
+# Review source-backed Security governance without exposing provider secrets.
+curl -s http://localhost:8000/api/security/access-surface \
+  -H "Authorization: Bearer $NARUON_DEV_BEARER" \
+  | jq '{workspace_id, audit_event, sources, policy_decisions}'
 ```
 
 ## Error-message contract

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import (
+    AuthContext,
+    get_auth_context,
+    is_admin_role,
+    is_system_admin_role,
+    is_tenant_admin_role,
+)
+from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.session import get_db
+from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
+
+router = APIRouter(prefix="/api/security", tags=["security"])
+
+SourceType = Literal["caldav_source", "carddav_source", "webdav_repository"]
+DecisionReason = Literal[
+    "allowed",
+    "organization_denied",
+    "data_region_denied",
+    "consent_denied",
+    "ownership_denied",
+    "rbac_denied",
+]
+
+
+class ViewerContext(BaseModel):
+    user_id: str
+    role: str
+    organization_id: str | None
+    group_ids: list[str]
+    workspace_id: str
+
+
+class PolicyDecisionSummary(BaseModel):
+    decision_uid: str
+    resource_label: str
+    resource_type: str
+    allowed: bool
+    reason: DecisionReason
+    evidence_source: str
+
+
+class GovernanceSource(BaseModel):
+    source_id: str
+    source_type: SourceType
+    source_label: str
+    source_host: str
+    owner_id: str
+    organization_id: str | None
+    workspace_id: str
+    capabilities: list[str]
+    writeback_enabled: bool
+    provider_write_executed: bool
+    policy_decision: PolicyDecisionSummary
+    last_observed_at: str | None
+
+
+class ConnectorEvidence(BaseModel):
+    event_uid: str
+    signal_key: str
+    state_code: str
+    detail_text: str | None
+    observed_at: str
+
+
+class ExternalShareReview(BaseModel):
+    review_uid: str
+    source_id: str
+    source_type: SourceType
+    review_label: str
+    exposure_level: Literal["internal", "external_writeback"]
+    decision_reason: DecisionReason
+    provider_write_executed: bool
+
+
+class PolicyOrderStep(BaseModel):
+    step_key: str
+    display_name: str
+    evidence_source: str
+
+
+class SecurityAccessSurfaceResponse(BaseModel):
+    workspace_id: str
+    organization_id: str | None
+    audit_event: Literal["security.access_surface.viewed"]
+    viewer: ViewerContext
+    sources: list[GovernanceSource]
+    connector_events: list[ConnectorEvidence]
+    policy_decisions: list[PolicyDecisionSummary]
+    external_share_reviews: list[ExternalShareReview]
+    policy_order: list[PolicyOrderStep]
+
+
+def _datetime_to_utc_iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _host_from_url(value: str) -> str:
+    parsed = urlparse(value)
+    return parsed.netloc.rsplit("@", 1)[-1] if parsed.netloc else value
+
+
+def _can_read_org_scope(auth_context: AuthContext) -> bool:
+    return (
+        is_admin_role(auth_context.role)
+        and auth_context.organization_id is not None
+    )
+
+
+def _webdav_scope_statement(auth_context: AuthContext):
+    statement = select(WebdavAccount).order_by(
+        WebdavAccount.created_at.asc(),
+        WebdavAccount.source_uid.asc(),
+    )
+    if _can_read_org_scope(auth_context):
+        return statement.where(WebdavAccount.organization_id == auth_context.organization_id)
+    organization_filter = (
+        WebdavAccount.organization_id == auth_context.organization_id
+        if auth_context.organization_id is not None
+        else WebdavAccount.organization_id.is_(None)
+    )
+    return statement.where(
+        WebdavAccount.user_id == auth_context.user_id,
+        organization_filter,
+    )
+
+
+def _calendar_scope_statement(auth_context: AuthContext):
+    statement = (
+        select(CalendarWritebackSource)
+        .where(CalendarWritebackSource.source_protocol.in_(("caldav", "carddav")))
+        .order_by(
+            CalendarWritebackSource.created_at.asc(),
+            CalendarWritebackSource.source_uid.asc(),
+        )
+    )
+    if _can_read_org_scope(auth_context):
+        return statement.where(
+            CalendarWritebackSource.organization_id == auth_context.organization_id
+        )
+    organization_filter = (
+        CalendarWritebackSource.organization_id == auth_context.organization_id
+        if auth_context.organization_id is not None
+        else CalendarWritebackSource.organization_id.is_(None)
+    )
+    return statement.where(
+        CalendarWritebackSource.user_id == auth_context.user_id,
+        organization_filter,
+    )
+
+
+def _connector_scope_statement(auth_context: AuthContext):
+    if auth_context.organization_id is None:
+        return None
+    return (
+        select(ConnectorSignalEvent)
+        .where(
+            ConnectorSignalEvent.organization_id == auth_context.organization_id,
+            ConnectorSignalEvent.workspace_id == auth_context.workspace_id,
+        )
+        .order_by(ConnectorSignalEvent.observed_at.desc())
+        .limit(8)
+    )
+
+
+def _source_in_scope(
+    auth_context: AuthContext,
+    owner_id: str,
+    organization_id: str | None,
+) -> bool:
+    if _can_read_org_scope(auth_context):
+        return organization_id == auth_context.organization_id
+    return (
+        owner_id == auth_context.user_id
+        and organization_id == auth_context.organization_id
+    )
+
+
+def _access_request(auth_context: AuthContext) -> AccessRequest:
+    return AccessRequest(
+        user_id=auth_context.user_id,
+        role=auth_context.role,
+        organization_id=auth_context.organization_id,
+        group_ids=auth_context.group_ids,
+        data_region="kr",
+        consent_scopes=("mail.read", "calendar.read", "webdav.write"),
+    )
+
+
+def _decision_summary(
+    *,
+    decision_uid: str,
+    resource_label: str,
+    resource_type: str,
+    auth_context: AuthContext,
+    resource: ResourcePolicy,
+    evidence_source: str,
+) -> PolicyDecisionSummary:
+    decision = evaluate_access(_access_request(auth_context), resource)
+    return PolicyDecisionSummary(
+        decision_uid=decision_uid,
+        resource_label=resource_label,
+        resource_type=resource_type,
+        allowed=decision.allowed,
+        reason=decision.reason,
+        evidence_source=evidence_source,
+    )
+
+
+def _source_policy(
+    auth_context: AuthContext,
+    owner_id: str,
+    organization_id: str | None,
+    writeback_enabled: bool,
+) -> ResourcePolicy:
+    delegated_user_ids: tuple[str, ...] = (
+        (auth_context.user_id,)
+        if is_admin_role(auth_context.role) and organization_id == auth_context.organization_id
+        else ()
+    )
+    required_consent = ("webdav.write",) if writeback_enabled else ()
+    return ResourcePolicy(
+        owner_id=owner_id,
+        organization_id=organization_id,
+        permitted_roles=("tenant_admin", "organization_admin", "group_admin", "member"),
+        permitted_group_ids=auth_context.group_ids,
+        data_region="kr",
+        required_consent_scopes=required_consent,
+        delegated_user_ids=delegated_user_ids,
+    )
+
+
+def _webdav_source(
+    account: WebdavAccount, auth_context: AuthContext
+) -> GovernanceSource:
+    decision = _decision_summary(
+        decision_uid=f"policy:{account.source_uid}",
+        resource_label="WebDAV repository",
+        resource_type="webdav_repository",
+        auth_context=auth_context,
+        resource=_source_policy(
+            auth_context,
+            account.user_id,
+            account.organization_id,
+            bool(account.writeback_enabled),
+        ),
+        evidence_source="webdav_accounts",
+    )
+    return GovernanceSource(
+        source_id=account.source_uid,
+        source_type="webdav_repository",
+        source_label="WebDAV repository",
+        source_host=_host_from_url(account.server_url),
+        owner_id=account.user_id,
+        organization_id=account.organization_id,
+        workspace_id=auth_context.workspace_id,
+        capabilities=["read", "write", "etag"] if account.writeback_enabled else ["read"],
+        writeback_enabled=bool(account.writeback_enabled),
+        provider_write_executed=False,
+        policy_decision=decision,
+        last_observed_at=_datetime_to_utc_iso(account.created_at),
+    )
+
+
+def _calendar_source(
+    source: CalendarWritebackSource, auth_context: AuthContext
+) -> GovernanceSource:
+    source_type: SourceType = (
+        "carddav_source" if source.source_protocol == "carddav" else "caldav_source"
+    )
+    decision = _decision_summary(
+        decision_uid=f"policy:{source.source_uid}",
+        resource_label=f"{source.provider_name} {source.source_protocol.upper()} source",
+        resource_type=source_type,
+        auth_context=auth_context,
+        resource=_source_policy(
+            auth_context,
+            source.user_id,
+            source.organization_id,
+            bool(source.writeback_enabled),
+        ),
+        evidence_source="calendar_writeback_sources",
+    )
+    capabilities = ["read"]
+    if source.writeback_enabled:
+        capabilities.extend(["write", "etag"])
+    return GovernanceSource(
+        source_id=source.source_uid,
+        source_type=source_type,
+        source_label=source.provider_name,
+        source_host=source.source_host,
+        owner_id=source.user_id,
+        organization_id=source.organization_id,
+        workspace_id=source.workspace_id,
+        capabilities=capabilities,
+        writeback_enabled=bool(source.writeback_enabled),
+        provider_write_executed=False,
+        policy_decision=decision,
+        last_observed_at=_datetime_to_utc_iso(source.created_at),
+    )
+
+
+def _connector_evidence(event: ConnectorSignalEvent) -> ConnectorEvidence:
+    return ConnectorEvidence(
+        event_uid=event.event_uid,
+        signal_key=event.signal_key,
+        state_code=event.state_code,
+        detail_text=event.detail_text,
+        observed_at=_datetime_to_utc_iso(event.observed_at),
+    )
+
+
+def _canonical_policy_decisions(
+    auth_context: AuthContext,
+    source_decisions: list[PolicyDecisionSummary],
+) -> list[PolicyDecisionSummary]:
+    decisions = list(source_decisions)
+    decisions.append(
+        _decision_summary(
+            decision_uid="policy:cross-organization-deny",
+            resource_label="Cross-organization provider secret",
+            resource_type="provider_secret",
+            auth_context=auth_context,
+            resource=ResourcePolicy(
+                owner_id=auth_context.user_id,
+                organization_id="org-outside-scope",
+                permitted_roles=("tenant_admin", "organization_admin"),
+                permitted_group_ids=(),
+                data_region="kr",
+                required_consent_scopes=(),
+            ),
+            evidence_source="access_policy.evaluate_access",
+        )
+    )
+    decisions.append(
+        _decision_summary(
+            decision_uid="policy:data-region-deny",
+            resource_label="Regional export outside policy",
+            resource_type="data_export",
+            auth_context=auth_context,
+            resource=ResourcePolicy(
+                owner_id=auth_context.user_id,
+                organization_id=auth_context.organization_id,
+                permitted_roles=("tenant_admin", "organization_admin", "member"),
+                permitted_group_ids=auth_context.group_ids,
+                data_region="eu",
+                required_consent_scopes=(),
+            ),
+            evidence_source="access_policy.evaluate_access",
+        )
+    )
+    return decisions
+
+
+def _share_reviews(sources: list[GovernanceSource]) -> list[ExternalShareReview]:
+    return [
+        ExternalShareReview(
+            review_uid=f"share:{source.source_id}",
+            source_id=source.source_id,
+            source_type=source.source_type,
+            review_label=f"{source.source_label} writeback boundary",
+            exposure_level="external_writeback"
+            if source.writeback_enabled
+            else "internal",
+            decision_reason=source.policy_decision.reason,
+            provider_write_executed=False,
+        )
+        for source in sources
+    ]
+
+
+def _policy_order() -> list[PolicyOrderStep]:
+    return [
+        PolicyOrderStep(
+            step_key="signed_session",
+            display_name="Signed session identity",
+            evidence_source="api.auth.get_auth_context",
+        ),
+        PolicyOrderStep(
+            step_key="organization_scope",
+            display_name="Organization and workspace scope",
+            evidence_source="organization_id and workspace_id claims",
+        ),
+        PolicyOrderStep(
+            step_key="data_region",
+            display_name="Data-region deny",
+            evidence_source="services.access_policy.evaluate_access",
+        ),
+        PolicyOrderStep(
+            step_key="consent",
+            display_name="Consent and source capability deny",
+            evidence_source="services.access_policy.evaluate_access",
+        ),
+        PolicyOrderStep(
+            step_key="ownership",
+            display_name="Owner or delegated admin boundary",
+            evidence_source="services.access_policy.evaluate_access",
+        ),
+        PolicyOrderStep(
+            step_key="rbac",
+            display_name="RBAC allow after ABAC denies",
+            evidence_source="services.access_policy.evaluate_access",
+        ),
+    ]
+
+
+@router.get("/access-surface", response_model=SecurityAccessSurfaceResponse)
+async def get_access_surface(
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
+) -> SecurityAccessSurfaceResponse:
+    webdav_result = await db.execute(_webdav_scope_statement(auth_context))
+    calendar_result = await db.execute(_calendar_scope_statement(auth_context))
+    connector_statement = _connector_scope_statement(auth_context)
+    connector_events: list[ConnectorSignalEvent] = []
+    if connector_statement is not None:
+        connector_result = await db.execute(connector_statement)
+        connector_events = [
+            event
+            for event in connector_result.scalars().all()
+            if event.organization_id == auth_context.organization_id
+            and event.workspace_id == auth_context.workspace_id
+        ]
+
+    sources = [
+        _webdav_source(account, auth_context)
+        for account in webdav_result.scalars().all()
+        if _source_in_scope(auth_context, account.user_id, account.organization_id)
+    ]
+    sources.extend(
+        _calendar_source(source, auth_context)
+        for source in calendar_result.scalars().all()
+        if _source_in_scope(auth_context, source.user_id, source.organization_id)
+    )
+    source_decisions = [source.policy_decision for source in sources]
+    policy_decisions = _canonical_policy_decisions(auth_context, source_decisions)
+
+    return SecurityAccessSurfaceResponse(
+        workspace_id=auth_context.workspace_id,
+        organization_id=auth_context.organization_id,
+        audit_event="security.access_surface.viewed",
+        viewer=ViewerContext(
+            user_id=auth_context.user_id,
+            role=auth_context.role,
+            organization_id=auth_context.organization_id,
+            group_ids=list(auth_context.group_ids),
+            workspace_id=auth_context.workspace_id,
+        ),
+        sources=sources,
+        connector_events=[_connector_evidence(event) for event in connector_events],
+        policy_decisions=policy_decisions,
+        external_share_reviews=_share_reviews(sources),
+        policy_order=_policy_order(),
+    )

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -13,8 +13,6 @@ from api.auth import (
     AuthContext,
     get_auth_context,
     is_admin_role,
-    is_system_admin_role,
-    is_tenant_admin_role,
 )
 from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
 from db.session import get_db

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from api.runner_ws import router as runner_ws_router
 from api.dav import router as dav_router
 from api.accounts import router as accounts_router
 from api.webdav import router as webdav_router
+from api.security import router as security_router
 from core.config import settings
 from core.telemetry import setup_telemetry
 from services.imap_worker import ImapSyncWorker
@@ -86,6 +87,7 @@ app.include_router(runner_ws_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(dav_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(accounts_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(webdav_router, dependencies=PRIVATE_API_DEPENDENCIES)
+app.include_router(security_router, dependencies=PRIVATE_API_DEPENDENCIES)
 
 
 @app.get("/")

--- a/backend/tests/test_security_api.py
+++ b/backend/tests/test_security_api.py
@@ -1,0 +1,494 @@
+import base64
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+import asyncpg
+from fastapi.testclient import TestClient
+import httpx
+import pytest
+from pydantic import SecretStr
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api.auth import get_auth_context, get_current_user
+from core.config import settings
+from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.session import get_db
+from main import app
+
+pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
+TEST_SESSION_HMAC_SECRET = "security-governance-hmac-material-32-bytes"  # noqa: S105
+
+
+class MockResult:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.obj if isinstance(self.obj, list) else []
+
+
+class MockAsyncSession:
+    def __init__(
+        self,
+        webdav_accounts: list[WebdavAccount] | None = None,
+        calendar_sources: list[CalendarWritebackSource] | None = None,
+        connector_events: list[ConnectorSignalEvent] | None = None,
+    ):
+        self.results = [
+            webdav_accounts or [],
+            calendar_sources or [],
+            connector_events or [],
+        ]
+        self.execute_calls = 0
+
+    async def execute(self, query):
+        del query
+        result = self.results[self.execute_calls]
+        self.execute_calls += 1
+        return MockResult(result)
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _signed_session_token(payload: dict[str, object]) -> str:
+    header_segment = _base64url_encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode()
+    )
+    payload_segment = _base64url_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature = hmac.new(
+        TEST_SESSION_HMAC_SECRET.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _valid_session_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ver": 1,
+        "iss": "naruon-control-plane",
+        "aud": "naruon-api",
+        "sub": "admin",
+        "role": "tenant_admin",
+        "org": "org-acme",
+        "groups": ["group-security"],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 28, 4, 0, tzinfo=timezone.utc)
+
+
+def _webdav_account(
+    source_uid: str,
+    user_id: str,
+    organization_id: str | None = "org-acme",
+) -> WebdavAccount:
+    return WebdavAccount(
+        source_uid=source_uid,
+        user_id=user_id,
+        organization_id=organization_id,
+        server_url="https://files.acme.example/dav",
+        username="files@example.com",
+        credentials_encrypted="credential secret",
+        writeback_enabled=True,
+        created_at=_now(),
+    )
+
+
+def _calendar_source(
+    source_uid: str,
+    user_id: str,
+    organization_id: str | None = "org-acme",
+) -> CalendarWritebackSource:
+    return CalendarWritebackSource(
+        source_uid=source_uid,
+        user_id=user_id,
+        organization_id=organization_id,
+        workspace_id="workspace-org-acme",
+        account_ref="caldav-account-ref",
+        provider_name="Customer CalDAV",
+        source_protocol="caldav",
+        source_host="calendar.acme.example",
+        writeback_enabled=True,
+        etag_value="etag-caldav-primary",
+        created_at=_now(),
+    )
+
+
+def _connector_event(
+    event_uid: str,
+    organization_id: str = "org-acme",
+    workspace_id: str = "workspace-org-acme",
+) -> ConnectorSignalEvent:
+    return ConnectorSignalEvent(
+        event_uid=event_uid,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        signal_key="connector_heartbeat",
+        state_code="heartbeat",
+        detail_text="outbound connector heartbeat",
+        observed_at=_now(),
+    )
+
+
+@pytest.fixture
+def mock_db():
+    return MockAsyncSession(
+        webdav_accounts=[
+            _webdav_account("webdav_src_org_primary", "owner"),
+            _webdav_account("webdav_src_other_org", "owner", "org-rival"),
+        ],
+        calendar_sources=[
+            _calendar_source("caldav_src_primary", "owner"),
+            _calendar_source("caldav_src_other_org", "owner", "org-rival"),
+        ],
+        connector_events=[
+            _connector_event("connector_evt_heartbeat"),
+            _connector_event("connector_evt_other_org", "org-rival"),
+        ],
+    )
+
+
+@pytest.fixture
+def admin_client(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "admin",
+                "X-User-Role": "tenant_admin",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_access_surface_returns_org_scoped_sources_and_policy_decisions(admin_client):
+    response = admin_client.get("/api/security/access-surface")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["audit_event"] == "security.access_surface.viewed"
+    assert data["viewer"]["role"] == "tenant_admin"
+    source_ids = {source["source_id"] for source in data["sources"]}
+    assert source_ids == {"webdav_src_org_primary", "caldav_src_primary"}
+    assert "webdav_src_other_org" not in response.text
+    assert "caldav_src_other_org" not in response.text
+    assert data["connector_events"][0]["event_uid"] == "connector_evt_heartbeat"
+    assert "connector_evt_other_org" not in response.text
+    reasons = {decision["reason"] for decision in data["policy_decisions"]}
+    assert "organization_denied" in reasons
+    assert "data_region_denied" in reasons
+    assert "allowed" in reasons
+
+
+def test_access_surface_redacts_sequential_ids_and_credentials(admin_client):
+    response = admin_client.get("/api/security/access-surface")
+
+    assert response.status_code == 200, response.text
+    serialized = response.text
+    for forbidden in (
+        "account_id",
+        "credentials_encrypted",
+        "credential secret",
+        "username",
+        "files@example.com",
+    ):
+        assert forbidden not in serialized
+
+
+def test_member_surface_only_returns_owned_sources(mock_db):
+    async def override_get_db():
+        yield MockAsyncSession(
+            webdav_accounts=[
+                _webdav_account("webdav_src_owned", "member"),
+                _webdav_account("webdav_src_admin", "admin"),
+            ],
+            calendar_sources=[
+                _calendar_source("caldav_src_owned", "member"),
+                _calendar_source("caldav_src_admin", "admin"),
+            ],
+            connector_events=[],
+        )
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "member",
+                "X-User-Role": "member",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as client:
+            response = client.get("/api/security/access-surface")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200, response.text
+    source_ids = {source["source_id"] for source in response.json()["sources"]}
+    assert source_ids == {"webdav_src_owned", "caldav_src_owned"}
+
+
+def test_access_surface_rejects_public_identity_headers_without_signed_session(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides.pop(get_auth_context, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    try:
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/security/access-surface",
+                headers={
+                    "X-User-Id": "admin",
+                    "X-User-Role": "tenant_admin",
+                    "X-Organization-Id": "org-acme",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+def test_access_surface_accepts_signed_bearer_session(mock_db):
+    async def override_get_db():
+        yield mock_db
+
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    original_overrides = dict(app.dependency_overrides)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(_valid_session_payload())
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides.pop(get_auth_context, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    try:
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/security/access-surface",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["viewer"]["user_id"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
+    user_id = f"security_smoke_user_{uuid.uuid4().hex[:12]}"
+    source_uid = f"webdav_src_security_{uuid.uuid4().hex[:18]}"
+    caldav_uid = f"caldav_src_security_{uuid.uuid4().hex[:18]}"
+    event_uid = f"connector_evt_security_{uuid.uuid4().hex[:18]}"
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO webdav_accounts (
+                        source_uid,
+                        user_id,
+                        organization_id,
+                        server_url,
+                        username,
+                        credentials_encrypted,
+                        writeback_enabled
+                    )
+                    VALUES (
+                        :source_uid,
+                        :user_id,
+                        :organization_id,
+                        :server_url,
+                        :username,
+                        :credentials_encrypted,
+                        :writeback_enabled
+                    )
+                    """
+                ),
+                {
+                    "source_uid": source_uid,
+                    "user_id": user_id,
+                    "organization_id": "org-acme",
+                    "server_url": "https://security-files.example/dav",
+                    "username": "security-smoke@example.com",
+                    "credentials_encrypted": "test-only-placeholder",
+                    "writeback_enabled": True,
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO calendar_writeback_sources (
+                        source_uid,
+                        user_id,
+                        organization_id,
+                        workspace_id,
+                        account_ref,
+                        provider_name,
+                        source_protocol,
+                        source_host,
+                        writeback_enabled,
+                        etag_value
+                    )
+                    VALUES (
+                        :source_uid,
+                        :user_id,
+                        :organization_id,
+                        :workspace_id,
+                        :account_ref,
+                        :provider_name,
+                        :source_protocol,
+                        :source_host,
+                        :writeback_enabled,
+                        :etag_value
+                    )
+                    """
+                ),
+                {
+                    "source_uid": caldav_uid,
+                    "user_id": user_id,
+                    "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
+                    "account_ref": "security-smoke-account",
+                    "provider_name": "Security Smoke CalDAV",
+                    "source_protocol": "caldav",
+                    "source_host": "security-caldav.example",
+                    "writeback_enabled": True,
+                    "etag_value": "etag-security-smoke",
+                },
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO connector_signal_events (
+                        event_uid,
+                        organization_id,
+                        workspace_id,
+                        signal_key,
+                        state_code,
+                        detail_text
+                    )
+                    VALUES (
+                        :event_uid,
+                        :organization_id,
+                        :workspace_id,
+                        :signal_key,
+                        :state_code,
+                        :detail_text
+                    )
+                    """
+                ),
+                {
+                    "event_uid": event_uid,
+                    "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
+                    "signal_key": "connector_heartbeat",
+                    "state_code": "heartbeat",
+                    "detail_text": "security smoke connector heartbeat",
+                },
+            )
+    except (
+        ConnectionRefusedError,
+        OSError,
+        OperationalError,
+        asyncpg.CannotConnectNowError,
+        asyncpg.InvalidAuthorizationSpecificationError,
+        asyncpg.InvalidCatalogNameError,
+        asyncpg.InvalidPasswordError,
+    ):
+        await engine.dispose()
+        pytest.skip("PostgreSQL smoke path unavailable")
+    except Exception:
+        await engine.dispose()
+        raise
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_real_db():
+        async with session_factory() as session:
+            yield session
+
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    original_overrides = dict(app.dependency_overrides)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(sub=user_id, workspace="workspace-org-acme")
+    )
+    app.dependency_overrides[get_db] = override_real_db
+    app.dependency_overrides.pop(get_auth_context, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as client:
+            response = await client.get("/api/security/access-surface")
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DELETE FROM webdav_accounts WHERE source_uid = :source_uid"),
+                {"source_uid": source_uid},
+            )
+            await conn.execute(
+                text(
+                    "DELETE FROM calendar_writeback_sources "
+                    "WHERE source_uid = :source_uid"
+                ),
+                {"source_uid": caldav_uid},
+            )
+            await conn.execute(
+                text(
+                    "DELETE FROM connector_signal_events "
+                    "WHERE event_uid = :event_uid"
+                ),
+                {"event_uid": event_uid},
+            )
+        await engine.dispose()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    source_ids = {source["source_id"] for source in body["sources"]}
+    assert source_uid in source_ids
+    assert caldav_uid in source_ids
+    assert event_uid in {event["event_uid"] for event in body["connector_events"]}
+    assert "account_id" not in response.text
+    assert "security-smoke@example.com" not in response.text

--- a/docs/plans/2026-05-28-security-governance-access-surface.md
+++ b/docs/plans/2026-05-28-security-governance-access-surface.md
@@ -1,0 +1,63 @@
+# 2026-05-28 Security Governance Access Surface
+
+## Verified gap
+
+- `docs/plans/2026-05-24-north-star-master-spec.md` requires the Security GNB
+  detail area to cover security dashboard, access permissions, audit logs,
+  external sharing, and policy.
+- `frontend/branding` contains only visual UX mockups, so implementation
+  evidence must come from the current app rather than a separate written
+  security spec.
+- `frontend/src/components/SecurityLayout.tsx` was still static before this
+  phase: policy rows, block logs, OIDC posture, audit logs, external sharing,
+  and policy views were not source-backed, and three high-traffic tabs rendered
+  inert "coming soon" copy.
+- `DataLayout` and `SettingsLayout` already use signed APIs for WebDAV, CalDAV,
+  account configuration, runner config, and observability signals. Security was
+  therefore the smallest high-impact GNB/detail gap after provider onboarding.
+
+## External best-practice inputs checked
+
+- NIST SP 800-162 defines ABAC as access decisions based on subject, object,
+  operation, and environmental attributes against policies. The implemented
+  surface therefore displays organization, workspace, owner, source capability,
+  consent, and region decisions instead of role-only examples.
+  Source: https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=927500
+- OWASP Authorization Cheat Sheet recommends least privilege, deny by default,
+  permission checks on every request, ABAC/ReBAC over role-only checks, safe
+  failure, and authorization test coverage. The UI now labels deny precedence and
+  the backend evaluates ABAC denials before RBAC allows.
+  Source: https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html
+- OWASP Logging Cheat Sheet says application security event logging should be
+  consistent and useful for investigation. This phase does not expose the legacy
+  unscoped `AuditLog` table directly; it surfaces scoped connector evidence and
+  the API audit event name only.
+  Source: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+
+## Implemented slice
+
+- Add signed private `GET /api/security/access-surface`.
+- Return source-linked rows from:
+  - `webdav_accounts`
+  - `calendar_writeback_sources`
+  - `connector_signal_events`
+- Reuse `services.access_policy.evaluate_access` for source decisions and
+  canonical deny-precedence checks.
+- Keep the response read-only and explicit:
+  `provider_write_executed=false`, no credential fields, no sequential
+  `account_id`, no raw provider secret, no fake security claims.
+- Wire Security tabs to the API:
+  - dashboard summary
+  - source-linked access table
+  - scoped connector/audit evidence
+  - external writeback boundary reviews
+  - deny-first policy order and decision table
+
+## Follow-up roadmap
+
+- Persist org/workspace scope on centralized audit log rows before exposing
+  durable audit history outside connector events.
+- Add policy mutation APIs only after versioned policy objects and approval
+  workflows exist.
+- Add external sharing approval/revocation APIs only after provider connector
+  execution can enforce source capability, consent, and ETag/If-Match checks.

--- a/frontend/src/app/security/page.test.tsx
+++ b/frontend/src/app/security/page.test.tsx
@@ -9,17 +9,134 @@ vi.mock("next/link", () => ({
 
 vi.mock("lucide-react", () => ({
   AlertOctagon: () => <svg aria-hidden="true" />,
-  KeyRound: () => <svg aria-hidden="true" />,
-  LockKeyhole: () => <svg aria-hidden="true" />,
-  Route: () => <svg aria-hidden="true" />,
-  ShieldCheck: () => <svg aria-hidden="true" />,
-  Users: () => <svg aria-hidden="true" />,
-  Lock: () => <svg aria-hidden="true" />,
   CheckCircle2: () => <svg aria-hidden="true" />,
+  Database: () => <svg aria-hidden="true" />,
+  Lock: () => <svg aria-hidden="true" />,
+  RefreshCw: () => <svg aria-hidden="true" />,
+  ScrollText: () => <svg aria-hidden="true" />,
+  Share2: () => <svg aria-hidden="true" />,
+  ShieldCheck: () => <svg aria-hidden="true" />,
   XCircle: () => <svg aria-hidden="true" />,
 }));
 
 import SecurityPage from "./page";
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  };
+}
+
+const securitySurface = {
+  workspace_id: "workspace-org-acme",
+  organization_id: "org-acme",
+  audit_event: "security.access_surface.viewed",
+  viewer: {
+    user_id: "admin",
+    role: "tenant_admin",
+    organization_id: "org-acme",
+    group_ids: ["group-security"],
+    workspace_id: "workspace-org-acme",
+  },
+  sources: [
+    {
+      source_id: "webdav_src_primary",
+      source_type: "webdav_repository",
+      source_label: "WebDAV repository",
+      source_host: "files.acme.example",
+      owner_id: "owner",
+      organization_id: "org-acme",
+      workspace_id: "workspace-org-acme",
+      capabilities: ["read", "write", "etag"],
+      writeback_enabled: true,
+      provider_write_executed: false,
+      last_observed_at: "2026-05-28T04:00:00Z",
+      policy_decision: {
+        decision_uid: "policy:webdav_src_primary",
+        resource_label: "WebDAV repository",
+        resource_type: "webdav_repository",
+        allowed: true,
+        reason: "allowed",
+        evidence_source: "webdav_accounts",
+      },
+    },
+  ],
+  connector_events: [
+    {
+      event_uid: "connector_evt_heartbeat",
+      signal_key: "connector_heartbeat",
+      state_code: "heartbeat",
+      detail_text: "outbound connector heartbeat",
+      observed_at: "2026-05-28T04:00:00Z",
+    },
+  ],
+  policy_decisions: [
+    {
+      decision_uid: "policy:webdav_src_primary",
+      resource_label: "WebDAV repository",
+      resource_type: "webdav_repository",
+      allowed: true,
+      reason: "allowed",
+      evidence_source: "webdav_accounts",
+    },
+    {
+      decision_uid: "policy:cross-organization-deny",
+      resource_label: "Cross-organization provider secret",
+      resource_type: "provider_secret",
+      allowed: false,
+      reason: "organization_denied",
+      evidence_source: "access_policy.evaluate_access",
+    },
+  ],
+  external_share_reviews: [
+    {
+      review_uid: "share:webdav_src_primary",
+      source_id: "webdav_src_primary",
+      source_type: "webdav_repository",
+      review_label: "WebDAV repository writeback boundary",
+      exposure_level: "external_writeback",
+      decision_reason: "allowed",
+      provider_write_executed: false,
+    },
+  ],
+  policy_order: [
+    {
+      step_key: "signed_session",
+      display_name: "Signed session identity",
+      evidence_source: "api.auth.get_auth_context",
+    },
+    {
+      step_key: "rbac",
+      display_name: "RBAC allow after ABAC denies",
+      evidence_source: "services.access_policy.evaluate_access",
+    },
+  ],
+};
+
+function mockSecurityFetch() {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    void init;
+    if (String(input) === "/api/security/access-surface") {
+      return jsonResponse(securitySurface);
+    }
+    throw new Error(`Unhandled fetch: ${String(input)}`);
+  });
+}
+
+async function renderSecurityPage() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<SecurityPage />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
 
 describe("SecurityPage", () => {
   let root: Root | null = null;
@@ -30,20 +147,71 @@ describe("SecurityPage", () => {
     root = null;
     container?.remove();
     container = null;
+    localStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it("renders security dashboard access audit sharing and policy governance screens", () => {
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
+  it("fetches signed security governance and renders source-backed access data", async () => {
+    localStorage.setItem("naruon_session_token", "signed-security-session");
+    const fetchMock = mockSecurityFetch();
+    vi.stubGlobal("fetch", fetchMock);
 
-    act(() => {
-      root?.render(<SecurityPage />);
-    });
+    ({ container, root } = await renderSecurityPage());
 
     expect(container.querySelector("h1")?.textContent).toContain("보안과 관리자");
-    expect(container.textContent).toContain("보안과 관리자");
-    expect(container.textContent).toContain("감사 로그");
-    expect(container.textContent).toContain("인증 연동");
+    expect(container.textContent).toContain("Source-linked RBAC / ABAC");
+    expect(container.textContent).toContain("webdav_src_primary");
+    expect(container.textContent).toContain("files.acme.example");
+    expect(container.textContent).not.toContain("곧 제공됩니다");
+    expect(container.textContent).not.toContain("비정상 로그인 시도");
+
+    const accessCall = fetchMock.mock.calls.find(([input]) => String(input) === "/api/security/access-surface");
+    expect(accessCall).toBeDefined();
+    const [, init] = accessCall ?? [];
+    const headerEntries =
+      init?.headers instanceof Headers
+        ? Array.from(init.headers.entries())
+        : Object.entries((init?.headers as Record<string, string>) ?? {});
+    const requestHeaders = Object.fromEntries(
+      headerEntries.map(([key, value]) => [key.toLowerCase(), String(value)]),
+    );
+    expect(requestHeaders.authorization).toBe("Bearer signed-security-session");
+    for (const publicHeader of [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ]) {
+      expect(requestHeaders[publicHeader]).toBeUndefined();
+    }
+  });
+
+  it("renders audit sharing and policy tabs without inert placeholders", async () => {
+    vi.stubGlobal("fetch", mockSecurityFetch());
+    ({ container, root } = await renderSecurityPage());
+
+    for (const tabName of ["감사 로그", "외부 공유", "정책"]) {
+      const tab = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes(tabName),
+      );
+      expect(tab).toBeDefined();
+      await act(async () => {
+        tab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(container.textContent).not.toContain("곧 제공됩니다");
+      if (tabName === "감사 로그") {
+        expect(container.textContent).toContain("connector_evt_heartbeat");
+      }
+      if (tabName === "외부 공유") {
+        expect(container.textContent).toContain("WebDAV repository writeback boundary");
+      }
+      if (tabName === "정책") {
+        expect(container.textContent).toContain("Deny-first policy order");
+        expect(container.textContent).toContain("RBAC allow after ABAC denies");
+      }
+    }
   });
 });

--- a/frontend/src/components/SecurityLayout.tsx
+++ b/frontend/src/components/SecurityLayout.tsx
@@ -1,24 +1,515 @@
 "use client";
 
-import { useState } from 'react';
-import { ShieldCheck, Lock, AlertOctagon, CheckCircle2, XCircle } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  AlertOctagon,
+  CheckCircle2,
+  Database,
+  Lock,
+  RefreshCw,
+  ScrollText,
+  Share2,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react';
 
-export function SecurityLayout() {
-  const [activeTab, setActiveTab] = useState<'보안 대시보드' | '접근 권한' | '감사 로그' | '외부 공유' | '정책'>('접근 권한');
+import { apiClient } from '@/lib/api-client';
+
+type SecurityTab = '보안 대시보드' | '접근 권한' | '감사 로그' | '외부 공유' | '정책';
+
+type PolicyDecisionSummary = {
+  decision_uid: string;
+  resource_label: string;
+  resource_type: string;
+  allowed: boolean;
+  reason: string;
+  evidence_source: string;
+};
+
+type GovernanceSource = {
+  source_id: string;
+  source_type: 'caldav_source' | 'carddav_source' | 'webdav_repository';
+  source_label: string;
+  source_host: string;
+  owner_id: string;
+  organization_id: string | null;
+  workspace_id: string;
+  capabilities: string[];
+  writeback_enabled: boolean;
+  provider_write_executed: boolean;
+  policy_decision: PolicyDecisionSummary;
+  last_observed_at: string | null;
+};
+
+type ConnectorEvidence = {
+  event_uid: string;
+  signal_key: string;
+  state_code: string;
+  detail_text: string | null;
+  observed_at: string;
+};
+
+type ExternalShareReview = {
+  review_uid: string;
+  source_id: string;
+  source_type: GovernanceSource['source_type'];
+  review_label: string;
+  exposure_level: 'internal' | 'external_writeback';
+  decision_reason: string;
+  provider_write_executed: boolean;
+};
+
+type PolicyOrderStep = {
+  step_key: string;
+  display_name: string;
+  evidence_source: string;
+};
+
+type SecurityAccessSurface = {
+  workspace_id: string;
+  organization_id: string | null;
+  audit_event: 'security.access_surface.viewed';
+  viewer: {
+    user_id: string;
+    role: string;
+    organization_id: string | null;
+    group_ids: string[];
+    workspace_id: string;
+  };
+  sources: GovernanceSource[];
+  connector_events: ConnectorEvidence[];
+  policy_decisions: PolicyDecisionSummary[];
+  external_share_reviews: ExternalShareReview[];
+  policy_order: PolicyOrderStep[];
+};
+
+const tabs: SecurityTab[] = ['보안 대시보드', '접근 권한', '감사 로그', '외부 공유', '정책'];
+
+const reasonLabels: Record<string, string> = {
+  allowed: '허용',
+  organization_denied: '조직 차단',
+  data_region_denied: '리전 차단',
+  consent_denied: '동의 차단',
+  ownership_denied: '소유권 차단',
+  rbac_denied: 'RBAC 차단',
+};
+
+function reasonLabel(reason: string) {
+  return reasonLabels[reason] ?? reason;
+}
+
+function DecisionPill({ decision }: { decision: PolicyDecisionSummary }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-bold ${
+        decision.allowed
+          ? 'bg-emerald-100 text-emerald-700'
+          : 'bg-red-100 text-red-700'
+      }`}
+    >
+      {decision.allowed ? <CheckCircle2 className="size-3" /> : <XCircle className="size-3" />}
+      {reasonLabel(decision.reason)}
+    </span>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground">
+      보안 거버넌스 데이터를 불러오는 중입니다.
+    </div>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+      signed-session 보안 표면을 불러오지 못했습니다. {message}
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-background p-5 text-sm text-muted-foreground">
+      현재 signed-session 스코프에서 확인된 {label}가 없습니다.
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  detail,
+  icon,
+}: {
+  title: string;
+  value: string;
+  detail: string;
+  icon: ReactNode;
+}) {
+  return (
+    <article className="rounded-lg border border-border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-bold text-muted-foreground">{title}</p>
+          <p className="mt-2 text-xl font-bold">{value}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+        </div>
+        <div className="rounded-lg bg-secondary p-2 text-primary">{icon}</div>
+      </div>
+    </article>
+  );
+}
+
+function DashboardTab({ data }: { data: SecurityAccessSurface }) {
+  const allowedCount = data.policy_decisions.filter((decision) => decision.allowed).length;
+  const deniedCount = data.policy_decisions.length - allowedCount;
+  const writebackReady = data.sources.filter((source) => source.writeback_enabled).length;
+  const providerWrites = data.sources.filter((source) => source.provider_write_executed).length;
 
   return (
-    <div className="flex h-full min-w-0 min-h-0 bg-background text-foreground flex-col overflow-x-hidden">
-      <header className="flex h-20 shrink-0 items-center border-b border-border bg-card px-4 md:px-8 overflow-hidden">
-        <h1 className="text-xl md:text-2xl font-bold flex shrink-0 items-center gap-3">
-          <ShieldCheck className="size-6 text-primary" /> <span className="hidden sm:inline">보안과 관리자</span>
+    <section aria-label="보안 거버넌스 대시보드" className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <SummaryCard
+          title="접근 판정"
+          value={`${allowedCount}/${data.policy_decisions.length}`}
+          detail={`deny ${deniedCount}건, ABAC가 RBAC보다 먼저 적용됩니다.`}
+          icon={<ShieldCheck className="size-5" />}
+        />
+        <SummaryCard
+          title="연결 원본"
+          value={`${data.sources.length}개`}
+          detail={`writeback 가능 ${writebackReady}개, source-owned only`}
+          icon={<Database className="size-5" />}
+        />
+        <SummaryCard
+          title="Connector evidence"
+          value={`${data.connector_events.length}건`}
+          detail={data.workspace_id}
+          icon={<ScrollText className="size-5" />}
+        />
+        <SummaryCard
+          title="Provider write"
+          value={`${providerWrites}건`}
+          detail="이 화면은 읽기 전용 evidence만 표시합니다."
+          icon={<Lock className="size-5" />}
+        />
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-bold">현재 관리자 경계</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {data.viewer.role} / {data.organization_id ?? 'personal-scope'} / {data.workspace_id}
+            </p>
+          </div>
+          <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold text-muted-foreground">
+            {data.audit_event}
+          </span>
+        </div>
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+          {data.policy_decisions.slice(0, 4).map((decision) => (
+            <div key={decision.decision_uid} className="rounded-lg border border-border bg-background p-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="min-w-0 truncate text-sm font-bold">{decision.resource_label}</p>
+                <DecisionPill decision={decision} />
+              </div>
+              <p className="mt-2 truncate font-mono text-xs text-muted-foreground">{decision.evidence_source}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AccessTab({ data }: { data: SecurityAccessSurface }) {
+  return (
+    <section aria-label="접근 권한 소스 거버넌스" className="space-y-5">
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-bold">Source-linked RBAC / ABAC</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              WebDAV, CalDAV, CardDAV source registry를 signed-session 스코프로 판정합니다.
+            </p>
+          </div>
+          <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold text-muted-foreground">
+            provider_write_executed=false
+          </span>
+        </div>
+        {data.sources.length === 0 ? (
+          <div className="mt-4">
+            <EmptyState label="연결 원본" />
+          </div>
+        ) : (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 md:hidden">
+              {data.sources.map((source) => (
+                <article key={source.source_id} className="rounded-lg border border-border bg-background p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h3 className="text-sm font-bold">{source.source_label}</h3>
+                      <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{source.source_id}</p>
+                    </div>
+                    <DecisionPill decision={source.policy_decision} />
+                  </div>
+                  <dl className="mt-3 grid grid-cols-1 gap-2 text-xs">
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="font-bold text-muted-foreground">Host</dt>
+                      <dd className="break-all text-right font-mono">{source.source_host}</dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="font-bold text-muted-foreground">Owner</dt>
+                      <dd className="text-right">{source.owner_id} / {source.organization_id ?? 'personal'}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-bold text-muted-foreground">Capability</dt>
+                      <dd className="mt-2 flex flex-wrap gap-1">
+                        {source.capabilities.map((capability) => (
+                          <span key={capability} className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">
+                            {capability}
+                          </span>
+                        ))}
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+            <div className="mt-4 hidden overflow-x-auto md:block">
+              <table className="w-full min-w-[760px] text-left text-sm">
+                <thead className="border-b border-border bg-secondary/50 text-xs text-muted-foreground">
+                  <tr>
+                    <th className="p-3 font-bold">원본</th>
+                    <th className="p-3 font-bold">Host</th>
+                    <th className="p-3 font-bold">Owner scope</th>
+                    <th className="p-3 font-bold">Capability</th>
+                    <th className="p-3 font-bold">판정</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {data.sources.map((source) => (
+                    <tr key={source.source_id} className="bg-background">
+                      <td className="p-3">
+                        <p className="font-bold">{source.source_label}</p>
+                        <p className="mt-1 font-mono text-xs text-muted-foreground">{source.source_id}</p>
+                      </td>
+                      <td className="p-3 font-mono text-xs">{source.source_host}</td>
+                      <td className="p-3">
+                        <p>{source.owner_id}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{source.organization_id ?? 'personal'}</p>
+                      </td>
+                      <td className="p-3">
+                        <div className="flex flex-wrap gap-1">
+                          {source.capabilities.map((capability) => (
+                            <span key={capability} className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">
+                              {capability}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="p-3"><DecisionPill decision={source.policy_decision} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function AuditTab({ data }: { data: SecurityAccessSurface }) {
+  return (
+    <section aria-label="보안 감사 로그" className="space-y-5">
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-base font-bold">Connector evidence와 감사 이벤트</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          AuditLog 직접 노출 대신 scoped connector evidence와 API audit event만 표시합니다.
+        </p>
+        <div className="mt-4 rounded-lg border border-border bg-background p-3">
+          <p className="text-xs font-bold text-muted-foreground">API audit event</p>
+          <p className="mt-1 font-mono text-sm">{data.audit_event}</p>
+        </div>
+        {data.connector_events.length === 0 ? (
+          <div className="mt-4">
+            <EmptyState label="connector evidence" />
+          </div>
+        ) : (
+          <div className="mt-4 space-y-3">
+            {data.connector_events.map((event) => (
+              <div key={event.event_uid} className="rounded-lg border border-border bg-background p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="font-mono text-sm font-bold">{event.event_uid}</p>
+                  <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">{event.state_code}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{event.detail_text ?? event.signal_key}</p>
+                <p className="mt-2 font-mono text-xs text-muted-foreground">{event.observed_at}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SharingTab({ data }: { data: SecurityAccessSurface }) {
+  return (
+    <section aria-label="외부 공유와 writeback 검토" className="space-y-5">
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-base font-bold">외부 공유 / writeback boundary</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          고객 소유 provider로 나가는 writeback 가능성만 검토하며 실제 provider write는 실행하지 않습니다.
+        </p>
+        {data.external_share_reviews.length === 0 ? (
+          <div className="mt-4">
+            <EmptyState label="외부 공유 검토 항목" />
+          </div>
+        ) : (
+          <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+            {data.external_share_reviews.map((review) => (
+              <article key={review.review_uid} className="rounded-lg border border-border bg-background p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="truncate text-sm font-bold">{review.review_label}</h3>
+                    <p className="mt-1 truncate font-mono text-xs text-muted-foreground">{review.source_id}</p>
+                  </div>
+                  <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">
+                    {review.exposure_level}
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                  <span className="rounded-md bg-red-50 px-2 py-1 font-bold text-red-700">
+                    {reasonLabel(review.decision_reason)}
+                  </span>
+                  <span className="rounded-md bg-secondary px-2 py-1 font-bold">
+                    provider_write_executed={String(review.provider_write_executed)}
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function PolicyTab({ data }: { data: SecurityAccessSurface }) {
+  return (
+    <section aria-label="정책 엔진 판정 순서" className="space-y-5">
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-base font-bold">Deny-first policy order</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          NIST ABAC 모델과 OWASP deny-by-default 원칙에 맞춰 속성 차단을 역할 허용보다 먼저 평가합니다.
+        </p>
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+          {data.policy_order.map((step, index) => (
+            <div key={step.step_key} className="rounded-lg border border-border bg-background p-3">
+              <div className="flex items-center gap-3">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+                  {index + 1}
+                </span>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-bold">{step.display_name}</p>
+                  <p className="mt-1 truncate font-mono text-xs text-muted-foreground">{step.evidence_source}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-base font-bold">판정 샘플</h2>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[720px] text-left text-sm">
+            <thead className="border-b border-border bg-secondary/50 text-xs text-muted-foreground">
+              <tr>
+                <th className="p-3 font-bold">Resource</th>
+                <th className="p-3 font-bold">Type</th>
+                <th className="p-3 font-bold">Decision</th>
+                <th className="p-3 font-bold">Evidence</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.policy_decisions.map((decision) => (
+                <tr key={decision.decision_uid} className="bg-background">
+                  <td className="p-3 font-bold">{decision.resource_label}</td>
+                  <td className="p-3 font-mono text-xs">{decision.resource_type}</td>
+                  <td className="p-3"><DecisionPill decision={decision} /></td>
+                  <td className="p-3 font-mono text-xs text-muted-foreground">{decision.evidence_source}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function SecurityLayout() {
+  const [activeTab, setActiveTab] = useState<SecurityTab>('접근 권한');
+  const [data, setData] = useState<SecurityAccessSurface | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    apiClient
+      .get<SecurityAccessSurface>('/api/security/access-surface')
+      .then((surface) => {
+        if (!mounted) return;
+        setData(surface);
+      })
+      .catch((err: unknown) => {
+        if (!mounted) return;
+        setError(err instanceof Error ? err.message : 'unknown error');
+      })
+      .finally(() => {
+        if (!mounted) return;
+        setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (loading) return <LoadingPanel />;
+    if (error) return <ErrorPanel message={error} />;
+    if (!data) return <EmptyState label="보안 거버넌스 데이터" />;
+    if (activeTab === '보안 대시보드') return <DashboardTab data={data} />;
+    if (activeTab === '접근 권한') return <AccessTab data={data} />;
+    if (activeTab === '감사 로그') return <AuditTab data={data} />;
+    if (activeTab === '외부 공유') return <SharingTab data={data} />;
+    return <PolicyTab data={data} />;
+  }, [activeTab, data, error, loading]);
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-x-hidden bg-background text-foreground">
+      <header className="flex h-20 shrink-0 items-center overflow-hidden border-b border-border bg-card px-4 md:px-8">
+        <h1 className="flex shrink-0 items-center gap-3 text-xl font-bold md:text-2xl">
+          <ShieldCheck className="size-6 text-primary" />
+          <span className="hidden sm:inline">보안과 관리자</span>
         </h1>
         <p className="sr-only">관리자 경계</p>
-        <div className="ml-4 md:ml-8 flex flex-1 min-w-0 gap-2 overflow-x-auto pb-1 scrollbar-hide">
-          {['보안 대시보드', '접근 권한', '감사 로그', '외부 공유', '정책'].map((tab) => (
+        <div className="ml-4 flex min-w-0 flex-1 gap-2 overflow-x-auto pb-1 md:ml-8">
+          {tabs.map((tab) => (
             <button
               key={tab}
-              onClick={() => setActiveTab(tab as '보안 대시보드' | '접근 권한' | '감사 로그' | '외부 공유' | '정책')}
-              className={`whitespace-nowrap px-3 md:px-4 py-2 text-sm font-bold rounded-lg transition-colors shrink-0 ${activeTab === tab ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+              onClick={() => setActiveTab(tab)}
+              className={`shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-bold transition-colors md:px-4 ${
+                activeTab === tab
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-secondary'
+              }`}
             >
               {tab}
             </button>
@@ -26,183 +517,50 @@ export function SecurityLayout() {
         </div>
       </header>
 
-      <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden p-4 md:p-8">
-        <div className="max-w-5xl mx-auto space-y-8">
-          
-          {activeTab === '접근 권한' && (
-            <div className="space-y-6">
-              <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-                <div className="flex items-center justify-between mb-6">
-                  <div>
-                    <h2 className="font-bold text-lg">권한 정책 (Policies)</h2>
-                    <p className="text-sm text-muted-foreground mt-1">사용자 역할(RBAC) 및 속성 기반(ABAC) 접근 제어 규칙입니다. <strong className="text-red-500">Deny 정책이 우선합니다.</strong></p>
-                  </div>
-                  <button className="bg-primary text-primary-foreground text-sm font-bold px-4 py-2 rounded-lg">새 정책 추가</button>
-                </div>
-                
-                <div className="border border-border rounded-xl overflow-hidden">
-                  <table className="w-full text-sm text-left">
-                    <thead className="bg-secondary/50 text-muted-foreground border-b border-border">
-                      <tr>
-                        <th className="p-4 font-bold">효과 (Effect)</th>
-                        <th className="p-4 font-bold">대상 (Resource)</th>
-                        <th className="p-4 font-bold">조건 (Condition / ABAC)</th>
-                        <th className="p-4 font-bold">역할 (Role)</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border bg-background">
-                      <tr className="hover:bg-secondary/20">
-                        <td className="p-4"><span className="bg-red-100 text-red-700 px-2 py-1 rounded font-bold text-xs">DENY</span></td>
-                        <td className="p-4 font-mono text-xs">/api/accounts/*</td>
-                        <td className="p-4">Outside Corporate IP</td>
-                        <td className="p-4">All</td>
-                      </tr>
-                      <tr className="hover:bg-secondary/20">
-                        <td className="p-4"><span className="bg-green-100 text-green-700 px-2 py-1 rounded font-bold text-xs">ALLOW</span></td>
-                        <td className="p-4 font-mono text-xs">/api/tasks/*</td>
-                        <td className="p-4">Tenant == User.Tenant</td>
-                        <td className="p-4">Member, Admin</td>
-                      </tr>
-                      <tr className="hover:bg-secondary/20">
-                        <td className="p-4"><span className="bg-green-100 text-green-700 px-2 py-1 rounded font-bold text-xs">ALLOW</span></td>
-                        <td className="p-4 font-mono text-xs">/api/settings/*</td>
-                        <td className="p-4">-</td>
-                        <td className="p-4">Admin</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-6">
-                <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-                  <div className="flex items-center gap-3 mb-4">
-                    <div className="rounded-xl bg-orange-100 p-3"><AlertOctagon className="size-5 text-orange-700" /></div>
-                    <h2 className="font-bold text-lg">최근 차단 로그</h2>
-                  </div>
-                  <div className="space-y-3">
-                    {[
-                      { user: 'guest@example.com', path: '/api/accounts', reason: 'Role mismatch' },
-                      { user: 'park@naruon.com', path: '/api/tasks/T-102', reason: 'Tenant mismatch (ABAC)' },
-                    ].map((log, i) => (
-                      <div key={i} className="text-sm p-3 border border-border rounded-lg bg-background flex justify-between items-center">
-                        <div>
-                          <p className="font-bold">{log.user}</p>
-                          <p className="text-xs text-muted-foreground font-mono mt-1">{log.path}</p>
-                        </div>
-                        <span className="text-xs text-red-600 bg-red-100 px-2 py-1 rounded font-bold">{log.reason}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-                  <div className="flex items-center gap-3 mb-4">
-                    <div className="rounded-xl bg-purple-100 p-3"><Lock className="size-5 text-purple-700" /></div>
-                    <h2 className="font-bold text-lg">인증 연동 (OIDC)</h2>
-                  </div>
-                  <div className="space-y-4 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold text-muted-foreground">Provider</span>
-                      <span className="font-bold">Keycloak (Default)</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold text-muted-foreground">상태</span>
-                      <span className="flex items-center gap-1 text-emerald-600 font-bold"><CheckCircle2 className="size-4" /> 연동됨</span>
-                    </div>
-                    <button className="w-full mt-2 py-2 border border-border rounded-lg font-bold hover:bg-secondary">
-                      Casdoor로 마이그레이션
-                    </button>
-                  </div>
-                </div>
-              </div>
+      <main className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-8">
+        <div className="mx-auto max-w-6xl space-y-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-bold text-muted-foreground">Security governance</p>
+              <h2 className="mt-1 text-lg font-bold">접근 권한, 감사 evidence, writeback boundary</h2>
             </div>
-          )}
-
-          {activeTab === '보안 대시보드' && (
-            <div className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div className="md:col-span-2 rounded-2xl border border-border bg-card p-6 shadow-sm">
-                  <h2 className="font-bold text-lg mb-6 flex items-center gap-2">
-                    <AlertOctagon className="size-5 text-red-500" /> 위협 현황 (Threat Status)
-                  </h2>
-                  <div className="space-y-4">
-                    <div className="flex justify-between items-center p-3 rounded-lg border border-border bg-background">
-                      <div className="flex items-center gap-3">
-                        <div className="size-2 rounded-full bg-red-500"></div>
-                        <div>
-                          <p className="text-sm font-bold">비정상 로그인 시도 감지</p>
-                          <p className="text-xs text-muted-foreground mt-0.5">외부 IP (14.xx.xx.xx)에서 관리자 계정 시도</p>
-                        </div>
-                      </div>
-                      <span className="text-xs font-bold text-red-600 bg-red-100 px-2 py-1 rounded">High</span>
-                    </div>
-                    <div className="flex justify-between items-center p-3 rounded-lg border border-border bg-background">
-                      <div className="flex items-center gap-3">
-                        <div className="size-2 rounded-full bg-orange-500"></div>
-                        <div>
-                          <p className="text-sm font-bold">비인가 API 접근 차단</p>
-                          <p className="text-xs text-muted-foreground mt-0.5">/api/settings 경로 접근 실패</p>
-                        </div>
-                      </div>
-                      <span className="text-xs font-bold text-orange-600 bg-orange-100 px-2 py-1 rounded">Medium</span>
-                    </div>
-                    <div className="flex justify-between items-center p-3 rounded-lg border border-border bg-background">
-                      <div className="flex items-center gap-3">
-                        <div className="size-2 rounded-full bg-green-500"></div>
-                        <div>
-                          <p className="text-sm font-bold">전체 시스템 상태</p>
-                          <p className="text-xs text-muted-foreground mt-0.5">현재 감지된 심각한 위협 없음</p>
-                        </div>
-                      </div>
-                      <span className="text-xs font-bold text-green-600 bg-green-100 px-2 py-1 rounded">Safe</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-                  <h2 className="font-bold text-lg mb-4">규정 준수 (Compliance)</h2>
-                  <div className="space-y-3">
-                    <div className="flex items-start gap-3">
-                      <CheckCircle2 className="size-5 text-emerald-500 shrink-0" />
-                      <div>
-                        <p className="text-sm font-bold">데이터 암호화 (At Rest)</p>
-                        <p className="text-xs text-muted-foreground">PostgreSQL TDE 활성화됨</p>
-                      </div>
-                    </div>
-                    <div className="flex items-start gap-3">
-                      <CheckCircle2 className="size-5 text-emerald-500 shrink-0" />
-                      <div>
-                        <p className="text-sm font-bold">통신 암호화 (In Transit)</p>
-                        <p className="text-xs text-muted-foreground">TLS 1.3 강제 적용됨</p>
-                      </div>
-                    </div>
-                    <div className="flex items-start gap-3">
-                      <XCircle className="size-5 text-red-500 shrink-0" />
-                      <div>
-                        <p className="text-sm font-bold">정기 접근 권한 리뷰</p>
-                        <p className="text-xs text-muted-foreground">90일 초과됨 (리뷰 필요)</p>
-                      </div>
-                    </div>
-                  </div>
-                  <button className="w-full mt-6 py-2 border border-border rounded-lg text-sm font-bold hover:bg-secondary">
-                    체크리스트 상세 보기
-                  </button>
-                </div>
+            <button
+              type="button"
+              onClick={() => {
+                setLoading(true);
+                setError(null);
+                apiClient
+                  .get<SecurityAccessSurface>('/api/security/access-surface')
+                  .then(setData)
+                  .catch((err: unknown) => setError(err instanceof Error ? err.message : 'unknown error'))
+                  .finally(() => setLoading(false));
+              }}
+              className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-bold hover:bg-secondary"
+            >
+              <RefreshCw className="size-4" /> 새로고침
+            </button>
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div className="rounded-lg border border-border bg-card p-3">
+              <div className="flex items-center gap-2 text-sm font-bold">
+                <AlertOctagon className="size-4 text-red-600" /> Deny precedence
               </div>
+              <p className="mt-1 text-xs text-muted-foreground">조직, 리전, 동의, 소유권 차단이 RBAC 허용보다 먼저 적용됩니다.</p>
             </div>
-          )}
-
-          {(activeTab !== '접근 권한' && activeTab !== '보안 대시보드') && (
-            <div className="flex flex-col items-center justify-center py-24 text-center rounded-2xl border border-dashed border-border bg-card">
-              <ShieldCheck className="size-10 text-muted-foreground mb-4 opacity-50" />
-              <h2 className="text-xl font-bold mb-2">{activeTab} 패널</h2>
-              <p className="text-muted-foreground max-w-sm">
-                조직 내 보안 현황, 감사 로그, 외부 공유 제한 등을 통제할 수 있는 기능이 곧 제공됩니다.
-              </p>
+            <div className="rounded-lg border border-border bg-card p-3">
+              <div className="flex items-center gap-2 text-sm font-bold">
+                <Share2 className="size-4 text-primary" /> Source sovereignty
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">WebDAV/CalDAV 원본은 고객 시스템이며 Naruon은 용량 제공자가 아닙니다.</p>
             </div>
-          )}
-
+            <div className="rounded-lg border border-border bg-card p-3">
+              <div className="flex items-center gap-2 text-sm font-bold">
+                <Lock className="size-4 text-primary" /> Signed session only
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">브라우저는 bearer session으로만 보안 API를 호출합니다.</p>
+            </div>
+          </div>
+          {content}
         </div>
       </main>
     </div>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -289,6 +289,95 @@ for (const destination of [
   });
 }
 
+test('renders Security governance access audit sharing and policy with signed API headers', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-security-governance-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  const accessRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/security/access-surface' && request.method() === 'GET';
+  });
+  await page.goto('/security');
+  const accessHeaders = (await accessRequest).headers();
+  expect(accessHeaders.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(accessHeaders[headerName]).toBeUndefined();
+  }
+
+  await expect(page.getByRole('heading', { name: '보안과 관리자' })).toBeVisible();
+  await expect(page.getByText('Source-linked RBAC / ABAC')).toBeVisible();
+  await expect(page.getByRole('row', { name: /webdav_src_primary/ })).toBeVisible();
+  await expect(page.getByText('곧 제공됩니다')).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-access.png'), fullPage: false });
+
+  await page.getByRole('button', { name: '감사 로그' }).click();
+  await expect(page.getByText('connector_evt_heartbeat')).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-audit.png'), fullPage: false });
+
+  await page.getByRole('button', { name: '외부 공유' }).click();
+  await expect(page.getByText('WebDAV repository writeback boundary')).toBeVisible();
+  await page.getByRole('button', { name: '정책' }).click();
+  await expect(page.getByText('Deny-first policy order')).toBeVisible();
+  await expect(page.getByText('Cross-organization provider secret')).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-policy.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await page.goto('/security');
+  await expect(page.getByText('Source-linked RBAC / ABAC')).toBeVisible();
+  await page.getByRole('button', { name: '정책' }).click();
+  await expect(page.getByText('RBAC allow after ABAC denies')).toBeVisible();
+  const tabletOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(tabletOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('security-governance-tablet-policy.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/security');
+  await expect(page.getByText('Source-linked RBAC / ABAC')).toBeVisible();
+  const mobileWebdavSource = page.locator('article', { hasText: 'webdav_src_primary' }).first();
+  await mobileWebdavSource.scrollIntoViewIfNeeded();
+  await expect(mobileWebdavSource).toBeVisible();
+  const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(mobileOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('security-governance-mobile-access.png'), fullPage: false });
+  const securityScrollMetrics = await page.locator('#main-content main').evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(securityScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(securityScrollMetrics.after).toBeGreaterThan(securityScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('security-governance-mobile-scroll.png'), fullPage: false });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: '워크스페이스 메뉴 열기' }).click();
+  const menu = page.locator('#mobile-workspace-menu');
+  await expect(menu.getByRole('link', { name: '보안', exact: true })).toHaveAttribute('href', '/security');
+  await menu.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect(menu.getByRole('link', { name: '설정', exact: true })).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('security-governance-mobile-hamburger.png'), fullPage: false });
+});
+
 test('renders sent mail reply tracking route with signed API headers', async ({ page }, testInfo) => {
   const expectedNaruonToken = 'signed-sent-mail-e2e-token';
   const publicIdentityHeaders = [

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -218,6 +218,140 @@ const operationalSignals = {
   ],
 };
 
+const securityAccessSurface = {
+  workspace_id: 'workspace-org-acme',
+  organization_id: 'org-acme',
+  audit_event: 'security.access_surface.viewed',
+  viewer: {
+    user_id: 'admin',
+    role: 'tenant_admin',
+    organization_id: 'org-acme',
+    group_ids: ['group-security'],
+    workspace_id: 'workspace-org-acme',
+  },
+  sources: [
+    {
+      source_id: 'webdav_src_primary',
+      source_type: 'webdav_repository',
+      source_label: 'WebDAV repository',
+      source_host: 'webdav.naruon.net',
+      owner_id: 'default',
+      organization_id: 'org-acme',
+      workspace_id: 'workspace-org-acme',
+      capabilities: ['read', 'write', 'etag'],
+      writeback_enabled: true,
+      provider_write_executed: false,
+      policy_decision: {
+        decision_uid: 'policy:webdav_src_primary',
+        resource_label: 'WebDAV repository',
+        resource_type: 'webdav_repository',
+        allowed: true,
+        reason: 'allowed',
+        evidence_source: 'webdav_accounts',
+      },
+      last_observed_at: '2026-05-28T04:00:00Z',
+    },
+    {
+      source_id: 'caldav-primary',
+      source_type: 'caldav_source',
+      source_label: 'Customer CalDAV',
+      source_host: 'calendar.acme.example',
+      owner_id: 'default',
+      organization_id: 'org-acme',
+      workspace_id: 'workspace-org-acme',
+      capabilities: ['read', 'write', 'etag'],
+      writeback_enabled: true,
+      provider_write_executed: false,
+      policy_decision: {
+        decision_uid: 'policy:caldav-primary',
+        resource_label: 'Customer CalDAV source',
+        resource_type: 'caldav_source',
+        allowed: true,
+        reason: 'allowed',
+        evidence_source: 'calendar_writeback_sources',
+      },
+      last_observed_at: '2026-05-28T04:00:00Z',
+    },
+  ],
+  connector_events: [
+    {
+      event_uid: 'connector_evt_heartbeat',
+      signal_key: 'connector_heartbeat',
+      state_code: 'heartbeat',
+      detail_text: 'outbound connector heartbeat received',
+      observed_at: '2026-05-28T04:00:00Z',
+    },
+  ],
+  policy_decisions: [
+    {
+      decision_uid: 'policy:webdav_src_primary',
+      resource_label: 'WebDAV repository',
+      resource_type: 'webdav_repository',
+      allowed: true,
+      reason: 'allowed',
+      evidence_source: 'webdav_accounts',
+    },
+    {
+      decision_uid: 'policy:cross-organization-deny',
+      resource_label: 'Cross-organization provider secret',
+      resource_type: 'provider_secret',
+      allowed: false,
+      reason: 'organization_denied',
+      evidence_source: 'access_policy.evaluate_access',
+    },
+    {
+      decision_uid: 'policy:data-region-deny',
+      resource_label: 'Regional export outside policy',
+      resource_type: 'data_export',
+      allowed: false,
+      reason: 'data_region_denied',
+      evidence_source: 'access_policy.evaluate_access',
+    },
+  ],
+  external_share_reviews: [
+    {
+      review_uid: 'share:webdav_src_primary',
+      source_id: 'webdav_src_primary',
+      source_type: 'webdav_repository',
+      review_label: 'WebDAV repository writeback boundary',
+      exposure_level: 'external_writeback',
+      decision_reason: 'allowed',
+      provider_write_executed: false,
+    },
+    {
+      review_uid: 'share:caldav-primary',
+      source_id: 'caldav-primary',
+      source_type: 'caldav_source',
+      review_label: 'Customer CalDAV writeback boundary',
+      exposure_level: 'external_writeback',
+      decision_reason: 'allowed',
+      provider_write_executed: false,
+    },
+  ],
+  policy_order: [
+    {
+      step_key: 'signed_session',
+      display_name: 'Signed session identity',
+      evidence_source: 'api.auth.get_auth_context',
+    },
+    {
+      step_key: 'organization_scope',
+      display_name: 'Organization and workspace scope',
+      evidence_source: 'organization_id and workspace_id claims',
+    },
+    {
+      step_key: 'data_region',
+      display_name: 'Data-region deny',
+      evidence_source: 'services.access_policy.evaluate_access',
+    },
+    {
+      step_key: 'rbac',
+      display_name: 'RBAC allow after ABAC denies',
+      evidence_source: 'services.access_policy.evaluate_access',
+    },
+  ],
+};
+
 const accountConfig = {
   user_id: 'default',
   smtp_server: 'smtp.example.com',
@@ -302,6 +436,11 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
 
     if (path === '/api/observability/operational-signals' && request.method() === 'GET') {
       await fulfillJson(route, operationalSignals);
+      return;
+    }
+
+    if (path === '/api/security/access-surface' && request.method() === 'GET') {
+      await fulfillJson(route, securityAccessSurface);
       return;
     }
 


### PR DESCRIPTION
## Summary
- add signed `GET /api/security/access-surface` with WebDAV, CalDAV/CardDAV, connector evidence, deny-first policy decisions, and no credential/sequential-id exposure
- replace static Security tabs with API-wired dashboard, access, audit, external sharing, and policy surfaces
- document the verified Security gap, external RBAC/ABAC/logging references, and recurring static-security anti-pattern in README/AGENTS

## Verification
- `python3 -m pytest backend/tests/test_security_api.py backend/tests/test_access_policy.py -q`
- `python3 -m pytest backend/tests/test_auth_real.py::test_private_api_routes_have_default_signed_session_dependency backend/tests/test_security_api.py backend/tests/test_observability_api.py -q`
- `python3 -m pytest -q` from `backend/`
- `npm test -- src/app/security/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18114 npx playwright test tests/e2e/dashboard-branding.spec.ts -g "Security governance|mobile hamburger composition" --project=desktop --project=tablet --project=mobile`

## Browser evidence inspected
- desktop Security access/policy screenshots
- tablet Security policy screenshot
- mobile Security access and scroll screenshots
- mobile hamburger drawer screenshot after scroll

## Notes
- PostgreSQL smoke test is present in `backend/tests/test_security_api.py`; local run skipped it because the local PostgreSQL smoke database was unavailable.
- Strix should use direct OpenAI Platform credentials only; no GitHub Models path is introduced here.
