### PR TITLE
feat(projects): wire source-backed workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,11 @@
   vector counts, unsupported embedding model names, static quality totals, or
   provider-write success claims; Data mocks and E2E fixtures must preserve the
   bearer-session call and omit public identity headers.
+- Project workspace lists, milestones, task links, and decision logs must be
+  source-backed by signed `/api/webdav/folders` and `/api/tasks` data or
+  explicitly labeled pending. Do not reintroduce static project names, inert
+  report/filter buttons, provider write success claims, or sequential database
+  ids in project UI/tests.
 - Self-hosted connector APM history must be persisted as scoped control-plane
   signal events before the UI claims durable heartbeat evidence. Do not expose
   runner registration tokens, path tokens, or raw provider credentials in event

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ mail/calendar/file systems.
   coverage, quality checks, and connector evidence from existing rows, returns
   `provider_write_executed=false`, and does not expose provider credentials,
   raw usernames, server URLs, or sequential ids.
+- Projects are source-backed through signed `/api/webdav/folders` and
+  `/api/tasks`. The workspace derives project boundaries from customer-owned
+  WebDAV folders, task progress from opaque public ticket ids, and labels
+  provider writes as deferred intent work.
   
 ## Agentic Ontology & Auto-Organization
 
@@ -297,7 +301,8 @@ Context Search, AI Hub, Data, Security, and Settings. The `/mail`, `/search`,
 `/settings` destinations must render real work-detail surfaces rather than
 static placeholder copy: calendar month/week/detail/coordination and CalDAV
 writeback queues, ticket task boards and source-linked details, integrated
-search result/detail graph timelines, project decision logs, document
+search result/detail graph timelines, source-backed project folders and
+decision-evidence logs, document
 repository/ingestion/embedding/quality queues, security dashboards and policy
 screens, and operational settings. Provider write execution and enterprise
 identity remain future connector/auth slices until source-backed integrations

--- a/docs/plans/2026-05-29-projects-source-backed-workspace.md
+++ b/docs/plans/2026-05-29-projects-source-backed-workspace.md
@@ -1,0 +1,49 @@
+# 2026-05-29 Projects Source-Backed Workspace
+
+## Verified gap
+
+- `frontend/branding/naruon-ux-mockup-5.png` specifies a dense project surface:
+  project list, project detail, milestones, decision logs, linked mail,
+  documents, and tasks.
+- `docs/plans/2026-05-18-project-workspace-menu-roadmap.md` intentionally made
+  `/projects` route-oriented and frontend-only. The current route therefore
+  still used static project, milestone, and decision examples.
+- Existing signed APIs already expose the minimum source evidence needed for a
+  small implementation slice:
+  - `/api/webdav/folders` for customer-owned project folder boundaries.
+  - `/api/tasks` for source-linked ticket tasks and public task ids.
+- No project provider write execution exists yet, so this slice must remain a
+  read-only workspace view and label `provider_write_executed=false`.
+
+## Implementation scope
+
+1. Replace static `/projects` examples with signed API reads from
+   `/api/webdav/folders` and `/api/tasks`.
+2. Render project list entries from WebDAV project folders. If no folders exist,
+   show a source-linked task backlog fallback instead of pretending seeded
+   projects exist.
+3. Derive milestone counts from ticket task statuses and keep task ids opaque;
+   never expose sequential database ids.
+4. Render the decision-log panel as source evidence: project folder boundary and
+   ticket workflow evidence. Provider writes stay linked to Data/WebDAV intent
+   flows.
+5. Add unit and Playwright coverage for signed bearer headers, absence of public
+   identity headers, desktop/mobile overflow, mobile scroll, and hamburger menu
+   composition.
+
+## Non-goals
+
+- No new project tables or columns.
+- No provider writeback execution.
+- No browser-side WebDAV/CalDAV mutation.
+- No fake decision-log persistence; durable decision objects are a future
+  backend slice.
+
+## Verification plan
+
+- `npm test -- src/app/projects/page.test.tsx`
+- `npm run typecheck`
+- `npm run lint`
+- `PLAYWRIGHT_PORT=<port> npm run test:e2e -- --project=desktop -g "source-backed Projects"`
+- Inspect captured desktop, mobile scroll, and mobile menu screenshots before
+  merge.

--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -8,25 +8,32 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
-  Search: () => <svg aria-hidden="true" />,
-  Filter: () => <svg aria-hidden="true" />,
-  FolderOpen: () => <svg aria-hidden="true" />,
-  MoreHorizontal: () => <svg aria-hidden="true" />,
-  FileText: () => <svg aria-hidden="true" />,
-  User: () => <svg aria-hidden="true" />,
-  Clock: () => <svg aria-hidden="true" />,
-  AlertCircle: () => <svg aria-hidden="true" />,
   CalendarDays: () => <svg aria-hidden="true" />,
   CheckCircle2: () => <svg aria-hidden="true" />,
