### PR TITLE
fix(projects): scope webdav folders before render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,11 @@
   explicitly labeled pending. Do not reintroduce static project names, inert
   report/filter buttons, provider write success claims, or sequential database
   ids in project UI/tests.
+- Project workspace folder rendering must prove owner scope before display:
+  `/api/webdav/folders` includes server-scoped `owner_user_id` and
+  `organization_id`, and the browser filters those folders against decoded
+  signed-session claims before building project cards. Keep `folder_uid` as an
+  internal opaque key only; do not render it as visible UI text.
 - Self-hosted connector APM history must be persisted as scoped control-plane
   signal events before the UI claims durable heartbeat evidence. Do not expose
   runner registration tokens, path tokens, or raw provider credentials in event

--- a/backend/api/webdav.py
+++ b/backend/api/webdav.py
@@ -26,6 +26,8 @@ class ProjectFolderResponse(BaseModel):
     folder_uid: str
     project_name: str
     webdav_path: str
+    owner_user_id: str
+    organization_id: str | None
 
 class WritebackIntentRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/backend/services/webdav_service.py
+++ b/backend/services/webdav_service.py
@@ -53,12 +53,16 @@ class WebDavService:
                 {
                     "folder_uid": "webdav_folder_demo_roadmap",
                     "project_name": "Naruon Roadmap 2026",
-                    "webdav_path": "/Projects/Naruon_Roadmap_2026"
+                    "webdav_path": "/Projects/Naruon_Roadmap_2026",
+                    "owner_user_id": "demo_user",
+                    "organization_id": None,
                 },
                 {
                     "folder_uid": "webdav_folder_demo_marketing",
                     "project_name": "Marketing Assets",
-                    "webdav_path": "/Projects/Marketing_Assets"
+                    "webdav_path": "/Projects/Marketing_Assets",
+                    "owner_user_id": "demo_user",
+                    "organization_id": None,
                 }
             ]
         }
@@ -121,6 +125,8 @@ class WebDavService:
                 "folder_uid": folder.folder_uid,
                 "project_name": folder.project_name,
                 "webdav_path": folder.webdav_path,
+                "owner_user_id": folder.user_id,
+                "organization_id": folder.organization_id,
             }
             for folder in result.scalars().all()
         ]

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -79,11 +79,15 @@ def stub_webdav_service(monkeypatch):
                 "folder_uid": "webdav_folder_demo_roadmap",
                 "project_name": "Naruon Roadmap 2026",
                 "webdav_path": "/Projects/Naruon_Roadmap_2026",
+                "owner_user_id": "alice",
+                "organization_id": "org-acme",
             },
             {
                 "folder_uid": "webdav_folder_demo_marketing",
                 "project_name": "Marketing Assets",
                 "webdav_path": "/Projects/Marketing_Assets",
+                "owner_user_id": "alice",
+                "organization_id": "org-acme",
             },
         ] if user_id == "alice" and organization_id == "org-acme" else []
 
@@ -241,6 +245,8 @@ def test_get_project_folders(auth_client):
     assert len(body) == 2
     assert body[0]["folder_uid"] == "webdav_folder_demo_roadmap"
     assert body[0]["project_name"] == "Naruon Roadmap 2026"
+    assert body[0]["owner_user_id"] == "alice"
+    assert body[0]["organization_id"] == "org-acme"
     assert body[1]["project_name"] == "Marketing Assets"
     assert "folder_id" not in body[0]
 
@@ -886,6 +892,8 @@ async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
             "folder_uid": folder_uid,
             "project_name": "Source-backed Folder",
             "webdav_path": "/Projects/Source_Backed_Folder",
+            "owner_user_id": user_id,
+            "organization_id": "org-acme",
         }
     ]
     assert "folder_id" not in body[0]

--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -28,6 +28,11 @@ function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500) {
   } as Response);
 }
 
