### PR TITLE
🧹 Refactor OntologyService.save_relationship to use dataclass

### DIFF
--- a/backend/services/ontology_service.py
+++ b/backend/services/ontology_service.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from collections.abc import Iterable
 from typing import Any, Dict
 from sqlalchemy import select
@@ -7,6 +8,17 @@ from services.email_service import process_self_to_self
 from services.knowledge_extractor import extract_knowledge_from_self_sent
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RelationshipData:
+    user_email: str
+    sender_email: str
+    email_content: str
+    user_id: str
+    organization_id: str | None = None
+    source_message_id: str | None = None
+    source_thread_id: str | None = None
 
 
 class OntologyService:
@@ -71,24 +83,18 @@ class OntologyService:
     async def save_relationship(
         self,
         session,
-        user_email: str,
-        sender_email: str,
-        email_content: str,
-        user_id: str,
-        organization_id: str | None,
-        source_message_id: str | None = None,
-        source_thread_id: str | None = None,
+        data: RelationshipData,
     ):
         analysis = self.analyze_sender_relationship(
-            user_email, sender_email, email_content
+            data.user_email, data.sender_email, data.email_content
         )
 
         stmt = select(SenderRelationship).where(
-            SenderRelationship.user_id == user_id,
-            SenderRelationship.organization_id == organization_id,
-            SenderRelationship.sender_email == sender_email,
-            SenderRelationship.source_message_id == source_message_id,
-            SenderRelationship.source_thread_id == source_thread_id,
+            SenderRelationship.user_id == data.user_id,
+            SenderRelationship.organization_id == data.organization_id,
+            SenderRelationship.sender_email == data.sender_email,
+            SenderRelationship.source_message_id == data.source_message_id,
+            SenderRelationship.source_thread_id == data.source_thread_id,
         )
         result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
@@ -96,15 +102,15 @@ class OntologyService:
         if existing:
             existing.relationship_type = analysis["type"]
             existing.confidence_score = analysis["confidence"]
-            existing.source_message_id = source_message_id
-            existing.source_thread_id = source_thread_id
+            existing.source_message_id = data.source_message_id
+            existing.source_thread_id = data.source_thread_id
         else:
             new_rel = SenderRelationship(
-                user_id=user_id,
-                organization_id=organization_id,
-                sender_email=sender_email,
-                source_message_id=source_message_id,
-                source_thread_id=source_thread_id,
+                user_id=data.user_id,
+                organization_id=data.organization_id,
+                sender_email=data.sender_email,
+                source_message_id=data.source_message_id,
+                source_thread_id=data.source_thread_id,
                 relationship_type=analysis["type"],
                 confidence_score=analysis["confidence"],
             )

--- a/backend/tests/test_ontology_pipeline.py
+++ b/backend/tests/test_ontology_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from db.models import Email, SenderRelationship
-from services.ontology_service import OntologyService
+from services.ontology_service import OntologyService, RelationshipData
 
 @pytest.mark.asyncio
 async def test_sender_relationship_insertion():
@@ -16,13 +16,15 @@ async def test_sender_relationship_insertion():
     
     relationship = await ontology_service.save_relationship(
         session_mock,
-        user_email="user@test.com",
-        sender_email="colleague@test.com",
-        email_content="Hey let's talk about the project",
-        user_id="user_1",
-        organization_id="org_1",
-        source_message_id="<project@test.com>",
-        source_thread_id="thread-project",
+        data=RelationshipData(
+            user_email="user@test.com",
+            sender_email="colleague@test.com",
+            email_content="Hey let's talk about the project",
+            user_id="user_1",
+            organization_id="org_1",
+            source_message_id="<project@test.com>",
+            source_thread_id="thread-project",
+        )
     )
     
     session_mock.add.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored `OntologyService.save_relationship` to accept a single dataclass `RelationshipData` instead of a long list of individual parameters.

💡 **Why:** How this improves maintainability
Passing numerous parameters to a function makes the signature hard to read, increases cognitive load, and can easily lead to bugs if the order is confused. A dataclass groups related data logically, reducing the parameter list and making the code more readable and maintainable.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite (`cd backend && pytest`) which confirmed all tests passed successfully across the codebase, ensuring no existing functionality was broken. Also checked code formatting and linting using `ruff`.

✨ **Result:** The improvement achieved
A cleaner and more cohesive method signature for `save_relationship` using the new `RelationshipData` dataclass, both in the implementation and in tests.

---
*PR created automatically by Jules for task [1354869767633361675](https://jules.google.com/task/1354869767633361675) started by @seonghobae*