-  LockKeyhole: () => <svg aria-hidden="true" />,
-  Mail: () => <svg aria-hidden="true" />,
-  Network: () => <svg aria-hidden="true" />,
-  Plus: () => <svg aria-hidden="true" />,
-  ServerCog: () => <svg aria-hidden="true" />,
-  ShieldCheck: () => <svg aria-hidden="true" />,
+  Clock: () => <svg aria-hidden="true" />,
+  FolderOpen: () => <svg aria-hidden="true" />,
+  ListChecks: () => <svg aria-hidden="true" />,
+  Search: () => <svg aria-hidden="true" />,
+  User: () => <svg aria-hidden="true" />,
 }));
 
 import ProjectsPage from "./page";
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500) {
+  return Promise.resolve({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Server Error",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
 
 describe("ProjectsPage", () => {
   let root: Root | null = null;
@@ -37,19 +44,93 @@ describe("ProjectsPage", () => {
     root = null;
     container?.remove();
     container = null;
+    vi.restoreAllMocks();
+    window.localStorage.clear();
   });
 
-  it("renders project execution surfaces with decision logs and source boundaries", () => {
+  it("loads project folders and ticket tasks through signed APIs", async () => {
+    window.localStorage.setItem("naruon_session_token", "signed.projects.token");
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer signed.projects.token");
+      expect(headers.get("X-User-Id")).toBeNull();
+      expect(headers.get("X-Organization-Id")).toBeNull();
+
+      const path = String(input);
+      if (path === "/api/webdav/folders") {
+        return jsonResponse([
+          {
+            folder_uid: "webdav_folder_roadmap",
+            project_name: "Naruon Roadmap 2026",
+            webdav_path: "/Projects/Naruon_Roadmap_2026",
+          },
+        ]);
+      }
+      if (path === "/api/tasks") {
+        return jsonResponse([
+          {
+            id: "task-q2-owner",
+            title: "리소스 배정 검토 회의",
+            status: "blocked",
+            priority: "urgent",
+            source_type: "email",
+            source_email_id: "<q2@example.com>",
+            related_thread_id: "thread-q2",
+            created_at: "2026-05-19T00:00:00Z",
+            updated_at: "2026-05-21T00:00:00Z",
+          },
+          {
+            id: "task-webdav-evidence",
+            title: "첨부파일 WebDAV 폴더 정리",
+            status: "done",
+            priority: "low",
+            source_type: "webdav",
+            source_email_id: "<q2@example.com>",
+            related_thread_id: "thread-q2",
+            created_at: "2026-05-19T00:00:00Z",
+            updated_at: "2026-05-24T00:00:00Z",
+          },
+        ]);
+      }
+      return jsonResponse({}, false, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root?.render(<ProjectsPage />);
     });
+    await flushAsyncWork();
 
-    expect(container.textContent).toContain("새 프로젝트");
-    expect(container.textContent).toContain("진행 중");
-    expect(container.textContent).toContain("제품 개발");
+    expect(fetchMock).toHaveBeenCalledWith("/api/webdav/folders", expect.objectContaining({ headers: expect.any(Object) }));
+    expect(fetchMock).toHaveBeenCalledWith("/api/tasks", expect.objectContaining({ headers: expect.any(Object) }));
+    expect(container.textContent).toContain("Naruon Roadmap 2026");
+    expect(container.textContent).toContain("provider_write_executed=false");
+    expect(container.textContent).toContain("리소스 배정 검토 회의");
+    expect(container.textContent).toContain("순차 DB id는 화면에 노출하지 않습니다");
+    expect(container.textContent).not.toContain("Naruon 2.0 런칭");
+  });
+
+  it("renders an actionable fallback when project evidence fails", async () => {
+    window.localStorage.setItem("naruon_session_token", "signed.projects.error");
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({ detail: "failed" }, false, 500)));
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<ProjectsPage />);
+    });
+    await flushAsyncWork();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("/api/webdav/folders");
+    expect(
+      Array.from(container.querySelectorAll('a[href="/data"]')).some((link) => link.textContent?.includes("Data evidence")),
+    ).toBe(true);
+    expect(container.textContent).toContain("Source-linked 작업 Backlog");
   });
 });

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -1,184 +1,392 @@
 "use client";
 
-import { useState } from 'react';
-import { Plus, Search, Filter, FolderOpen, CheckCircle2, User, Clock, CalendarDays } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarDays, CheckCircle2, Clock, FolderOpen, ListChecks, Search, User } from 'lucide-react';
 
-const MOCK_PROJECTS = [
-  { id: 'P-01', title: 'Naruon 2.0 런칭', status: '진행 중', progress: 68, category: '제품 개발' },
-  { id: 'P-02', title: '엔터프라이즈 SSO 연동', status: '대기 중', progress: 15, category: '보안/인프라' },
-  { id: 'P-03', title: 'Q2 마케팅 캠페인', status: '완료', progress: 100, category: '마케팅' },
-];
+import { apiClient } from '@/lib/api-client';
+import { toSafeReactText } from '@/lib/safe-text';
 
