### PR TITLE
🧹 [code health improvement] Refactor save_relationship to use request dataclass

### DIFF
--- a/backend/services/ontology_service.py
+++ b/backend/services/ontology_service.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, Dict
 from sqlalchemy import select
 from db.models import Email, SenderRelationship
@@ -7,6 +8,18 @@ from services.email_service import process_self_to_self
 from services.knowledge_extractor import extract_knowledge_from_self_sent
 
 logger = logging.getLogger(__name__)
+
+
+
+@dataclass
+class SaveRelationshipRequest:
+    user_email: str
+    sender_email: str
+    email_content: str
+    user_id: str
+    organization_id: str | None
+    source_message_id: str | None = None
+    source_thread_id: str | None = None
 
 
 class OntologyService:
@@ -71,24 +84,18 @@ class OntologyService:
     async def save_relationship(
         self,
         session,
-        user_email: str,
-        sender_email: str,
-        email_content: str,
-        user_id: str,
-        organization_id: str | None,
-        source_message_id: str | None = None,
-        source_thread_id: str | None = None,
+        request: SaveRelationshipRequest,
     ):
         analysis = self.analyze_sender_relationship(
-            user_email, sender_email, email_content
+            request.user_email, request.sender_email, request.email_content
         )
 
         stmt = select(SenderRelationship).where(
-            SenderRelationship.user_id == user_id,
-            SenderRelationship.organization_id == organization_id,
-            SenderRelationship.sender_email == sender_email,
-            SenderRelationship.source_message_id == source_message_id,
-            SenderRelationship.source_thread_id == source_thread_id,
+            SenderRelationship.user_id == request.user_id,
+            SenderRelationship.organization_id == request.organization_id,
+            SenderRelationship.sender_email == request.sender_email,
+            SenderRelationship.source_message_id == request.source_message_id,
+            SenderRelationship.source_thread_id == request.source_thread_id,
         )
         result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
@@ -96,15 +103,15 @@ class OntologyService:
         if existing:
             existing.relationship_type = analysis["type"]
             existing.confidence_score = analysis["confidence"]
-            existing.source_message_id = source_message_id
-            existing.source_thread_id = source_thread_id
+            existing.source_message_id = request.source_message_id
+            existing.source_thread_id = request.source_thread_id
         else:
             new_rel = SenderRelationship(
-                user_id=user_id,
-                organization_id=organization_id,
-                sender_email=sender_email,
-                source_message_id=source_message_id,
-                source_thread_id=source_thread_id,
+                user_id=request.user_id,
+                organization_id=request.organization_id,
+                sender_email=request.sender_email,
+                source_message_id=request.source_message_id,
+                source_thread_id=request.source_thread_id,
                 relationship_type=analysis["type"],
                 confidence_score=analysis["confidence"],
             )

--- a/backend/tests/test_ontology_pipeline.py
+++ b/backend/tests/test_ontology_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from db.models import Email, SenderRelationship
-from services.ontology_service import OntologyService
+from services.ontology_service import OntologyService, SaveRelationshipRequest
 
 @pytest.mark.asyncio
 async def test_sender_relationship_insertion():
@@ -16,13 +16,15 @@ async def test_sender_relationship_insertion():
     
     relationship = await ontology_service.save_relationship(
         session_mock,
-        user_email="user@test.com",
-        sender_email="colleague@test.com",
-        email_content="Hey let's talk about the project",
-        user_id="user_1",
-        organization_id="org_1",
-        source_message_id="<project@test.com>",
-        source_thread_id="thread-project",
+        request=SaveRelationshipRequest(
+            user_email="user@test.com",
+            sender_email="colleague@test.com",
+            email_content="Hey let's talk about the project",
+            user_id="user_1",
+            organization_id="org_1",
+            source_message_id="<project@test.com>",
+            source_thread_id="thread-project",
+        )
     )
     
     session_mock.add.assert_called_once()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6715,7 +6715,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** Extracted the parameters of `save_relationship` into a `SaveRelationshipRequest` dataclass.
💡 **Why:** Refactoring long parameter lists to data classes is a straightforward structural change that reduces cognitive load and improves maintainability of the codebase.
✅ **Verification:** Ran test suite using `cd backend && python -m pytest tests/test_ontology_pipeline.py`.
✨ **Result:** Improved maintainability while preserving existing behavior.

---
*PR created automatically by Jules for task [304208828678358849](https://jules.google.com/task/304208828678358849) started by @seonghobae*