### PR TITLE
fix: accept direct OpenAI Strix model names

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -85,11 +85,12 @@ jobs:
         run: |
           strix_model="$(printf '%s' "$STRIX_OPENAI_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
+            gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
             openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example openai/gpt-5.4.'
+              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example gpt-5.4 or openai/gpt-5.4.'
               exit 1
               ;;
           esac
@@ -152,8 +153,11 @@ jobs:
             openai/*)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
+            gpt-*)
+              printf 'openai/%s' "$strix_model" > "$strix_llm_file"
+              ;;
             *)
-              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example openai/gpt-5.4.'
+              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example gpt-5.4 or openai/gpt-5.4.'
               exit 1
               ;;
           esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
   OpenAI Platform credential with an OpenAI GPT-5.4-or-newer model. Do not route
   Strix through GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini,
   Google/Vertex, GPT-4o, or GPT-4.1; record direct-provider evidence in the PR.
+  Direct OpenAI model names may be plain (`gpt-5.4`) or provider-qualified
+  (`openai/gpt-5.4`), but must never use the GitHub Models
+  `openai/openai/...` prefix.
   Keep architecture docs and reusable Strix gate tests aligned with this rule so
   stale GitHub Models examples cannot re-enter copied workflow guidance.
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -83,6 +83,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
 	assert_file_contains "$workflow_file" 'STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || '"'"'openai/gpt-5.4'"'"' }}' "strix workflow defaults STRIX_LLM to GPT-5.4"
 	assert_file_contains "$workflow_file" "STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model" "strix workflow rejects older GPT inputs"
+	assert_file_contains "$workflow_file" "gpt-5.4 or openai/gpt-5.4" "strix workflow documents both direct OpenAI model formats"
 	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
 	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow uses only explicit direct GPT-5 credentials"
 	assert_file_contains "$workflow_file" 'LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow masks only the direct OpenAI credential"
@@ -109,6 +110,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 assert_strix_gpt54_model_guard_semantics() {
 	local model="$1"
 	case "$model" in
+	gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
 	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
 		return 0
 		;;
@@ -121,6 +123,12 @@ assert_strix_gpt54_model_guard_semantics() {
 assert_strix_gpt54_model_guard_cases() {
 	if assert_strix_gpt54_model_guard_semantics "openai/gpt-5"; then
 		record_failure "strix GPT-5.4 guard must reject plain openai/gpt-5"
+	fi
+	if assert_strix_gpt54_model_guard_semantics "gpt-5"; then
+		record_failure "strix GPT-5.4 guard must reject plain gpt-5"
+	fi
+	if ! assert_strix_gpt54_model_guard_semantics "gpt-5.4"; then
+		record_failure "strix GPT-5.4 guard must accept direct OpenAI gpt-5.4"
 	fi
 	if ! assert_strix_gpt54_model_guard_semantics "openai/gpt-5.4"; then
 		record_failure "strix GPT-5.4 guard must accept openai/gpt-5.4"


### PR DESCRIPTION
## Summary
- allow direct OpenAI STRIX_LLM values such as gpt-5.4 as well as openai/gpt-5.4
- normalize plain direct OpenAI GPT model names into the openai provider form before writing STRIX_LLM_FILE
- keep GitHub Models openai/openai prefixes rejected and document the regression in AGENTS.md

## Verification
- bash scripts/ci/test_strix_quick_gate.sh
- git diff --check

## Evidence
- prior master Strix run 26568477038 failed in Gate Strix secrets because STRIX_LLM did not match the provider-qualified-only guard
- workflow still uses STRIX_OPENAI_API_KEY and has no models: read permission or GitHub Models inference URL