-const MOCK_MILESTONES = [
-  { title: '베타 테스트 (내부)', date: '5/10 - 5/20', status: '완료' },
-  { title: '출시 회의 및 리뷰', date: '5/23 - 5/25', status: '진행 중' },
-  { title: '정식 배포 (GA)', date: '6/01 - 6/05', status: '대기 중' },
-];
+type ProjectViewMode = '프로젝트 상세' | '마일스톤' | '의사결정 로그';
+type TaskStatus = 'open' | 'in_progress' | 'blocked' | 'done';
+type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
-const MOCK_DECISIONS = [
-  { id: 'D-01', title: 'OIDC Provider 선정', decision: 'Keycloak 대신 Casdoor 도입 결정 (통합 UI 사유)', date: '2일 전', author: '박지현 PM' },
-  { id: 'D-02', title: '캘린더 연동 방식', decision: 'CalDAV 직접 연동 후 로컬 캐싱', date: '1주 전', author: '최서연 Developer' },
-];
+interface ProjectFolder {
+  folder_uid: string;
+  project_name: string;
+  webdav_path: string;
+}
+
+interface TicketTask {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  source_type: string;
+  source_email_id: string | null;
+  related_thread_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProjectSummary {
+  id: string;
+  title: string;
+  status: '진행 중' | '대기 중' | '완료' | '검토 중';
+  progress: number;
+  category: string;
+  evidence: string;
+  sourcePath: string | null;
+}
+
+const projectStatusClass = {
+  '완료': 'bg-emerald-100 text-emerald-700',
+  '진행 중': 'bg-blue-100 text-blue-700',
+  '검토 중': 'bg-violet-100 text-violet-700',
+  '대기 중': 'bg-slate-100 text-slate-700',
+} satisfies Record<ProjectSummary['status'], string>;
+
+const taskStatusLabel: Record<TaskStatus, string> = {
+  open: '할 일',
+  in_progress: '진행 중',
+  blocked: '검토 필요',
+  done: '완료',
+};
+
+const taskStatusClass: Record<TaskStatus, string> = {
+  open: 'bg-slate-100 text-slate-700',
+  in_progress: 'bg-blue-100 text-blue-700',
+  blocked: 'bg-amber-100 text-amber-800',
+  done: 'bg-emerald-100 text-emerald-700',
+};
+
+const priorityLabel: Record<TaskPriority, string> = {
+  urgent: '긴급',
+  high: '높음',
+  normal: '보통',
+  low: '낮음',
+};
+
+function safeText(value: string | null | undefined, fallback = '') {
+  return toSafeReactText(value, fallback).trim() || fallback;
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '날짜 미정';
+  return new Intl.DateTimeFormat('ko-KR', { month: 'short', day: 'numeric' }).format(date);
+}
+
+function buildProgress(tasks: TicketTask[]) {
+  if (tasks.length === 0) return 0;
+  return Math.round((tasks.filter((task) => task.status === 'done').length / tasks.length) * 100);
+}
+
+function buildProjectStatus(tasks: TicketTask[]): ProjectSummary['status'] {
+  if (tasks.some((task) => task.status === 'blocked')) return '검토 중';
+  if (tasks.some((task) => task.status === 'in_progress')) return '진행 중';
+  if (tasks.length > 0 && tasks.every((task) => task.status === 'done')) return '완료';
+  return '대기 중';
+}
+
+function buildProjects(folders: ProjectFolder[], tasks: TicketTask[]): ProjectSummary[] {
+  const progress = buildProgress(tasks);
+  const status = buildProjectStatus(tasks);
+  const folderProjects = folders.map((folder) => ({
+    id: folder.folder_uid,
+    title: safeText(folder.project_name, '이름 없는 프로젝트'),
+    status,
+    progress,
+    category: 'WebDAV 프로젝트',
+    evidence: 'project_folders',
+    sourcePath: safeText(folder.webdav_path, ''),
+  }));
+
+  if (folderProjects.length > 0) return folderProjects;
+
+  return [
+    {
+      id: 'workspace_task_backlog',
+      title: 'Source-linked 작업 Backlog',
+      status,
+      progress,
+      category: 'Ticket tasks',
+      evidence: 'ticket_tasks',
+      sourcePath: null,
+    },
+  ];
+}
+
+function countByStatus(tasks: TicketTask[], status: TaskStatus) {
+  return tasks.filter((task) => task.status === status).length;
+}
 
 export function ProjectsLayout() {
-  const [activeProject, setActiveProject] = useState(MOCK_PROJECTS[0]);
-  const [viewMode, setViewMode] = useState<'프로젝트 상세' | '마일스톤' | '의사결정 로그'>('프로젝트 상세');
+  const [folders, setFolders] = useState<ProjectFolder[]>([]);
+  const [tasks, setTasks] = useState<TicketTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ProjectViewMode>('프로젝트 상세');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void Promise.all([
+      apiClient.get<ProjectFolder[]>('/api/webdav/folders'),
+      apiClient.get<TicketTask[]>('/api/tasks'),
+    ])
+      .then(([folderRows, taskRows]) => {
+        if (cancelled) return;
+        setFolders(Array.isArray(folderRows) ? folderRows : []);
+        setTasks(Array.isArray(taskRows) ? taskRows : []);
+        setError(null);
+      })
+      .catch((fetchError: Error) => {
+        if (cancelled) return;
+        setFolders([]);
+        setTasks([]);
+        setError(fetchError.message || '프로젝트 source evidence를 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const projects = useMemo(() => buildProjects(folders, tasks), [folders, tasks]);
+  const activeProject = projects.find((project) => project.id === selectedProjectId) ?? projects[0];
+  const projectTasks = tasks;
+  const openCount = countByStatus(projectTasks, 'open');
+  const inProgressCount = countByStatus(projectTasks, 'in_progress');
+  const blockedCount = countByStatus(projectTasks, 'blocked');
+  const doneCount = countByStatus(projectTasks, 'done');
+  const sourceTypeCount = new Set(projectTasks.map((task) => task.source_type)).size;
 
   return (
-    <div className="flex h-full min-w-0 min-h-0 bg-background text-foreground overflow-x-hidden">
-      {/* Left Sidebar - Project List */}
-      <aside className="w-72 shrink-0 flex-col overflow-y-auto border-r border-border bg-card hidden lg:flex">
-        <div className="p-4 border-b border-border">
-          <button className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">
-            <Plus className="size-4" />새 프로젝트
-          </button>
+    <div className="flex h-full min-h-0 min-w-0 overflow-x-hidden bg-background text-foreground">
+      <aside className="hidden w-72 shrink-0 flex-col overflow-y-auto border-r border-border bg-card lg:flex">
+        <div className="border-b border-border p-4">
+          <a href="/data" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">
+            <FolderOpen className="size-4" /> Source 등록
+          </a>
           <div className="relative mt-4">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-            <input type="text" placeholder="프로젝트 검색..." className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <input type="text" readOnly value="source evidence" aria-label="프로젝트 source 검색" className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm text-muted-foreground" />
           </div>
         </div>
-        
-        <div className="flex-1 p-3 space-y-1">
-          {MOCK_PROJECTS.map((proj) => (
-            <div
-              key={proj.id}
-              onClick={() => setActiveProject(proj)}
-              className={`cursor-pointer rounded-lg px-3 py-3 transition-colors ${activeProject.id === proj.id ? 'bg-secondary border border-primary/20' : 'hover:bg-secondary/50 border border-transparent'}`}
+
+        <div className="flex-1 space-y-1 p-3">
+          {loading ? (
+            <div role="status" className="rounded-lg border border-border bg-background p-3 text-sm font-semibold text-muted-foreground">프로젝트 evidence를 불러오는 중입니다.</div>
+          ) : null}
+          {projects.map((project) => (
+            <button
+              key={project.id}
+              type="button"
+              onClick={() => setSelectedProjectId(project.id)}
+              className={`w-full rounded-lg border px-3 py-3 text-left transition-colors ${activeProject.id === project.id ? 'border-primary/30 bg-secondary' : 'border-transparent hover:bg-secondary/50'}`}
             >
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-bold text-muted-foreground">{proj.category}</span>
-                <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${proj.status === '완료' ? 'bg-green-100 text-green-700' : proj.status === '진행 중' ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-700'}`}>{proj.status}</span>
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate text-xs font-bold text-muted-foreground">{project.category}</span>
+                <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold ${projectStatusClass[project.status]}`}>{project.status}</span>
               </div>
-              <h3 className="mt-1 font-bold text-sm text-foreground">{proj.title}</h3>
+              <h3 className="mt-1 line-clamp-2 font-bold text-sm text-foreground">{project.title}</h3>
               <div className="mt-3 flex items-center gap-2">
-                <div className="h-1.5 flex-1 rounded-full bg-border overflow-hidden">
-                  <div className={`h-full ${proj.progress === 100 ? 'bg-green-500' : 'bg-primary'}`} style={{ width: `${proj.progress}%` }}></div>
+                <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-border">
+                  <div className={`h-full ${project.progress === 100 ? 'bg-emerald-500' : 'bg-primary'}`} style={{ width: `${project.progress}%` }} />
                 </div>
-                <span className="text-xs font-semibold text-muted-foreground">{proj.progress}%</span>
+                <span className="text-xs font-semibold text-muted-foreground">{project.progress}%</span>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </aside>
 
-      {/* Main Project Area */}
       <main className="flex min-w-0 flex-1 flex-col bg-background">
-        <header className="flex h-20 shrink-0 items-center justify-between border-b border-border px-6 bg-card">
-          <div>
-            <h1 className="sr-only">프로젝트 워크스페이스</h1>
-            <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground mb-1">
+        <header className="flex shrink-0 flex-col gap-3 border-b border-border bg-card px-4 py-4 lg:h-24 lg:flex-row lg:items-center lg:justify-between lg:px-6">
+          <div className="min-w-0">
+            <h1 className="break-keep text-sm font-black text-foreground lg:text-base">프로젝트 워크스페이스</h1>
+            <div className="mb-1 flex flex-wrap items-center gap-2 text-xs font-bold text-muted-foreground">
               <span>{activeProject.category}</span>
               <span>/</span>
-              <span>{activeProject.id}</span>
+              <span className="font-mono">{activeProject.id}</span>
             </div>
-            <h2 className="text-2xl font-bold">{activeProject.title}</h2>
+            <h2 className="break-keep text-xl font-bold leading-tight lg:text-2xl">{activeProject.title}</h2>
           </div>
-          <div className="flex items-center gap-6">
-            <div className="flex overflow-hidden rounded-md border border-border">
-              {['프로젝트 상세', '마일스톤', '의사결정 로그'].map((mode) => (
+          <div className="flex min-w-0 flex-col gap-3 lg:items-end">
+            <div className="flex gap-2 overflow-x-auto pb-1 lg:hidden">
+              {projects.map((project) => (
+                <button
+                  key={project.id}
+                  type="button"
+                  onClick={() => setSelectedProjectId(project.id)}
+                  className={`min-h-10 shrink-0 rounded-xl px-3 text-xs font-bold ${activeProject.id === project.id ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground'}`}
+                >
+                  {project.title}
+                </button>
+              ))}
+            </div>
+            <div className="flex overflow-x-auto rounded-md border border-border">
+              {(['프로젝트 상세', '마일스톤', '의사결정 로그'] as ProjectViewMode[]).map((mode) => (
                 <button
                   key={mode}
-                  onClick={() => setViewMode(mode as '프로젝트 상세' | '마일스톤' | '의사결정 로그')}
-                  className={`px-4 py-1.5 text-sm font-semibold transition-colors ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
+                  type="button"
+                  onClick={() => setViewMode(mode)}
+                  className={`min-h-9 shrink-0 px-3 text-xs font-semibold transition-colors sm:px-4 sm:text-sm ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
                 >
                   {mode}
                 </button>
               ))}
             </div>
-            <div className="flex items-center gap-3">
-              <button className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary">
-                <Filter className="size-4" /> 필터
-              </button>
-              <button className="flex items-center gap-2 rounded-md bg-primary px-4 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90">
-                보고서 생성
-              </button>
+            <div className="flex flex-wrap items-center gap-2">
+              <a href="/tasks" className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary">작업 보드</a>
+              <a href="/data" className="rounded-md bg-primary px-4 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90">Data evidence</a>
             </div>
           </div>
         </header>
 
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-6 min-w-0">
-            {/* View Logic */}
-            {(viewMode === '프로젝트 상세' || viewMode === '마일스톤') && (
-              <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden mb-6">
-                <div className="border-b border-border p-5 flex items-center justify-between">
-                  <h2 className="font-bold text-lg">마일스톤 (Milestones)</h2>
-                  <button className="text-sm text-primary font-semibold hover:underline">추가</button>
-                </div>
-                <div className="p-5">
-                  <div className="relative border-l-2 border-border ml-3 space-y-6">
-                    {MOCK_MILESTONES.map((ms, idx) => (
-                      <div key={idx} className="relative pl-6">
-                        <div className={`absolute -left-[9px] top-1 size-4 rounded-full border-2 border-card ${ms.status === '완료' ? 'bg-green-500' : ms.status === '진행 중' ? 'bg-primary' : 'bg-border'}`}></div>
-                        <div className="flex items-start justify-between">
-                          <div>
-                            <h3 className="font-bold text-sm">{ms.title}</h3>
-                            <p className="text-xs text-muted-foreground mt-1"><Clock className="inline size-3 mr-1" />{ms.date}</p>
-                          </div>
-                          <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${ms.status === '완료' ? 'bg-green-100 text-green-700' : ms.status === '진행 중' ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-700'}`}>{ms.status}</span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+        <div role="region" aria-label="프로젝트 내용" className="grid flex-1 gap-6 overflow-y-auto p-4 md:p-6 lg:grid-cols-3">
+          <div className="min-w-0 space-y-6 lg:col-span-2">
+            {error ? (
+              <div role="alert" className="rounded-2xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">
+                {error}
               </div>
+            ) : null}
+
+            {(viewMode === '프로젝트 상세' || viewMode === '마일스톤') && (
+              <section aria-label="프로젝트 마일스톤" className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+                <div className="flex items-center justify-between border-b border-border p-5">
+                  <h2 className="font-bold text-lg">마일스톤</h2>
+                  <span className="rounded-full bg-secondary px-2.5 py-1 font-mono text-xs font-semibold text-foreground">ticket_tasks</span>
+                </div>
+                <div className="grid gap-4 p-5 md:grid-cols-4">
+                  {[
+                    { label: '할 일', count: openCount, status: 'open' as const },
+                    { label: '진행 중', count: inProgressCount, status: 'in_progress' as const },
+                    { label: '검토 필요', count: blockedCount, status: 'blocked' as const },
+                    { label: '완료', count: doneCount, status: 'done' as const },
+                  ].map((milestone) => (
+                    <article key={milestone.status} className="rounded-xl border border-border bg-background p-4">
+                      <div className={`inline-flex rounded-full px-2.5 py-1 text-xs font-bold ${taskStatusClass[milestone.status]}`}>{milestone.label}</div>
+                      <p className="mt-4 text-2xl font-black">{milestone.count}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">source-linked ticket</p>
+                    </article>
+                  ))}
+                </div>
+              </section>
             )}
 
             {(viewMode === '프로젝트 상세' || viewMode === '의사결정 로그') && (
-              <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden">
-                <div className="border-b border-border p-5 flex items-center justify-between bg-primary/5">
+              <section aria-label="프로젝트 의사결정 로그" className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+                <div className="flex items-center justify-between border-b border-border bg-primary/5 p-5">
                   <h2 className="font-bold text-lg text-primary">의사결정 로그</h2>
-                  <button className="text-sm text-primary font-semibold hover:underline">기록 추가</button>
+                  <span className="rounded-full bg-background px-2.5 py-1 font-mono text-xs font-semibold text-foreground">provider_write_executed=false</span>
                 </div>
                 <div className="divide-y divide-border">
-                  {MOCK_DECISIONS.map((log) => (
-                    <div key={log.id} className="p-5 hover:bg-secondary/20 transition-colors">
-                      <div className="flex items-start justify-between mb-2">
-                        <h3 className="font-bold text-base flex items-center gap-2">
-                          <CheckCircle2 className="size-4 text-emerald-500" />
-                          {log.title}
-                        </h3>
-                        <span className="text-xs text-muted-foreground">{log.date}</span>
-                      </div>
-                      <div className="rounded-lg bg-background border border-border p-3 text-sm text-foreground">
-                        {log.decision}
-                      </div>
-                      <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground font-semibold">
-                        <User className="size-3.5" /> 승인자: {log.author}
-                      </div>
+                  <article className="p-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="flex items-center gap-2 font-bold text-base"><CheckCircle2 className="size-4 text-emerald-500" /> Source registry 연결</h3>
+                      <span className="text-xs text-muted-foreground">{folders.length} folders</span>
                     </div>
-                  ))}
+                    <p className="mt-2 rounded-lg border border-border bg-background p-3 text-sm leading-6 text-foreground">
+                      WebDAV project folder를 프로젝트 경계로 사용합니다. 원천 provider에 쓰는 작업은 Data/WebDAV intent에서 별도로 승인합니다.
+                    </p>
+                    <p className="mt-3 flex items-center gap-2 text-xs font-semibold text-muted-foreground"><User className="size-3.5" /> evidence: project_folders</p>
+                  </article>
+                  <article className="p-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="flex items-center gap-2 font-bold text-base"><ListChecks className="size-4 text-primary" /> Ticket workflow 반영</h3>
+                      <span className="text-xs text-muted-foreground">{projectTasks.length} tasks</span>
+                    </div>
+                    <p className="mt-2 rounded-lg border border-border bg-background p-3 text-sm leading-6 text-foreground">
+                      작업 상태는 `/api/tasks`의 공개 task id와 source email/thread evidence를 기준으로 집계합니다. 순차 DB id는 화면에 노출하지 않습니다.
+                    </p>
+                    <p className="mt-3 flex items-center gap-2 text-xs font-semibold text-muted-foreground"><User className="size-3.5" /> evidence: ticket_tasks</p>
+                  </article>
                 </div>
-              </div>
+              </section>
             )}
+
+            <section aria-label="프로젝트 작업 목록" className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+              <div className="flex items-center justify-between border-b border-border p-5">
+                <h2 className="font-bold text-lg">연결 작업</h2>
+                <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-bold text-muted-foreground">{projectTasks.length}건</span>
+              </div>
+              {projectTasks.length > 0 ? (
+                <ol className="divide-y divide-border">
+                  {projectTasks.slice(0, 8).map((task) => (
+                    <li key={task.id} className="grid gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${taskStatusClass[task.status]}`}>{taskStatusLabel[task.status]}</span>
+                          <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-bold text-muted-foreground">{priorityLabel[task.priority]}</span>
+                          <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">{safeText(task.source_type, 'source')}</span>
+                        </div>
+                        <h3 className="mt-2 break-keep font-bold text-sm">{safeText(task.title, '제목 없는 작업')}</h3>
+                        <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{task.related_thread_id ?? task.source_email_id ?? task.id}</p>
+                      </div>
+                      <time className="flex items-center gap-1 text-xs text-muted-foreground sm:justify-end"><Clock className="size-3" />{formatDate(task.updated_at)}</time>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <div className="p-5">
+                  <p className="rounded-xl border border-dashed border-border p-4 text-sm font-semibold text-muted-foreground">연결된 ticket task가 아직 없습니다.</p>
+                </div>
+              )}
+            </section>
           </div>
 
-          {/* Right Column - Project Metadata */}
-          <div className="col-span-1 space-y-6">
-            <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-              <h2 className="font-bold text-base mb-4">프로젝트 개요</h2>
-              <div className="space-y-4 text-sm">
+          <aside className="space-y-6">
+            <section aria-label="프로젝트 개요" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+              <h2 className="mb-4 font-bold text-base">프로젝트 개요</h2>
+              <dl className="space-y-4 text-sm">
                 <div>
-                  <p className="text-muted-foreground font-semibold mb-1">책임자 (Owner)</p>
-                  <div className="flex items-center gap-2">
-                    <div className="size-6 rounded-full bg-primary/20 text-primary grid place-items-center"><User className="size-3" /></div>
-                    <span className="font-bold">최서연 Developer</span>
-                  </div>
+                  <dt className="mb-1 font-semibold text-muted-foreground">책임 경계</dt>
+                  <dd className="flex items-center gap-2 font-bold"><User className="size-4 text-primary" /> signed workspace scope</dd>
                 </div>
                 <div>
-                  <p className="text-muted-foreground font-semibold mb-1">상태</p>
-                  <span className="rounded px-2 py-1 text-xs font-bold bg-blue-100 text-blue-700">{activeProject.status}</span>
+                  <dt className="mb-1 font-semibold text-muted-foreground">상태</dt>
+                  <dd><span className={`rounded px-2 py-1 text-xs font-bold ${projectStatusClass[activeProject.status]}`}>{activeProject.status}</span></dd>
                 </div>
                 <div>
-                  <p className="text-muted-foreground font-semibold mb-1">연결된 자원</p>
-                  <ul className="space-y-2 mt-2">
-                    <li className="flex items-center gap-2 text-primary font-semibold hover:underline cursor-pointer"><FolderOpen className="size-4" /> WebDAV 산출물 폴더</li>
-                    <li className="flex items-center gap-2 text-primary font-semibold hover:underline cursor-pointer"><CalendarDays className="size-4" /> CalDAV 팀 캘린더</li>
-                  </ul>
+                  <dt className="mb-1 font-semibold text-muted-foreground">진행률</dt>
+                  <dd className="flex items-center gap-3">
+                    <div className="h-2 flex-1 overflow-hidden rounded-full bg-border">
+                      <div className="h-full bg-primary" style={{ width: `${activeProject.progress}%` }} />
+                    </div>
+                    <span className="font-mono text-xs font-bold">{activeProject.progress}%</span>
+                  </dd>
                 </div>
-              </div>
-            </div>
-          </div>
+                <div>
+                  <dt className="mb-1 font-semibold text-muted-foreground">Source evidence</dt>
+                  <dd className="break-all font-mono text-xs">{activeProject.evidence}</dd>
+                  {activeProject.sourcePath ? <dd className="mt-1 break-all font-mono text-xs text-muted-foreground">{activeProject.sourcePath}</dd> : null}
+                </div>
+              </dl>
+            </section>
+
+            <section aria-label="연결된 자원" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+              <h2 className="mb-4 font-bold text-base">연결된 자원</h2>
+              <ul className="space-y-3 text-sm">
+                <li className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 font-semibold"><FolderOpen className="size-4 text-primary" /> WebDAV 폴더</span>
+                  <span className="font-mono text-xs text-muted-foreground">{folders.length}</span>
+                </li>
+                <li className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 font-semibold"><ListChecks className="size-4 text-primary" /> Ticket tasks</span>
+                  <span className="font-mono text-xs text-muted-foreground">{projectTasks.length}</span>
+                </li>
+                <li className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 font-semibold"><CalendarDays className="size-4 text-primary" /> Source types</span>
+                  <span className="font-mono text-xs text-muted-foreground">{sourceTypeCount}</span>
+                </li>
+              </ul>
+            </section>
+          </aside>
         </div>
       </main>
     </div>

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -174,7 +174,9 @@ export function ProjectsLayout() {
           </a>
           <div className="relative mt-4">
             <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <input type="text" readOnly value="source evidence" aria-label="프로젝트 source 검색" className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm text-muted-foreground" />
+            <p aria-label="프로젝트 source 검색 상태" className="flex h-9 w-full items-center rounded-md border border-border bg-background pl-9 pr-4 text-sm text-muted-foreground">
+              source evidence
+            </p>
           </div>
         </div>
 

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -289,6 +289,80 @@ for (const destination of [
   });
 }
 
+test('renders source-backed Projects workspace with signed API headers and mobile scroll', async ({ page }, testInfo) => {
+  const expectedNaruonToken = 'signed-projects-e2e-token';
+  const publicIdentityHeaders = [
+    'x-user-id',
+    'x-organization-id',
+    'x-group-id',
+    'x-group-ids',
+    'x-user-role',
+    'x-dev-auth-token',
+  ];
+  await mockDashboardApi(page);
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, expectedNaruonToken);
+
+  await page.setViewportSize({ width: 1280, height: 1024 });
+  const desktopFoldersRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/webdav/folders' && request.method() === 'GET';
+  });
+  const desktopTasksRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/tasks' && request.method() === 'GET';
+  });
+  await page.goto('/projects');
+  for (const request of [await desktopFoldersRequest, await desktopTasksRequest]) {
+    const headers = request.headers();
+    expect(headers.authorization).toBe(`Bearer ${expectedNaruonToken}`);
+    for (const headerName of publicIdentityHeaders) {
+      expect(headers[headerName]).toBeUndefined();
+    }
+  }
+
+  await expect(page.getByRole('heading', { name: '프로젝트 워크스페이스' })).toBeVisible();
+  await expect(page.getByText('Naruon Roadmap 2026').first()).toBeVisible();
+  await expect(page.getByText('provider_write_executed=false').first()).toBeVisible();
+  await expect(page.getByText('리소스 배정 검토 회의').first()).toBeVisible();
+  await expect(page.getByText('순차 DB id는 화면에 노출하지 않습니다').first()).toBeVisible();
+  const desktopOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(desktopOverflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: testInfo.outputPath('projects-source-backed-desktop.png'), fullPage: false });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileFoldersRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/webdav/folders' && request.method() === 'GET';
+  });
+  await page.goto('/projects');
+  expect((await mobileFoldersRequest).headers().authorization).toBe(`Bearer ${expectedNaruonToken}`);
+  await expect(page.getByRole('heading', { name: '프로젝트 워크스페이스' })).toBeVisible();
+  await page.getByRole('heading', { name: '연결 작업' }).scrollIntoViewIfNeeded();
+  await expect(page.getByText('첨부파일 WebDAV 폴더 정리')).toBeVisible();
+  const mobileScrollMetrics = await page.getByRole('region', { name: '프로젝트 내용' }).evaluate((scroller) => {
+    scroller.scrollTop = 0;
+    const before = scroller.scrollTop;
+    scroller.scrollTop = scroller.scrollHeight;
+    return {
+      before,
+      after: scroller.scrollTop,
+      maxScroll: scroller.scrollHeight - scroller.clientHeight,
+    };
+  });
+  expect(mobileScrollMetrics.maxScroll).toBeGreaterThan(0);
+  expect(mobileScrollMetrics.after).toBeGreaterThan(mobileScrollMetrics.before);
+  await page.screenshot({ path: testInfo.outputPath('projects-source-backed-mobile-scroll.png'), fullPage: false });
+
+  await page.getByRole('button', { name: '워크스페이스 메뉴 열기' }).click();
+  const menu = page.getByRole('dialog', { name: '모바일 워크스페이스 메뉴' });
+  await menu.getByRole('link', { name: '프로젝트', exact: true }).scrollIntoViewIfNeeded();
+  await expect(menu.getByRole('link', { name: '프로젝트', exact: true })).toHaveAttribute('href', '/projects');
+  await expect(menu.getByRole('link', { name: '데이터', exact: true })).toHaveAttribute('href', '/data');
+  await page.screenshot({ path: testInfo.outputPath('projects-source-backed-mobile-menu.png'), fullPage: false });
+});
+
 test('renders Security governance access audit sharing and policy with signed API headers', async ({ page }, testInfo) => {
   const expectedNaruonToken = 'signed-security-governance-e2e-token';
   const publicIdentityHeaders = [


### PR DESCRIPTION
Summary
- Replace static Projects mock data with signed /api/webdav/folders and /api/tasks reads.
- Render WebDAV project folder boundaries, task-derived milestones, source-evidence decision logs, and no provider write execution claims.
- Document the Projects source-backed workspace contract in README, AGENTS, and docs/plans.

Verification
- npm test -- src/app/projects/page.test.tsx
- npm test -- src/app/projects/page.test.tsx src/components/DashboardLayout.test.tsx
- npm run typecheck
- npm run lint
- NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run build
- PLAYWRIGHT_PORT=18150 npm run test:e2e -- --project=desktop -g source-backed Projects
- PLAYWRIGHT_PORT=18151 npm run test:e2e -- --project=desktop -g renders the /projects workspace destination

Screenshots inspected
- projects-source-backed-desktop.png
- projects-source-backed-mobile-scroll.png
- projects-source-backed-mobile-menu.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects workspace now loads live project data instead of static mock examples.
  * Milestones display real task counts organized by status.
  * Decision logs show source-backed evidence and metrics.

* **Documentation**
  * Added governance standards for project workspace UI.
  * Updated project scope documentation and implementation plan.

* **Tests**
  * Enhanced test coverage for API-driven project loading and error handling.
  * Added end-to-end verification for workspace rendering and mobile responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Replacement note
- Replaces #295 without changing head e3e53fa75d344f702fdf90e0a50fd95cc1125f86.
- #295 was closed because a prior-head CodeRabbit CHANGES_REQUESTED review object remained stale after the inline thread was resolved and required CodeRabbit/security checks passed.
- No review was dismissed and no admin merge was used.