### PR TITLE
fix: preflight backend runtime settings before uvicorn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,10 @@
   orchestrator secret. Do not add code defaults, and do not mount or declare the
   full `~/.env` as a Compose `env_file` because unrelated local secrets may leak
   into the backend container.
+- Backend container entrypoints must pass through `python scripts/start_backend.py`
+  before `uvicorn` imports `main:app`. Do not reintroduce Dockerfile, Compose,
+  live-E2E, or gateway commands that call `uvicorn main:app` directly and expose
+  Pydantic import tracebacks for missing runtime settings.
 - DAV/WebDAV/CalDAV routes are private integration surfaces unless explicitly
   documented otherwise. Register them with the default signed-session dependency,
   escape XML response fields before interpolation, and keep path values separate

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ defaults; Compose and Kubernetes must inject them explicitly. For Compose,
 uses `~/.env` if present, and falls back to the project `.env`. It passes that
 file to Docker Compose only as an interpolation source so the backend service
 receives the whitelisted variables in `docker-compose*.yml`, not every local
-secret present in `~/.env`.
+secret present in `~/.env`. The backend image starts through
+`python scripts/start_backend.py`, which checks the same required settings before
+`uvicorn` imports the app. A direct `docker run` therefore still needs explicit
+environment injection through `--env`, an orchestrator secret, or a minimal
+Naruon-specific env file containing only the backend settings needed by the
+container.
 
 ## Manual development path
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,11 @@ Docker Compose, CI secrets, or the runtime environment. Backend settings read
 environment variables first, then `.env`, `../.env`, and `~/.env`; this supports
 running from `backend/`, the repository root, or a local operator env file
 without adding code defaults. The backend still fails closed when either
-required value is missing.
+required value is missing. The Docker image runs `scripts/start_backend.py`
+before `uvicorn`, so missing runtime settings are reported as a concise startup
+configuration error instead of an import-time traceback. Direct container runs
+must inject only the required backend settings through `--env`, an orchestrator
+secret, or a minimal Naruon-specific env file.
 
 Outbound SMTP/IMAP/POP3 connector destinations fail closed unless the normalized
 tenant host is listed in the matching `ALLOWED_*_HOSTS` setting and the port is

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -3,26 +3,9 @@ from typing import Any, cast
 from pydantic import SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-MIN_AUTH_SESSION_HMAC_SECRET_BYTES = 32
