### PR TITLE
feat: fail closed self-hosted runner adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,11 @@
   and a server-side WorkspaceRunnerConfig registration token before accepting the
   socket. Do not use the raw path token as identity, a log value, or the sole
   active-connection key.
+- Self-hosted connector command handlers must never return placeholder or mock
+  success for IMAP/SMTP execution. If no local customer-network adapter is
+  configured, fail closed with `adapter_not_configured` and
+  `provider_write_executed=false`; if an adapter is configured, wrap only the
+  adapter's actual result in the standard runner response envelope.
 - Calendar UI actions must request `/api/calendar/writeback-intent` with
   server-authoritative source selection and provenance. Do not wire browser
   actions back to legacy `/api/calendar/sync` unless a trusted backend credential

--- a/backend/runner/connector.py
+++ b/backend/runner/connector.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import logging
-from typing import Dict, Any
+from collections.abc import Awaitable, Callable
+from typing import Any, Dict
 
 try:
     import websockets
@@ -11,6 +12,9 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+RunnerActionHandler = Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
 def _get_account_name(payload: Dict[str, Any]) -> str | None:
     account = payload.get("account")
     if not isinstance(account, str):
@@ -19,10 +23,29 @@ def _get_account_name(payload: Dict[str, Any]) -> str | None:
     return account or None
 
 
+def _get_request_id(payload: Dict[str, Any]) -> str | None:
+    request_id = payload.get("request_id")
+    if not isinstance(request_id, str):
+        return None
+    request_id = request_id.strip()
+    if not request_id or len(request_id) > 128:
+        return None
+    return request_id
+
+
 class SelfHostedConnector:
-    def __init__(self, target_ws_url: str, token: str):
+    def __init__(
+        self,
+        target_ws_url: str,
+        token: str,
+        *,
+        imap_fetch_handler: RunnerActionHandler | None = None,
+        smtp_send_handler: RunnerActionHandler | None = None,
+    ):
         self.target_ws_url = target_ws_url
         self.token = token
+        self.imap_fetch_handler = imap_fetch_handler
+        self.smtp_send_handler = smtp_send_handler
         self.connection = None
         self.is_connected = False
         
@@ -112,9 +135,13 @@ class SelfHostedConnector:
                 "error": "missing account",
             })
             return
-        logger.info("Executing local IMAP fetch for configured account.")
-        # Placeholder for actual internal IMAP logic
-        await self.send_response({"status": "success", "action": "fetch_imap", "data": "IMAP data placeholder"})
+        logger.info("Dispatching local IMAP fetch adapter for configured account.")
+        await self._execute_local_adapter(
+            action="fetch_imap",
+            protocol="IMAP",
+            payload=payload,
+            handler=self.imap_fetch_handler,
+        )
         
     async def _handle_send_smtp(self, payload: Dict[str, Any]):
         if _get_account_name(payload) is None:
@@ -125,9 +152,70 @@ class SelfHostedConnector:
                 "error": "missing account",
             })
             return
-        logger.info("Executing local SMTP send for configured account.")
-        # Placeholder for actual internal SMTP logic
-        await self.send_response({"status": "success", "action": "send_smtp", "message_id": "mock_id_123"})
+        logger.info("Dispatching local SMTP send adapter for configured account.")
+        await self._execute_local_adapter(
+            action="send_smtp",
+            protocol="SMTP",
+            payload=payload,
+            handler=self.smtp_send_handler,
+        )
+
+    async def _execute_local_adapter(
+        self,
+        *,
+        action: str,
+        protocol: str,
+        payload: Dict[str, Any],
+        handler: RunnerActionHandler | None,
+    ):
+        account = _get_account_name(payload)
+        response: Dict[str, Any] = {
+            "status": "error",
+            "action": action,
+            "protocol": protocol,
+            "account": account,
+            "request_id": _get_request_id(payload),
+            "provider_write_executed": False,
+        }
+        if account is None:
+            response["error"] = "missing account"
+            await self.send_response(response)
+            return
+        if handler is None:
+            response["error"] = "adapter_not_configured"
+            await self.send_response(response)
+            return
+
+        try:
+            adapter_result = await handler(dict(payload))
+        except Exception:
+            logger.exception("%s local adapter failed.", protocol)
+            response["error"] = "adapter_failed"
+            await self.send_response(response)
+            return
+
+        if not isinstance(adapter_result, dict):
+            response["error"] = "invalid_adapter_response"
+            await self.send_response(response)
+            return
+
+        status_value = adapter_result.get("status", "success")
+        response["status"] = status_value if isinstance(status_value, str) else "success"
+        response["provider_write_executed"] = bool(
+            adapter_result.get("provider_write_executed", False)
+        )
+        reserved_keys = {
+            "action",
+            "account",
+            "protocol",
+            "request_id",
+            "provider_write_executed",
+        }
+        for key, value in adapter_result.items():
+            if key in reserved_keys:
+                continue
+            response[key] = value
+        await self.send_response(response)
 
     async def send_response(self, response: Dict[str, Any]):
         if self.is_connected and self.connection:

