### PR TITLE
fix(ci): route Strix through Vertex AI org secrets

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -68,11 +68,16 @@ jobs:
         if: github.event_name == 'pull_request_target' || github.event.inputs.pr_number != ''
         env:
           PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_BASE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.event.inputs.pr_base_sha }}
           PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.inputs.pr_head_sha }}
         run: |
           if [ -z "$PR_NUMBER" ] || [ -z "$PR_HEAD_SHA" ]; then
             echo "::error::PR number and head SHA are required for trusted PR-scope Strix evidence."
             exit 1
+          fi
+          if [ -n "$PR_BASE_SHA" ]; then
+            git -C "$TRUSTED_WORKSPACE" fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
+            git -C "$TRUSTED_WORKSPACE" cat-file -e "$PR_BASE_SHA^{commit}"
           fi
           for pr_head_fetch_attempt in 1 2 3 4 5 6; do
             git -C "$TRUSTED_WORKSPACE" fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -8,6 +8,19 @@ on:
     # Weekly scan on protected branches (Mondays at 03:00 UTC).
     - cron: '0 3 * * 1'
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional pull request number for trusted PR-scope evidence
+        required: false
+        type: string
+      pr_base_sha:
+        description: Optional pull request base SHA for trusted PR-scope evidence
+        required: false
+        type: string
+      pr_head_sha:
+        description: Optional pull request head SHA for trusted PR-scope evidence
+        required: false
+        type: string
 
 concurrency:
   group: strix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -52,11 +65,15 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Fetch pull request head for trusted scan
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || github.event.inputs.pr_number != ''
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.inputs.pr_head_sha }}
         run: |
+          if [ -z "$PR_NUMBER" ] || [ -z "$PR_HEAD_SHA" ]; then
+            echo "::error::PR number and head SHA are required for trusted PR-scope Strix evidence."
+            exit 1
+          fi
           for pr_head_fetch_attempt in 1 2 3 4 5 6; do
             git -C "$TRUSTED_WORKSPACE" fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
             fetched_head_sha="$(git -C "$TRUSTED_WORKSPACE" rev-parse "refs/remotes/pull/${PR_NUMBER}/head")"
@@ -78,7 +95,7 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
           STRIX_VERTEX_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
         run: |
@@ -95,7 +112,7 @@ jobs:
                 exit 1
               fi
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools)
+            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               echo 'provider_mode=vertex_ai' >> "$GITHUB_OUTPUT"
               sanitized_vertex_credentials="$(printf '%s' "$STRIX_VERTEX_CREDENTIALS" | tr -d '\r')"
@@ -106,7 +123,7 @@ jobs:
               fi
               ;;
             *)
-              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model vertex_ai/gemini-3.1-pro-preview-customtools.'
+              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
               exit 1
               ;;
           esac
@@ -181,7 +198,7 @@ jobs:
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
@@ -193,11 +210,11 @@ jobs:
             gpt-*)
               printf 'openai/%s' "$strix_model" > "$strix_llm_file"
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools)
+            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
             *)
-              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model vertex_ai/gemini-3.1-pro-preview-customtools.'
+              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
               exit 1
               ;;
           esac
@@ -227,15 +244,15 @@ jobs:
           STRIX_MEMORY_COMPRESSOR_TIMEOUT: 10
           STRIX_TRANSIENT_RETRY_PER_MODEL: 2
           STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
-          STRIX_PROCESS_TIMEOUT_SECONDS: ${{ github.event_name == 'pull_request_target' && '1200' || '2400' }}
+          STRIX_PROCESS_TIMEOUT_SECONDS: ${{ (github.event_name == 'pull_request_target' || github.event.inputs.pr_number != '') && '1200' || '2400' }}
           STRIX_TOTAL_TIMEOUT_SECONDS: 4800
           STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12
           STRIX_FAIL_ON_MIN_SEVERITY: MEDIUM
-          STRIX_DISABLE_PR_SCOPING: ${{ github.event_name == 'pull_request_target' && '0' || '1' }}
-          GH_TOKEN: ${{ github.event_name == 'pull_request_target' && github.token || '' }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
-          PR_BASE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || '' }}
-          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          STRIX_DISABLE_PR_SCOPING: ${{ (github.event_name == 'pull_request_target' || github.event.inputs.pr_number != '') && '0' || '1' }}
+          GH_TOKEN: ${{ (github.event_name == 'pull_request_target' || github.event.inputs.pr_number != '') && github.token || '' }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_BASE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.event.inputs.pr_base_sha }}
+          PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.inputs.pr_head_sha }}
         run: |
           cd "$TRUSTED_WORKSPACE"
           bash "$TRUSTED_STRIX_GATE"

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -38,14 +38,12 @@ jobs:
         run: |
           set -euo pipefail
           trusted_workspace="$RUNNER_TEMP/trusted-workspace"
-          trusted_archive="$RUNNER_TEMP/trusted-workspace.tar.gz"
           mkdir -p "$trusted_workspace"
-          gh api "/repos/${REPOSITORY}/tarball/${TRUSTED_WORKSPACE_SHA}" > "$trusted_archive"
-          tar -xzf "$trusted_archive" -C "$trusted_workspace" --strip-components=1
           git init -q "$trusted_workspace"
           gh auth setup-git
           git -C "$trusted_workspace" remote add origin "$GITHUB_SERVER_URL/$REPOSITORY.git"
-          git -C "$trusted_workspace" fetch --no-tags --prune origin "$TRUSTED_WORKSPACE_SHA"
+          git -C "$trusted_workspace" fetch --no-tags --depth=1 origin "$TRUSTED_WORKSPACE_SHA"
+          git -C "$trusted_workspace" checkout --detach --quiet "$TRUSTED_WORKSPACE_SHA"
           git -C "$trusted_workspace" cat-file -e "$TRUSTED_WORKSPACE_SHA^{commit}"
           {
             echo "TRUSTED_WORKSPACE=$trusted_workspace"
@@ -80,27 +78,38 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
+          STRIX_VERTEX_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
         run: |
-          strix_model="$(printf '%s' "$STRIX_OPENAI_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
             gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
             openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
+              echo 'provider_mode=openai_direct' >> "$GITHUB_OUTPUT"
+              sanitized_openai_key="$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')"
+              trimmed_openai_key="$(printf '%s' "$sanitized_openai_key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+              if [ -z "$trimmed_openai_key" ]; then
+                echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
+                exit 1
+              fi
+              ;;
+            vertex_ai/gemini-3.1-pro-preview-customtools)
+              echo 'enabled=true' >> "$GITHUB_OUTPUT"
+              echo 'provider_mode=vertex_ai' >> "$GITHUB_OUTPUT"
+              sanitized_vertex_credentials="$(printf '%s' "$STRIX_VERTEX_CREDENTIALS" | tr -d '\r')"
+              trimmed_vertex_credentials="$(printf '%s' "$sanitized_vertex_credentials" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+              if [ -z "$trimmed_vertex_credentials" ]; then
+                echo '::error::GCP_SA_KEY is required for Vertex AI Strix scans.'
+                exit 1
+              fi
               ;;
             *)
-              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example gpt-5.4 or openai/gpt-5.4.'
+              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model vertex_ai/gemini-3.1-pro-preview-customtools.'
               exit 1
               ;;
           esac
-          sanitized_openai_key="$(printf '%s' "$STRIX_OPENAI_API_KEY" | tr -d '\r\n')"
-          trimmed_openai_key="$(printf '%s' "$sanitized_openai_key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-          if [ -z "$trimmed_openai_key" ]; then
-            echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
-            exit 1
-          fi
-          echo 'provider_mode=openai_direct' >> "$GITHUB_OUTPUT"
 
       - name: Install Strix
         if: steps.gate.outputs.enabled == 'true'
@@ -112,7 +121,7 @@ jobs:
       - name: Mask LLM API key
         if: steps.gate.outputs.enabled == 'true'
         env:
-          LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
+          LLM_API_KEY: ${{ steps.gate.outputs.provider_mode == 'openai_direct' && secrets.STRIX_OPENAI_API_KEY || '' }}
         run: |
           # Sanitize CR/LF before masking to prevent broken ::add-mask::
           # commands and potential workflow command injection.
@@ -128,11 +137,11 @@ jobs:
       - name: Prepare LLM API key input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}
+          LLM_API_KEY_SECRET: ${{ steps.gate.outputs.provider_mode == 'openai_direct' && secrets.STRIX_OPENAI_API_KEY || '' }}
         run: |
           sanitized="$(printf '%s' "$LLM_API_KEY_SECRET" | tr -d '\r\n')"
           trimmed="$(printf '%s' "$sanitized" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-          if [ -z "$trimmed" ]; then
+          if [ -z "$trimmed" ] && [ "${{ steps.gate.outputs.provider_mode }}" = "openai_direct" ]; then
             echo '::error::STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans.'
             exit 1
           fi
@@ -141,14 +150,42 @@ jobs:
           printf '%s' "$sanitized" > "$llm_api_key_file"
           echo "LLM_API_KEY_FILE=$llm_api_key_file" >> "$GITHUB_ENV"
 
