### PR TITLE
feat: surface scoped security audit evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,9 @@
   repository root, and backend working directory, and require Compose/Kubernetes
   to inject the mandatory values so missing runtime configuration fails before
   deployment rather than during `uvicorn main:app` import.
+- Backend Docker image and Compose commands must run through
+  `python scripts/start_backend.py` before `uvicorn main:app`; direct uvicorn
+  CMDs can recreate missing-env stack traces instead of the intended preflight.
 - Python standard library `re` flags (`re.IGNORECASE`) must be passed via the `flags=` keyword argument. Do not use inline `(?i)` at the start of the expression, as it will trigger `DeprecationWarning` regressions in Python 3.11+ test suites.
 - Next.js builds in memory-constrained CI environments (e.g., GitHub Actions) can fail with OOM errors due to PostCSS worker explosion. Set `POSTCSS_WORKERS: "1"` and `DISABLE_POSTCSS_WORKERS: "true"` in the build environment to limit memory usage.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
+ENV BACKEND_BIND_HOST=0.0.0.0
+ENV BACKEND_BIND_PORT=8000
 
 # Install system dependencies if any are needed for pgvector/psycopg2
 RUN apt-get update \
@@ -23,4 +25,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "scripts/start_backend.py"]

--- a/README.md
+++ b/README.md
@@ -101,12 +101,17 @@ threading proof path works offline.
 
 Backend settings read environment variables first, then `.env`, `../.env`, and
 `~/.env`. `DATABASE_URL` and `AUTH_SESSION_HMAC_SECRET` still have no code
-defaults; Compose and Kubernetes must inject them explicitly. For Compose,
+defaults; Compose and Kubernetes must inject them explicitly. A container image
+starts through `python scripts/start_backend.py`, which checks those mandatory
+values before `uvicorn main:app` imports application code. For Compose,
 `./scripts/naruon_compose.sh` reads `${NARUON_ENV_FILE}` when set, otherwise
 uses `~/.env` if present, and falls back to the project `.env`. It passes that
 file to Docker Compose only as an interpolation source so the backend service
 receives the whitelisted variables in `docker-compose*.yml`, not every local
-secret present in `~/.env`.
+secret present in `~/.env`. Direct image runs must use explicit env injection,
+for example `docker run --env-file ~/.env ... naruon-backend:local`, or mount a
+backend-only env file and set `NARUON_ENV_FILE`/`NARUON_BACKEND_ENV_FILE` to
+that mounted path.
 
 ## Manual development path
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,10 +14,12 @@ uvicorn main:app --reload
 
 Set `DATABASE_URL` and `AUTH_SESSION_HMAC_SECRET` explicitly through `.env`,
 Docker Compose, CI secrets, or the runtime environment. Backend settings read
-environment variables first, then `.env`, `../.env`, and `~/.env`; this supports
-running from `backend/`, the repository root, or a local operator env file
-without adding code defaults. The backend still fails closed when either
-required value is missing.
+environment variables first, then `NARUON_BACKEND_ENV_FILE`/`NARUON_ENV_FILE`
+when set, then `.env`, `../.env`, and `~/.env`; this supports running from
+`backend/`, the repository root, or a local operator env file without adding
+code defaults. Container images start through `python scripts/start_backend.py`
+so missing mandatory env fails before `uvicorn main:app` imports application
+code. The backend still fails closed when either required value is missing.
 
 Outbound SMTP/IMAP/POP3 connector destinations fail closed unless the normalized
 tenant host is listed in the matching `ALLOWED_*_HOSTS` setting and the port is

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -82,6 +82,25 @@ def _provider_owner_filter(auth_context: AuthContext):
     return LLMProvider.organization_id == _required_provider_organization(auth_context)
 
 
