### PR TITLE
🧹 [Code Health] Refactor email_client to use dataclasses for parameters

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -6,7 +6,7 @@ from db.models import Email
 from pydantic import BaseModel, EmailStr, Field
 import datetime
 from typing import Literal
-from services.email_client import send_email, validate_smtp_destination
+from services.email_client import EmailMessageParams, SmtpConfig, send_email, validate_smtp_destination
 from services.reply_tracking_service import (
     check_missing_replies,
     configured_email_addresses,
@@ -454,16 +454,22 @@ async def send_email_endpoint(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             raise
 
-        send_result = await send_email(
-            request.to,
-            request.subject,
-            request.body,
+        message_params = EmailMessageParams(
+            to_address=request.to,
+            subject=request.subject,
+            body=request.body,
+            in_reply_to=request.in_reply_to,
+            references=request.references,
+        )
+        smtp_config = SmtpConfig(
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             smtp_username=smtp_username,
             smtp_password=smtp_password,
-            in_reply_to=request.in_reply_to,
-            references=request.references,
+        )
+        send_result = await send_email(
+            message_params=message_params,
+            smtp_config=smtp_config,
         )
         if send_result.get("status") not in {"sent", "simulated"}:
             raise HTTPException(status_code=500, detail="Failed to send email")

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -45,6 +45,22 @@ class ValidatedSmtpDestination:
     proto: int
     sockaddr: tuple[Any, ...]
 
+@dataclass(frozen=True)
+class EmailMessageParams:
+    to_address: str
+    subject: str
+    body: str
+    in_reply_to: str | None = None
+    references: str | None = None
+
+@dataclass(frozen=True)
+class SmtpConfig:
+    smtp_server: str
+    smtp_port: int
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+
+
 
 def generate_oauth2_string(user: str, access_token: str) -> bytes:
     """Generates an OAuth2 string for IMAP/SMTP authentication."""
@@ -494,56 +510,46 @@ async def _send_pinned_smtp_message(
 
 
 def build_email_message(
-    to_address: str,
-    subject: str,
-    body: str,
+    message_params: EmailMessageParams,
     from_address: str,
-    in_reply_to: str | None = None,
-    references: str | None = None,
 ) -> EmailMessage:
     """Build an outbound email message with optional threading headers."""
     message = EmailMessage()
     message["From"] = _validate_email_header_value(from_address)
-    message["To"] = _validate_email_header_value(to_address)
-    message["Subject"] = _validate_email_header_value(subject)
-    if in_reply_to:
-        message["In-Reply-To"] = _validate_email_header_value(in_reply_to)
-    if references:
-        message["References"] = _validate_email_header_value(references)
-    message.set_content(body)
+    message["To"] = _validate_email_header_value(message_params.to_address)
+    message["Subject"] = _validate_email_header_value(message_params.subject)
+    if message_params.in_reply_to:
+        message["In-Reply-To"] = _validate_email_header_value(message_params.in_reply_to)
+    if message_params.references:
+        message["References"] = _validate_email_header_value(message_params.references)
+    message.set_content(message_params.body)
     return message
 
 
 async def send_email(
-    to_address: str,
-    subject: str,
-    body: str,
-    smtp_server: str | None = None,
-    smtp_port: int | None = None,
-    smtp_username: str | None = None,
-    smtp_password: str | None = None,
-    in_reply_to: str | None = None,
-    references: str | None = None,
+    message_params: EmailMessageParams,
+    smtp_config: SmtpConfig | None = None,
 ) -> SendEmailResult:
     """Sends an email using SMTP."""
-    safe_to_address = _sanitize_log_value(to_address)
+    safe_to_address = _sanitize_log_value(message_params.to_address)
+
+    from_address = "me@example.com"
+    if smtp_config and smtp_config.smtp_username:
+        from_address = smtp_config.smtp_username
+
     message = build_email_message(
-        to_address=to_address,
-        subject=subject,
-        body=body,
-        from_address=smtp_username or "me@example.com",
-        in_reply_to=in_reply_to,
-        references=references,
+        message_params=message_params,
+        from_address=from_address,
     )
 
-    if not smtp_server or not smtp_port:
+    if not smtp_config or not smtp_config.smtp_server or not smtp_config.smtp_port:
         logger.info(
             "Simulating sending email to %s (no SMTP server configured)",
             safe_to_address,
         )
         return {"status": "simulated", "simulated": True}
 
-    smtp_destination = validate_smtp_destination(smtp_server, smtp_port)
+    smtp_destination = validate_smtp_destination(smtp_config.smtp_server, smtp_config.smtp_port)
 
     try:
         smtp_socket = await _connect_validated_smtp_socket(smtp_destination)
@@ -553,8 +559,8 @@ async def send_email(
                 smtp_socket=smtp_socket,
                 smtp_server=smtp_destination.hostname,
                 smtp_port=smtp_destination.port,
-                smtp_username=smtp_username,
-                smtp_password=smtp_password,
+                smtp_username=smtp_config.smtp_username,
+                smtp_password=smtp_config.smtp_password,
             )
         finally:
             smtp_socket.close()

--- a/backend/tests/test_email_client.py
+++ b/backend/tests/test_email_client.py
@@ -3,6 +3,7 @@ import logging
 
 import pytest
 from services.email_client import (
+    EmailMessageParams,
     _sanitize_log_value,
     build_email_message,
     generate_oauth2_string,
@@ -18,13 +19,16 @@ def test_generate_oauth2_string():
 
 
 def test_build_email_message_sets_reply_headers():
-    message = build_email_message(
+    params = EmailMessageParams(
         to_address="test@example.com",
         subject="Re: Test",
         body="Reply body",
-        from_address="sender@example.com",
         in_reply_to="<parent@example.com>",
         references="<root@example.com> <parent@example.com>",
+    )
+    message = build_email_message(
+        message_params=params,
+        from_address="sender@example.com",
     )
 
     assert message["In-Reply-To"] == "<parent@example.com>"
@@ -51,25 +55,31 @@ def test_build_email_message_rejects_newlines_in_header_fields(
         "to_address": "victim@example.com",
         "subject": "Status",
         "body": "Body text\nwith allowed body newlines",
-        "from_address": "sender@example.com",
         "in_reply_to": "<parent@example.com>",
         "references": "<root@example.com> <parent@example.com>",
     }
-    kwargs[field_name] = field_value
 
+    from_address = "sender@example.com"
+    if field_name == "from_address":
+        from_address = field_value
+    else:
+        kwargs[field_name] = field_value
+
+    params = EmailMessageParams(**kwargs)
     with pytest.raises(ValueError, match="Email header fields must not contain newlines"):
-        build_email_message(**kwargs)
+        build_email_message(message_params=params, from_address=from_address)
 
 
 @pytest.mark.asyncio
 async def test_send_email_logs_sanitized_recipient(caplog):
     caplog.set_level(logging.INFO, logger="services.email_client")
 
-    result = await send_email(
+    params = EmailMessageParams(
         to_address="victim@example.com",
         subject="Test",
         body="Body",
     )
+    result = await send_email(message_params=params)
 
     assert result == {"status": "simulated", "simulated": True}
     messages = [record.getMessage() for record in caplog.records]

--- a/backend/tests/test_email_client_smtp.py
+++ b/backend/tests/test_email_client_smtp.py
@@ -271,13 +271,19 @@ async def test_send_email_rejects_private_smtp_host_before_network(monkeypatch):
     monkeypatch.setattr("services.email_client.aiosmtplib.send", fail_if_called)
 
     with pytest.raises(ValueError, match="SMTP server is not allowed"):
-        await email_client.send_email(
+        message_params = email_client.EmailMessageParams(
             to_address="test@example.com",
             subject="Test",
             body="Body",
+        )
+        smtp_config = email_client.SmtpConfig(
             smtp_server="127.0.0.1",
             smtp_port=587,
             smtp_username="testuser",
+        )
+        await email_client.send_email(
+            message_params=message_params,
+            smtp_config=smtp_config,
         )
 
 
@@ -331,13 +337,19 @@ async def test_send_email_uses_validated_address_without_second_dns(monkeypatch)
         fake_validate_smtp_destination,
     )
 
-    result = await email_client.send_email(
+    message_params = email_client.EmailMessageParams(
         to_address="test@example.com",
         subject="Test",
         body="Body",
+    )
+    smtp_config = email_client.SmtpConfig(
         smtp_server="smtp.example.com",
         smtp_port=587,
         smtp_username="testuser",
+    )
+    result = await email_client.send_email(
+        message_params=message_params,
+        smtp_config=smtp_config,
     )
 
     assert result == {"status": "sent", "simulated": False}
@@ -432,13 +444,19 @@ async def test_send_email_pins_first_validated_sockaddr_across_dns_rebinding(
 
     monkeypatch.setattr(email_client, "_send_pinned_smtp_message", fake_pinned_send)
 
-    result = await email_client.send_email(
+    message_params = email_client.EmailMessageParams(
         to_address="test@example.com",
         subject="Test",
         body="Body",
+    )
+    smtp_config = email_client.SmtpConfig(
         smtp_server="smtp.example.com",
         smtp_port=587,
         smtp_username="testuser",
+    )
+    result = await email_client.send_email(
+        message_params=message_params,
+        smtp_config=smtp_config,
     )
 
     assert result == {"status": "sent", "simulated": False}
@@ -514,10 +532,13 @@ async def test_starttls_existing_transport_delegates_to_public_starttls_api():
 async def test_pinned_smtp_send_passes_original_hostname_and_socket(monkeypatch):
     smtp_socket = _make_socket()
     fake_client = FakeSmtpClient()
-    message = email_client.build_email_message(
+    message_params = email_client.EmailMessageParams(
         to_address="test@example.com",
         subject="Test",
         body="Body",
+    )
+    message = email_client.build_email_message(
+        message_params=message_params,
         from_address="sender@example.com",
     )
 
@@ -613,12 +634,18 @@ async def test_send_email_raises_error_when_smtp_fails(monkeypatch):
     )
 
     with pytest.raises(Exception, match="Failed to send email"):
-        await email_client.send_email(
+        message_params = email_client.EmailMessageParams(
             to_address="test@example.com",
             subject="Test Failure",
             body="Should fail because SMTP server is invalid",
+        )
+        smtp_config = email_client.SmtpConfig(
             smtp_server="smtp.example.com",
             smtp_port=587,
             smtp_username="testuser",
+        )
+        await email_client.send_email(
+            message_params=message_params,
+            smtp_config=smtp_config,
         )
     assert smtp_socket.fileno() == -1

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -939,16 +939,23 @@ def test_send_email_endpoint(mock_send_email, monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"status": "simulated", "simulated": True}
     assert validate_calls == [True]
-    mock_send_email.assert_called_once_with(
-        "test@example.com",
-        "Re: Test",
-        "This is a reply.",
+    from services.email_client import EmailMessageParams, SmtpConfig
+    expected_params = EmailMessageParams(
+        to_address="test@example.com",
+        subject="Re: Test",
+        body="This is a reply.",
+        in_reply_to="<parent@example.com>",
+        references="<root@example.com> <parent@example.com>",
+    )
+    expected_config = SmtpConfig(
         smtp_server="smtp.example.com",
         smtp_port=587,
         smtp_username="testuser",
         smtp_password=None,
-        in_reply_to="<parent@example.com>",
-        references="<root@example.com> <parent@example.com>",
+    )
+    mock_send_email.assert_called_once_with(
+        message_params=expected_params,
+        smtp_config=expected_config,
     )
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6715,6 +6715,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6715,7 +6715,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** The `send_email` and `build_email_message` functions in `backend/services/email_client.py` have been refactored to use `EmailMessageParams` and `SmtpConfig` dataclasses instead of a long list of individual arguments.
💡 **Why:** This reduces cognitive load by logically grouping message parameters and SMTP configuration, resolving the 'Too Many Parameters' code health issue and making the code more maintainable and easier to read.
✅ **Verification:** Updated the callers in `backend/api/emails.py` and the test files (`backend/tests/test_email_client.py`, `backend/tests/test_email_client_smtp.py`, `backend/tests/test_emails_api.py`). Ran the full test suite and all tests pass successfully, confirming that functionality is preserved. Pre-commit check verified.
✨ **Result:** Improved structural readability without changing system behavior.

---
*PR created automatically by Jules for task [3792921141667151471](https://jules.google.com/task/3792921141667151471) started by @seonghobae*