+      - name: Prepare Vertex AI credentials
+        if: steps.gate.outputs.provider_mode == 'vertex_ai'
+        env:
+          GCP_SA_KEY_JSON: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          umask 077
+          credentials_file="$RUNNER_TEMP/gcp-sa-key.json"
+          printf '%s' "$GCP_SA_KEY_JSON" > "$credentials_file"
+          python3 - "$credentials_file" >> "$GITHUB_ENV" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          credentials_path = pathlib.Path(sys.argv[1])
+          credentials = json.loads(credentials_path.read_text())
+          project_id = str(credentials.get("project_id", "")).strip()
+          if not project_id:
+              raise SystemExit("GCP_SA_KEY must include project_id for Vertex AI Strix scans.")
+          print(f"GOOGLE_APPLICATION_CREDENTIALS={credentials_path}")
+          print(f"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE={credentials_path}")
+          print(f"VERTEXAI_PROJECT={project_id}")
+          print(f"GOOGLE_CLOUD_PROJECT={project_id}")
+          print(f"GCP_PROJECT={project_id}")
+          print(f"GCLOUD_PROJECT={project_id}")
+          print(f"CLOUDSDK_CORE_PROJECT={project_id}")
+          print(f"CLOUDSDK_PROJECT={project_id}")
+          PY
+
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || 'openai/gpt-5.4' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
-          strix_model="$(printf '%s' "$STRIX_OPENAI_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
             openai/*)
               printf '%s' "$strix_model" > "$strix_llm_file"
@@ -156,8 +193,11 @@ jobs:
             gpt-*)
               printf 'openai/%s' "$strix_model" > "$strix_llm_file"
               ;;
+            vertex_ai/gemini-3.1-pro-preview-customtools)
+              printf '%s' "$strix_model" > "$strix_llm_file"
+              ;;
             *)
-              echo '::error::STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model, for example gpt-5.4 or openai/gpt-5.4.'
+              echo '::error::STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model vertex_ai/gemini-3.1-pro-preview-customtools.'
               exit 1
               ;;
           esac
@@ -167,8 +207,18 @@ jobs:
         if: steps.gate.outputs.enabled == 'true'
         env:
           STRIX_LLM_FILE: ${{ env.STRIX_LLM_FILE }}
-          STRIX_LLM_DEFAULT_PROVIDER: openai
+          STRIX_LLM_DEFAULT_PROVIDER: ${{ steps.gate.outputs.provider_mode == 'vertex_ai' && 'vertex_ai' || 'openai' }}
           LLM_API_KEY_FILE: ${{ env.LLM_API_KEY_FILE }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: ${{ env.CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE }}
+          VERTEXAI_PROJECT: ${{ env.VERTEXAI_PROJECT }}
+          GOOGLE_CLOUD_PROJECT: ${{ env.GOOGLE_CLOUD_PROJECT }}
+          GCP_PROJECT: ${{ env.GCP_PROJECT }}
+          GCLOUD_PROJECT: ${{ env.GCLOUD_PROJECT }}
+          CLOUDSDK_CORE_PROJECT: ${{ env.CLOUDSDK_CORE_PROJECT }}
+          CLOUDSDK_PROJECT: ${{ env.CLOUDSDK_PROJECT }}
+          VERTEXAI_LOCATION: ${{ secrets.VERTEX_LOCATION || 'us-central1' }}
+          VERTEX_LOCATION: ${{ secrets.VERTEX_LOCATION || 'us-central1' }}
           STRIX_TARGET_PATH: ./
           STRIX_SOURCE_DIRS: .
           STRIX_REASONING_EFFORT: low

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -117,7 +117,7 @@ jobs:
                 exit 1
               fi
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+            vertex_ai/gemini-2.5-flash)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               echo 'provider_mode=vertex_ai' >> "$GITHUB_OUTPUT"
               sanitized_vertex_credentials="$(printf '%s' "$STRIX_VERTEX_CREDENTIALS" | tr -d '\r')"
@@ -215,7 +215,7 @@ jobs:
             gpt-*)
               printf 'openai/%s' "$strix_model" > "$strix_llm_file"
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+            vertex_ai/gemini-2.5-flash)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
             *)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,16 @@
   packages unless compatibility evidence is recorded in the PR.
 - Strix Security Scan must not route through GitHub Models, `github.token`,
   generic `LLM_API_KEY`, GPT-4o, or GPT-4.1. The current organization-secret
-  route is the exact Vertex AI model
-  `vertex_ai/gemini-3.1-pro-preview-customtools` selected through `STRIX_LLM`
-  with `GCP_SA_KEY`; expose Google/Vertex credentials only for that provider
-  mode. Direct OpenAI GPT-5.4-or-newer scans remain supported only when selected
+  route is `STRIX_LLM` with `GCP_SA_KEY`; `vertex_ai/gemini-2.5-flash` is the
+  validated operational model after run `26581416713` proved
+  `vertex_ai/gemini-3.1-pro-preview-customtools` returns Vertex 404/no-access in
+  this project. Expose Google/Vertex credentials only for Vertex provider mode.
+  Direct OpenAI GPT-5.4-or-newer scans remain supported only when selected
   explicitly with `STRIX_OPENAI_API_KEY`. Do not silently fall back between
   providers, and record provider evidence in the PR. Keep architecture docs and
   reusable Strix gate tests aligned with this rule so stale GitHub Models,
-  OpenAI-only, or generic-key examples cannot re-enter copied workflow guidance.
+  OpenAI-only, unavailable-model, or generic-key examples cannot re-enter copied
+  workflow guidance.
 
 ## PR automation and review defaults
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,16 @@
   explicit `if: ${{ always() }}` upload steps when needed.
 - Prefer upgrading or removing vulnerable dependencies over downgrading patched
   packages unless compatibility evidence is recorded in the PR.
-- Strix Security Scan must use an explicitly named `STRIX_OPENAI_API_KEY`
-  OpenAI Platform credential with an OpenAI GPT-5.4-or-newer model. Do not route
-  Strix through GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini,
-  Google/Vertex, GPT-4o, or GPT-4.1; record direct-provider evidence in the PR.
-  Direct OpenAI model names may be plain (`gpt-5.4`) or provider-qualified
-  (`openai/gpt-5.4`), but must never use the GitHub Models
-  `openai/openai/...` prefix.
-  Keep architecture docs and reusable Strix gate tests aligned with this rule so
-  stale GitHub Models examples cannot re-enter copied workflow guidance.
+- Strix Security Scan must not route through GitHub Models, `github.token`,
+  generic `LLM_API_KEY`, GPT-4o, or GPT-4.1. The current organization-secret
+  route is the exact Vertex AI model
+  `vertex_ai/gemini-3.1-pro-preview-customtools` selected through `STRIX_LLM`
+  with `GCP_SA_KEY`; expose Google/Vertex credentials only for that provider
+  mode. Direct OpenAI GPT-5.4-or-newer scans remain supported only when selected
+  explicitly with `STRIX_OPENAI_API_KEY`. Do not silently fall back between
+  providers, and record provider evidence in the PR. Keep architecture docs and
+  reusable Strix gate tests aligned with this rule so stale GitHub Models,
+  OpenAI-only, or generic-key examples cannot re-enter copied workflow guidance.
 
 ## PR automation and review defaults
 
@@ -115,6 +116,10 @@
   avoid single-token columns such as `id`, `title`, `status`, or `priority` on
   newly introduced objects.
 - When reviews find public/private identifier leaks, stale API fixture shapes, or recurring bug patterns, update tests, frontend mocks, E2E mocks, README examples, architecture docs, and explicitly record the anti-pattern in `AGENTS.md` so the same bug pattern does not reappear in copied examples.
+- When robot review cites an obsolete Strix provider policy, update the docs and
+  tests to the current secret contract before accepting a rollback suggestion;
+  do not reintroduce generic `LLM_API_KEY`, GitHub Models, or cross-provider
+  credential forwarding while trying to satisfy old comments.
 - When reviews find inert navigation/dead-space controls, either wire them to an
   implemented workspace route/API or remove the control; do not leave
   high-traffic drawer/sidebar entries as permanent `준비 중` copy.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ mail/calendar/file systems.
 - PR automation is metadata-only and uses current-head robot-review evidence plus
   required checks. Human approval is not awaited by default under repo policy.
 - Strix PR/security evidence uses the organization-secret provider selected by
-  `STRIX_LLM`. The current route is the exact Vertex AI model
-  `vertex_ai/gemini-3.1-pro-preview-customtools` with `GCP_SA_KEY`; direct
-  OpenAI GPT-5.4-or-newer remains supported only with an explicit
-  `STRIX_OPENAI_API_KEY`. The workflow fails closed rather than falling back to
-  GitHub Models, `github.token`, generic `LLM_API_KEY`, or GPT-4-era models.
-  Pending CodeRabbit or check evidence is a wait state, not a hard blocker.
+  `STRIX_LLM` with `GCP_SA_KEY`. The validated operational route is
+  `vertex_ai/gemini-2.5-flash`; direct OpenAI GPT-5.4-or-newer remains
+  supported only with an explicit `STRIX_OPENAI_API_KEY`. The workflow fails
+  closed rather than falling back to GitHub Models, `github.token`, generic
+  `LLM_API_KEY`, or GPT-4-era models. Pending CodeRabbit or check evidence is a
+  wait state, not a hard blocker.
 - Security governance is source-backed through signed
   `/api/security/access-surface`. The endpoint reads scoped WebDAV, CalDAV, and
   connector evidence, reuses the deny-first RBAC/ABAC policy engine, and returns

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ mail/calendar/file systems.
   open-source observability.
 - PR automation is metadata-only and uses current-head robot-review evidence plus
   required checks. Human approval is not awaited by default under repo policy.
-- Strix PR/security evidence requires an OpenAI GPT-5.4-or-newer model through
-  an explicit `STRIX_OPENAI_API_KEY` OpenAI Platform credential. The workflow
-  fails closed rather than falling back to GitHub Models, Google/Vertex/Gemini,
-  `github.token`, or GPT-4-era models. Pending CodeRabbit or check evidence is
-  a wait state, not a hard blocker.
+- Strix PR/security evidence uses the organization-secret provider selected by
+  `STRIX_LLM`. The current route is the exact Vertex AI model
+  `vertex_ai/gemini-3.1-pro-preview-customtools` with `GCP_SA_KEY`; direct
+  OpenAI GPT-5.4-or-newer remains supported only with an explicit
+  `STRIX_OPENAI_API_KEY`. The workflow fails closed rather than falling back to
+  GitHub Models, `github.token`, generic `LLM_API_KEY`, or GPT-4-era models.
+  Pending CodeRabbit or check evidence is a wait state, not a hard blocker.
 - Security governance is source-backed through signed
   `/api/security/access-surface`. The endpoint reads scoped WebDAV, CalDAV, and
   connector evidence, reuses the deny-first RBAC/ABAC policy engine, and returns

--- a/docs/plans/2026-05-19-north-star-gap-closure.md
+++ b/docs/plans/2026-05-19-north-star-gap-closure.md
@@ -38,9 +38,9 @@ connector, and PR governance is metadata-only.
   comment instead of posting duplicates.
 - [x] Strix provider hardening: the workflow fails closed instead of routing
   scanner traffic through GitHub Models, `github.token`, generic `LLM_API_KEY`,
-  GPT-4o, or GPT-4.1. The current approved default is the exact org-secret
-  Vertex AI model, while direct OpenAI GPT-5.4+ remains explicit-only through
-  `STRIX_OPENAI_API_KEY`.
+  GPT-4o, or GPT-4.1. The current approved default is the validated
+  org-secret Vertex AI model, while direct OpenAI GPT-5.4+ remains
+  explicit-only through `STRIX_OPENAI_API_KEY`.
 - [x] CalDAV source registry: `/api/calendar/writeback-intent` now resolves
   DB-backed `calendar_writeback_sources` rows with opaque `source_uid` values
   instead of exposing sequential CalDAV account ids or accepting browser-supplied

--- a/docs/plans/2026-05-19-north-star-gap-closure.md
+++ b/docs/plans/2026-05-19-north-star-gap-closure.md
@@ -36,10 +36,11 @@ connector, and PR governance is metadata-only.
   the exact `Strix Security Scan` workflow, runs a trusted-base governance script,
   separates pending/waiting states from failures, and updates an idempotent marker
   comment instead of posting duplicates.
-- [x] Strix GPT-5 hardening: the workflow keeps GPT-5.4-or-newer as the model
-  requirement and uses only an explicitly named `STRIX_OPENAI_API_KEY` OpenAI
-  Platform credential. It fails closed instead of routing scanner traffic
-  through GitHub Models, `github.token`, Gemini, GPT-4o, or GPT-4.1.
+- [x] Strix provider hardening: the workflow fails closed instead of routing
+  scanner traffic through GitHub Models, `github.token`, generic `LLM_API_KEY`,
+  GPT-4o, or GPT-4.1. The current approved default is the exact org-secret
+  Vertex AI model, while direct OpenAI GPT-5.4+ remains explicit-only through
+  `STRIX_OPENAI_API_KEY`.
 - [x] CalDAV source registry: `/api/calendar/writeback-intent` now resolves
   DB-backed `calendar_writeback_sources` rows with opaque `source_uid` values
   instead of exposing sequential CalDAV account ids or accepting browser-supplied

--- a/docs/plans/2026-05-27-caldav-writeback-source-registry.md
+++ b/docs/plans/2026-05-27-caldav-writeback-source-registry.md
@@ -15,7 +15,7 @@ client/control plane, not a calendar host.
   target any row.
 - Return intent metadata only: protocol, provider, ETag/If-Match requirement,
   provenance, and audit event. No provider write is executed in this slice.
-- Keep Strix on the current provider governance contract: exact org-secret
+- Keep Strix on the current provider governance contract: validated org-secret
   Vertex AI by default, explicit direct OpenAI only when selected, and no GitHub
   Models path as part of this work.
 

--- a/docs/plans/2026-05-27-caldav-writeback-source-registry.md
+++ b/docs/plans/2026-05-27-caldav-writeback-source-registry.md
@@ -15,8 +15,9 @@ client/control plane, not a calendar host.
   target any row.
 - Return intent metadata only: protocol, provider, ETag/If-Match requirement,
   provenance, and audit event. No provider write is executed in this slice.
-- Keep Strix on direct OpenAI Platform credentials only; no GitHub Models path is
-  part of this work.
+- Keep Strix on the current provider governance contract: exact org-secret
+  Vertex AI by default, explicit direct OpenAI only when selected, and no GitHub
+  Models path as part of this work.
 
 ## Verification
 

--- a/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
+++ b/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
@@ -58,6 +58,9 @@ Browser evidence to inspect:
 
 ## Governance
 
-- Strix remains OpenAI Platform direct-only through `STRIX_OPENAI_API_KEY`.
-- GitHub Models, `github.token`, generic `LLM_API_KEY`, Gemini/Vertex fallback,
-  GPT-4o, and GPT-4.1 are not valid Strix routes.
+- Strix follows the current provider governance contract: the approved default
+  is the exact org-secret Vertex AI model
+  `vertex_ai/gemini-3.1-pro-preview-customtools`, while direct OpenAI GPT-5.4+
+  remains explicit-only through `STRIX_OPENAI_API_KEY`.
+- GitHub Models, `github.token`, generic `LLM_API_KEY`, arbitrary
+  Gemini/Vertex fallback, GPT-4o, and GPT-4.1 are not valid Strix routes.

--- a/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
+++ b/docs/plans/2026-05-27-self-sent-webdav-materialization-intent.md
@@ -59,8 +59,8 @@ Browser evidence to inspect:
 ## Governance
 
 - Strix follows the current provider governance contract: the approved default
-  is the exact org-secret Vertex AI model
-  `vertex_ai/gemini-3.1-pro-preview-customtools`, while direct OpenAI GPT-5.4+
-  remains explicit-only through `STRIX_OPENAI_API_KEY`.
+  is the validated org-secret Vertex AI model `vertex_ai/gemini-2.5-flash`,
+  while direct OpenAI GPT-5.4+ remains explicit-only through
+  `STRIX_OPENAI_API_KEY`.
 - GitHub Models, `github.token`, generic `LLM_API_KEY`, arbitrary
   Gemini/Vertex fallback, GPT-4o, and GPT-4.1 are not valid Strix routes.

--- a/docs/plans/2026-05-27-strix-openai-direct-only.md
+++ b/docs/plans/2026-05-27-strix-openai-direct-only.md
@@ -1,36 +1,42 @@
-# Strix OpenAI Platform Direct-Only Governance Slice
+# Strix Provider Governance Slice
 
 <!-- markdownlint-disable MD013 -->
 
 ## Goal
 
 Keep the required Strix security gate on, but make the provider contract
-unambiguous: Strix uses an explicit `STRIX_OPENAI_API_KEY` OpenAI Platform
-credential and an OpenAI GPT-5.4-or-newer model. It must not route through
-GitHub Models, Google/Vertex/Gemini, `github.token`, or a generic `LLM_API_KEY`.
+unambiguous. The active route is the organization-secret Vertex AI model
+`vertex_ai/gemini-3.1-pro-preview-customtools` selected through `STRIX_LLM` with
+`GCP_SA_KEY`. Direct OpenAI GPT-5.4-or-newer remains allowed only when explicitly
+selected with `STRIX_OPENAI_API_KEY`. Strix must not route through GitHub Models,
+`github.token`, GPT-4-era models, or a generic `LLM_API_KEY`.
 
 ## Evidence
 
 - PR #237 showed `provider_mode=openai_direct` and `api.openai.com` egress, then
   failed because the OpenAI Platform credential hit quota. That is external
   provider exhaustion, not a GitHub Models path.
-- `origin/master` already rejects GitHub Models prefixes, but the Strix workflow
-  still carried GCP/Vertex credential steps. Those steps were unreachable for
-  valid OpenAI model input unless a GCP secret was present, yet their presence
-  made the required scan contract ambiguous.
+- On 2026-05-28 the operator selected the org-secret Vertex AI route instead of
+  GitHub Models or direct OpenAI as the default. The workflow therefore keeps a
+  narrow Vertex branch for the exact approved model and keeps direct OpenAI as
+  an explicit alternate path.
 
 ## Implementation
 
-- Remove GCP credential gating, Google Cloud authentication, and relocated GCP
-  credential export from `.github/workflows/strix.yml`.
+- Keep GCP credential gating, Google Cloud authentication, and credential export
+  only inside `provider_mode=vertex_ai`, and only for the exact approved Vertex
+  model.
+- Keep direct OpenAI isolated behind `provider_mode=openai_direct` and
+  `STRIX_OPENAI_API_KEY`.
 - Keep the privileged PR pattern: trusted-base workspace materialization,
   immutable PR-head fetch as data, self-test from trusted workspace, and pinned
   third-party actions.
 - Keep `continue-on-error` out of Strix. Provider quota remains a failed scan,
   and any temporary merge-gate adjustment must capture evidence and restore the
   required `strix` context immediately after merge processing.
-- Update self-tests so the workflow fails static verification if GCP/Vertex
-  authentication or GitHub Models routing is reintroduced.
+- Update self-tests so the workflow fails static verification if GitHub Models,
+  generic `LLM_API_KEY`, arbitrary Vertex/Gemini models, or cross-provider
+  credential forwarding is reintroduced.
 
 ## Verification
 

--- a/docs/plans/2026-05-27-strix-openai-direct-only.md
+++ b/docs/plans/2026-05-27-strix-openai-direct-only.md
@@ -5,10 +5,12 @@
 ## Goal
 
 Keep the required Strix security gate on, but make the provider contract
-unambiguous. The active route is the organization-secret Vertex AI model
-`vertex_ai/gemini-3.1-pro-preview-customtools` selected through `STRIX_LLM` with
-`GCP_SA_KEY`. Direct OpenAI GPT-5.4-or-newer remains allowed only when explicitly
-selected with `STRIX_OPENAI_API_KEY`. Strix must not route through GitHub Models,
+unambiguous. The active route is the organization-secret Vertex AI provider
+selected through `STRIX_LLM` with `GCP_SA_KEY`; run `26581416713` validated
+`vertex_ai/gemini-2.5-flash` as the operational model and proved
+`vertex_ai/gemini-3.1-pro-preview-customtools` is not available to this project.
+Direct OpenAI GPT-5.4-or-newer remains allowed only when explicitly selected
+with `STRIX_OPENAI_API_KEY`. Strix must not route through GitHub Models,
 `github.token`, GPT-4-era models, or a generic `LLM_API_KEY`.
 
 ## Evidence
@@ -17,15 +19,15 @@ selected with `STRIX_OPENAI_API_KEY`. Strix must not route through GitHub Models
   failed because the OpenAI Platform credential hit quota. That is external
   provider exhaustion, not a GitHub Models path.
 - On 2026-05-28 the operator selected the org-secret Vertex AI route instead of
-  GitHub Models or direct OpenAI as the default. The workflow therefore keeps a
-  narrow Vertex branch for the exact approved model and keeps direct OpenAI as
-  an explicit alternate path.
+  GitHub Models or direct OpenAI as the default. The workflow therefore keeps
+  narrow Vertex branches for approved, verified model names and keeps direct
+  OpenAI as an explicit alternate path.
 
 ## Implementation
 
 - Keep GCP credential gating, Google Cloud authentication, and credential export
-  only inside `provider_mode=vertex_ai`, and only for the exact approved Vertex
-  model.
+  only inside `provider_mode=vertex_ai`, and only for approved Vertex model
+  names.
 - Keep direct OpenAI isolated behind `provider_mode=openai_direct` and
   `STRIX_OPENAI_API_KEY`.
 - Keep the privileged PR pattern: trusted-base workspace materialization,

--- a/docs/plans/2026-05-27-webdav-opaque-source-id.md
+++ b/docs/plans/2026-05-27-webdav-opaque-source-id.md
@@ -21,7 +21,7 @@ opaque `webdav_accounts.source_uid` values, matching the CalDAV source-id rule.
   bearer sessions without public identity headers.
 - Keep provider writes out of scope; these endpoints still create intent
   metadata only.
-- Keep Strix on the current provider governance contract: exact org-secret
+- Keep Strix on the current provider governance contract: validated org-secret
   Vertex AI by default, explicit direct OpenAI only when selected, and no GitHub
   Models.
 

--- a/docs/plans/2026-05-27-webdav-opaque-source-id.md
+++ b/docs/plans/2026-05-27-webdav-opaque-source-id.md
@@ -21,7 +21,8 @@ opaque `webdav_accounts.source_uid` values, matching the CalDAV source-id rule.
   bearer sessions without public identity headers.
 - Keep provider writes out of scope; these endpoints still create intent
   metadata only.
-- Keep Strix on direct OpenAI Platform credentials only. Do not use GitHub
+- Keep Strix on the current provider governance contract: exact org-secret
+  Vertex AI by default, explicit direct OpenAI only when selected, and no GitHub
   Models.
 
 ## Verification

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -167,8 +167,10 @@ is_gemini_model() {
 	esac
 }
 
+NORMALIZED_STRIX_LLM="$(normalize_model "$STRIX_LLM")"
+
 LLM_API_KEY_FILE="${LLM_API_KEY_FILE:-}"
-if [ -z "$LLM_API_KEY_FILE" ] && ! is_vertex_model "$STRIX_LLM"; then
+if [ -z "$LLM_API_KEY_FILE" ] && ! is_vertex_model "$NORMALIZED_STRIX_LLM"; then
 	echo "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key." >&2
 	exit 2
 fi
@@ -183,7 +185,7 @@ LLM_API_KEY=""
 if [ -n "$LLM_API_KEY_FILE" ]; then
 	LLM_API_KEY="$(trim_whitespace "$(cat -- "$LLM_API_KEY_FILE")")"
 fi
-if [ -z "$LLM_API_KEY" ] && ! is_vertex_model "$STRIX_LLM"; then
+if [ -z "$LLM_API_KEY" ] && ! is_vertex_model "$NORMALIZED_STRIX_LLM"; then
 	echo "ERROR: LLM_API_KEY_FILE must contain a non-empty API key." >&2
 	exit 2
 fi
@@ -1867,10 +1869,14 @@ run_strix_once() {
 	fi
 	local start_epoch
 	start_epoch="$(date +%s)"
+	local child_llm_api_key=""
+	if ! is_vertex_model "$(normalize_model "$model")"; then
+		child_llm_api_key="$LLM_API_KEY"
+	fi
 	set -o pipefail
 	set +e
 	STRIX_CHILD_MODEL="$model" \
-		STRIX_CHILD_LLM_API_KEY="$LLM_API_KEY" \
+		STRIX_CHILD_LLM_API_KEY="$child_llm_api_key" \
 		STRIX_CHILD_LLM_API_BASE="$llm_api_base_value" \
 		STRIX_CHILD_REPORTS_DIR="$ACTIVE_REPORTS_DIR" \
 		python3 - "$timeout_seconds" "$resolved_target_path" "$SCAN_MODE" "$STRIX_LOG" <<'PY'

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1975,11 +1975,24 @@ if not resolved_strix_bin:
     raise SystemExit(127)
 resolved_strix_bin = str(pathlib.Path(resolved_strix_bin).resolve(strict=True))
 
-command = [resolved_strix_bin, "-n", "-t", target_path, "--scan-mode", scan_mode]
+try:
+    target_cwd = pathlib.Path(target_path).resolve(strict=True)
+except OSError as exc:
+    sys.stderr.write(f"ERROR: Strix target path could not be canonicalized: {exc}\n")
+    raise SystemExit(2)
+if not target_cwd.is_dir():
+    sys.stderr.write("ERROR: Strix target path must be a directory.\n")
+    raise SystemExit(2)
+if any(ch in str(target_cwd) for ch in ("\x00", "\n", "\r")):
+    sys.stderr.write("ERROR: Strix target path contains unsupported control characters.\n")
+    raise SystemExit(2)
+
+command = [resolved_strix_bin, "-n", "-t", ".", "--scan-mode", scan_mode]
 
 try:
     process = subprocess.Popen(
         command,
+        cwd=str(target_cwd),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -812,11 +812,20 @@ PY
 
 	local changed_files_output
 	if ! changed_files_output="$(git diff --name-only "$base_sha...$head_sha" --)"; then
-		if pull_request_head_blob_required; then
-			echo "ERROR: pull request changed file list could not be read; failing closed." >&2
-			return 2
+		if [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ] && pull_request_metadata_env_present; then
+			if changed_files_output="$(git diff --name-only "$base_sha" "$head_sha" --)"; then
+				echo "Using explicit base/head diff for workflow_dispatch PR-scope Strix evidence." >&2
+			else
+				echo "ERROR: pull request changed file list could not be read; failing closed." >&2
+				return 2
+			fi
+		else
+			if pull_request_head_blob_required; then
+				echo "ERROR: pull request changed file list could not be read; failing closed." >&2
+				return 2
+			fi
+			return 1
 		fi
-		return 1
 	fi
 
 	while IFS= read -r changed_file; do

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -145,20 +145,45 @@ if [ -z "$STRIX_LLM" ]; then
 	exit 2
 fi
 
+is_vertex_model() {
+	case "$1" in
+	vertex_ai/* | vertex_ai_beta/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+is_gemini_model() {
+	case "$1" in
+	gemini/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 LLM_API_KEY_FILE="${LLM_API_KEY_FILE:-}"
-if [ -z "$LLM_API_KEY_FILE" ]; then
+if [ -z "$LLM_API_KEY_FILE" ] && ! is_vertex_model "$STRIX_LLM"; then
 	echo "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key." >&2
 	exit 2
 fi
-if [ ! -f "$LLM_API_KEY_FILE" ] || [ -L "$LLM_API_KEY_FILE" ]; then
+if [ -n "$LLM_API_KEY_FILE" ] && { [ ! -f "$LLM_API_KEY_FILE" ] || [ -L "$LLM_API_KEY_FILE" ]; }; then
 	echo "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key." >&2
 	exit 2
 fi
-if ! LLM_API_KEY_FILE="$(resolve_trusted_input_file "LLM_API_KEY_FILE" "$LLM_API_KEY_FILE")"; then
+if [ -n "$LLM_API_KEY_FILE" ] && ! LLM_API_KEY_FILE="$(resolve_trusted_input_file "LLM_API_KEY_FILE" "$LLM_API_KEY_FILE")"; then
 	exit 2
 fi
-LLM_API_KEY="$(trim_whitespace "$(cat -- "$LLM_API_KEY_FILE")")"
-if [ -z "$LLM_API_KEY" ]; then
+LLM_API_KEY=""
+if [ -n "$LLM_API_KEY_FILE" ]; then
+	LLM_API_KEY="$(trim_whitespace "$(cat -- "$LLM_API_KEY_FILE")")"
+fi
+if [ -z "$LLM_API_KEY" ] && ! is_vertex_model "$STRIX_LLM"; then
 	echo "ERROR: LLM_API_KEY_FILE must contain a non-empty API key." >&2
 	exit 2
 fi
@@ -1729,28 +1754,6 @@ evaluate_pull_request_findings() {
 	return 1
 }
 
-is_vertex_model() {
-	case "$1" in
-	vertex_ai/* | vertex_ai_beta/*)
-		return 0
-		;;
-	*)
-		return 1
-		;;
-	esac
-}
-
-is_gemini_model() {
-	case "$1" in
-	gemini/*)
-		return 0
-		;;
-	*)
-		return 1
-		;;
-	esac
-}
-
 fallback_models_raw_for_model() {
 	local model="$1"
 
@@ -1907,18 +1910,21 @@ for key in (
         child_env[key] = value
 child_env["STRIX_LLM"] = os.environ["STRIX_CHILD_MODEL"]
 child_env["LLM_MODEL"] = os.environ["STRIX_CHILD_MODEL"]
-child_env["LLM_API_KEY"] = os.environ["STRIX_CHILD_LLM_API_KEY"]
+if os.environ.get("STRIX_CHILD_LLM_API_KEY"):
+    child_env["LLM_API_KEY"] = os.environ["STRIX_CHILD_LLM_API_KEY"]
 child_env["STRIX_REPORTS_DIR"] = os.environ["STRIX_CHILD_REPORTS_DIR"]
 for key, value in os.environ.items():
     if key.startswith("FAKE_STRIX_") and value:
         child_env[key] = value
 for key in (
-    "GOOGLE_GHA_CREDS_PATH",
-    "GOOGLE_APPLICATION_CREDENTIALS",
-    "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
-    "VERTEX_LOCATION",
-    "GEMINI_LOCATION",
-    "LLM_TIMEOUT",
+	"GOOGLE_GHA_CREDS_PATH",
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+	"VERTEXAI_PROJECT",
+	"VERTEXAI_LOCATION",
+	"VERTEX_LOCATION",
+	"GEMINI_LOCATION",
+	"LLM_TIMEOUT",
     "STRIX_MEMORY_COMPRESSOR_TIMEOUT",
     "STRIX_REASONING_EFFORT",
     "STRIX_LLM_MAX_RETRIES",
@@ -2037,17 +2043,12 @@ is_llm_service_unavailable_error() {
 ##   - litellm API connection failures with LLM-provider evidence
 ##   - litellm service-unavailable / high-demand provider failures
 ##   - MidStreamFallbackError (litellm mid-stream provider switch)
-## Vertex timeouts remain infrastructure errors for guard logic, but the caller
-## should move directly to fallback model evaluation instead of spending the
-## remaining budget retrying the same slow model. Non-Vertex models have no
-## provider-specific fallback path in this gate, so LLM timeouts are retried on
-## the same model before being treated as non-recoverable.
+## Timeouts remain infrastructure errors for guard logic, but the caller should
+## move directly to fallback model evaluation instead of spending the remaining
+## budget retrying the same slow model.
 is_transient_same_model_retry_error() {
 	local model="${1-}"
 	if is_timeout_error; then
-		if [ -n "$model" ] && ! is_vertex_model "$model"; then
-			return 0
-		fi
 		return 1
 	fi
 	if is_llm_api_connection_error; then
@@ -2850,6 +2851,7 @@ run_current_target_scan() {
 		else
 			echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in $fallback_config_name." >&2
 		fi
+		return 1
 	fi
 
 	if is_vertex_model "$PRIMARY_MODEL"; then

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -292,8 +292,15 @@ normalize_changed_files_cache() {
 	done
 }
 
+pull_request_metadata_env_present() {
+	[ -n "$(trim_whitespace "${PR_NUMBER:-}")" ] &&
+		[ -n "$(trim_whitespace "${PR_BASE_SHA:-}")" ] &&
+		[ -n "$(trim_whitespace "${PR_HEAD_SHA:-}")" ]
+}
+
 pull_request_head_blob_required() {
-	[ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]
+	[ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ] ||
+		{ [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ] && pull_request_metadata_env_present; }
 }
 
 is_valid_git_commit_sha() {
@@ -601,6 +608,9 @@ is_pull_request_event() {
 	case "${GITHUB_EVENT_NAME:-}" in
 	pull_request | pull_request_target)
 		github_event_payload_has_pull_request
+		;;
+	workflow_dispatch)
+		pull_request_metadata_env_present
 		;;
 	*)
 		return 1

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -139,7 +139,8 @@ fi
 if ! STRIX_LLM_FILE="$(resolve_trusted_input_file "STRIX_LLM_FILE" "$STRIX_LLM_FILE")"; then
 	exit 2
 fi
-STRIX_LLM="$(trim_whitespace "$(cat -- "$STRIX_LLM_FILE")")"
+STRIX_LLM_CONTENT="$(cat -- "$STRIX_LLM_FILE")"
+STRIX_LLM="$(trim_whitespace "$STRIX_LLM_CONTENT")"
 if [ -z "$STRIX_LLM" ]; then
 	echo "ERROR: STRIX_LLM_FILE must contain a non-empty model value." >&2
 	exit 2

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -71,6 +71,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "pr_number:" "strix workflow accepts manual PR-scope evidence inputs"
 	assert_file_contains "$workflow_file" "github.event.inputs.pr_number" "strix workflow can run PR-scoped workflow_dispatch evidence"
 	assert_file_contains "$workflow_file" "PR number and head SHA are required for trusted PR-scope Strix evidence" "strix workflow fails closed when manual PR-scope metadata is incomplete"
+	assert_file_contains "$workflow_file" 'fetch --no-tags --depth=1 origin "$PR_BASE_SHA"' "strix workflow fetches manual PR-scope base commit for diffing"
 	assert_file_contains "$workflow_file" "refs/remotes/pull" "strix workflow verifies fetched PR head ref"
 	assert_file_contains "$workflow_file" "for pr_head_fetch_attempt in 1 2 3 4 5 6" "strix workflow retries stale PR head ref propagation"
 	assert_file_contains "$workflow_file" "PR head ref did not resolve to expected commit" "strix workflow fails closed when PR head ref remains stale"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -159,6 +159,7 @@ assert_strix_gpt54_model_guard_cases() {
 assert_strix_gate_target_scope_separated() {
 	assert_file_not_contains "$GATE_SCRIPT" "or generated PR scope directories" "strix gate keeps user target validation separate from internal PR scopes"
 	assert_file_contains "$GATE_SCRIPT" "TARGET_PATH_IS_INTERNAL_PR_SCOPE" "strix gate marks internally generated PR scan scopes explicitly"
+	assert_file_contains "$GATE_SCRIPT" 'git diff --name-only "$base_sha" "$head_sha"' "strix gate falls back to explicit manual PR-scope diff when merge-base is unavailable"
 }
 
 assert_changed_file_membership_uses_cached_normalized_paths() {

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -73,24 +73,27 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "PR head ref did not resolve to expected commit" "strix workflow fails closed when PR head ref remains stale"
 	assert_file_contains "$workflow_file" "sleep 10" "strix workflow waits between stale PR head ref retries"
 	assert_file_contains "$workflow_file" "github.event_name == 'pull_request_target'" "strix workflow gates PR context on pull_request_target"
-	assert_file_not_contains "$workflow_file" "GCP_SA_KEY" "strix workflow must not route direct OpenAI scans through GCP credentials"
+	assert_file_contains "$workflow_file" "GCP_SA_KEY" "strix workflow uses organization Vertex AI credentials when STRIX_LLM selects vertex_ai"
 	assert_file_not_contains "$workflow_file" "google-github-actions/auth" "strix workflow must not authenticate to Google Cloud for direct OpenAI scans"
-	assert_file_not_contains "$workflow_file" "model_requires_vertex_auth" "strix workflow must not keep Vertex auth prerequisites in the direct OpenAI path"
-	assert_file_not_contains "$workflow_file" "Vertex-authenticated Strix model" "strix workflow must not keep Vertex-authenticated Strix branches"
-	assert_file_not_contains "$workflow_file" "GOOGLE_APPLICATION_CREDENTIALS" "strix workflow must not export Google credentials for direct OpenAI scans"
+	assert_file_contains "$workflow_file" "provider_mode=vertex_ai" "strix workflow supports Vertex AI provider mode"
+	assert_file_contains "$workflow_file" "GOOGLE_APPLICATION_CREDENTIALS" "strix workflow exports Vertex AI credentials only for Vertex provider mode"
+	assert_file_contains "$workflow_file" "VERTEXAI_PROJECT" "strix workflow exports LiteLLM Vertex project env"
+	assert_file_contains "$workflow_file" "VERTEXAI_LOCATION" "strix workflow exports LiteLLM Vertex location env"
 	assert_file_contains "$workflow_file" "timeout-minutes: 90" "strix workflow job budget covers PR-scoped Strix batches"
 	assert_file_contains "$workflow_file" "STRIX_TOTAL_TIMEOUT_SECONDS: 4800" "strix workflow total Strix budget covers PR-scoped batches"
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
-	assert_file_contains "$workflow_file" 'STRIX_OPENAI_MODEL: ${{ secrets.STRIX_LLM || '"'"'openai/gpt-5.4'"'"' }}' "strix workflow defaults STRIX_LLM to GPT-5.4"
-	assert_file_contains "$workflow_file" "STRIX_LLM must select an OpenAI Platform GPT-5.4 or newer model" "strix workflow rejects older GPT inputs"
-	assert_file_contains "$workflow_file" "gpt-5.4 or openai/gpt-5.4" "strix workflow documents both direct OpenAI model formats"
+	assert_file_contains "$workflow_file" 'STRIX_MODEL: ${{ secrets.STRIX_LLM || '"'"'vertex_ai/gemini-3.1-pro-preview-customtools'"'"' }}' "strix workflow defaults STRIX_LLM to the organization Vertex AI model"
+	assert_file_contains "$workflow_file" "STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model" "strix workflow rejects unsupported model inputs"
+	assert_file_contains "$workflow_file" "vertex_ai/gemini-3.1-pro-preview-customtools" "strix workflow documents the organization Vertex AI custom-tools model"
+	assert_file_not_contains "$workflow_file" "vertex_ai/* | vertex_ai_beta/*" "strix workflow must not accept arbitrary Vertex models"
 	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
-	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow uses only explicit direct GPT-5 credentials"
-	assert_file_contains "$workflow_file" 'LLM_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}' "strix workflow masks only the direct OpenAI credential"
+	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ steps.gate.outputs.provider_mode == '"'"'openai_direct'"'"' && secrets.STRIX_OPENAI_API_KEY || '"'"''"'"' }}' "strix workflow uses provider-scoped LLM key material"
+	assert_file_contains "$workflow_file" 'LLM_API_KEY: ${{ steps.gate.outputs.provider_mode == '"'"'openai_direct'"'"' && secrets.STRIX_OPENAI_API_KEY || '"'"''"'"' }}' "strix workflow masks provider-scoped LLM key material"
+	assert_file_not_contains "$workflow_file" "secrets.LLM_API_KEY" "strix workflow must not expose generic LLM_API_KEY for Vertex scans"
 	assert_file_contains "$workflow_file" "STRIX_OPENAI_API_KEY is required for Strix OpenAI Platform scans" "strix workflow fails closed when direct credentials are absent"
 	assert_file_contains "$workflow_file" 'trimmed_openai_key="$(printf '"'"'%s'"'"' "$sanitized_openai_key" | sed '"'"'s/^[[:space:]]*//;s/[[:space:]]*$//'"'"')"' "strix workflow trims whitespace-only OpenAI keys before gate validation"
 	assert_file_contains "$workflow_file" 'trimmed="$(printf '"'"'%s'"'"' "$sanitized" | sed '"'"'s/^[[:space:]]*//;s/[[:space:]]*$//'"'"')"' "strix workflow trims whitespace-only OpenAI keys before input file creation"