+function sessionToken(payload: Record<string, unknown>) {
+  const encode = (value: unknown) => btoa(JSON.stringify(value)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
 async function flushAsyncWork() {
   await act(async () => {
     await Promise.resolve();
@@ -49,10 +54,11 @@ describe("ProjectsPage", () => {
   });
 
   it("loads project folders and ticket tasks through signed APIs", async () => {
-    window.localStorage.setItem("naruon_session_token", "signed.projects.token");
+    const expectedSessionToken = sessionToken({ sub: "alice", org: "org-acme", workspace: "workspace-org-acme" });
+    window.localStorage.setItem("naruon_session_token", expectedSessionToken);
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
-      expect(headers.get("Authorization")).toBe("Bearer signed.projects.token");
+      expect(headers.get("Authorization")).toBe(`Bearer ${expectedSessionToken}`);
       expect(headers.get("X-User-Id")).toBeNull();
       expect(headers.get("X-Organization-Id")).toBeNull();
 
@@ -63,6 +69,15 @@ describe("ProjectsPage", () => {
             folder_uid: "webdav_folder_roadmap",
             project_name: "Naruon Roadmap 2026",
             webdav_path: "/Projects/Naruon_Roadmap_2026",
+            owner_user_id: "alice",
+            organization_id: "org-acme",
+          },
+          {
+            folder_uid: "webdav_folder_rival",
+            project_name: "Rival Project",
+            webdav_path: "/Projects/Rival_Project",
+            owner_user_id: "mallory",
+            organization_id: "org-rival",
           },
         ]);
       }
@@ -108,6 +123,8 @@ describe("ProjectsPage", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/webdav/folders", expect.objectContaining({ headers: expect.any(Object) }));
     expect(fetchMock).toHaveBeenCalledWith("/api/tasks", expect.objectContaining({ headers: expect.any(Object) }));
     expect(container.textContent).toContain("Naruon Roadmap 2026");
+    expect(container.textContent).not.toContain("Rival Project");
+    expect(container.textContent).not.toContain("webdav_folder_roadmap");
     expect(container.textContent).toContain("provider_write_executed=false");
     expect(container.textContent).toContain("리소스 배정 검토 회의");
     expect(container.textContent).toContain("순차 DB id는 화면에 노출하지 않습니다");

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -14,6 +14,8 @@ interface ProjectFolder {
   folder_uid: string;
   project_name: string;
   webdav_path: string;
+  owner_user_id: string;
+  organization_id: string | null;
 }
 
 interface TicketTask {
@@ -36,6 +38,11 @@ interface ProjectSummary {
   category: string;
   evidence: string;
   sourcePath: string | null;
+}
+
+interface ProjectAccessScope {
+  userId: string | null;
+  organizationId: string | null;
 }
 
 const projectStatusClass = {
@@ -88,6 +95,12 @@ function buildProjectStatus(tasks: TicketTask[]): ProjectSummary['status'] {
   return '대기 중';
 }
 
+function isAuthorizedToViewProject(folder: ProjectFolder, scope: ProjectAccessScope) {
+  const ownerUserId = safeText(folder.owner_user_id);
+  if (!ownerUserId || !scope.userId || ownerUserId !== scope.userId) return false;
+  return (folder.organization_id ?? null) === scope.organizationId;
+}
+
 function buildProjects(folders: ProjectFolder[], tasks: TicketTask[]): ProjectSummary[] {
   const progress = buildProgress(tasks);
   const status = buildProjectStatus(tasks);
@@ -127,6 +140,10 @@ export function ProjectsLayout() {
   const [error, setError] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ProjectViewMode>('프로젝트 상세');
+  const projectScope = useMemo(() => {
+    const claims = apiClient.getSessionClaims();
+    return { userId: claims.userId, organizationId: claims.organizationId };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -156,7 +173,11 @@ export function ProjectsLayout() {
     };
   }, []);
 
-  const projects = useMemo(() => buildProjects(folders, tasks), [folders, tasks]);
+  const authorizedFolders = useMemo(
+    () => folders.filter((folder) => isAuthorizedToViewProject(folder, projectScope)),
+    [folders, projectScope],
+  );
+  const projects = useMemo(() => buildProjects(authorizedFolders, tasks), [authorizedFolders, tasks]);
   const activeProject = projects.find((project) => project.id === selectedProjectId) ?? projects[0];
   const projectTasks = tasks;
   const openCount = countByStatus(projectTasks, 'open');
@@ -214,7 +235,7 @@ export function ProjectsLayout() {
             <div className="mb-1 flex flex-wrap items-center gap-2 text-xs font-bold text-muted-foreground">
               <span>{activeProject.category}</span>
               <span>/</span>
-              <span className="font-mono">{activeProject.id}</span>
+              <span className="font-mono">{activeProject.evidence}</span>
             </div>
             <h2 className="break-keep text-xl font-bold leading-tight lg:text-2xl">{activeProject.title}</h2>
           </div>
@@ -291,7 +312,7 @@ export function ProjectsLayout() {
                   <article className="p-5">
                     <div className="flex items-start justify-between gap-3">
                       <h3 className="flex items-center gap-2 font-bold text-base"><CheckCircle2 className="size-4 text-emerald-500" /> Source registry 연결</h3>
-                      <span className="text-xs text-muted-foreground">{folders.length} folders</span>
+                      <span className="text-xs text-muted-foreground">{authorizedFolders.length} folders</span>
                     </div>
                     <p className="mt-2 rounded-lg border border-border bg-background p-3 text-sm leading-6 text-foreground">
                       WebDAV project folder를 프로젝트 경계로 사용합니다. 원천 provider에 쓰는 작업은 Data/WebDAV intent에서 별도로 승인합니다.
@@ -376,7 +397,7 @@ export function ProjectsLayout() {
               <ul className="space-y-3 text-sm">
                 <li className="flex items-center justify-between gap-3">
                   <span className="flex items-center gap-2 font-semibold"><FolderOpen className="size-4 text-primary" /> WebDAV 폴더</span>
-                  <span className="font-mono text-xs text-muted-foreground">{folders.length}</span>
+                  <span className="font-mono text-xs text-muted-foreground">{authorizedFolders.length}</span>
                 </li>
                 <li className="flex items-center justify-between gap-3">
                   <span className="flex items-center gap-2 font-semibold"><ListChecks className="size-4 text-primary" /> Ticket tasks</span>

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,3 +1,9 @@
+export interface SessionClaims {
+  userId: string | null;
+  organizationId: string | null;
+  workspaceId: string | null;
+}
+
 const CLIENT_CONTROLLED_AUTHORITY_HEADERS = new Set([
   'authorization',
   'x-dev-auth-token',
@@ -66,12 +72,16 @@ export class ApiClient {
     return stored || null;
   }
 
-  getCurrentUserId() {
+  getSessionClaims(): SessionClaims {
     const sessionToken = this.getSessionToken();
-    if (!sessionToken) return null;
+    if (!sessionToken) {
+      return { userId: null, organizationId: null, workspaceId: null };
+    }
 
     const [, payloadSegment] = sessionToken.split('.');
-    if (!payloadSegment) return null;
+    if (!payloadSegment) {
+      return { userId: null, organizationId: null, workspaceId: null };
+    }
 
     try {
       const normalizedPayload = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
@@ -79,12 +89,22 @@ export class ApiClient {
         Math.ceil(normalizedPayload.length / 4) * 4,
         '=',
       );
-      const decodedPayload = JSON.parse(atob(paddedPayload)) as { sub?: unknown };
-      if (typeof decodedPayload.sub !== 'string') return null;
-      return decodedPayload.sub.trim() || null;
+      const decodedPayload = JSON.parse(atob(paddedPayload)) as {
+        sub?: unknown;
+        org?: unknown;
+        workspace?: unknown;
+      };
+      const userId = typeof decodedPayload.sub === 'string' ? decodedPayload.sub.trim() || null : null;
+      const organizationId = typeof decodedPayload.org === 'string' ? decodedPayload.org.trim() || null : null;
+      const workspaceId = typeof decodedPayload.workspace === 'string' ? decodedPayload.workspace.trim() || null : null;
+      return { userId, organizationId, workspaceId };
     } catch {
-      return null;
+      return { userId: null, organizationId: null, workspaceId: null };
     }
+  }
+
+  getCurrentUserId() {
+    return this.getSessionClaims().userId;
   }
 
   async get<T>(endpoint: string, init?: RequestInit): Promise<T> {

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from '@playwright/test';
 
 import { mockDashboardApi } from './helpers';
 
+function e2eSessionToken(payload: Record<string, unknown>) {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+}
+
 test('renders the desktop Naruon shell with local brand assets', async ({ page }) => {
   const requestedUrls: string[] = [];
   page.on('request', (request) => requestedUrls.push(request.url()));
@@ -290,7 +295,7 @@ for (const destination of [
 }
 
 test('renders source-backed Projects workspace with signed API headers and mobile scroll', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-projects-e2e-token';
+  const expectedNaruonToken = e2eSessionToken({ sub: 'alice', org: 'org-acme', workspace: 'workspace-org-acme' });
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -324,6 +329,7 @@ test('renders source-backed Projects workspace with signed API headers and mobil
 
   await expect(page.getByRole('heading', { name: '프로젝트 워크스페이스' })).toBeVisible();
   await expect(page.getByText('Naruon Roadmap 2026').first()).toBeVisible();
+  await expect(page.getByText('webdav_folder_roadmap')).toHaveCount(0);
   await expect(page.getByText('provider_write_executed=false').first()).toBeVisible();
   await expect(page.getByText('리소스 배정 검토 회의').first()).toBeVisible();
   await expect(page.getByText('순차 DB id는 화면에 노출하지 않습니다').first()).toBeVisible();

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -752,11 +752,15 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
           folder_uid: 'webdav_folder_roadmap',
           project_name: 'Naruon Roadmap 2026',
           webdav_path: '/Projects/Naruon_Roadmap_2026',
+          owner_user_id: 'alice',
+          organization_id: 'org-acme',
         },
         {
           folder_uid: 'webdav_folder_marketing',
           project_name: 'Marketing Assets',
           webdav_path: '/Projects/Marketing_Assets',
+          owner_user_id: 'alice',
+          organization_id: 'org-acme',
         },
       ]);
       return;


### PR DESCRIPTION
## Summary
- Fixes the post-merge Strix finding from PR #296 / run 26610947059 by filtering WebDAV project folders against signed-session owner and organization claims before rendering Projects cards.
- Extends `/api/webdav/folders` responses with server-scoped `owner_user_id` and `organization_id` evidence.
- Stops exposing internal `folder_uid` in the Projects header and uses source evidence copy instead.
- Records the repeated review pattern in `AGENTS.md` so project folder rendering proves owner scope before display.

## Verification
- `env -u NO_COLOR npm test -- src/app/projects/page.test.tsx`
- `PYTHONDONTWRITEBYTECODE=1 DISABLE_BACKGROUND_WORKERS=1 python3 -m pytest backend/tests/test_webdav_api.py -q`
- `env -u NO_COLOR npm run typecheck`
- `env -u NO_COLOR npm run lint`
- `git diff --check`
- `env -u NO_COLOR PLAYWRIGHT_PORT=18152 NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run test:e2e -- --project=desktop -g "source-backed Projects"`
- `env -u NO_COLOR NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=4096 NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true NEXT_STATIC_GENERATION_MAX_CONCURRENCY=1 NEXT_STATIC_GENERATION_MIN_PAGES_PER_WORKER=100 npm run build`

## Browser evidence
- Reviewed desktop Projects screenshot: authorized source-backed project folders render without visible `folder_uid` values or overlap.
- Reviewed mobile scroll screenshot: source evidence remains visible and layout scrolls correctly.
- Reviewed mobile hamburger screenshot: drawer navigation remains usable for Projects/Data/Security/Settings.