### PR TITLE
🧹 [code health improvement] Refactor `validate_mail_config_update` to reduce cyclomatic complexity

### DIFF
--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -107,16 +107,7 @@ def _field_value(
     return None
 
 
-def validate_mail_config_update(
-    config_data: dict, db_config: TenantConfig | None
-) -> None:
-    smtp_server = _field_value(config_data, db_config, "smtp_server")
-    smtp_port = _field_value(config_data, db_config, "smtp_port")
-    imap_server = _field_value(config_data, db_config, "imap_server")
-    imap_port = _field_value(config_data, db_config, "imap_port")
-    pop3_server = _field_value(config_data, db_config, "pop3_server")
-    pop3_port = _field_value(config_data, db_config, "pop3_port")
-
+def _validate_smtp_config(smtp_server: str | None, smtp_port: int | None) -> None:
     try:
         if smtp_server is not None:
             validate_smtp_host(smtp_server, resolve_host=True)
@@ -127,6 +118,7 @@ def validate_mail_config_update(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+def _validate_imap_config(imap_server: str | None, imap_port: int | None) -> None:
     try:
         if imap_server is not None and imap_port is not None:
             validate_imap_destination(imap_server, imap_port)
@@ -140,6 +132,7 @@ def validate_mail_config_update(
             detail=f"imap_server/imap_port validation failed: {exc}",
         ) from exc
 
+def _validate_pop3_config(pop3_server: str | None, pop3_port: int | None) -> None:
     try:
         if pop3_server is not None and pop3_port is not None:
             validate_pop3_destination(pop3_server, pop3_port)
@@ -152,6 +145,20 @@ def validate_mail_config_update(
             status_code=400,
             detail=f"pop3_server/pop3_port validation failed: {exc}",
         ) from exc
+
+def validate_mail_config_update(
+    config_data: dict, db_config: TenantConfig | None
+) -> None:
+    smtp_server = _field_value(config_data, db_config, "smtp_server")
+    smtp_port = _field_value(config_data, db_config, "smtp_port")
+    imap_server = _field_value(config_data, db_config, "imap_server")
+    imap_port = _field_value(config_data, db_config, "imap_port")
+    pop3_server = _field_value(config_data, db_config, "pop3_server")
+    pop3_port = _field_value(config_data, db_config, "pop3_port")
+
+    _validate_smtp_config(smtp_server, smtp_port)
+    _validate_imap_config(imap_server, imap_port)
+    _validate_pop3_config(pop3_server, pop3_port)
 
 
 @router.post("")


### PR DESCRIPTION
🎯 What: Extracted protocol-specific validation logic (SMTP, IMAP, POP3) into three smaller helper functions (`_validate_smtp_config`, `_validate_imap_config`, `_validate_pop3_config`) and updated the main function to call these helpers.
💡 Why: The original function had high cyclomatic complexity due to multiple nested try/except blocks handling different mail protocols. Splitting it improves readability, separation of concerns, and maintainability.
✅ Verification: Ran the full backend pytest test suite to ensure no regressions were introduced.
✨ Result: `validate_mail_config_update` is now simpler and easier to understand, acting as an orchestrator for the specific protocol validation functions.

---
*PR created automatically by Jules for task [15358145667804130056](https://jules.google.com/task/15358145667804130056) started by @seonghobae*