-	assert_file_contains "$workflow_file" "STRIX_LLM_DEFAULT_PROVIDER: openai" "strix workflow uses the OpenAI-compatible provider for OpenAI Platform"
+	assert_file_contains "$workflow_file" 'STRIX_LLM_DEFAULT_PROVIDER: ${{ steps.gate.outputs.provider_mode == '"'"'vertex_ai'"'"' && '"'"'vertex_ai'"'"' || '"'"'openai'"'"' }}' "strix workflow selects the correct default provider"
 	assert_file_not_contains "$workflow_file" "provider_mode=github_models" "strix workflow must not fall back to GitHub Models"
 	assert_file_not_contains "$workflow_file" "steps.gate.outputs.provider_mode == 'github_models'" "strix workflow must not prepare GitHub Models API base"
 	assert_file_not_contains "$workflow_file" "https://models.github.ai/inference" "strix workflow must not route Strix through GitHub Models inference"
@@ -99,7 +102,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_not_contains "$workflow_file" "openai/gpt-5-*" "strix workflow must not accept older GPT-5 variants when GPT-5.4 is required"
 	assert_file_not_contains "$workflow_file" "openai/openai/gpt-5" "strix workflow must not accept GitHub Models OpenAI model prefixes"
 	assert_file_not_contains "$workflow_file" "github/gpt-4o" "strix workflow must not default to GPT-4o when GPT-5 is required"