--- a/backend/tests/test_runner_connector.py
+++ b/backend/tests/test_runner_connector.py
@@ -8,31 +8,131 @@ from runner.connector import SelfHostedConnector
 
 @pytest.mark.asyncio
 async def test_handle_message_dispatches_fetch_imap():
-    connector = SelfHostedConnector("ws://gateway.example/api/runner/ws", "token")
+    async def fetch_imap_adapter(payload):
+        assert payload["account"] == "mailbox-1"
+        return {
+            "status": "success",
+            "messages_imported": 2,
+            "provider_write_executed": False,
+        }
+
+    connector = SelfHostedConnector(
+        "ws://gateway.example/api/runner/ws",
+        "token",
+        imap_fetch_handler=fetch_imap_adapter,
+    )
     original_handler = connector._handle_fetch_imap
     connector._handle_fetch_imap = AsyncMock(wraps=original_handler)
     connector.send_response = AsyncMock()
 
-    await connector.handle_message(json.dumps({"action": "fetch_imap", "account": "mailbox-1"}))
+    await connector.handle_message(
+        json.dumps(
+            {
+                "action": "fetch_imap",
+                "account": "mailbox-1",
+                "request_id": "runner_req_1",
+            }
+        )
+    )
 
     connector._handle_fetch_imap.assert_awaited_once()
     connector.send_response.assert_awaited_once_with(
-        {"status": "success", "action": "fetch_imap", "data": "IMAP data placeholder"}
+        {
+            "status": "success",
+            "action": "fetch_imap",
+            "protocol": "IMAP",
+            "account": "mailbox-1",
+            "request_id": "runner_req_1",
+            "provider_write_executed": False,
+            "messages_imported": 2,
+        }
     )
 
 
 @pytest.mark.asyncio
 async def test_handle_message_dispatches_send_smtp():
-    connector = SelfHostedConnector("ws://gateway.example/api/runner/ws", "token")
+    async def send_smtp_adapter(payload):
+        assert payload["account"] == "mailbox-1"
+        return {
+            "status": "success",
+            "message_id": "<sent-123@example.com>",
+            "provider_write_executed": True,
+        }
+
+    connector = SelfHostedConnector(
+        "ws://gateway.example/api/runner/ws",
+        "token",
+        smtp_send_handler=send_smtp_adapter,
+    )
     original_handler = connector._handle_send_smtp
     connector._handle_send_smtp = AsyncMock(wraps=original_handler)
     connector.send_response = AsyncMock()
 
