### PR TITLE
fix(ci): exit early when all fallback models match primary

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -2850,6 +2850,7 @@ run_current_target_scan() {
 		else
 			echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in $fallback_config_name." >&2
 		fi
+		return 1
 	fi
 
 	if is_vertex_model "$PRIMARY_MODEL"; then


### PR DESCRIPTION
The script was previously failing to exit after printing an ERROR when all fallback models matched the primary model (Bug 13). Adding `return 1` fixes this logic so that the gate correctly halts execution and fails.

---
*PR created automatically by Jules for task [14209078825298172874](https://jules.google.com/task/14209078825298172874) started by @seonghobae*