### PR TITLE
🧪 [testing improvement] Add tests for email_owner_filters

### DIFF
--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1139,3 +1139,36 @@ async def test_get_pending_replies(client: AsyncClient, db_session):
     assert data["emails"][0]["sender"] == "testuser@example.com"
     assert data["emails"][0]["thread_id"] == "thread3"
     assert data["emails"][0]["requires_reply"] is True
+
+def test_email_owner_filters():
+    from api.emails import email_owner_filters
+    from api.auth import AuthContext
+    from db.models import Email
+
+    # Test with organization_id
+    ctx1 = AuthContext(
+        user_id="user-123",
+        role="member",
+        organization_id="org-456",
+        group_ids=(),
+        workspace_id="ws-789",
+    )
+    filters1 = email_owner_filters(ctx1)
+
+    assert len(filters1) == 2
+    assert str(filters1[0].compile(compile_kwargs={"literal_binds": True})) == "emails.user_id = 'user-123'"
+    assert str(filters1[1].compile(compile_kwargs={"literal_binds": True})) == "emails.organization_id = 'org-456'"
+
+    # Test with None organization_id
+    ctx2 = AuthContext(
+        user_id="user-123",
+        role="member",
+        organization_id=None,
+        group_ids=(),
+        workspace_id="ws-789",
+    )
+    filters2 = email_owner_filters(ctx2)
+
+    assert len(filters2) == 2
+    assert str(filters2[0].compile(compile_kwargs={"literal_binds": True})) == "emails.user_id = 'user-123'"
+    assert str(filters2[1].compile(compile_kwargs={"literal_binds": True})) == "emails.organization_id IS NULL"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `email_owner_filters` function in `backend/api/emails.py`, which is responsible for returning SQLAlchemy filters based on the provided `AuthContext`, was previously untested.

📊 **Coverage:** What scenarios are now tested
Two specific scenarios were added in `test_email_owner_filters`:
- Providing an `AuthContext` with an `organization_id` ensuring the correct filter (`emails.organization_id = 'org-456'`) is generated.
- Providing an `AuthContext` with a `None` `organization_id` ensuring the correct IS NULL filter (`emails.organization_id IS NULL`) is generated.
In both scenarios, we also verify the standard user ID filtering (`emails.user_id = 'user-123'`) is applied correctly.

✨ **Result:** The improvement in test coverage
We now have reliable, isolated tests for the authorization filtering logic on emails. These tests compile the SQLAlchemy filters into strings to evaluate the raw query structure, making sure that future changes don't accidentally omit critical ownership and organizational constraints.

---
*PR created automatically by Jules for task [13586882547897009678](https://jules.google.com/task/13586882547897009678) started by @seonghobae*