-    await connector.handle_message(json.dumps({"action": "send_smtp", "account": "mailbox-1"}))
+    await connector.handle_message(
+        json.dumps(
+            {
+                "action": "send_smtp",
+                "account": "mailbox-1",
+                "request_id": "runner_req_2",
+            }
+        )
+    )
 
     connector._handle_send_smtp.assert_awaited_once()
     connector.send_response.assert_awaited_once_with(
-        {"status": "success", "action": "send_smtp", "message_id": "mock_id_123"}
+        {
+            "status": "success",
+            "action": "send_smtp",
+            "protocol": "SMTP",
+            "account": "mailbox-1",
+            "request_id": "runner_req_2",
+            "provider_write_executed": True,
+            "message_id": "<sent-123@example.com>",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_fetch_imap_fails_closed_without_adapter():
+    connector = SelfHostedConnector("ws://gateway.example/api/runner/ws", "token")
+    connector.send_response = AsyncMock()
+
+    await connector.handle_message(
+        json.dumps({"action": "fetch_imap", "account": "mailbox-1"})
+    )
+
+    connector.send_response.assert_awaited_once_with(
+        {
+            "status": "error",
+            "action": "fetch_imap",
+            "protocol": "IMAP",
+            "account": "mailbox-1",
+            "request_id": None,
+            "provider_write_executed": False,
+            "error": "adapter_not_configured",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_send_smtp_fails_closed_without_adapter():
+    connector = SelfHostedConnector("ws://gateway.example/api/runner/ws", "token")
+    connector.send_response = AsyncMock()
+
+    await connector.handle_message(
+        json.dumps({"action": "send_smtp", "account": "mailbox-1"})
+    )
+
+    connector.send_response.assert_awaited_once_with(
+        {
+            "status": "error",
+            "action": "send_smtp",
+            "protocol": "SMTP",
+            "account": "mailbox-1",
+            "request_id": None,
+            "provider_write_executed": False,
+            "error": "adapter_not_configured",
+        }
     )
 
 

--- a/docs/architecture/self-hosted-runner-design.md
+++ b/docs/architecture/self-hosted-runner-design.md
@@ -26,6 +26,10 @@ To connect to these private network mail servers without exposing them to the pu
 - Written in Python (sharing models/schemas with the main Naruon backend) or Go (for minimal footprint).
 - Authenticates with Naruon using a `Registration Token` mapped to the `organization_id` and `workspace_id`.
 - Periodically polls or maintains a persistent connection for tasks (e.g., "Send email", "Fetch new emails").
+- Executes private-network protocol commands only through configured local
+  adapters. Missing IMAP/SMTP adapters must return `adapter_not_configured` with
+  `provider_write_executed=false`; the runner must not create mock message ids,
+  placeholder IMAP data, or other fake provider-success evidence.
 
 ## Security & RBAC/ABAC
 - The runner only executes commands authorized by the Naruon RBAC/ABAC policy engine.

--- a/docs/operations/email-relay-proxy-boundary.md
+++ b/docs/operations/email-relay-proxy-boundary.md
@@ -49,6 +49,12 @@
   local client adapters for IMAP, POP3, SMTP, CalDAV, CardDAV, and WebDAV.
 - The `/api/runner-config` manifest describes this production connector role, but
   GitHub self-hosted runners remain CI smoke infrastructure only.
+- Connector command handlers must not synthesize successful IMAP/SMTP results.
+  If a local customer-network adapter is not configured, the runner returns
+  `adapter_not_configured` with `provider_write_executed=false`. If configured,
+  the runner wraps the local adapter result in a standard action/protocol/account
+  envelope so Naruon can distinguish accepted intent, local execution, and
+  provider write evidence.
 - Customer mail/calendar/file systems remain the source-of-truth; see
   `docs/operations/source-of-truth-and-writeback-sovereignty.md`.
 

--- a/docs/plans/2026-05-28-runner-local-adapter-contract.md
+++ b/docs/plans/2026-05-28-runner-local-adapter-contract.md
@@ -1,0 +1,40 @@
+# Self-hosted Runner Local Adapter Contract
+
+## Goal
+
+Remove fake IMAP/SMTP success from the customer-network connector path while
+keeping Naruon framed as a web workspace/control plane, not an email server.
+
+## Verified Gap
+
+- `docs/operations/email-relay-proxy-boundary.md` says private-network mail
+  access must go through an outbound-only customer-hosted connector.
+- `backend/runner/connector.py` previously returned `IMAP data placeholder` and
+  `mock_id_123` as successful `fetch_imap` and `send_smtp` responses.
+- That made the runner look as if it had executed provider operations even when
+  no local IMAP/SMTP adapter existed.
+
+## Implemented Slice
+
+- `SelfHostedConnector` now accepts optional local `imap_fetch_handler` and
+  `smtp_send_handler` adapters.
+- `fetch_imap` and `send_smtp` responses use a standard envelope:
+  `status`, `action`, `protocol`, `account`, `request_id`, and
+  `provider_write_executed`.
+- If the local adapter is missing, the connector fails closed with
+  `adapter_not_configured` and `provider_write_executed=false`.
+- If the adapter is present, the connector forwards only the adapter's actual
+  result fields inside the envelope. It does not synthesize message ids or IMAP
+  data.
+
+## Out Of Scope
+
+- Full local IMAP/SMTP protocol implementation.
+- Persisted command queues and retry scheduling.
+- Provider write execution for CalDAV/CardDAV/WebDAV.
+
+## Verification
+
+```bash
+PYTHONWARNINGS=error python3 -m pytest -q backend/tests/test_runner_connector.py
+```


### PR DESCRIPTION
## Summary
- replace fake IMAP/SMTP runner success responses with a local adapter contract
- fail closed with adapter_not_configured when no customer-network adapter is installed
- document the anti-pattern in AGENTS and runner architecture/operations plans

## Verification
- PYTHONWARNINGS=error python3 -m pytest -q backend/tests/test_runner_connector.py backend/tests/test_runner_ws_api.py backend/tests/test_runner_config_api.py
- python3 -m py_compile backend/runner/connector.py
- git diff --check

## Notes
- No browser UI changed in this slice; runner connector responses are backend/client adapter contract only.
- Strix remains temporarily non-required because direct OpenAI Platform quota is exhausted; required gates remain security and CodeRabbit.