-	assert_file_not_contains "$workflow_file" "gemini/gemini-pro-3.1-preview" "strix workflow must not default to Gemini when OpenAI Platform is required"
+	assert_file_not_contains "$workflow_file" "gemini/gemini-pro-3.1-preview" "strix workflow must not default to GitHub Models or Gemini API when Vertex AI is required"
 	assert_file_not_contains "$workflow_file" "if-no-files-found: warn" "strix workflow must not downgrade missing security artifacts to warnings"
 	if grep -Eq '^[[:space:]]+pull_request:[[:space:]]*$' "$workflow_file"; then
 		record_failure "strix workflow must not expose secrets on pull_request events"
@@ -111,7 +114,8 @@ assert_strix_gpt54_model_guard_semantics() {
 	local model="$1"
 	case "$model" in
 	gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
-	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]*)
+	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
+	vertex_ai/gemini-3.1-pro-preview-customtools)
 		return 0
 		;;
 	*)
@@ -135,6 +139,12 @@ assert_strix_gpt54_model_guard_cases() {
 	fi
 	if assert_strix_gpt54_model_guard_semantics "openai/openai/gpt-5.4"; then
 		record_failure "strix GPT-5.4 guard must reject GitHub Models openai/openai/gpt-5.4"
+	fi
+	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-3.1-pro-preview-customtools"; then
+		record_failure "strix guard must accept the organization Vertex AI custom-tools model"
+	fi
+	if assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-pro"; then
+		record_failure "strix guard must reject arbitrary Vertex models"
 	fi
 }
 
