### PR TITLE
🧪 Add tests for extract_emails function

### DIFF
--- a/backend/tests/test_network_api.py
+++ b/backend/tests/test_network_api.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from main import app
 from db.session import get_db
 from unittest.mock import patch
+from api.network import extract_emails
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
@@ -161,3 +162,23 @@ def test_network_graph_query_is_scoped_to_current_user():
     query_text = str(session.queries[-1]).lower()
     assert "emails.user_id" in query_text
     assert "emails.organization_id" in query_text
+
+def test_extract_emails_valid():
+    assert extract_emails("foo@example.com") == ["foo@example.com"]
+    assert extract_emails("User <foo.bar@example.co.uk>") == ["foo.bar@example.co.uk"]
+    assert extract_emails("foo+bar@example.com") == ["foo+bar@example.com"]
+    assert extract_emails("a@b.com and c@d.org") == ["a@b.com", "c@d.org"]
+    assert extract_emails("Mixed case: Foo@Bar.com") == ["Foo@Bar.com"]
+    assert extract_emails("123@numbers.com") == ["123@numbers.com"]
+
+def test_extract_emails_invalid():
+    assert extract_emails("not_an_email") == []
+    assert extract_emails("foo@bar") == []
+    assert extract_emails("foo@.com") == []
+    assert extract_emails("@domain.com") == []
+    assert extract_emails("foo@bar.") == []
+
+def test_extract_emails_empty_or_none():
+    assert extract_emails("") == []
+    assert extract_emails(None) == []
+    assert extract_emails("   ") == []

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6715,6 +6715,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6715,7 +6715,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** The testing gap for `extract_emails` function in `backend/api/network.py` is addressed.
📊 **Coverage:** Covered standard email addresses, multiple emails in a string, emails with symbols, malformed strings, and empty/none inputs.
✨ **Result:** Improved test coverage and reliability for network email extraction.

---
*PR created automatically by Jules for task [18154739092489701891](https://jules.google.com/task/18154739092489701891) started by @seonghobae*