-_LOW_ENTROPY_PLACEHOLDER_TERMS = ("change", "example", "password", "secret")
-_KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS = frozenset(
-    {"naruon-session-hmac-token-32-byte-minimum"}
+from core.runtime_secrets import (
+    validate_auth_session_hmac_secret_value,
 )
-
-
-def validate_auth_session_hmac_secret_value(secret: str) -> None:
-    secret_bytes = secret.encode("utf-8")
-    if len(secret_bytes) < MIN_AUTH_SESSION_HMAC_SECRET_BYTES:
-        raise ValueError(
-            "AUTH_SESSION_HMAC_SECRET must be at least 32 bytes in all environments"
-        )
-    if len(set(secret)) == 1:
-        raise ValueError("AUTH_SESSION_HMAC_SECRET must not be a repeated character")
-    normalized_secret = secret.lower()
-    if normalized_secret in _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS:
-        raise ValueError("AUTH_SESSION_HMAC_SECRET must not use a public fixture value")
-    if any(term in normalized_secret for term in _LOW_ENTROPY_PLACEHOLDER_TERMS):
-        raise ValueError("AUTH_SESSION_HMAC_SECRET must not contain placeholder terms")
 
 
 class Settings(BaseSettings):

--- a/backend/core/runtime_secrets.py
+++ b/backend/core/runtime_secrets.py
@@ -1,0 +1,20 @@
+MIN_AUTH_SESSION_HMAC_SECRET_BYTES = 32
+_LOW_ENTROPY_PLACEHOLDER_TERMS = ("change", "example", "password", "secret")
+_KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS = frozenset(
+    {"naruon-session-hmac-token-32-byte-minimum"}
+)
+
+
+def validate_auth_session_hmac_secret_value(secret: str) -> None:
+    secret_bytes = secret.encode("utf-8")
+    if len(secret_bytes) < MIN_AUTH_SESSION_HMAC_SECRET_BYTES:
+        raise ValueError(
+            "AUTH_SESSION_HMAC_SECRET must be at least 32 bytes in all environments"
+        )
+    if len(set(secret)) == 1:
+        raise ValueError("AUTH_SESSION_HMAC_SECRET must not be a repeated character")
+    normalized_secret = secret.lower()
+    if normalized_secret in _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS:
+        raise ValueError("AUTH_SESSION_HMAC_SECRET must not use a public fixture value")
+    if any(term in normalized_secret for term in _LOW_ENTROPY_PLACEHOLDER_TERMS):
+        raise ValueError("AUTH_SESSION_HMAC_SECRET must not contain placeholder terms")

--- a/backend/scripts/start_backend.py
+++ b/backend/scripts/start_backend.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import sys
+from argparse import ArgumentParser
+from collections.abc import Sequence
+from pathlib import Path
+
+from core.runtime_secrets import validate_auth_session_hmac_secret_value
+
+DEFAULT_SERVER_HOST = "127.0.0.1"
+DEFAULT_SERVER_PORT = 8000
+ENV_FILE_PATHS = ("~/.env", "../.env", ".env")
+REQUIRED_SETTINGS = ("DATABASE_URL", "AUTH_SESSION_HMAC_SECRET")
+OIDC_SETTINGS = ("OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_JWKS_URL")
+
+
+def _strip_env_value(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists() or not path.is_file():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        key, separator, value = line.partition("=")
+        if not separator:
+            continue
+        key = key.strip()
+        if key:
+            values[key] = _strip_env_value(value)
+    return values
+
+
+def _runtime_values() -> tuple[dict[str, str], list[Path]]:
+    values: dict[str, str] = {}
+    checked_paths: list[Path] = []
+    for env_file in ENV_FILE_PATHS:
+        path = Path(env_file).expanduser()
+        checked_paths.append(path)
+        values.update(_read_env_file(path))
+    values.update({key: value for key, value in os.environ.items() if value})
+    return values, checked_paths
+
+
+def validate_runtime_settings() -> list[str]:
+    values, checked_paths = _runtime_values()
+    messages: list[str] = []
+
+    missing_settings = [
+        setting_name for setting_name in REQUIRED_SETTINGS if not values.get(setting_name)
+    ]
+    if missing_settings:
+        checked = ", ".join(str(path) for path in checked_paths)
+        messages.append(
+            "Missing required runtime settings: "
+            f"{', '.join(missing_settings)}. "
+            "Set them in the container environment, Docker Compose env file, "
+            f"or one of: {checked}."
+        )
+
+    session_secret = values.get("AUTH_SESSION_HMAC_SECRET")
+    if session_secret:
+        try:
+            validate_auth_session_hmac_secret_value(session_secret)
+        except ValueError as exc:
+            messages.append(str(exc))
+
+    configured_oidc = [
+        setting_name for setting_name in OIDC_SETTINGS if values.get(setting_name)
+    ]
+    if configured_oidc and len(configured_oidc) != len(OIDC_SETTINGS):
+        messages.append(
+            "OIDC_ISSUER_URL, OIDC_CLIENT_ID, and OIDC_JWKS_URL must be set together"
+        )
+
+    return messages
+
+
+def _argument_parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Validate runtime settings and start Naruon")
+    parser.add_argument("--host", default=DEFAULT_SERVER_HOST)
+    parser.add_argument("--port", default=DEFAULT_SERVER_PORT, type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _argument_parser().parse_args(argv)
+    errors = validate_runtime_settings()
+    if errors:
+        print("Startup configuration error:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 78
+
+    if os.environ.get("NARUON_STARTUP_PREFLIGHT_ONLY") == "1":
+        return 0
+
+    import uvicorn
+
+    uvicorn.run("main:app", host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -167,6 +167,16 @@ def test_backend_dockerfile_uses_modern_env_syntax() -> None:
     assert "ENV PYTHONUNBUFFERED=1" in dockerfile
     assert "ENV PYTHONDONTWRITEBYTECODE 1" not in dockerfile
     assert "ENV PYTHONUNBUFFERED 1" not in dockerfile
+    assert '"scripts/start_backend.py"' in dockerfile
+    assert "uvicorn" not in dockerfile.split("CMD", 1)[1]
+
+
+def test_backend_compose_commands_use_startup_preflight() -> None:
+    compose = read_repo_text("docker-compose.yml")
+    live_e2e_compose = read_repo_text("docker-compose.live-e2e.yml")
+
+    assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
+    assert '"scripts/start_backend.py"' in live_e2e_compose
 
 
 def test_compose_log_scanner_exists_for_warning_policy() -> None:

--- a/backend/tests/test_start_backend.py
+++ b/backend/tests/test_start_backend.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import secrets
+
+from scripts import start_backend
+
+
+def _clear_runtime_settings(monkeypatch) -> None:
+    for setting_name in (
+        "DATABASE_URL",
+        "AUTH_SESSION_HMAC_SECRET",
+        "OIDC_ISSUER_URL",
+        "OIDC_CLIENT_ID",
+        "OIDC_JWKS_URL",
+    ):
+        monkeypatch.delenv(setting_name, raising=False)
+
+
+def test_start_backend_reports_missing_database_url_without_import_traceback(
+    monkeypatch, tmp_path, capsys
+):
+    _clear_runtime_settings(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = start_backend.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 78
+    assert "Missing required runtime settings: DATABASE_URL" in captured.err
+    assert "AUTH_SESSION_HMAC_SECRET" in captured.err
+    assert "Traceback" not in captured.err
+    assert "pydantic" not in captured.err
+
+
+def test_start_backend_accepts_operator_home_env_file(monkeypatch, tmp_path):
+    _clear_runtime_settings(monkeypatch)
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    (home_dir / ".env").write_text(
+        "\n".join(
+            [
+                "DATABASE_URL=postgresql+asyncpg://test:test@localhost:5432/test_db",
+                f"AUTH_SESSION_HMAC_SECRET={secrets.token_urlsafe(48)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    assert start_backend.validate_runtime_settings() == []
+
+
+def test_start_backend_can_run_preflight_only_with_valid_settings(monkeypatch):
+    _clear_runtime_settings(monkeypatch)
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"
+    )
+    monkeypatch.setenv("AUTH_SESSION_HMAC_SECRET", secrets.token_urlsafe(48))
+    monkeypatch.setenv("NARUON_STARTUP_PREFLIGHT_ONLY", "1")
+
+    assert start_backend.main([]) == 0
+
+
+def test_start_backend_rejects_partial_oidc_configuration(monkeypatch, tmp_path):
+    _clear_runtime_settings(monkeypatch)
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"
+    )
+    monkeypatch.setenv("AUTH_SESSION_HMAC_SECRET", secrets.token_urlsafe(48))
+    monkeypatch.setenv("OIDC_ISSUER_URL", "https://login.example.test/realms/naruon")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+
+    assert start_backend.validate_runtime_settings() == [
+        "OIDC_ISSUER_URL, OIDC_CLIENT_ID, and OIDC_JWKS_URL must be set together"
+    ]

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -58,7 +58,7 @@ services:
         condition: service_completed_successfully
     expose:
       - "8000"
-    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]
 
   frontend:
     image: ${FRONTEND_IMAGE:?Set FRONTEND_IMAGE to a pre-built frontend image}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
     ports:
       - "8000:8000"
-    command: ["sh", "-c", "python scripts/bootstrap_db.py && uvicorn main:app --host 0.0.0.0 --port 8000"]
+    command: ["sh", "-c", "python scripts/bootstrap_db.py && python scripts/start_backend.py --host 0.0.0.0 --port 8000"]
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
- route backend Docker/Compose startup through scripts/start_backend.py before uvicorn imports main:app
- keep DATABASE_URL and AUTH_SESSION_HMAC_SECRET fail-closed with no code defaults
- document the runtime env injection path and record the direct-uvicorn traceback anti-pattern in AGENTS.md

## Verification
- PYTHONWARNINGS=error python3 -m pytest -q backend/tests/test_start_backend.py backend/tests/test_config.py backend/tests/test_release_governance.py
- manual subprocess startup preflight: missing env exits 78 without Traceback/pydantic output; valid minimal home env execs command

## Notes
- Subagent delegation was attempted for read-only startup audit, but the current thread limit rejected new agents; this PR proceeds with local verification evidence.