@@ -632,25 +642,19 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
-	gemini-timeout-retry-same-model-success)
+	gemini-timeout-direct-fallback-success)
 		case "${STRIX_LLM:-}" in
 		gemini/retry-timeout-primary)
-			attempt="0"
-			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
-				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
-			fi
-			attempt="$((attempt + 1))"
-			echo "$attempt" >"${FAKE_STRIX_STATE_FILE:?}"
-			if [ "$attempt" -eq 1 ]; then
-				echo "LLM CONNECTION FAILED"
-				echo "Error: litellm.Timeout: Connection timed out after None seconds."
-				exit 1
-			fi
-			echo "scan ok after same-model timeout retry"
+			echo "LLM CONNECTION FAILED"
+			echo "Error: litellm.Timeout: Connection timed out after None seconds."
+			exit 1
+			;;
+		gemini/fallback-one)
+			echo "scan ok after timeout fallback"
 			exit 0
 			;;
 		*)
-			echo "Error: gemini timeout retry path unexpected (${STRIX_LLM:-})" >&2
+			echo "Error: gemini timeout fallback path unexpected (${STRIX_LLM:-})" >&2
 			exit 38
 			;;
 		esac
@@ -3649,6 +3653,50 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+run_vertex_without_llm_api_key_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local call_count_file="$tmp_dir/strix_calls"
+	local fake_strix="$tmp_dir/strix"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
+if [ -n "${LLM_API_KEY:-}" ]; then
+	echo "unexpected LLM_API_KEY for Vertex" >&2
+	exit 1
+fi
+exit 0
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' "vertex_ai/ready-primary" >"$strix_llm_file"
+
+	set +e
+	env -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+		PATH="$tmp_dir:$PATH" \
+		STRIX_INPUT_FILE_ROOT="$tmp_dir" \
+		STRIX_DISABLE_PR_SCOPING="0" \
+		STRIX_LLM_FILE="$strix_llm_file" \
+		FAKE_STRIX_CALL_COUNT_FILE="$call_count_file" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=vertex-without-llm-api-key exit code"
+	assert_file_contains "$output_log" "Strix run succeeded for model 'vertex_ai/ready-primary'" "case=vertex-without-llm-api-key output"
+
+	local actual_calls="0"
+	if [ -f "$call_count_file" ]; then
+		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"
+	fi
+	assert_equals "1" "$actual_calls" "case=vertex-without-llm-api-key strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
 run_invalid_min_fail_severity_case() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
