### PR TITLE
🧹 [Refactor `parse_eml` to reduce cyclomatic complexity]

### DIFF
--- a/backend/services/email_parser.py
+++ b/backend/services/email_parser.py
@@ -50,58 +50,62 @@ def _sanitize_address_display_text(text: str) -> str:
     return _sanitize_display_text(text)
 
 
-def parse_eml(file_path: str | Path) -> EmailData:
-    """Parses an EML file and extracts email metadata and body.
-
-    Raises:
-        EmailParseError: If there is an issue reading the file.
-    """
-    try:
-        with open(file_path, "rb") as f:
-            msg = email.message_from_binary_file(f, policy=policy.default)
-    except OSError as e:
-        raise EmailParseError(f"Failed to read file {file_path}: {e}") from e
-
+def _process_multipart_body(msg: email.message.Message) -> tuple[str, str, list[dict]]:
     plain_body = ""
     html_body = ""
     attachments = []
 
-    if msg.is_multipart():
-        for part in msg.walk():
-            content_type = part.get_content_type()
-            filename = part.get_filename()
-            # Skip attachments
-            if filename:
-                if content_type == "text/plain":
-                    part_content = part.get_content()
-                    if isinstance(part_content, str):
-                        attachments.append(
-                            {
-                                "filename": _sanitize_display_text(filename),
-                                "content": _sanitize_display_text(part_content),
-                            }
-                        )
-                continue
-
+    for part in msg.walk():
+        content_type = part.get_content_type()
+        filename = part.get_filename()
+        # Skip attachments
+        if filename:
             if content_type == "text/plain":
                 part_content = part.get_content()
                 if isinstance(part_content, str):
-                    plain_body += part_content
-            elif content_type == "text/html":
-                part_content = part.get_content()
-                if isinstance(part_content, str):
-                    html_body += part_content
+                    attachments.append(
+                        {
+                            "filename": _sanitize_display_text(filename),
+                            "content": _sanitize_display_text(part_content),
+                        }
+                    )
+            continue
+
+        if content_type == "text/plain":
+            part_content = part.get_content()
+            if isinstance(part_content, str):
+                plain_body += part_content
+        elif content_type == "text/html":
+            part_content = part.get_content()
+            if isinstance(part_content, str):
+                html_body += part_content
+    return plain_body, html_body, attachments
+
+
+def _process_singlepart_body(msg: email.message.Message) -> tuple[str, str, list[dict]]:
+    plain_body = ""
+    html_body = ""
+    content_type = msg.get_content_type()
+    part_content = msg.get_content()
+    if isinstance(part_content, str):
+        if content_type == "text/html":
+            html_body = part_content
+        else:
+            plain_body = part_content
+    return plain_body, html_body, []
+
+
+def _extract_body_and_attachments(msg: email.message.Message) -> tuple[str, list[dict]]:
+    if msg.is_multipart():
+        plain_body, html_body, attachments = _process_multipart_body(msg)
     else:
-        content_type = msg.get_content_type()
-        part_content = msg.get_content()
-        if isinstance(part_content, str):
-            if content_type == "text/html":
-                html_body = part_content
-            else:
-                plain_body = part_content
+        plain_body, html_body, attachments = _process_singlepart_body(msg)
 
     body = plain_body if plain_body else html_body
+    return body, attachments
 
+
+def _extract_date(msg: email.message.Message) -> datetime.datetime:
     date_header = msg.get("Date")
     parsed_date = None
     if date_header:
@@ -112,10 +116,10 @@ def parse_eml(file_path: str | Path) -> EmailData:
 
     if not parsed_date:
         parsed_date = datetime.datetime.now(datetime.timezone.utc)
+    return parsed_date
 
-    message_id = _sanitize_nul(msg.get("Message-ID", ""))
 
-    # Extract thread_id
+def _extract_thread_id(msg: email.message.Message, message_id: str) -> str | None:
     thread_id = None
     references = msg.get("References")  # O3: email threading support
     in_reply_to = msg.get("In-Reply-To")
@@ -133,6 +137,26 @@ def parse_eml(file_path: str | Path) -> EmailData:
 
     if not thread_id:
         thread_id = message_id
+
+    return thread_id
+
+
+def parse_eml(file_path: str | Path) -> EmailData:
+    """Parses an EML file and extracts email metadata and body.
+
+    Raises:
+        EmailParseError: If there is an issue reading the file.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            msg = email.message_from_binary_file(f, policy=policy.default)
+    except OSError as e:
+        raise EmailParseError(f"Failed to read file {file_path}: {e}") from e
+
+    body, attachments = _extract_body_and_attachments(msg)
+    parsed_date = _extract_date(msg)
+    message_id = _sanitize_nul(msg.get("Message-ID", ""))
+    thread_id = _extract_thread_id(msg, message_id)
 
     return {
         "message_id": message_id,


### PR DESCRIPTION
🎯 **What:** The `parse_eml` function in `backend/services/email_parser.py` was refactored by extracting its body, date, and thread ID parsing logic into smaller helper functions: `_extract_body_and_attachments`, `_process_multipart_body`, `_process_singlepart_body`, `_extract_date`, and `_extract_thread_id`.

💡 **Why:** The original `parse_eml` function had high cyclomatic complexity and contained too many local variables, branches, and statements, making it difficult to read and maintain. By breaking it into smaller helper functions, the logic is easier to follow, isolated, and more maintainable.

✅ **Verification:** I ran `pylint services/email_parser.py` inside the `backend` directory to confirm the score improved from 9.48/10 to 9.82/10 and the "Too many branches/locals/statements" errors were resolved. I also ran the full backend test suite (`python -m pytest tests`), and all tests passed (including `test_email_parser.py`), confirming that no functionality was broken.

✨ **Result:** The codebase is cleaner and `parse_eml`'s cyclomatic complexity has been significantly reduced without altering any functionality.

---
*PR created automatically by Jules for task [5585770454253940154](https://jules.google.com/task/5585770454253940154) started by @seonghobae*