+def _provider_audit_log(
+    *,
+    auth_context: AuthContext,
+    action: str,
+    provider_name: str,
+    resource_id: str | None = None,
+) -> AuditLog:
+    return AuditLog(
+        user_id=auth_context.user_id,
+        organization_id=auth_context.organization_id,
+        workspace_id=auth_context.workspace_id,
+        event_name=f"llm_provider.{action}",
+        action=action,
+        resource_type="llm_provider",
+        resource_id=resource_id,
+        details=f"{action.title()} provider {provider_name}",
+    )
+
+
 @router.get("", response_model=List[LLMProviderResponse])
 async def list_providers(
     db: AsyncSession = Depends(get_db),
@@ -125,11 +144,10 @@ async def create_provider(
         is_active=data.is_active,
     )
     db.add(provider)
-    audit = AuditLog(
-        user_id=auth_context.user_id,
+    audit = _provider_audit_log(
+        auth_context=auth_context,
         action="create",
-        resource_type="llm_provider",
-        details=f"Created provider {data.name}",
+        provider_name=data.name,
     )
     db.add(audit)
     try:
@@ -186,12 +204,11 @@ async def update_provider(
         updated = True
 
     if updated:
-        audit = AuditLog(
-            user_id=auth_context.user_id,
+        audit = _provider_audit_log(
+            auth_context=auth_context,
             action="update",
-            resource_type="llm_provider",
+            provider_name=provider.name,
             resource_id=str(provider.id),
-            details=f"Updated provider {provider.name}",
         )
         db.add(audit)
         await db.commit()
@@ -226,12 +243,11 @@ async def delete_provider(
         raise HTTPException(status_code=404, detail="Provider not found")
 
     await db.delete(provider)
-    audit = AuditLog(
-        user_id=auth_context.user_id,
+    audit = _provider_audit_log(
+        auth_context=auth_context,
         action="delete",
-        resource_type="llm_provider",
+        provider_name=provider.name,
         resource_id=str(provider.id),
-        details=f"Deleted provider {provider.name}",
     )
     db.add(audit)
     await db.commit()

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -1,20 +1,27 @@
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timezone
 from typing import Literal
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import (
     AuthContext,
     get_auth_context,
     is_admin_role,
+    is_system_admin_role,
 )
-from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.models import (
+    AuditLog,
+    CalendarWritebackSource,
+    ConnectorSignalEvent,
+    WebdavAccount,
+)
 from db.session import get_db
 from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
 
@@ -71,6 +78,19 @@ class ConnectorEvidence(BaseModel):
     observed_at: str
 
 
+class AuditEventEvidence(BaseModel):
+    audit_uid: str
+    event_name: str
+    actor_user_id: str
+    organization_id: str | None
+    workspace_id: str | None
+    resource_type: str
+    resource_ref: str | None
+    event_action: str
+    event_summary: str | None
+    observed_at: str
+
+
 class ExternalShareReview(BaseModel):
     review_uid: str
     source_id: str
@@ -94,6 +114,7 @@ class SecurityAccessSurfaceResponse(BaseModel):
     viewer: ViewerContext
     sources: list[GovernanceSource]
     connector_events: list[ConnectorEvidence]
+    audit_events: list[AuditEventEvidence]
     policy_decisions: list[PolicyDecisionSummary]
     external_share_reviews: list[ExternalShareReview]
     policy_order: list[PolicyOrderStep]
@@ -173,6 +194,34 @@ def _connector_scope_statement(auth_context: AuthContext):
     )
 
 
+def _audit_scope_statement(auth_context: AuthContext):
+    statement = select(AuditLog).order_by(AuditLog.timestamp.desc()).limit(12)
+    if is_system_admin_role(auth_context.role):
+        return statement
+    legacy_own_filter = (
+        AuditLog.user_id == auth_context.user_id,
+        AuditLog.organization_id.is_(None),
+        AuditLog.workspace_id.is_(None),
+    )
+    if _can_read_org_scope(auth_context):
+        return statement.where(
+            or_(
+                AuditLog.organization_id == auth_context.organization_id,
+                and_(*legacy_own_filter),
+            )
+        )
+    organization_filter = (
+        AuditLog.organization_id == auth_context.organization_id
+        if auth_context.organization_id is not None
+        else AuditLog.organization_id.is_(None)
+    )
+    return statement.where(
+        AuditLog.user_id == auth_context.user_id,
+        organization_filter,
+        or_(AuditLog.workspace_id == auth_context.workspace_id, AuditLog.workspace_id.is_(None)),
+    )
+
+
 def _source_in_scope(
     auth_context: AuthContext,
     owner_id: str,
@@ -186,6 +235,26 @@ def _source_in_scope(
     )
 
 
+def _audit_log_in_scope(auth_context: AuthContext, audit_log: AuditLog) -> bool:
+    log_organization_id = audit_log.organization_id
+    log_workspace_id = audit_log.workspace_id
+    if is_system_admin_role(auth_context.role):
+        return True
+    if _can_read_org_scope(auth_context):
+        if log_organization_id == auth_context.organization_id:
+            return True
+        return (
+            log_organization_id is None
+            and log_workspace_id is None
+            and audit_log.user_id == auth_context.user_id
+        )
+    if audit_log.user_id != auth_context.user_id:
+        return False
+    if log_organization_id != auth_context.organization_id:
+        return log_organization_id is None and log_workspace_id is None
+    return log_workspace_id in {None, auth_context.workspace_id}
+
+
 def _access_request(auth_context: AuthContext) -> AccessRequest:
     return AccessRequest(
         user_id=auth_context.user_id,
@@ -194,6 +263,50 @@ def _access_request(auth_context: AuthContext) -> AccessRequest:
         group_ids=auth_context.group_ids,
         data_region="kr",
         consent_scopes=("mail.read", "calendar.read", "webdav.write"),
+    )
+
+
+def _public_resource_ref(audit_log: AuditLog) -> str | None:
+    if not audit_log.resource_id:
+        return None
+    raw_value = ":".join(
+        [
+            audit_log.resource_type,
+            audit_log.resource_id,
+            audit_log.organization_id or "",
+            audit_log.workspace_id or "",
+        ]
+    )
+    return f"res_{hashlib.sha256(raw_value.encode('utf-8')).hexdigest()[:10]}"
+
+
+def _public_audit_uid(audit_log: AuditLog) -> str:
+    if audit_log.audit_uid:
+        return audit_log.audit_uid
+    raw_value = ":".join(
+        [
+            audit_log.user_id,
+            audit_log.resource_type,
+            audit_log.action,
+            _datetime_to_utc_iso(audit_log.timestamp),
+        ]
+    )
+    return f"audit_{hashlib.sha256(raw_value.encode('utf-8')).hexdigest()[:24]}"
+
+
+def _audit_event_evidence(audit_log: AuditLog) -> AuditEventEvidence:
+    event_name = audit_log.event_name or f"{audit_log.resource_type}.{audit_log.action}"
+    return AuditEventEvidence(
+        audit_uid=_public_audit_uid(audit_log),
+        event_name=event_name,
+        actor_user_id=audit_log.user_id,
+        organization_id=audit_log.organization_id,
+        workspace_id=audit_log.workspace_id,
+        resource_type=audit_log.resource_type,
+        resource_ref=_public_resource_ref(audit_log),
+        event_action=audit_log.action,
+        event_summary=audit_log.details,
+        observed_at=_datetime_to_utc_iso(audit_log.timestamp),
     )
 
 
@@ -431,6 +544,12 @@ async def get_access_surface(
             if event.organization_id == auth_context.organization_id
             and event.workspace_id == auth_context.workspace_id
         ]
+    audit_result = await db.execute(_audit_scope_statement(auth_context))
+    audit_events = [
+        _audit_event_evidence(audit_log)
+        for audit_log in audit_result.scalars().all()
+        if _audit_log_in_scope(auth_context, audit_log)
+    ]
 
     sources = [
         _webdav_source(account, auth_context)
@@ -458,6 +577,7 @@ async def get_access_surface(
         ),
         sources=sources,
         connector_events=[_connector_evidence(event) for event in connector_events],
+        audit_events=audit_events,
         policy_decisions=policy_decisions,
         external_share_reviews=_share_reviews(sources),
         policy_order=_policy_order(),

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, cast
 
 from pydantic import SecretStr, model_validator
@@ -8,6 +9,17 @@ _LOW_ENTROPY_PLACEHOLDER_TERMS = ("change", "example", "password", "secret")
 _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS = frozenset(
     {"naruon-session-hmac-token-32-byte-minimum"}
 )
+_DEFAULT_SETTINGS_ENV_FILES = ("~/.env", "../.env", ".env")
+
+
+def _settings_env_files() -> tuple[str, ...]:
+    env_files = list(_DEFAULT_SETTINGS_ENV_FILES)
+    explicit_env_file = os.environ.get("NARUON_BACKEND_ENV_FILE") or os.environ.get(
+        "NARUON_ENV_FILE"
+    )
+    if explicit_env_file:
+        env_files.append(explicit_env_file)
+    return tuple(env_files)
 
 
 def validate_auth_session_hmac_secret_value(secret: str) -> None:
@@ -51,10 +63,15 @@ class Settings(BaseSettings):
     OIDC_JWKS_URL: str | None = None
 
     model_config = SettingsConfigDict(
-        env_file=("~/.env", "../.env", ".env"),
+        env_file=_settings_env_files(),
         env_file_encoding="utf-8",
         extra="ignore",
     )
+
+    def __init__(self, **values: Any) -> None:
+        if "_env_file" not in values:
+            values["_env_file"] = _settings_env_files()
+        super().__init__(**values)
 
     @model_validator(mode="after")
     def validate_session_secret(self) -> "Settings":

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -72,10 +72,18 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id: Mapped[int] = mapped_column(primary_key=True)
+    audit_uid: Mapped[str] = mapped_column(
+        String(32), default=lambda: uuid.uuid4().hex, unique=True, index=True
+    )
     timestamp: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.datetime.utcnow
     )
     user_id: Mapped[str] = mapped_column(String, index=True)
+    organization_id: Mapped[str | None] = mapped_column(
+        String, index=True, nullable=True
+    )
+    workspace_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    event_name: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     action: Mapped[str] = mapped_column(String)
     resource_type: Mapped[str] = mapped_column(String)
     resource_id: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -26,6 +26,12 @@ def schema_backfill_sql():
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS thread_id varchar"),
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS user_id varchar"),
         text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS organization_id varchar"),
+        text("ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS audit_uid varchar"),
+        text(
+            "ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
+        text("ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS workspace_id varchar"),
+        text("ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS event_name varchar"),
         text("ALTER TABLE llm_providers ADD COLUMN IF NOT EXISTS user_id varchar"),
         text(
             "ALTER TABLE llm_providers ADD COLUMN IF NOT EXISTS organization_id varchar"
@@ -104,6 +110,32 @@ def schema_backfill_sql():
         text(
             "CREATE INDEX IF NOT EXISTS ix_llm_providers_organization_id "
             "ON llm_providers (organization_id)"
+        ),
+        text(
+            "UPDATE audit_logs "
+            "SET audit_uid = md5("
+            "random()::text || ':' || clock_timestamp()::text || ':' || "
+            "coalesce(user_id, '') || ':' || coalesce(resource_type, '') || ':' || "
+            "coalesce(action, '')"
+            ") "
+            "WHERE audit_uid IS NULL OR audit_uid = ''"
+        ),
+        text(
+            "UPDATE audit_logs "
+            "SET event_name = resource_type || '.' || action "
+            "WHERE event_name IS NULL OR event_name = ''"
+        ),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_audit_logs_audit_uid "
+            "ON audit_logs (audit_uid)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_scope_time "
+            "ON audit_logs (organization_id, workspace_id, timestamp)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_audit_logs_user_time "
+            "ON audit_logs (user_id, timestamp)"
         ),
         text(
             "CREATE INDEX IF NOT EXISTS ix_calendar_writeback_sources_scope "

--- a/backend/scripts/start_backend.py
+++ b/backend/scripts/start_backend.py
@@ -1,0 +1,95 @@
+import os
+import sys
+from pathlib import Path
+
+REQUIRED_ENV_VARS = ("DATABASE_URL", "AUTH_SESSION_HMAC_SECRET")
+DEFAULT_ENV_FILE_CANDIDATES = ("~/.env", "../.env", ".env")
+DEFAULT_BIND_HOST = "127.0.0.1"
+DEFAULT_BIND_PORT = "8000"
+CONFIG_ERROR_EXIT_CODE = 78
+
+
+def _candidate_env_files() -> list[Path]:
+    candidates = [
+        os.environ.get("NARUON_BACKEND_ENV_FILE"),
+        os.environ.get("NARUON_ENV_FILE"),
+        *DEFAULT_ENV_FILE_CANDIDATES,
+    ]
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate).expanduser()
+        try:
+            key = str(path.resolve(strict=False))
+        except OSError:
+            key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append(path)
+    return paths
+
+
+def _non_empty_env_keys(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+
+    keys: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").lstrip()
+        key, raw_value = line.split("=", 1)
+        normalized_value = raw_value.strip().strip("'\"")
+        if key.strip() and normalized_value:
+            keys.add(key.strip())
+    return keys
+
+
+def missing_required_env() -> list[str]:
+    env_file_keys: set[str] = set()
+    for env_file in _candidate_env_files():
+        env_file_keys.update(_non_empty_env_keys(env_file))
+
+    return [
+        name
+        for name in REQUIRED_ENV_VARS
+        if not os.environ.get(name) and name not in env_file_keys
+    ]
+
+
+def main() -> int:
+    missing = missing_required_env()
+    if missing:
+        sys.stderr.write(
+            "Missing required backend runtime env: "
+            + ", ".join(missing)
+            + ".\n"
+        )
+        sys.stderr.write(
+            "Inject them with Docker/Compose/Kubernetes secrets, or mount a "
+            "backend-only env file and point NARUON_ENV_FILE or "
+            "NARUON_BACKEND_ENV_FILE at it. Code defaults are intentionally "
+            "not provided.\n"
+        )
+        return CONFIG_ERROR_EXIT_CODE
+
+    if os.environ.get("NARUON_STARTUP_CHECK_ONLY") == "1":
+        return 0
+
+    import uvicorn
+
+    uvicorn.run(
+        "main:app",
+        host=os.environ.get("BACKEND_BIND_HOST", DEFAULT_BIND_HOST),
+        port=int(os.environ.get("BACKEND_BIND_PORT", DEFAULT_BIND_PORT)),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -8,6 +8,7 @@ from core.config import settings
 from db.models import Base
 from scripts.bootstrap_db import schema_backfill_sql
 from db.models import (
+    AuditLog,
     CalendarWritebackSource,
     ConnectorSignalEvent,
     ProjectFolder,
@@ -432,6 +433,47 @@ def test_connector_signal_event_model_uses_two_word_names():
         "observed_at",
     }
     assert all("_" in column_name for column_name in column_names)
+
+
+def test_audit_log_model_exposes_durable_scope_columns():
+    column_names = {column.name for column in AuditLog.__table__.columns}
+
+    assert {
+        "audit_uid",
+        "organization_id",
+        "workspace_id",
+        "event_name",
+    }.issubset(column_names)
+    for new_column_name in (
+        "audit_uid",
+        "organization_id",
+        "workspace_id",
+        "event_name",
+    ):
+        assert "_" in new_column_name
+
+
+def test_schema_backfill_adds_audit_log_scope_columns():
+    statements = [str(statement).lower() for statement in schema_backfill_sql()]
+
+    assert any(
+        "alter table audit_logs add column if not exists audit_uid" in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table audit_logs add column if not exists organization_id" in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table audit_logs add column if not exists workspace_id" in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table audit_logs add column if not exists event_name" in statement
+        for statement in statements
+    )
+    assert any("uq_audit_logs_audit_uid" in statement for statement in statements)
+    assert any("ix_audit_logs_scope_time" in statement for statement in statements)
 
 
 def test_schema_backfill_creates_connector_signal_events():

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -100,6 +100,28 @@ def test_settings_load_operator_home_env_when_project_env_is_absent(
     assert loaded_settings.DATABASE_URL == database_url
 
 
+def test_settings_load_operator_env_file_from_naruon_env_file(monkeypatch, tmp_path):
+    env_file = tmp_path / "backend.env"
+    database_url = "postgresql+asyncpg://operator:operator@localhost:5432/operator_db"
+    env_file.write_text(
+        "\n".join(
+            [
+                f"DATABASE_URL={database_url}",
+                f"AUTH_SESSION_HMAC_SECRET={TEST_AUTH_SESSION_HMAC_SECRET}",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AUTH_SESSION_HMAC_SECRET", raising=False)
+    monkeypatch.delenv("NARUON_BACKEND_ENV_FILE", raising=False)
+    monkeypatch.setenv("NARUON_ENV_FILE", str(env_file))
+
+    loaded_settings = Settings()
+
+    assert loaded_settings.DATABASE_URL == database_url
+
+
 def test_production_settings_reject_missing_auth_session_hmac_secret(monkeypatch):
     monkeypatch.setenv(
         "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -141,6 +141,9 @@ def test_llm_provider_crud_admin(admin_client):
     assert "api_key" not in data
     assert mock_session.providers[0].user_id == "admin"
     assert mock_session.providers[0].organization_id == "org-acme"
+    assert mock_session.audits[0].event_name == "llm_provider.create"
+    assert mock_session.audits[0].organization_id == "org-acme"
+    assert mock_session.audits[0].workspace_id == "workspace-org-acme"
 
     provider_id = data["id"]
 

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -19,6 +19,14 @@ def test_backend_dockerfile_suppresses_pip_root_warning():
     assert "PIP_DISABLE_PIP_VERSION_CHECK=1" in dockerfile
 
 
+def test_backend_dockerfile_runs_startup_preflight_before_uvicorn_import():
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+
+    assert 'CMD ["python", "scripts/start_backend.py"]' in dockerfile
+    assert 'CMD ["uvicorn"' not in dockerfile
+    assert "ENV BACKEND_BIND_HOST=0.0.0.0" in dockerfile
+
+
 def test_backend_requirements_do_not_pin_yanked_email_validator():
     requirements = (REPO_ROOT / "backend" / "requirements.txt").read_text()
 
@@ -48,6 +56,14 @@ def test_compose_wrapper_uses_operator_env_file_without_bulk_secret_injection():
     assert 'docker compose --env-file "${env_file}" "$@"' in wrapper
     assert "env_file:" not in gateway_compose
     assert "env_file:" not in local_compose
+
+
+def test_compose_backend_uses_startup_preflight_before_uvicorn_import():
+    local_compose = (REPO_ROOT / "docker-compose.yml").read_text()
+    live_compose = (REPO_ROOT / "docker-compose.live-e2e.yml").read_text()
+
+    assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in local_compose
+    assert 'command: ["python", "scripts/start_backend.py"]' in live_compose
 
 
 def test_postgres_ha_compose_requires_external_postgres_password():

--- a/backend/tests/test_security_api.py
+++ b/backend/tests/test_security_api.py
@@ -17,7 +17,12 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api.auth import get_auth_context, get_current_user
 from core.config import settings
-from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.models import (
+    AuditLog,
+    CalendarWritebackSource,
+    ConnectorSignalEvent,
+    WebdavAccount,
+)
 from db.session import get_db
 from main import app
 
@@ -42,11 +47,13 @@ class MockAsyncSession:
         webdav_accounts: list[WebdavAccount] | None = None,
         calendar_sources: list[CalendarWritebackSource] | None = None,
         connector_events: list[ConnectorSignalEvent] | None = None,
+        audit_logs: list[AuditLog] | None = None,
     ):
         self.results = [
             webdav_accounts or [],
             calendar_sources or [],
             connector_events or [],
+            audit_logs or [],
         ]
         self.execute_calls = 0
 
@@ -150,6 +157,26 @@ def _connector_event(
     )
 
 
+def _audit_log(
+    audit_uid: str,
+    user_id: str = "admin",
+    organization_id: str | None = "org-acme",
+    workspace_id: str | None = "workspace-org-acme",
+) -> AuditLog:
+    return AuditLog(
+        audit_uid=audit_uid,
+        user_id=user_id,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        event_name="llm_provider.update",
+        action="update",
+        resource_type="llm_provider",
+        resource_id="42",
+        details="Updated provider acme-ai",
+        timestamp=_now(),
+    )
+
+
 @pytest.fixture
 def mock_db():
     return MockAsyncSession(
@@ -164,6 +191,10 @@ def mock_db():
         connector_events=[
             _connector_event("connector_evt_heartbeat"),
             _connector_event("connector_evt_other_org", "org-rival"),
+        ],
+        audit_logs=[
+            _audit_log("audit_llm_provider_update"),
+            _audit_log("audit_other_org", "rival-admin", "org-rival", "workspace-org-rival"),
         ],
     )
 
@@ -201,6 +232,11 @@ def test_access_surface_returns_org_scoped_sources_and_policy_decisions(admin_cl
     assert "caldav_src_other_org" not in response.text
     assert data["connector_events"][0]["event_uid"] == "connector_evt_heartbeat"
     assert "connector_evt_other_org" not in response.text
+    audit_uids = {event["audit_uid"] for event in data["audit_events"]}
+    assert audit_uids == {"audit_llm_provider_update"}
+    assert data["audit_events"][0]["event_name"] == "llm_provider.update"
+    assert data["audit_events"][0]["resource_ref"] != "42"
+    assert "resource_id" not in data["audit_events"][0]
     reasons = {decision["reason"] for decision in data["policy_decisions"]}
     assert "organization_denied" in reasons
     assert "data_region_denied" in reasons
@@ -234,6 +270,10 @@ def test_member_surface_only_returns_owned_sources(mock_db):
                 _calendar_source("caldav_src_admin", "admin"),
             ],
             connector_events=[],
+            audit_logs=[
+                _audit_log("audit_member_owned", "member"),
+                _audit_log("audit_admin_peer", "admin"),
+            ],
         )
 
     app.dependency_overrides[get_db] = override_get_db
@@ -253,6 +293,8 @@ def test_member_surface_only_returns_owned_sources(mock_db):
     assert response.status_code == 200, response.text
     source_ids = {source["source_id"] for source in response.json()["sources"]}
     assert source_ids == {"webdav_src_owned", "caldav_src_owned"}
+    audit_uids = {event["audit_uid"] for event in response.json()["audit_events"]}
+    assert audit_uids == {"audit_member_owned"}
 
 
 def test_access_surface_rejects_public_identity_headers_without_signed_session(mock_db):

--- a/backend/tests/test_start_backend.py
+++ b/backend/tests/test_start_backend.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "start_backend.py"
+
+
+def _load_start_backend_module():
+    spec = importlib.util.spec_from_file_location("start_backend", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_missing_database_url_fails_before_uvicorn_import(
+    monkeypatch, tmp_path, capsys
+):
+    module = _load_start_backend_module()
+    home_dir = tmp_path / "home"
+    app_dir = tmp_path / "app"
+    home_dir.mkdir()
+    app_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AUTH_SESSION_HMAC_SECRET", raising=False)
+    monkeypatch.delenv("NARUON_ENV_FILE", raising=False)
+    monkeypatch.delenv("NARUON_BACKEND_ENV_FILE", raising=False)
+    monkeypatch.chdir(app_dir)
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == module.CONFIG_ERROR_EXIT_CODE
+    assert "Missing required backend runtime env: DATABASE_URL" in captured.err
+    assert "AUTH_SESSION_HMAC_SECRET" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_operator_env_file_passes_startup_preflight(monkeypatch, tmp_path):
+    module = _load_start_backend_module()
+    env_file = tmp_path / "backend.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+asyncpg://test:test@localhost:5432/test_db",
+                "AUTH_SESSION_HMAC_SECRET=local-runtime-session-key-0123456789",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AUTH_SESSION_HMAC_SECRET", raising=False)
+    monkeypatch.setenv("NARUON_ENV_FILE", str(env_file))
+    monkeypatch.setenv("NARUON_STARTUP_CHECK_ONLY", "1")
+
+    assert module.main() == 0

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -58,7 +58,7 @@ services:
         condition: service_completed_successfully
     expose:
       - "8000"
-    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["python", "scripts/start_backend.py"]
 
   frontend:
     image: ${FRONTEND_IMAGE:?Set FRONTEND_IMAGE to a pre-built frontend image}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
     ports:
       - "8000:8000"
-    command: ["sh", "-c", "python scripts/bootstrap_db.py && uvicorn main:app --host 0.0.0.0 --port 8000"]
+    command: ["sh", "-c", "python scripts/bootstrap_db.py && python scripts/start_backend.py"]
 
   frontend:
     build:

--- a/frontend/src/app/security/page.test.tsx
+++ b/frontend/src/app/security/page.test.tsx
@@ -73,6 +73,20 @@ const securitySurface = {
       observed_at: "2026-05-28T04:00:00Z",
     },
   ],
+  audit_events: [
+    {
+      audit_uid: "audit_llm_provider_update",
+      event_name: "llm_provider.update",
+      actor_user_id: "admin",
+      organization_id: "org-acme",
+      workspace_id: "workspace-org-acme",
+      resource_type: "llm_provider",
+      resource_ref: "res_9c0f7c85",
+      event_action: "update",
+      event_summary: "Updated provider acme-ai",
+      observed_at: "2026-05-28T05:00:00Z",
+    },
+  ],
   policy_decisions: [
     {
       decision_uid: "policy:webdav_src_primary",
@@ -204,6 +218,10 @@ describe("SecurityPage", () => {
       expect(container.textContent).not.toContain("곧 제공됩니다");
       if (tabName === "감사 로그") {
         expect(container.textContent).toContain("connector_evt_heartbeat");
+        expect(container.textContent).toContain("audit_llm_provider_update");
+        expect(container.textContent).toContain("llm_provider.update");
+        expect(container.textContent).toContain("res_9c0f7c85");
+        expect(container.textContent).not.toContain("resource_id");
       }
       if (tabName === "외부 공유") {
         expect(container.textContent).toContain("WebDAV repository writeback boundary");

--- a/frontend/src/components/SecurityLayout.tsx
+++ b/frontend/src/components/SecurityLayout.tsx
@@ -49,6 +49,19 @@ type ConnectorEvidence = {
   observed_at: string;
 };
 
+type AuditEventEvidence = {
+  audit_uid: string;
+  event_name: string;
+  actor_user_id: string;
+  organization_id: string | null;
+  workspace_id: string | null;
+  resource_type: string;
+  resource_ref: string | null;
+  event_action: string;
+  event_summary: string | null;
+  observed_at: string;
+};
+
 type ExternalShareReview = {
   review_uid: string;
   source_id: string;
@@ -78,6 +91,7 @@ type SecurityAccessSurface = {
   };
   sources: GovernanceSource[];
   connector_events: ConnectorEvidence[];
+  audit_events: AuditEventEvidence[];
   policy_decisions: PolicyDecisionSummary[];
   external_share_reviews: ExternalShareReview[];
   policy_order: PolicyOrderStep[];
@@ -328,14 +342,47 @@ function AuditTab({ data }: { data: SecurityAccessSurface }) {
   return (
     <section aria-label="보안 감사 로그" className="space-y-5">
       <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
-        <h2 className="text-base font-bold">Connector evidence와 감사 이벤트</h2>
+        <h2 className="text-base font-bold">Scoped AuditLog와 connector evidence</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          AuditLog 직접 노출 대신 scoped connector evidence와 API audit event만 표시합니다.
+          조직/워크스페이스로 제한된 audit event를 opaque uid와 resource reference로 표시합니다.
         </p>
         <div className="mt-4 rounded-lg border border-border bg-background p-3">
           <p className="text-xs font-bold text-muted-foreground">API audit event</p>
           <p className="mt-1 font-mono text-sm">{data.audit_event}</p>
         </div>
+        {data.audit_events.length === 0 ? (
+          <div className="mt-4">
+            <EmptyState label="durable audit event" />
+          </div>
+        ) : (
+          <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+            {data.audit_events.map((event) => (
+              <article key={event.audit_uid} className="rounded-lg border border-border bg-background p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="font-mono text-sm font-bold">{event.audit_uid}</p>
+                  <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">{event.event_action}</span>
+                </div>
+                <p className="mt-2 text-sm font-bold">{event.event_name}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{event.event_summary ?? event.resource_type}</p>
+                <dl className="mt-3 grid grid-cols-1 gap-2 text-xs">
+                  <div className="flex items-center justify-between gap-3">
+                    <dt className="font-bold text-muted-foreground">Actor</dt>
+                    <dd className="text-right">{event.actor_user_id}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <dt className="font-bold text-muted-foreground">Scope</dt>
+                    <dd className="text-right">{event.organization_id ?? 'personal'} / {event.workspace_id ?? 'legacy'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <dt className="font-bold text-muted-foreground">Resource</dt>
+                    <dd className="text-right font-mono">{event.resource_ref ?? event.resource_type}</dd>
+                  </div>
+                </dl>
+                <p className="mt-3 font-mono text-xs text-muted-foreground">{event.observed_at}</p>
+              </article>
+            ))}
+          </div>
+        )}
         {data.connector_events.length === 0 ? (
           <div className="mt-4">
             <EmptyState label="connector evidence" />

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -324,6 +324,9 @@ test('renders Security governance access audit sharing and policy with signed AP
 
   await page.getByRole('button', { name: '감사 로그' }).click();
   await expect(page.getByText('connector_evt_heartbeat')).toBeVisible();
+  await expect(page.getByText('audit_llm_provider_update')).toBeVisible();
+  await expect(page.getByText('llm_provider.update')).toBeVisible();
+  await expect(page.getByText('res_9c0f7c85')).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-audit.png'), fullPage: false });
 
   await page.getByRole('button', { name: '외부 공유' }).click();

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -282,6 +282,20 @@ const securityAccessSurface = {
       observed_at: '2026-05-28T04:00:00Z',
     },
   ],
+  audit_events: [
+    {
+      audit_uid: 'audit_llm_provider_update',
+      event_name: 'llm_provider.update',
+      actor_user_id: 'admin',
+      organization_id: 'org-acme',
+      workspace_id: 'workspace-org-acme',
+      resource_type: 'llm_provider',
+      resource_ref: 'res_9c0f7c85',
+      event_action: 'update',
+      event_summary: 'Updated provider acme-ai',
+      observed_at: '2026-05-28T05:00:00Z',
+    },
+  ],
   policy_decisions: [
     {
       decision_uid: 'policy:webdav_src_primary',


### PR DESCRIPTION
## Summary
- add durable scoped AuditLog evidence to the signed Security access surface and UI audit tab
- stamp LLM provider audit events with organization/workspace/event metadata and hide raw resource identifiers
- add backend startup preflight so missing DATABASE_URL/AUTH_SESSION_HMAC_SECRET fails before uvicorn import, while supporting NARUON_ENV_FILE/NARUON_BACKEND_ENV_FILE

## Verification
- PYTHONWARNINGS=error python3 -m pytest -q backend/tests/test_security_api.py backend/tests/test_llm_providers_api.py backend/tests/test_bootstrap_db.py backend/tests/test_config.py backend/tests/test_start_backend.py backend/tests/test_repo_hygiene.py
- npm test -- src/app/security/page.test.tsx
- npm run lint -- src/app/security/page.test.tsx src/components/SecurityLayout.tsx tests/e2e/dashboard-branding.spec.ts tests/e2e/helpers.ts
- npm run typecheck
- env -u FORCE_COLOR -u NO_COLOR PLAYWRIGHT_PORT=18185 NEXT_TELEMETRY_DISABLED=1 npx playwright test tests/e2e/dashboard-branding.spec.ts -g "Security governance" --project=desktop --workers=1
- ./scripts/naruon_compose.sh config --services
- manual startup preflight check: empty env exits 78 before uvicorn import, with no traceback

## Screenshot review
- inspected desktop access/audit/policy screenshots
- inspected tablet policy screenshot
- inspected mobile access, mobile scroll, and mobile hamburger screenshots for overlap and drawer scroll