### PR TITLE
fix: load compose env through operator wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,12 @@
 - Execution steps resulting in `Timeout`, `Fatal`, `Warn`, or `Denied` outputs are considered hard failures. Tests must run without these warnings to be considered passing.
 - DB-affecting API slices need both mocked fast tests and a real PostgreSQL
   bootstrap/smoke path before PR merge evidence is considered complete.
+- When a backend container reports missing `DATABASE_URL` or
+  `AUTH_SESSION_HMAC_SECRET`, verify the runtime path injects the operator env
+  through `scripts/naruon_compose.sh`, Kubernetes secrets, or an explicit
+  orchestrator secret. Do not add code defaults, and do not mount or declare the
+  full `~/.env` as a Compose `env_file` because unrelated local secrets may leak
+  into the backend container.
 - DAV/WebDAV/CalDAV routes are private integration surfaces unless explicitly
   documented otherwise. Register them with the default signed-session dependency,
   escape XML response fields before interpolation, and keep path values separate

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ env_text = env_text.replace(
 )
 env_path.write_text(env_text)
 PY
-docker compose up -d --build
-docker compose exec backend python import_fixtures.py
+./scripts/naruon_compose.sh up -d --build
+./scripts/naruon_compose.sh exec backend python import_fixtures.py
 curl -s http://localhost:8000/api/emails
 python3 -m webbrowser http://localhost:3000
 ```
@@ -101,7 +101,12 @@ threading proof path works offline.
 
 Backend settings read environment variables first, then `.env`, `../.env`, and
 `~/.env`. `DATABASE_URL` and `AUTH_SESSION_HMAC_SECRET` still have no code
-defaults; Compose and Kubernetes must inject them explicitly.
+defaults; Compose and Kubernetes must inject them explicitly. For Compose,
+`./scripts/naruon_compose.sh` reads `${NARUON_ENV_FILE}` when set, otherwise
+uses `~/.env` if present, and falls back to the project `.env`. It passes that
+file to Docker Compose only as an interpolation source so the backend service
+receives the whitelisted variables in `docker-compose*.yml`, not every local
+secret present in `~/.env`.
 
 ## Manual development path
 

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -38,6 +38,18 @@ def test_compose_externalizes_postgres_credentials():
     assert "${AUTH_SESSION_HMAC_SECRET:?" in compose
 
 
+def test_compose_wrapper_uses_operator_env_file_without_bulk_secret_injection():
+    wrapper = (REPO_ROOT / "scripts" / "naruon_compose.sh").read_text()
+    gateway_compose = (REPO_ROOT / "docker-compose.gateway.yml").read_text()
+    local_compose = (REPO_ROOT / "docker-compose.yml").read_text()
+
+    assert "NARUON_ENV_FILE" in wrapper
+    assert "${HOME}/.env" in wrapper
+    assert 'docker compose --env-file "${env_file}" "$@"' in wrapper
+    assert "env_file:" not in gateway_compose
+    assert "env_file:" not in local_compose
+
+
 def test_postgres_ha_compose_requires_external_postgres_password():
     compose = (REPO_ROOT / "docker-compose.postgres-ha.yml").read_text()
 

--- a/scripts/naruon_compose.sh
+++ b/scripts/naruon_compose.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${NARUON_ENV_FILE:-}" ]; then
+  env_file="${NARUON_ENV_FILE}"
+elif [ -f "${HOME}/.env" ]; then
+  env_file="${HOME}/.env"
+else
+  env_file=".env"
+fi
+
+if [ ! -f "${env_file}" ]; then
+  cat >&2 <<EOF
+Error: Naruon compose env file not found: ${env_file}
+Set NARUON_ENV_FILE=/path/to/env or create ${HOME}/.env.
+EOF
+  exit 1
+fi
+
+for arg in "$@"; do
+  if [ "${arg}" = "--env-file" ]; then
+    exec docker compose "$@"
+  fi
+done
+
+exec docker compose --env-file "${env_file}" "$@"


### PR DESCRIPTION
## Summary
- add scripts/naruon_compose.sh so Docker Compose reads NARUON_ENV_FILE or ~/.env as interpolation input
- keep backend container env whitelisted through compose environment blocks instead of bulk env_file injection
- document the startup failure pattern in README and AGENTS.md

## Verification
- python3 -m pytest -q backend/tests/test_repo_hygiene.py backend/tests/test_config.py
- bash -n scripts/naruon_compose.sh
- NARUON_ENV_FILE=<temp> ./scripts/naruon_compose.sh -f docker-compose.gateway.yml config, asserted STRIX_OPENAI_API_KEY is not injected
- NARUON_ENV_FILE=<temp> ./scripts/naruon_compose.sh config, asserted STRIX_OPENAI_API_KEY is not injected
- backend import smoke loaded settings from ~/.env without printing secret values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified local setup instructions to use the project's wrapper script for container management
  * Clarified environment variable selection and documented security practices preventing bulk secret injection into containers
  * Added operational guidance for managing credentials without embedding defaults in code

* **Tests**
  * Added validation test for environment file handling and secret isolation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->