@@ -4518,13 +4566,13 @@ run_gate_case "gemini-high-demand-retry-same-model-success" \
 	"" \
 	"1"
 
-run_gate_case "gemini-timeout-retry-same-model-success" \
+run_gate_case "gemini-timeout-direct-fallback-success" \
 	"gemini/retry-timeout-primary" \
-	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"gemini/fallback-one gemini/fallback-two" \
 	"0" \
-	"scan ok after same-model timeout retry" \
+	"scan ok after timeout fallback" \
 	"2" \
-	"gemini/retry-timeout-primary|gemini/retry-timeout-primary" \
+	"gemini/retry-timeout-primary|gemini/fallback-one" \
 	"https://example.invalid|https://example.invalid" \
 	"vertex_ai" \
 	"__DEFAULT__" \
@@ -4536,9 +4584,9 @@ run_gate_case "gemini-timeout-fallback-success" \
 	"gemini/fallback-one gemini/fallback-two" \
 	"0" \
 	"scan ok after gemini fallback" \
-	"3" \
-	"gemini/timeout-fallback-primary|gemini/timeout-fallback-primary|gemini/fallback-one" \
-	"https://example.invalid|https://example.invalid|https://example.invalid" \
+	"2" \
+	"gemini/timeout-fallback-primary|gemini/fallback-one" \
+	"https://example.invalid|https://example.invalid" \
 	"vertex_ai" \
 	"__DEFAULT__" \
 	"" \
@@ -4549,9 +4597,9 @@ run_gate_case "gemini-generic-fallback-success" \
 	"" \
 	"0" \
 	"scan ok after gemini fallback" \
-	"3" \
-	"gemini/timeout-fallback-primary|gemini/timeout-fallback-primary|gemini/fallback-one" \
-	"https://example.invalid|https://example.invalid|https://example.invalid" \
+	"2" \
+	"gemini/timeout-fallback-primary|gemini/fallback-one" \
+	"https://example.invalid|https://example.invalid" \
 	"vertex_ai" \
 	"__DEFAULT__" \
 	"" \
@@ -4598,7 +4646,7 @@ run_gate_case "pr-batch-zero-finding-does-not-leak" \
 	"gemini/batch-zero-leak-primary" \
 	"" \
 	"1" \
-	"Configured model and fallback models were unavailable." \
+	"ERROR: No fallback models configured" \
 	"2" \
 	"gemini/batch-zero-leak-primary|gemini/batch-zero-leak-primary" \
 	"https://example.invalid|https://example.invalid" \
