### PR TITLE
feat(security): persist scoped audit evidence

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: "1"
           NODE_OPTIONS: "--max-old-space-size=4096"
+          NEXT_BUILD_CPUS: "2"
           POSTCSS_WORKERS: "1"
           DISABLE_POSTCSS_WORKERS: "true"
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@
 - New database tables and columns must use at least two-word `snake_case` names;
   avoid single-token columns such as `id`, `title`, `status`, or `priority` on
   newly introduced objects.
+- Public audit/event identifiers that may use human-readable prefixes must not
+  be stored in artificially short `varchar(n)` columns; use opaque source UIDs
+  that fit seeded smoke data and provider evidence without truncation.
 - When reviews find public/private identifier leaks, stale API fixture shapes, or recurring bug patterns, update tests, frontend mocks, E2E mocks, README examples, architecture docs, and explicitly record the anti-pattern in `AGENTS.md` so the same bug pattern does not reappear in copied examples.
 - When robot review cites an obsolete Strix provider policy, update the docs and
   tests to the current secret contract before accepting a rollback suggestion;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,10 @@
   no-op. Do not place sensitive credential values, secret-derived values, or
   password-shaped field names in logs or raised exception text; use static
   non-secret labels such as "credential secret" instead.
+- SMTP, IMAP, and POP3 host validation must reject legacy numeric IP literal
+  forms such as decimal integers, hexadecimal integers, and octal dotted forms
+  before DNS or socket connection; `socket.getaddrinfo` may resolve those forms
+  to loopback/private addresses even when `ipaddress.ip_address` rejects them.
 - Settings account screens must be source-backed by signed-session APIs rather
   than static provider examples. Display only masked secret presence flags, keep
   blank secret fields out of save payloads so stored values are preserved, and

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ mail/calendar/file systems.
   wait state, not a hard blocker.
 - Security governance is source-backed through signed
   `/api/security/access-surface`. The endpoint reads scoped WebDAV, CalDAV, and
-  connector evidence, reuses the deny-first RBAC/ABAC policy engine, and returns
-  no sequential account ids, raw credentials, or fake security posture claims.
+  connector evidence plus durable `security_audit_events`, reuses the deny-first
+  RBAC/ABAC policy engine, and returns no sequential account ids, raw
+  credentials, legacy unscoped audit rows, or fake security posture claims.
 - Data quality is source-backed through signed `/api/data/quality-surface`.
   The endpoint summarizes scoped repositories, ingestion inventory, embedding
   coverage, quality checks, and connector evidence from existing rows, returns
@@ -138,8 +139,8 @@ npm run build
 npm run dev
 ```
 
-`next.config.ts` caps static generation concurrency by default
-(`NEXT_STATIC_GENERATION_MAX_CONCURRENCY=2`,
+`next.config.ts` caps build worker fan-out and static generation concurrency by
+default (`NEXT_BUILD_CPUS=2`, `NEXT_STATIC_GENERATION_MAX_CONCURRENCY=2`,
 `NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=50`) so constrained CI/build
 machines do not fan out excessive Node/PostCSS workers. Raise those values only
 with explicit build evidence.

--- a/README.md
+++ b/README.md
@@ -139,11 +139,13 @@ npm run build
 npm run dev
 ```
 
