### PR TITLE
fix(frontend): label icon-only workspace buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,9 @@
 - When reviews find inert navigation/dead-space controls, either wire them to an
   implemented workspace route/API or remove the control; do not leave
   high-traffic drawer/sidebar entries as permanent `준비 중` copy.
+- Icon-only workspace controls must carry localized `aria-label` text matching
+  the visible app language; do not rely on the SVG icon alone for Calendar,
+  Tasks, drawer, modal, or toolbar actions.
 - Execution steps resulting in `Timeout`, `Fatal`, `Warn`, or `Denied` outputs are considered hard failures. Tests must run without these warnings to be considered passing.
 - DB-affecting API slices need both mocked fast tests and a real PostgreSQL
   bootstrap/smoke path before PR merge evidence is considered complete.

--- a/frontend/src/app/calendar/page.test.tsx
+++ b/frontend/src/app/calendar/page.test.tsx
@@ -88,6 +88,10 @@ describe("CalendarPage", () => {
     expect(container.textContent).toContain("새 일정");
     expect(container.textContent).toContain("CalDAV/CardDAV/WebDAV writeback intent");
     expect(container.textContent).not.toContain("뷰는 아직 구현 중입니다");
+    expect(container.querySelector('button[aria-label="이전 달"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="다음 달"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="설정"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="닫기"]')).not.toBeNull();
   });
 
   it("creates a signed customer-owned calendar writeback intent", async () => {

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -69,6 +69,7 @@ describe("TasksPage", () => {
     expect(container.textContent).toContain("위임한 작업");
     expect(container.textContent).toContain("실제 티켓 큐");
     expect(container.textContent).toContain("연결된 티켓 없음");
+    expect(container.querySelector('button[aria-label="더보기"]')).not.toBeNull();
   });
 
   it("loads source-linked tickets from the signed task API", async () => {

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -157,8 +157,8 @@ export function CalendarLayout() {
           <div className="flex min-w-0 flex-wrap items-center gap-3 lg:gap-4">
             <button className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold">오늘</button>
             <div className="flex items-center gap-1">
-              <button className="grid size-8 place-items-center rounded-md hover:bg-secondary"><ChevronLeft className="size-5" /></button>
-              <button className="grid size-8 place-items-center rounded-md hover:bg-secondary"><ChevronRight className="size-5" /></button>
+              <button aria-label="이전 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary"><ChevronLeft className="size-5" /></button>
+              <button aria-label="다음 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary"><ChevronRight className="size-5" /></button>
             </div>
             <h1 className="text-xl font-bold">일정 관리</h1>
             <h2 className="text-sm font-bold text-muted-foreground lg:ml-2">2026년 5월</h2>
@@ -175,7 +175,7 @@ export function CalendarLayout() {
                 </button>
               ))}
             </div>
-            <button className="grid size-9 shrink-0 place-items-center rounded-md border border-border bg-background hover:bg-secondary">
+            <button aria-label="설정" className="grid size-9 shrink-0 place-items-center rounded-md border border-border bg-background hover:bg-secondary">
               <Settings className="size-5" />
             </button>
           </div>
@@ -428,7 +428,7 @@ export function CalendarLayout() {
             <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold text-muted-foreground">공개</span>
           </div>
           <div className="flex items-center gap-2">
-            <button className="grid size-8 place-items-center rounded-md hover:bg-secondary"><X className="size-4" /></button>
+            <button aria-label="닫기" className="grid size-8 place-items-center rounded-md hover:bg-secondary"><X className="size-4" /></button>
           </div>
         </div>
         

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -498,7 +498,7 @@ export function TasksLayout() {
                     <h2 className="font-bold text-sm">{col.title}</h2>
                     <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${col.color}`}>{col.count}</span>
                   </div>
-                  <button className="text-muted-foreground hover:text-foreground"><MoreHorizontal className="size-4" /></button>
+                  <button aria-label="더보기" className="text-muted-foreground hover:text-foreground"><MoreHorizontal className="size-4" /></button>
                 </div>
                 <div className="flex-1 overflow-y-auto p-3 space-y-3">
                   {tasks[col.id as keyof typeof MOCK_TASKS].map((task) => (


### PR DESCRIPTION
## Summary
- Add localized aria-labels to icon-only Calendar and Tasks controls.
- Add page-level regression assertions for the accessible labels.
- Record the icon-only control accessibility anti-pattern in AGENTS.md.

Replaces the useful UI portion of #289 without carrying over its stale Strix workflow changes.

## Verification
- git diff --check
- code-review-graph detect_changes risk score 0.00 for this slice
- Attempted: pnpm --dir frontend test -- src/app/calendar/page.test.tsx src/app/tasks/page.test.tsx (blocked locally because frontend/node_modules is not installed; CI will run in GitHub Actions)