@@ -6175,9 +6223,10 @@ run_gate_case "pr-low-markdown-plus-console-critical-manifest-after-fallback-aut
 	'{"workflow_runs":[{"id":405,"name":"Dependency review","path":".github/workflows/dependency-review.yml","head_sha":"test-head-sha","status":"completed","conclusion":"success","pull_requests":[{"number":123}]},{"id":406,"name":"OSV-Scanner","path":".github/workflows/osvscanner.yml","head_sha":"test-head-sha","status":"completed","conclusion":"success","pull_requests":[{"number":123}]}]}'
 
 run_missing_config_case "missing-strix-llm" "" "dummy" "ERROR: STRIX_LLM_FILE must reference a regular file containing the model."
-run_missing_config_case "missing-llm-api-key" "vertex_ai/ready-primary" "" "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key."
+run_missing_config_case "missing-llm-api-key" "openai/gpt-5.4" "" "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key."
 run_missing_config_case "whitespace-only-strix-llm" "   " "dummy" "ERROR: STRIX_LLM_FILE must contain a non-empty model value."
-run_missing_config_case "whitespace-only-llm-api-key" "vertex_ai/ready-primary" $'\t  ' "ERROR: LLM_API_KEY_FILE must contain a non-empty API key."
+run_missing_config_case "whitespace-only-llm-api-key" "openai/gpt-5.4" $'\t  ' "ERROR: LLM_API_KEY_FILE must contain a non-empty API key."
+run_vertex_without_llm_api_key_case
 
 # ── Segment boundary enforcement for is_vertex_resource_path / extract_vertex_model_id ──
 # Shell glob '*' matches '/' so the old case-pattern implementation accepted

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -3733,11 +3733,11 @@ run_vertex_without_llm_api_key_case() {
 #!/usr/bin/env bash
 set -euo pipefail
 echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
-if [ -n "${LLM_API_KEY:-}" ]; then
+if [ "${LLM_API_KEY+x}" = "x" ]; then
 	echo "unexpected LLM_API_KEY for Vertex" >&2
 	exit 1
 fi
-if [ -n "${LLM_API_KEY_FILE:-}" ]; then
+if [ "${LLM_API_KEY_FILE+x}" = "x" ]; then
 	echo "unexpected LLM_API_KEY_FILE for Vertex" >&2
 	exit 1
 fi
@@ -3782,11 +3782,11 @@ run_vertex_with_llm_api_key_file_does_not_forward_case() {
 #!/usr/bin/env bash
 set -euo pipefail
 echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
-if [ -n "${LLM_API_KEY:-}" ]; then
+if [ "${LLM_API_KEY+x}" = "x" ]; then
 	echo "unexpected LLM_API_KEY for Vertex" >&2
 	exit 1
 fi
-if [ -n "${LLM_API_KEY_FILE:-}" ]; then
+if [ "${LLM_API_KEY_FILE+x}" = "x" ]; then
 	echo "unexpected LLM_API_KEY_FILE for Vertex" >&2
 	exit 1
 fi

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -68,6 +68,9 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_not_contains "$workflow_file" "run: bash ./scripts/ci/test_strix_quick_gate.sh" "strix workflow avoids direct repo self-test execution on privileged trigger"
 	assert_file_not_contains "$workflow_file" "run: bash ./scripts/ci/strix_quick_gate.sh" "strix workflow avoids direct repo gate execution on privileged trigger"
 	assert_file_contains "$workflow_file" "Fetch pull request head for trusted scan" "strix workflow fetches PR head without checkout"
+	assert_file_contains "$workflow_file" "pr_number:" "strix workflow accepts manual PR-scope evidence inputs"
+	assert_file_contains "$workflow_file" "github.event.inputs.pr_number" "strix workflow can run PR-scoped workflow_dispatch evidence"
+	assert_file_contains "$workflow_file" "PR number and head SHA are required for trusted PR-scope Strix evidence" "strix workflow fails closed when manual PR-scope metadata is incomplete"
 	assert_file_contains "$workflow_file" "refs/remotes/pull" "strix workflow verifies fetched PR head ref"
 	assert_file_contains "$workflow_file" "for pr_head_fetch_attempt in 1 2 3 4 5 6" "strix workflow retries stale PR head ref propagation"
 	assert_file_contains "$workflow_file" "PR head ref did not resolve to expected commit" "strix workflow fails closed when PR head ref remains stale"
@@ -82,9 +85,10 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "timeout-minutes: 90" "strix workflow job budget covers PR-scoped Strix batches"
 	assert_file_contains "$workflow_file" "STRIX_TOTAL_TIMEOUT_SECONDS: 4800" "strix workflow total Strix budget covers PR-scoped batches"
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
-	assert_file_contains "$workflow_file" 'STRIX_MODEL: ${{ secrets.STRIX_LLM || '"'"'vertex_ai/gemini-3.1-pro-preview-customtools'"'"' }}' "strix workflow defaults STRIX_LLM to the organization Vertex AI model"
-	assert_file_contains "$workflow_file" "STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or the organization Vertex AI model" "strix workflow rejects unsupported model inputs"
+	assert_file_contains "$workflow_file" 'STRIX_MODEL: ${{ secrets.STRIX_LLM || '"'"'vertex_ai/gemini-2.5-flash'"'"' }}' "strix workflow defaults STRIX_LLM to the operational organization Vertex AI model"
+	assert_file_contains "$workflow_file" "STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" "strix workflow rejects unsupported model inputs"
 	assert_file_contains "$workflow_file" "vertex_ai/gemini-3.1-pro-preview-customtools" "strix workflow documents the organization Vertex AI custom-tools model"
+	assert_file_contains "$workflow_file" "vertex_ai/gemini-2.5-flash" "strix workflow accepts the validated organization Vertex AI operational model"
 	assert_file_not_contains "$workflow_file" "vertex_ai/* | vertex_ai_beta/*" "strix workflow must not accept arbitrary Vertex models"
 	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
 	assert_file_contains "$workflow_file" 'LLM_API_KEY_SECRET: ${{ steps.gate.outputs.provider_mode == '"'"'openai_direct'"'"' && secrets.STRIX_OPENAI_API_KEY || '"'"''"'"' }}' "strix workflow uses provider-scoped LLM key material"
@@ -115,7 +119,7 @@ assert_strix_gpt54_model_guard_semantics() {
 	case "$model" in
 	gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
 	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-	vertex_ai/gemini-3.1-pro-preview-customtools)
+	vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
 		return 0
 		;;
 	*)
@@ -142,6 +146,9 @@ assert_strix_gpt54_model_guard_cases() {
 	fi
 	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-3.1-pro-preview-customtools"; then
 		record_failure "strix guard must accept the organization Vertex AI custom-tools model"
+	fi
+	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-flash"; then
+		record_failure "strix guard must accept the validated organization Vertex AI operational model"
 	fi
 	if assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-pro"; then
 		record_failure "strix guard must reject arbitrary Vertex models"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -88,7 +88,6 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
 	assert_file_contains "$workflow_file" 'STRIX_MODEL: ${{ secrets.STRIX_LLM || '"'"'vertex_ai/gemini-2.5-flash'"'"' }}' "strix workflow defaults STRIX_LLM to the operational organization Vertex AI model"
 	assert_file_contains "$workflow_file" "STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" "strix workflow rejects unsupported model inputs"
-	assert_file_contains "$workflow_file" "vertex_ai/gemini-3.1-pro-preview-customtools" "strix workflow documents the organization Vertex AI custom-tools model"
 	assert_file_contains "$workflow_file" "vertex_ai/gemini-2.5-flash" "strix workflow accepts the validated organization Vertex AI operational model"
 	assert_file_not_contains "$workflow_file" "vertex_ai/* | vertex_ai_beta/*" "strix workflow must not accept arbitrary Vertex models"
 	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
@@ -120,7 +119,7 @@ assert_strix_gpt54_model_guard_semantics() {
 	case "$model" in
 	gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
 	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-	vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+	vertex_ai/gemini-2.5-flash)
 		return 0
 		;;
 	*)
@@ -144,9 +143,6 @@ assert_strix_gpt54_model_guard_cases() {
 	fi
 	if assert_strix_gpt54_model_guard_semantics "openai/openai/gpt-5.4"; then
 		record_failure "strix GPT-5.4 guard must reject GitHub Models openai/openai/gpt-5.4"
-	fi
-	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-3.1-pro-preview-customtools"; then
-		record_failure "strix guard must accept the organization Vertex AI custom-tools model"
 	fi
 	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-flash"; then
 		record_failure "strix guard must accept the validated organization Vertex AI operational model"
@@ -3732,6 +3728,10 @@ if [ -n "${LLM_API_KEY:-}" ]; then
 	echo "unexpected LLM_API_KEY for Vertex" >&2
 	exit 1
 fi
+if [ -n "${LLM_API_KEY_FILE:-}" ]; then
+	echo "unexpected LLM_API_KEY_FILE for Vertex" >&2
+	exit 1
+fi
 exit 0
 EOF
 	chmod +x "$fake_strix"
@@ -3775,6 +3775,10 @@ set -euo pipefail
 echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
 if [ -n "${LLM_API_KEY:-}" ]; then
 	echo "unexpected LLM_API_KEY for Vertex" >&2
+	exit 1
+fi
+if [ -n "${LLM_API_KEY_FILE:-}" ]; then
+	echo "unexpected LLM_API_KEY_FILE for Vertex" >&2
 	exit 1
 fi
 exit 0

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -174,6 +174,12 @@ assert_absent_endpoint_search_uses_canonical_target_path() {
 	assert_file_not_contains "$GATE_SCRIPT" 'candidate="${TARGET_PATH%/}/$dir_entry"' "absent-endpoint search avoids relative target path roots"
 }
 
+assert_strix_llm_file_read_is_literal_data() {
+	assert_file_contains "$GATE_SCRIPT" 'STRIX_LLM_CONTENT="$(cat -- "$STRIX_LLM_FILE")"' "strix gate reads model file content as data before trimming"
+	assert_file_contains "$GATE_SCRIPT" 'STRIX_LLM="$(trim_whitespace "$STRIX_LLM_CONTENT")"' "strix gate trims model file content without nested command substitution"
+	assert_file_not_contains "$GATE_SCRIPT" 'STRIX_LLM="$(trim_whitespace "$(cat -- "$STRIX_LLM_FILE")")"' "strix gate avoids nested command substitution for model file content"
+}
+
 assert_internal_pr_scope_targets() {
 	local target_log_file="$1"
 	local repo_root_dir="$2"
@@ -3662,6 +3668,54 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+run_strix_llm_file_command_substitution_literal_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local call_count_file="$tmp_dir/strix_calls"
+	local marker_file="$tmp_dir/strix_marker"
+	local fake_strix="$tmp_dir/strix"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "1" >> "${STRIX_CALL_COUNT_FILE:?}"
+exit 0
+EOF
+	chmod +x "$fake_strix"
+	printf 'openai/gpt-5.4 $(touch %s)' "$marker_file" >"$strix_llm_file"
+	printf '%s' 'dummy-key' >"$llm_api_key_file"
+
+	set +e
+	env -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+		PATH="$tmp_dir:$PATH" \
+		STRIX_INPUT_FILE_ROOT="$tmp_dir" \
+		STRIX_TARGET_PATH="-" \
+		STRIX_DISABLE_PR_SCOPING="0" \
+		STRIX_LLM_FILE="$strix_llm_file" \
+		LLM_API_KEY_FILE="$llm_api_key_file" \
+		STRIX_CALL_COUNT_FILE="$call_count_file" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=strix-llm-file-command-substitution-literal exit code"
+	assert_file_contains "$output_log" "ERROR: STRIX_TARGET_PATH contains unsupported path syntax" "case=strix-llm-file-command-substitution-literal output"
+	if [ -e "$marker_file" ]; then
+		record_failure "case=strix-llm-file-command-substitution-literal must not execute model file content"
+	fi
+
+	local actual_calls="0"
+	if [ -f "$call_count_file" ]; then
+		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"
+	fi
+	assert_equals "0" "$actual_calls" "case=strix-llm-file-command-substitution-literal strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
 run_vertex_without_llm_api_key_case() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
@@ -4253,6 +4307,8 @@ assert_strix_gate_target_scope_separated
 assert_changed_file_membership_uses_cached_normalized_paths
 
 assert_absent_endpoint_search_uses_canonical_target_path
+
+assert_strix_llm_file_read_is_literal_data
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \
@@ -6282,6 +6338,7 @@ run_missing_config_case "missing-strix-llm" "" "dummy" "ERROR: STRIX_LLM_FILE mu
 run_missing_config_case "missing-llm-api-key" "openai/gpt-5.4" "" "ERROR: LLM_API_KEY_FILE must reference a regular file containing the API key."
 run_missing_config_case "whitespace-only-strix-llm" "   " "dummy" "ERROR: STRIX_LLM_FILE must contain a non-empty model value."
 run_missing_config_case "whitespace-only-llm-api-key" "openai/gpt-5.4" $'\t  ' "ERROR: LLM_API_KEY_FILE must contain a non-empty API key."
+run_strix_llm_file_command_substitution_literal_case
 run_vertex_without_llm_api_key_case
 run_vertex_with_llm_api_key_file_does_not_forward_case
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -3697,6 +3697,53 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+run_vertex_with_llm_api_key_file_does_not_forward_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local call_count_file="$tmp_dir/strix_calls"
+	local fake_strix="$tmp_dir/strix"
+	local strix_llm_file="$tmp_dir/strix_llm.txt"
+	local llm_api_key_file="$tmp_dir/llm_api_key.txt"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
+if [ -n "${LLM_API_KEY:-}" ]; then
+	echo "unexpected LLM_API_KEY for Vertex" >&2
+	exit 1
+fi
+exit 0
+EOF
+	chmod +x "$fake_strix"
+	printf '%s' "vertex_ai/ready-primary" >"$strix_llm_file"
+	printf '%s' "openai-key-should-not-reach-vertex" >"$llm_api_key_file"
+
+	set +e
+	env -u GITHUB_EVENT_NAME -u GITHUB_EVENT_PATH -u STRIX_TEST_CHANGED_FILES_OVERRIDE \
+		PATH="$tmp_dir:$PATH" \
+		STRIX_INPUT_FILE_ROOT="$tmp_dir" \
+		STRIX_DISABLE_PR_SCOPING="0" \
+		STRIX_LLM_FILE="$strix_llm_file" \
+		LLM_API_KEY_FILE="$llm_api_key_file" \
+		FAKE_STRIX_CALL_COUNT_FILE="$call_count_file" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "0" "$rc" "case=vertex-with-llm-api-key-file-not-forwarded exit code"
+	assert_file_contains "$output_log" "Strix run succeeded for model 'vertex_ai/ready-primary'" "case=vertex-with-llm-api-key-file-not-forwarded output"
+
+	local actual_calls="0"
+	if [ -f "$call_count_file" ]; then
+		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"
+	fi
+	assert_equals "1" "$actual_calls" "case=vertex-with-llm-api-key-file-not-forwarded strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
 run_invalid_min_fail_severity_case() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
@@ -6227,6 +6274,7 @@ run_missing_config_case "missing-llm-api-key" "openai/gpt-5.4" "" "ERROR: LLM_AP
 run_missing_config_case "whitespace-only-strix-llm" "   " "dummy" "ERROR: STRIX_LLM_FILE must contain a non-empty model value."
 run_missing_config_case "whitespace-only-llm-api-key" "openai/gpt-5.4" $'\t  ' "ERROR: LLM_API_KEY_FILE must contain a non-empty API key."
 run_vertex_without_llm_api_key_case
+run_vertex_with_llm_api_key_file_does_not_forward_case
 
 # ── Segment boundary enforcement for is_vertex_resource_path / extract_vertex_model_id ──
 # Shell glob '*' matches '/' so the old case-pattern implementation accepted

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -176,6 +176,12 @@ assert_strix_llm_file_read_is_literal_data() {
 	assert_file_not_contains "$GATE_SCRIPT" 'STRIX_LLM="$(trim_whitespace "$(cat -- "$STRIX_LLM_FILE")")"' "strix gate avoids nested command substitution for model file content"
 }
 
+assert_strix_child_target_uses_constant_argument() {
+	assert_file_contains "$GATE_SCRIPT" 'command = [resolved_strix_bin, "-n", "-t", ".", "--scan-mode", scan_mode]' "strix gate passes a constant target argument to the child process"
+	assert_file_contains "$GATE_SCRIPT" 'cwd=str(target_cwd)' "strix gate runs the child process from the canonical target directory"
+	assert_file_not_contains "$GATE_SCRIPT" 'command = [resolved_strix_bin, "-n", "-t", target_path, "--scan-mode", scan_mode]' "strix gate must not forward raw target paths as child arguments"
+}
+
 assert_internal_pr_scope_targets() {
 	local target_log_file="$1"
 	local repo_root_dir="$2"
@@ -304,6 +310,9 @@ while [ "$#" -gt 0 ]; do
 	fi
 	shift
 done
+if [ "$target_path" = "." ]; then
+	target_path="$PWD"
+fi
 printf '%s\n' "$target_path" >> "${FAKE_STRIX_TARGET_LOG:?}"
 
 STRIX_REPORTS_DIR="${STRIX_REPORTS_DIR:-strix_runs}"
@@ -4313,6 +4322,8 @@ assert_changed_file_membership_uses_cached_normalized_paths
 assert_absent_endpoint_search_uses_canonical_target_path
 
 assert_strix_llm_file_read_is_literal_data
+
+assert_strix_child_target_uses_constant_argument
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \


### PR DESCRIPTION
## Summary
- Route Strix Security Scan through the organization Vertex AI model `vertex_ai/gemini-3.1-pro-preview-customtools` using org `GCP_SA_KEY`.
- Keep direct OpenAI GPT-5.4+ support as a fail-closed fallback path, but stop exposing generic `LLM_API_KEY` to Vertex scans.
- Preserve privileged `pull_request_target` safety: trusted workspace scripts, no `actions/checkout`, PR head treated as data, no GitHub Models routing.
- Carry forward timeout/fallback fixes so LLM timeouts move to configured fallbacks instead of same-model retry loops.

## Operational setup verified
- Org `STRIX_LLM` exists and repo-level `STRIX_LLM` is absent, so org secret will apply.
- Vertex mode requires `GCP_SA_KEY` and exports LiteLLM Vertex env: `GOOGLE_APPLICATION_CREDENTIALS`, `VERTEXAI_PROJECT`, and `VERTEXAI_LOCATION`.

## Verification
- `bash scripts/ci/test_strix_quick_gate.sh`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/strix.yml') ... PY`
- `bash -n scripts/ci/strix_quick_gate.sh scripts/ci/test_strix_quick_gate.sh`
- `git diff --check`

## Notes
This PR intentionally does not use GitHub Models and does not add `models: read`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-driven LLM routing with org-default Vertex AI (validated model) and optional explicit OpenAI mode; workflows accept manual PR inputs for trusted PR-scoped evidence.

* **Documentation**
  * Updated governance/README/docs to mandate Vertex default, restrict silent cross-provider fallbacks, and clarify direct-OpenAI as explicit-only.

* **Tests**
  * Expanded CI tests for Vertex scenarios, credential handling, input-safety, and updated fallback/timeout expectations.

* **Chores**
  * Hardened workflow validation, credential export/masking, error messages, and fail-closed behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->