-`next.config.ts` caps build worker fan-out and static generation concurrency by
-default (`NEXT_BUILD_CPUS=2`, `NEXT_STATIC_GENERATION_MAX_CONCURRENCY=2`,
+`next.config.ts` applies a best-effort local guard for build worker fan-out and
+static generation concurrency (`NEXT_BUILD_CPUS=2`,
+`NEXT_STATIC_GENERATION_MAX_CONCURRENCY=2`,
 `NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=50`) so constrained CI/build
-machines do not fan out excessive Node/PostCSS workers. Raise those values only
-with explicit build evidence.
+machines do not fan out excessive Node/PostCSS workers. Treat the Next.js CPU
+knob as experimental and enforce authoritative limits through CI, Docker, or the
+runner. Raise those values only with explicit build evidence.
 
 ## Threading proof points
 

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -8,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import AuthContext, get_auth_context, is_admin_role
-from db.models import AuditLog, LLMProvider
+from db.models import AuditLog, LLMProvider, SecurityAuditEvent
 from db.session import get_db
 from services.llm_provider_urls import (
     LLM_BASE_URL_NOT_ALLOWED,
@@ -82,6 +83,32 @@ def _provider_owner_filter(auth_context: AuthContext):
     return LLMProvider.organization_id == _required_provider_organization(auth_context)
 
 
+def _security_audit_event(
+    auth_context: AuthContext,
+    *,
+    event_action: str,
+    resource_uid: str | None,
+    detail_text: str,
+) -> SecurityAuditEvent:
+    return SecurityAuditEvent(
+        actor_user_id=auth_context.user_id,
+        actor_role=auth_context.role,
+        organization_id=auth_context.organization_id,
+        workspace_id=auth_context.workspace_id,
+        event_action=event_action,
+        resource_type="llm_provider",
+        resource_uid=resource_uid,
+        evidence_source="api.llm_providers",
+        detail_text=detail_text,
+    )
+
+
+def _provider_resource_uid(auth_context: AuthContext, provider_name: str) -> str:
+    scope = auth_context.organization_id or auth_context.user_id
+    digest = hashlib.sha256(f"{scope}:{provider_name}".encode("utf-8")).hexdigest()
+    return f"llm_provider:{digest[:16]}"
+
+
 @router.get("", response_model=List[LLMProviderResponse])
 async def list_providers(
     db: AsyncSession = Depends(get_db),
@@ -129,9 +156,17 @@ async def create_provider(
         user_id=auth_context.user_id,
         action="create",
         resource_type="llm_provider",
-        details=f"Created provider {data.name}",
+        details="Created provider configuration",
     )
     db.add(audit)
+    db.add(
+        _security_audit_event(
+            auth_context,
+            event_action="create",
+            resource_uid=_provider_resource_uid(auth_context, data.name),
+            detail_text="Created provider configuration",
+        )
+    )
     try:
         await db.commit()
         await db.refresh(provider)
@@ -191,9 +226,17 @@ async def update_provider(
             action="update",
             resource_type="llm_provider",
             resource_id=str(provider.id),
-            details=f"Updated provider {provider.name}",
+            details="Updated provider configuration",
         )
         db.add(audit)
+        db.add(
+            _security_audit_event(
+                auth_context,
+                event_action="update",
+                resource_uid=_provider_resource_uid(auth_context, provider.name),
+                detail_text="Updated provider configuration",
+            )
+        )
         await db.commit()
         await db.refresh(provider)
 
@@ -231,7 +274,15 @@ async def delete_provider(
         action="delete",
         resource_type="llm_provider",
         resource_id=str(provider.id),
-        details=f"Deleted provider {provider.name}",
+        details="Deleted provider configuration",
     )
     db.add(audit)
+    db.add(
+        _security_audit_event(
+            auth_context,
+            event_action="delete",
+            resource_uid=_provider_resource_uid(auth_context, provider.name),
+            detail_text="Deleted provider configuration",
+        )
+    )
     await db.commit()

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -103,9 +103,9 @@ def _security_audit_event(
     )
 
 
-def _provider_resource_uid(auth_context: AuthContext, provider_name: str) -> str:
+def _provider_resource_uid(auth_context: AuthContext, provider_id: int) -> str:
     scope = auth_context.organization_id or auth_context.user_id
-    digest = hashlib.sha256(f"{scope}:{provider_name}".encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(f"{scope}:{provider_id}".encode("utf-8")).hexdigest()
     return f"llm_provider:{digest[:16]}"
 
 
@@ -152,6 +152,12 @@ async def create_provider(
         is_active=data.is_active,
     )
     db.add(provider)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Provider name already exists")
+
     audit = AuditLog(
         user_id=auth_context.user_id,
         action="create",
@@ -163,7 +169,7 @@ async def create_provider(
         _security_audit_event(
             auth_context,
             event_action="create",
-            resource_uid=_provider_resource_uid(auth_context, data.name),
+            resource_uid=_provider_resource_uid(auth_context, provider.id),
             detail_text="Created provider configuration",
         )
     )
@@ -233,7 +239,7 @@ async def update_provider(
             _security_audit_event(
                 auth_context,
                 event_action="update",
-                resource_uid=_provider_resource_uid(auth_context, provider.name),
+                resource_uid=_provider_resource_uid(auth_context, provider.id),
                 detail_text="Updated provider configuration",
             )
         )
@@ -281,7 +287,7 @@ async def delete_provider(
         _security_audit_event(
             auth_context,
             event_action="delete",
-            resource_uid=_provider_resource_uid(auth_context, provider.name),
+            resource_uid=_provider_resource_uid(auth_context, provider.id),
             detail_text="Deleted provider configuration",
         )
     )

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -14,7 +14,12 @@ from api.auth import (
     get_auth_context,
     is_admin_role,
 )
-from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.models import (
+    CalendarWritebackSource,
+    ConnectorSignalEvent,
+    SecurityAuditEvent,
+    WebdavAccount,
+)
 from db.session import get_db
 from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
 
@@ -71,6 +76,20 @@ class ConnectorEvidence(BaseModel):
     observed_at: str
 
 
+class DurableAuditEvidence(BaseModel):
+    event_uid: str
+    actor_user_id: str
+    actor_role: str
+    organization_id: str | None
+    workspace_id: str
+    event_action: str
+    resource_type: str
+    resource_uid: str | None
+    evidence_source: str
+    detail_text: str | None
+    observed_at: str
+
+
 class ExternalShareReview(BaseModel):
     review_uid: str
     source_id: str
@@ -94,6 +113,7 @@ class SecurityAccessSurfaceResponse(BaseModel):
     viewer: ViewerContext
     sources: list[GovernanceSource]
     connector_events: list[ConnectorEvidence]
+    durable_audit_events: list[DurableAuditEvidence]
     policy_decisions: list[PolicyDecisionSummary]
     external_share_reviews: list[ExternalShareReview]
     policy_order: list[PolicyOrderStep]
@@ -170,6 +190,28 @@ def _connector_scope_statement(auth_context: AuthContext):
         )
         .order_by(ConnectorSignalEvent.observed_at.desc())
         .limit(8)
+    )
+
+
+def _durable_audit_scope_statement(auth_context: AuthContext):
+    statement = (
+        select(SecurityAuditEvent)
+        .where(SecurityAuditEvent.workspace_id == auth_context.workspace_id)
+        .order_by(SecurityAuditEvent.observed_at.desc())
+        .limit(12)
+    )
+    if _can_read_org_scope(auth_context):
+        return statement.where(
+            SecurityAuditEvent.organization_id == auth_context.organization_id
+        )
+    organization_filter = (
+        SecurityAuditEvent.organization_id == auth_context.organization_id
+        if auth_context.organization_id is not None
+        else SecurityAuditEvent.organization_id.is_(None)
+    )
+    return statement.where(
+        SecurityAuditEvent.actor_user_id == auth_context.user_id,
+        organization_filter,
     )
 
 
@@ -320,6 +362,22 @@ def _connector_evidence(event: ConnectorSignalEvent) -> ConnectorEvidence:
     )
 
 
+def _durable_audit_evidence(event: SecurityAuditEvent) -> DurableAuditEvidence:
+    return DurableAuditEvidence(
+        event_uid=event.event_uid,
+        actor_user_id=event.actor_user_id,
+        actor_role=event.actor_role,
+        organization_id=event.organization_id,
+        workspace_id=event.workspace_id,
+        event_action=event.event_action,
+        resource_type=event.resource_type,
+        resource_uid=event.resource_uid,
+        evidence_source=event.evidence_source,
+        detail_text=event.detail_text,
+        observed_at=_datetime_to_utc_iso(event.observed_at),
+    )
+
+
 def _canonical_policy_decisions(
     auth_context: AuthContext,
     source_decisions: list[PolicyDecisionSummary],
@@ -421,6 +479,7 @@ async def get_access_surface(
 ) -> SecurityAccessSurfaceResponse:
     webdav_result = await db.execute(_webdav_scope_statement(auth_context))
     calendar_result = await db.execute(_calendar_scope_statement(auth_context))
+    audit_result = await db.execute(_durable_audit_scope_statement(auth_context))
     connector_statement = _connector_scope_statement(auth_context)
     connector_events: list[ConnectorSignalEvent] = []
     if connector_statement is not None:
@@ -431,6 +490,23 @@ async def get_access_surface(
             if event.organization_id == auth_context.organization_id
             and event.workspace_id == auth_context.workspace_id
         ]
+
+    durable_audit_events = [
+        event
+        for event in audit_result.scalars().all()
+        if event.workspace_id == auth_context.workspace_id
+        and (
+            (
+                _can_read_org_scope(auth_context)
+                and event.organization_id == auth_context.organization_id
+            )
+            or (
+                not _can_read_org_scope(auth_context)
+                and event.actor_user_id == auth_context.user_id
+                and event.organization_id == auth_context.organization_id
+            )
+        )
+    ]
 
     sources = [
         _webdav_source(account, auth_context)
@@ -458,6 +534,9 @@ async def get_access_surface(
         ),
         sources=sources,
         connector_events=[_connector_evidence(event) for event in connector_events],
+        durable_audit_events=[
+            _durable_audit_evidence(event) for event in durable_audit_events
+        ],
         policy_decisions=policy_decisions,
         external_share_reviews=_share_reviews(sources),
         policy_order=_policy_order(),

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -82,6 +82,42 @@ class AuditLog(Base):
     details: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
+class SecurityAuditEvent(Base):
+    __tablename__ = "security_audit_events"
+
+    event_uid: Mapped[str] = mapped_column(
+        String, default=lambda: uuid.uuid4().hex, primary_key=True
+    )
+    actor_user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    actor_role: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    event_action: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    resource_type: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    resource_uid: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    evidence_source: Mapped[str] = mapped_column(String, nullable=False)
+    detail_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    observed_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        index=True,
+    )
+    __table_args__ = (
+        Index(
+            "ix_security_audit_events_scope_time",
+            "organization_id",
+            "workspace_id",
+            "observed_at",
+        ),
+        Index(
+            "ix_security_audit_events_actor_scope",
+            "actor_user_id",
+            "organization_id",
+            "workspace_id",
+        ),
+    )
+
+
 class LLMProvider(Base):
     __tablename__ = "llm_providers"
     __table_args__ = (

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -56,6 +56,21 @@ def schema_backfill_sql():
             "observed_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP"
             ")"
         ),
+        text(
+            "CREATE TABLE IF NOT EXISTS security_audit_events ("
+            "event_uid varchar PRIMARY KEY, "
+            "actor_user_id varchar NOT NULL, "
+            "actor_role varchar NOT NULL, "
+            "organization_id varchar, "
+            "workspace_id varchar NOT NULL, "
+            "event_action varchar NOT NULL, "
+            "resource_type varchar NOT NULL, "
+            "resource_uid varchar, "
+            "evidence_source varchar NOT NULL, "
+            "detail_text text, "
+            "observed_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP"
+            ")"
+        ),
         text("ALTER TABLE webdav_accounts ADD COLUMN IF NOT EXISTS source_uid varchar"),
         text(
             "ALTER TABLE webdav_accounts "
@@ -114,6 +129,16 @@ def schema_backfill_sql():
             "CREATE INDEX IF NOT EXISTS ix_connector_signal_events_scope_time "
             "ON connector_signal_events "
             "(organization_id, workspace_id, observed_at)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_security_audit_events_scope_time "
+            "ON security_audit_events "
+            "(organization_id, workspace_id, observed_at)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_security_audit_events_actor_scope "
+            "ON security_audit_events "
+            "(actor_user_id, organization_id, workspace_id)"
         ),
         text(
             "UPDATE webdav_accounts "

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import ipaddress
 import logging
+import re
 import socket
 from dataclasses import dataclass
 from email.message import EmailMessage
@@ -34,6 +35,9 @@ SMTP_EGRESS_PORTS = {25, 465, 587}
 IMAP_EGRESS_PORTS = {143, 993}
 POP3_EGRESS_PORTS = {110, 995}
 EMAIL_HEADER_NEWLINE_ERROR = "Email header fields must not contain newlines"
+LEGACY_NUMERIC_IP_LITERAL_PATTERN = re.compile(
+    r"^(?:0x[0-9a-f]+|0[0-7]+|[0-9]+)(?:\.(?:0x[0-9a-f]+|0[0-7]+|[0-9]+))*$"
+)
 
 
 @dataclass(frozen=True)
@@ -193,11 +197,9 @@ def _is_ip_literal(candidate: str) -> bool:
 
 
 def _looks_like_ip_literal(candidate: str) -> bool:
-    compact_candidate = candidate.replace(".", "").lower()
-    return (
-        ":" in candidate
-        or compact_candidate.isdigit()
-        or compact_candidate.startswith("0x")
+    normalized_candidate = candidate.lower()
+    return ":" in candidate or bool(
+        LEGACY_NUMERIC_IP_LITERAL_PATTERN.fullmatch(normalized_candidate)
     )
 
 

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import ipaddress
 import logging
-import re
 import socket
 from dataclasses import dataclass
 from email.message import EmailMessage
@@ -35,9 +34,6 @@ SMTP_EGRESS_PORTS = {25, 465, 587}
 IMAP_EGRESS_PORTS = {143, 993}
 POP3_EGRESS_PORTS = {110, 995}
 EMAIL_HEADER_NEWLINE_ERROR = "Email header fields must not contain newlines"
-LEGACY_NUMERIC_IP_LITERAL_PATTERN = re.compile(
-    r"^(?:0x[0-9a-f]+|0[0-7]+|[0-9]+)(?:\.(?:0x[0-9a-f]+|0[0-7]+|[0-9]+))*$"
-)
 
 
 @dataclass(frozen=True)
@@ -196,10 +192,23 @@ def _is_ip_literal(candidate: str) -> bool:
     return True
 
 
+def _is_legacy_numeric_ip_component(component: str) -> bool:
+    if not component:
+        return False
+    if component.startswith("0x"):
+        return len(component) > 2 and all(
+            character in "0123456789abcdef" for character in component[2:]
+        )
+    return component.isdigit()
+
+
 def _looks_like_ip_literal(candidate: str) -> bool:
     normalized_candidate = candidate.lower()
-    return ":" in candidate or bool(
-        LEGACY_NUMERIC_IP_LITERAL_PATTERN.fullmatch(normalized_candidate)
+    if ":" in normalized_candidate:
+        return True
+    return all(
+        _is_legacy_numeric_ip_component(component)
+        for component in normalized_candidate.split(".")
     )
 
 

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -11,6 +11,7 @@ from db.models import (
     CalendarWritebackSource,
     ConnectorSignalEvent,
     ProjectFolder,
+    SecurityAuditEvent,
     SenderRelationship,
     TenantConfig,
     TicketTask,
@@ -118,6 +119,13 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
         "create table if not exists calendar_writeback_sources" in statement
         for statement in statements
     )
+    assert any(
+        "create table if not exists security_audit_events" in statement
+        for statement in statements
+    )
+    assert any("actor_user_id varchar not null" in statement for statement in statements)
+    assert any("event_action varchar not null" in statement for statement in statements)
+    assert any("resource_uid varchar" in statement for statement in statements)
     assert any("source_uid varchar primary key" in statement for statement in statements)
     assert any("workspace_id varchar not null" in statement for statement in statements)
     assert any("provider_name varchar not null" in statement for statement in statements)
@@ -434,6 +442,29 @@ def test_connector_signal_event_model_uses_two_word_names():
     assert all("_" in column_name for column_name in column_names)
 
 
+def test_security_audit_event_model_uses_two_word_names():
+    assert SecurityAuditEvent.__tablename__ == "security_audit_events"
+    column_names = {column.name for column in SecurityAuditEvent.__table__.columns}
+    index_names = {index.name for index in SecurityAuditEvent.__table__.indexes}
+
+    assert column_names == {
+        "event_uid",
+        "actor_user_id",
+        "actor_role",
+        "organization_id",
+        "workspace_id",
+        "event_action",
+        "resource_type",
+        "resource_uid",
+        "evidence_source",
+        "detail_text",
+        "observed_at",
+    }
+    assert all("_" in column_name for column_name in column_names)
+    assert "ix_security_audit_events_scope_time" in index_names
+    assert "ix_security_audit_events_actor_scope" in index_names
+
+
 def test_schema_backfill_creates_connector_signal_events():
     statements = [str(statement).lower() for statement in schema_backfill_sql()]
 
@@ -443,6 +474,14 @@ def test_schema_backfill_creates_connector_signal_events():
     )
     assert any(
         "ix_connector_signal_events_scope_time" in statement
+        for statement in statements
+    )
+    assert any(
+        "ix_security_audit_events_scope_time" in statement
+        for statement in statements
+    )
+    assert any(
+        "ix_security_audit_events_actor_scope" in statement
         for statement in statements
     )
 

--- a/backend/tests/test_email_client_smtp.py
+++ b/backend/tests/test_email_client_smtp.py
@@ -134,6 +134,60 @@ def test_smtp_host_rejects_mixed_public_and_private_dns_answers(monkeypatch):
         email_client.validate_smtp_host("smtp.example.com", resolve_host=True)
 
 
+@pytest.mark.parametrize(
+    "numeric_host",
+    ["2130706433", "0x7f000001", "0177.0.0.1", "127001"],
+)
+def test_smtp_host_rejects_legacy_numeric_ip_literals_before_dns(
+    monkeypatch, numeric_host
+):
+    monkeypatch.setattr(email_client.settings, "ALLOWED_SMTP_HOSTS", numeric_host)
+
+    def fail_getaddrinfo(*args, **kwargs):
+        raise AssertionError("legacy numeric SMTP host must fail before DNS")
+
+    monkeypatch.setattr(email_client.socket, "getaddrinfo", fail_getaddrinfo)
+
+    with pytest.raises(ValueError, match=email_client.SMTP_HOST_NOT_ALLOWED):
+        email_client.validate_smtp_host(numeric_host, resolve_host=True)
+
+
+@pytest.mark.parametrize(
+    ("protocol_name", "allowed_setting", "validator", "host_error"),
+    [
+        (
+            "IMAP",
+            "ALLOWED_IMAP_HOSTS",
+            email_client.validate_imap_host,
+            email_client.IMAP_HOST_NOT_ALLOWED,
+        ),
+        (
+            "POP3",
+            "ALLOWED_POP3_HOSTS",
+            email_client.validate_pop3_host,
+            email_client.POP3_HOST_NOT_ALLOWED,
+        ),
+    ],
+)
+def test_inbound_mail_hosts_reject_legacy_numeric_ip_literals_before_dns(
+    monkeypatch,
+    protocol_name,
+    allowed_setting,
+    validator,
+    host_error,
+):
+    numeric_host = "2130706433"
+    monkeypatch.setattr(email_client.settings, allowed_setting, numeric_host)
+
+    def fail_getaddrinfo(*args, **kwargs):
+        raise AssertionError(f"legacy numeric {protocol_name} host must fail before DNS")
+
+    monkeypatch.setattr(email_client.socket, "getaddrinfo", fail_getaddrinfo)
+
+    with pytest.raises(ValueError, match=host_error):
+        validator(numeric_host, resolve_host=True)
+
+
 def test_smtp_destination_rejects_mixed_public_and_private_dns_answers(monkeypatch):
     monkeypatch.setattr(email_client.settings, "ALLOWED_SMTP_HOSTS", "smtp.example.com")
     monkeypatch.setattr(email_client.settings, "ALLOWED_SMTP_PORTS", "587")

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -82,6 +82,9 @@ class MockSession:
     async def commit(self):
         return None
 
+    async def flush(self):
+        return None
+
     async def refresh(self, obj):
         return None
 

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from core.config import settings
-from db.models import AuditLog, LLMProvider
+from db.models import AuditLog, LLMProvider, SecurityAuditEvent
 from db.session import get_db
 from main import app
 
@@ -36,6 +36,7 @@ class MockSession:
     def __init__(self):
         self.providers: list[LLMProvider] = []
         self.audits: list[AuditLog] = []
+        self.security_audits: list[SecurityAuditEvent] = []
 
     async def execute(self, stmt):
         stmt_str = str(stmt).lower()
@@ -70,6 +71,8 @@ class MockSession:
             self.providers.append(obj)
         elif isinstance(obj, AuditLog):
             self.audits.append(obj)
+        elif isinstance(obj, SecurityAuditEvent):
+            self.security_audits.append(obj)
 
     async def delete(self, obj):
         self.providers = [
@@ -96,6 +99,7 @@ def override_get_db():
     app.dependency_overrides.clear()
     mock_session.providers = []
     mock_session.audits = []
+    mock_session.security_audits = []
 
 
 @pytest.fixture
@@ -156,6 +160,31 @@ def test_llm_provider_crud_admin(admin_client):
 
     response = admin_client.delete(f"/api/llm-providers/{provider_id}")
     assert response.status_code == 204
+    assert [event.event_action for event in mock_session.security_audits] == [
+        "create",
+        "update",
+        "delete",
+    ]
+    assert {event.actor_user_id for event in mock_session.security_audits} == {"admin"}
+    assert {event.actor_role for event in mock_session.security_audits} == {
+        "tenant_admin"
+    }
+    assert {event.organization_id for event in mock_session.security_audits} == {
+        "org-acme"
+    }
+    assert {event.workspace_id for event in mock_session.security_audits} == {
+        "workspace-org-acme"
+    }
+    assert all(
+        event.resource_uid and event.resource_uid.startswith("llm_provider:")
+        for event in mock_session.security_audits
+    )
+    serialized_security_audits = " ".join(
+        f"{event.resource_uid or ''} {event.detail_text or ''}"
+        for event in mock_session.security_audits
+    )
+    assert "sk-12345" not in serialized_security_audits
+    assert "Primary OpenAI" not in serialized_security_audits
 
 
 def test_llm_provider_rejects_internal_base_url_on_create(admin_client):

--- a/backend/tests/test_security_api.py
+++ b/backend/tests/test_security_api.py
@@ -17,7 +17,12 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api.auth import get_auth_context, get_current_user
 from core.config import settings
-from db.models import CalendarWritebackSource, ConnectorSignalEvent, WebdavAccount
+from db.models import (
+    CalendarWritebackSource,
+    ConnectorSignalEvent,
+    SecurityAuditEvent,
+    WebdavAccount,
+)
 from db.session import get_db
 from main import app
 
@@ -41,11 +46,13 @@ class MockAsyncSession:
         self,
         webdav_accounts: list[WebdavAccount] | None = None,
         calendar_sources: list[CalendarWritebackSource] | None = None,
+        audit_events: list[SecurityAuditEvent] | None = None,
         connector_events: list[ConnectorSignalEvent] | None = None,
     ):
         self.results = [
             webdav_accounts or [],
             calendar_sources or [],
+            audit_events or [],
             connector_events or [],
         ]
         self.execute_calls = 0
@@ -150,6 +157,27 @@ def _connector_event(
     )
 
 
+def _audit_event(
+    event_uid: str,
+    actor_user_id: str = "admin",
+    organization_id: str | None = "org-acme",
+    workspace_id: str = "workspace-org-acme",
+) -> SecurityAuditEvent:
+    return SecurityAuditEvent(
+        event_uid=event_uid,
+        actor_user_id=actor_user_id,
+        actor_role="tenant_admin",
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        event_action="update",
+        resource_type="llm_provider",
+        resource_uid="llm_provider:provider_primary",
+        evidence_source="api.llm_providers",
+        detail_text="Updated provider configuration",
+        observed_at=_now(),
+    )
+
+
 @pytest.fixture
 def mock_db():
     return MockAsyncSession(
@@ -160,6 +188,10 @@ def mock_db():
         calendar_sources=[
             _calendar_source("caldav_src_primary", "owner"),
             _calendar_source("caldav_src_other_org", "owner", "org-rival"),
+        ],
+        audit_events=[
+            _audit_event("audit_evt_provider_update"),
+            _audit_event("audit_evt_other_org", organization_id="org-rival"),
         ],
         connector_events=[
             _connector_event("connector_evt_heartbeat"),
@@ -201,6 +233,10 @@ def test_access_surface_returns_org_scoped_sources_and_policy_decisions(admin_cl
     assert "caldav_src_other_org" not in response.text
     assert data["connector_events"][0]["event_uid"] == "connector_evt_heartbeat"
     assert "connector_evt_other_org" not in response.text
+    audit_event_ids = {event["event_uid"] for event in data["durable_audit_events"]}
+    assert audit_event_ids == {"audit_evt_provider_update"}
+    assert "audit_evt_other_org" not in response.text
+    assert data["durable_audit_events"][0]["workspace_id"] == "workspace-org-acme"
     reasons = {decision["reason"] for decision in data["policy_decisions"]}
     assert "organization_denied" in reasons
     assert "data_region_denied" in reasons
@@ -218,6 +254,9 @@ def test_access_surface_redacts_sequential_ids_and_credentials(admin_client):
         "credential secret",
         "username",
         "files@example.com",
+        "api_key",
+        "sk-",
+        "audit_id",
     ):
         assert forbidden not in serialized
 
@@ -232,6 +271,10 @@ def test_member_surface_only_returns_owned_sources(mock_db):
             calendar_sources=[
                 _calendar_source("caldav_src_owned", "member"),
                 _calendar_source("caldav_src_admin", "admin"),
+            ],
+            audit_events=[
+                _audit_event("audit_evt_member", actor_user_id="member"),
+                _audit_event("audit_evt_admin", actor_user_id="admin"),
             ],
             connector_events=[],
         )
@@ -253,6 +296,10 @@ def test_member_surface_only_returns_owned_sources(mock_db):
     assert response.status_code == 200, response.text
     source_ids = {source["source_id"] for source in response.json()["sources"]}
     assert source_ids == {"webdav_src_owned", "caldav_src_owned"}
+    audit_event_ids = {
+        event["event_uid"] for event in response.json()["durable_audit_events"]
+    }
+    assert audit_event_ids == {"audit_evt_member"}
 
 
 def test_access_surface_rejects_public_identity_headers_without_signed_session(mock_db):
@@ -313,6 +360,7 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
     source_uid = f"webdav_src_security_{uuid.uuid4().hex[:18]}"
     caldav_uid = f"caldav_src_security_{uuid.uuid4().hex[:18]}"
     event_uid = f"connector_evt_security_{uuid.uuid4().hex[:18]}"
+    audit_uid = f"audit_evt_security_{uuid.uuid4().hex[:18]}"
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
     try:
         async with engine.begin() as conn:
@@ -421,6 +469,48 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
                     "detail_text": "security smoke connector heartbeat",
                 },
             )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO security_audit_events (
+                        event_uid,
+                        actor_user_id,
+                        actor_role,
+                        organization_id,
+                        workspace_id,
+                        event_action,
+                        resource_type,
+                        resource_uid,
+                        evidence_source,
+                        detail_text
+                    )
+                    VALUES (
+                        :event_uid,
+                        :actor_user_id,
+                        :actor_role,
+                        :organization_id,
+                        :workspace_id,
+                        :event_action,
+                        :resource_type,
+                        :resource_uid,
+                        :evidence_source,
+                        :detail_text
+                    )
+                    """
+                ),
+                {
+                    "event_uid": audit_uid,
+                    "actor_user_id": user_id,
+                    "actor_role": "tenant_admin",
+                    "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
+                    "event_action": "update",
+                    "resource_type": "llm_provider",
+                    "resource_uid": "llm_provider:security_smoke",
+                    "evidence_source": "api.llm_providers",
+                    "detail_text": "Updated provider configuration",
+                },
+            )
     except (
         ConnectionRefusedError,
         OSError,
@@ -482,6 +572,13 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
                 ),
                 {"event_uid": event_uid},
             )
+            await conn.execute(
+                text(
+                    "DELETE FROM security_audit_events "
+                    "WHERE event_uid = :event_uid"
+                ),
+                {"event_uid": audit_uid},
+            )
         await engine.dispose()
 
     assert response.status_code == 200, response.text
@@ -490,5 +587,8 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
     assert source_uid in source_ids
     assert caldav_uid in source_ids
     assert event_uid in {event["event_uid"] for event in body["connector_events"]}
+    assert audit_uid in {
+        event["event_uid"] for event in body["durable_audit_events"]
+    }
     assert "account_id" not in response.text
     assert "security-smoke@example.com" not in response.text

--- a/docs/plans/2026-05-28-security-governance-access-surface.md
+++ b/docs/plans/2026-05-28-security-governance-access-surface.md
@@ -55,8 +55,10 @@
 
 ## Follow-up roadmap
 
-- Persist org/workspace scope on centralized audit log rows before exposing
-  durable audit history outside connector events.
+- Durable org/workspace-scoped audit history was split into
+  `docs/plans/2026-05-29-security-durable-audit-surface.md` and implemented as
+  a separate `security_audit_events` source. Do not expose the legacy unscoped
+  `AuditLog` table directly.
 - Add policy mutation APIs only after versioned policy objects and approval
   workflows exist.
 - Add external sharing approval/revocation APIs only after provider connector

--- a/docs/plans/2026-05-29-security-durable-audit-surface.md
+++ b/docs/plans/2026-05-29-security-durable-audit-surface.md
@@ -1,0 +1,61 @@
+# 2026-05-29 Security Durable Audit Surface
+
+## Verified gap
+
+- `docs/plans/2026-05-28-security-governance-access-surface.md` intentionally
+  avoided exposing the legacy `audit_logs` table because it lacks durable
+  organization and workspace scope.
+- Security tabs already read signed source evidence, but the audit tab could
+  only show connector events plus the current API audit event name. LLM provider
+  mutations still wrote only legacy `AuditLog` rows, so access-surface users
+  could not inspect scoped provider-governance changes.
+- The implementation must preserve the database naming rule for new objects:
+  every new table and column uses two-word `snake_case`; no new sequential ids
+  are exposed in the API.
+
+## Implemented slice
+
+- Add `security_audit_events` as the durable scoped audit source.
+- Write `create`, `update`, and `delete` LLM provider governance events with:
+  `actor_user_id`, `actor_role`, `organization_id`, `workspace_id`,
+  `event_action`, `resource_type`, `resource_uid`, `evidence_source`,
+  `detail_text`, and `observed_at`.
+- Keep durable LLM provider audit details generic and use scoped opaque
+  `resource_uid` values so accidental secret-like provider names are not copied
+  into the Security API or UI.
+- Bootstrap fresh and existing PostgreSQL databases with the table and scoped
+  indexes:
+  - `ix_security_audit_events_scope_time`
+  - `ix_security_audit_events_actor_scope`
+- Extend signed `GET /api/security/access-surface` to return
+  `durable_audit_events`.
+- Scope reads by signed context:
+  - organization admins see events in their organization and workspace;
+  - members see only their own actor events in their organization/workspace.
+- Keep legacy `AuditLog` as an internal compatibility sink only; it is not
+  returned by the Security API or UI.
+- Render durable audit evidence in the Security audit tab with event UID,
+  actor, workspace, resource UID, evidence source, observed time, and detail
+  text. Connector evidence remains separate.
+
+## Verification
+
+- Backend fast tests cover:
+  - `security_audit_events` naming and indexes;
+  - bootstrap SQL table/index creation;
+  - LLM provider CRUD writing three scoped durable audit events without API key
+    leakage;
+  - Security access-surface org/member filtering and redaction.
+- PostgreSQL smoke paths cover bootstrap/access behavior when a local test
+  database is available.
+- Frontend unit tests cover signed-session fetch headers and audit-tab rendering
+  of both durable audit and connector evidence.
+- Browser verification must still capture desktop, tablet, and mobile Security
+  screenshots before PR merge evidence is complete.
+
+## Remaining roadmap
+
+- Add versioned policy mutation and approval workflows before exposing write
+  controls from the policy tab.
+- Add external sharing approval/revocation APIs only after provider connector
+  execution can enforce source capability, consent, and ETag/If-Match checks.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   experimental: {
+    cpus: positiveIntegerFromEnv("NEXT_BUILD_CPUS", 2),
     staticGenerationMaxConcurrency: positiveIntegerFromEnv(
       "NEXT_STATIC_GENERATION_MAX_CONCURRENCY",
       2,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   experimental: {
+    // Best-effort local guard only: CI/Docker/runner CPU limits remain authoritative.
     cpus: positiveIntegerFromEnv("NEXT_BUILD_CPUS", 2),
     staticGenerationMaxConcurrency: positiveIntegerFromEnv(
       "NEXT_STATIC_GENERATION_MAX_CONCURRENCY",

--- a/frontend/src/app/security/page.test.tsx
+++ b/frontend/src/app/security/page.test.tsx
@@ -73,6 +73,21 @@ const securitySurface = {
       observed_at: "2026-05-28T04:00:00Z",
     },
   ],
+  durable_audit_events: [
+    {
+      event_uid: "audit_evt_provider_update",
+      actor_user_id: "admin",
+      actor_role: "tenant_admin",
+      organization_id: "org-acme",
+      workspace_id: "workspace-org-acme",
+      event_action: "update",
+      resource_type: "llm_provider",
+      resource_uid: "llm_provider:provider_primary",
+      evidence_source: "api.llm_providers",
+      detail_text: "Updated provider configuration",
+      observed_at: "2026-05-28T04:02:00Z",
+    },
+  ],
   policy_decisions: [
     {
       decision_uid: "policy:webdav_src_primary",
@@ -203,6 +218,9 @@ describe("SecurityPage", () => {
       });
       expect(container.textContent).not.toContain("곧 제공됩니다");
       if (tabName === "감사 로그") {
+        expect(container.textContent).toContain("Durable audit evidence");
+        expect(container.textContent).toContain("audit_evt_provider_update");
+        expect(container.textContent).toContain("llm_provider:provider_primary");
         expect(container.textContent).toContain("connector_evt_heartbeat");
       }
       if (tabName === "외부 공유") {

--- a/frontend/src/components/SecurityLayout.tsx
+++ b/frontend/src/components/SecurityLayout.tsx
@@ -49,6 +49,20 @@ type ConnectorEvidence = {
   observed_at: string;
 };
 
+type DurableAuditEvidence = {
+  event_uid: string;
+  actor_user_id: string;
+  actor_role: string;
+  organization_id: string | null;
+  workspace_id: string;
+  event_action: string;
+  resource_type: string;
+  resource_uid: string | null;
+  evidence_source: string;
+  detail_text: string | null;
+  observed_at: string;
+};
+
 type ExternalShareReview = {
   review_uid: string;
   source_id: string;
@@ -78,6 +92,7 @@ type SecurityAccessSurface = {
   };
   sources: GovernanceSource[];
   connector_events: ConnectorEvidence[];
+  durable_audit_events: DurableAuditEvidence[];
   policy_decisions: PolicyDecisionSummary[];
   external_share_reviews: ExternalShareReview[];
   policy_order: PolicyOrderStep[];
@@ -328,14 +343,65 @@ function AuditTab({ data }: { data: SecurityAccessSurface }) {
   return (
     <section aria-label="보안 감사 로그" className="space-y-5">
       <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
-        <h2 className="text-base font-bold">Connector evidence와 감사 이벤트</h2>
+        <h2 className="text-base font-bold">Durable audit evidence</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          AuditLog 직접 노출 대신 scoped connector evidence와 API audit event만 표시합니다.
+          organization_id와 workspace_id가 있는 새 감사 이벤트만 표시하고 legacy AuditLog는 직접 노출하지 않습니다.
         </p>
         <div className="mt-4 rounded-lg border border-border bg-background p-3">
           <p className="text-xs font-bold text-muted-foreground">API audit event</p>
           <p className="mt-1 font-mono text-sm">{data.audit_event}</p>
         </div>
+        {data.durable_audit_events.length === 0 ? (
+          <div className="mt-4">
+            <EmptyState label="durable audit event" />
+          </div>
+        ) : (
+          <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {data.durable_audit_events.map((event) => (
+              <article key={event.event_uid} className="rounded-lg border border-border bg-background p-3">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-bold">{event.event_action} / {event.resource_type}</h3>
+                    <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{event.resource_uid ?? event.event_uid}</p>
+                  </div>
+                  <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold">{event.actor_role}</span>
+                </div>
+                <dl className="mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+                  <div>
+                    <dt className="font-bold text-muted-foreground">event_uid</dt>
+                    <dd className="break-all font-mono">{event.event_uid}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-bold text-muted-foreground">actor_user_id</dt>
+                    <dd className="break-all font-mono">{event.actor_user_id}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-bold text-muted-foreground">workspace_id</dt>
+                    <dd className="break-all font-mono">{event.workspace_id}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-bold text-muted-foreground">evidence_source</dt>
+                    <dd className="break-all font-mono">{event.evidence_source}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-bold text-muted-foreground">observed_at</dt>
+                    <dd className="break-all font-mono">{event.observed_at}</dd>
+                  </div>
+                </dl>
+                {event.detail_text ? (
+                  <p className="mt-3 break-words text-sm text-muted-foreground">{event.detail_text}</p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-base font-bold">Connector evidence</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          outbound connector가 남긴 workspace-scoped 운영 신호입니다.
+        </p>
         {data.connector_events.length === 0 ? (
           <div className="mt-4">
             <EmptyState label="connector evidence" />

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -323,6 +323,8 @@ test('renders Security governance access audit sharing and policy with signed AP
   await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-access.png'), fullPage: false });
 
   await page.getByRole('button', { name: '감사 로그' }).click();
+  await expect(page.getByText('audit_evt_provider_update')).toBeVisible();
+  await expect(page.getByText('llm_provider:provider_primary')).toBeVisible();
   await expect(page.getByText('connector_evt_heartbeat')).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('security-governance-desktop-audit.png'), fullPage: false });
 

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -282,6 +282,21 @@ const securityAccessSurface = {
       observed_at: '2026-05-28T04:00:00Z',
     },
   ],
+  durable_audit_events: [
+    {
+      event_uid: 'audit_evt_provider_update',
+      actor_user_id: 'admin',
+      actor_role: 'tenant_admin',
+      organization_id: 'org-acme',
+      workspace_id: 'workspace-org-acme',
+      event_action: 'update',
+      resource_type: 'llm_provider',
+      resource_uid: 'llm_provider:provider_primary',
+      evidence_source: 'api.llm_providers',
+      detail_text: 'Updated provider configuration',
+      observed_at: '2026-05-28T04:02:00Z',
+    },
+  ],
   policy_decisions: [
     {
       decision_uid: 'policy:webdav_src_primary',


### PR DESCRIPTION
## Summary
- add `security_audit_events` as org/workspace-scoped durable audit evidence with bootstrap SQL and two-word snake_case columns
- write LLM provider create/update/delete governance events with opaque scoped resource UIDs and generic details, while keeping legacy `AuditLog` out of the Security API/UI
- extend `/api/security/access-surface`, Security audit UI, unit/E2E mocks, and docs/specs to surface durable audit evidence beside connector evidence
- cap Next build CPU workers through `NEXT_BUILD_CPUS=2` in config/CI to avoid uncontrolled Node/PostCSS fan-out

## Verification
- `cd backend && python -m pytest tests/test_bootstrap_db.py tests/test_security_api.py tests/test_llm_providers_api.py -q` -> 26 passed, 2 skipped
- `cd frontend && env -u NO_COLOR npm test -- src/app/security/page.test.tsx` -> 2 passed
- `cd frontend && env -u NO_COLOR npm run lint -- src/components/SecurityLayout.tsx src/app/security/page.test.tsx tests/e2e/helpers.ts tests/e2e/dashboard-branding.spec.ts next.config.ts`
- `cd frontend && env -u NO_COLOR npm run typecheck`
- `cd frontend && env -u NO_COLOR NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=4096 NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build` -> page data/static generation used 2 workers
- `cd frontend && env -u NO_COLOR PLAYWRIGHT_PORT=18131 NEXT_BUILD_CPUS=2 NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run test:e2e -- --project=desktop -g "renders Security governance access audit sharing and policy with signed API headers"` -> 1 passed; screenshots reviewed for desktop/tablet/mobile/scroll/hamburger

## Subagent review
- Backend durable audit review: no blocking findings; residual provider-name leak note addressed by opaque resource UIDs and generic detail text.
- Frontend/CI review: no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security audit event tracking for LLM provider create, update, and delete operations.
  * Extended security dashboard to display durable audit evidence with organization and workspace scoping.

* **Tests**
  * Expanded test coverage for security audit events and durable audit evidence functionality.

* **Chores**
  * Optimized frontend build configuration with CPU concurrency controls.
  * Updated governance documentation and database bootstrap for new audit event infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->