### PR TITLE
fix: require gateway backend runtime secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY backend/requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN PIP_ROOT_USER_ACTION=ignore PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY backend /app/
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ tiktoken==0.6.0
 google-api-python-client==2.126.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
-email-validator==2.1.0
+email-validator==2.3.0
 cryptography==47.0.0
 python-multipart==0.0.27
 prometheus-fastapi-instrumentator==7.0.0

--- a/backend/tests/test_infra_evaluations.py
+++ b/backend/tests/test_infra_evaluations.py
@@ -7,3 +7,11 @@ def test_postgres_ha_compose_exists():
 
 def test_gateway_compose_exists():
     assert (_REPO_ROOT / "docker-compose.gateway.yml").exists()
+
+
+def test_gateway_backend_requires_runtime_secrets():
+    compose = (_REPO_ROOT / "docker-compose.gateway.yml").read_text()
+
+    assert "DATABASE_URL: ${DATABASE_URL:?" in compose
+    assert "AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?" in compose
+    assert "postgresql+asyncpg://" not in compose

--- a/backend/tests/test_infra_evaluations.py
+++ b/backend/tests/test_infra_evaluations.py
@@ -15,3 +15,15 @@ def test_gateway_backend_requires_runtime_secrets():
     assert "DATABASE_URL: ${DATABASE_URL:?" in compose
     assert "AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?" in compose
     assert "postgresql+asyncpg://" not in compose
+
+
+def test_gateway_compose_does_not_expose_management_planes():
+    compose = (_REPO_ROOT / "docker-compose.gateway.yml").read_text()
+
+    assert "--api.insecure=true" not in compose
+    assert '"8080:8080"' not in compose
+    assert '"8081:8080"' not in compose
+    assert "KEYCLOAK_ADMIN=admin" not in compose
+    assert "KEYCLOAK_ADMIN_PASSWORD=admin" not in compose
+    assert "KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:?" in compose
+    assert "KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:?" in compose

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -12,6 +12,20 @@ def test_dockerignore_excludes_nested_environment_files_but_keeps_examples():
     assert "!**/.env.example" in dockerignore
 
 
+def test_backend_dockerfile_suppresses_pip_root_warning():
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+
+    assert "PIP_ROOT_USER_ACTION=ignore" in dockerfile
+    assert "PIP_DISABLE_PIP_VERSION_CHECK=1" in dockerfile
+
+
+def test_backend_requirements_do_not_pin_yanked_email_validator():
+    requirements = (REPO_ROOT / "backend" / "requirements.txt").read_text()
+
+    assert "email-validator==2.1.0" not in requirements
+    assert "email-validator==2.3.0" in requirements
+
+
 def test_compose_externalizes_postgres_credentials():
     compose = (REPO_ROOT / "docker-compose.yml").read_text()
 

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -27,6 +27,12 @@ services:
 
   backend:
     image: naruon-backend:local
+    environment:
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for gateway backend}
+      AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for gateway backend}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.backend.rule=Host(`api.localhost`)"

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -2,24 +2,25 @@ services:
   traefik:
     image: traefik:v3.0
     command:
-      - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
     ports:
       - "80:80"
-      - "8080:8080"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   keycloak:
     image: quay.io/keycloak/keycloak:24.0.3
     environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
-    command: start-dev
-    ports:
-      - "8081:8080"
+      - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:?Set KEYCLOAK_ADMIN for gateway}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:?Set KEYCLOAK_ADMIN_PASSWORD for gateway}
+      - KC_HOSTNAME=auth.localhost
+      - KC_HTTP_ENABLED=true
+      - KC_PROXY_HEADERS=xforwarded
+    command: start
+    expose:
+      - "8080"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.keycloak.rule=Host(`auth.localhost`)"

--- a/docs/operations/traefik-evaluation.md
+++ b/docs/operations/traefik-evaluation.md
@@ -5,6 +5,10 @@
 - `k8s/ingress.yaml` currently uses NGINX ingress annotations.
 - `docker-compose.gateway.yml` now implements a Traefik API gateway integrated
   with Keycloak for API protection and routing.
+- The gateway backend service is image-based and does not include a database
+  container. Run it with the base compose stack or inject `DATABASE_URL` and
+  `AUTH_SESSION_HMAC_SECRET` explicitly; the backend must fail closed instead of
+  inventing a database URL or session secret.
 
 ## Traefik & Keycloak/Casdoor 평가 (Issue #138)
 

--- a/docs/operations/traefik-evaluation.md
+++ b/docs/operations/traefik-evaluation.md
@@ -9,6 +9,10 @@
   container. Run it with the base compose stack or inject `DATABASE_URL` and
   `AUTH_SESSION_HMAC_SECRET` explicitly; the backend must fail closed instead of
   inventing a database URL or session secret.
+- The evaluation stack must not publish unauthenticated management planes.
+  Traefik's insecure dashboard/API is disabled, Keycloak has no direct host port
+  mapping, and Keycloak admin credentials must be injected through
+  `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD`.
 
 ## Traefik & Keycloak/Casdoor 평가 (Issue #138)
 


### PR DESCRIPTION
## Summary
- require explicit DATABASE_URL and AUTH_SESSION_HMAC_SECRET for the Traefik gateway backend path
- remove the yanked email-validator pin that caused pip WARNING output during Docker builds
- add hygiene coverage for gateway env injection and warning-free backend image builds

## Verification
- PYTHONWARNINGS=error python3 -m pytest -q tests/test_infra_evaluations.py tests/test_repo_hygiene.py tests/test_config.py
- DATABASE_URL=... AUTH_SESSION_HMAC_SECRET=... docker compose -f docker-compose.gateway.yml config
- env -u DATABASE_URL -u AUTH_SESSION_HMAC_SECRET docker compose -f docker-compose.gateway.yml config rejects missing DATABASE_URL
- docker build --progress=plain -t naruon-backend-envtest-20260528 . with log scan for WARNING/Warn/Fatal/Denied/Timeout
- docker run --rm -e DATABASE_URL=... -e AUTH_SESSION_HMAC_SECRET=... naruon-backend-envtest-20260528 python -c 'import main; print(...)' with log scan for WARNING/Warn/Fatal/Denied/Timeout/ValidationError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidelines for gateway backend security requirements.

* **Chores**
  * Updated email-validator dependency to version 2.3.0.
  * Gateway backend now requires `DATABASE_URL` and `AUTH_SESSION_HMAC_SECRET` environment variables at runtime.
  * Added OpenAI configuration environment variables with sensible defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->