### PR TITLE
Fix accounts mailbox owner auth boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,11 @@
   by `user_id` only. Frontend Settings onboarding must use bearer-session API
   calls for account config, CalDAV/WebDAV source readiness, and runner token
   rotation, and mocks must not reintroduce public identity headers.
+- User-owned mailbox/provider account endpoints must not treat `system_admin`
+  or `platform_admin` JWT roles as an owner session. Elevated operators need
+  separate audited support flows; `/api/accounts/config` must reject forged or
+  orgless privileged sessions before credential lookup, and tests must exercise
+  the real signed bearer path rather than only dev public-header overrides.
 - Reply-wait task escalation must reuse the server-authoritative pending reply
   path, create or update source-linked `reply_sla` ticket tasks by opaque task
   id, and sanitize generated task titles from email subjects before persistence.

--- a/backend/api/accounts.py
+++ b/backend/api/accounts.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.session import get_db
-from api.auth import AuthContext, get_auth_context
+from api.auth import AuthContext, get_auth_context, is_system_admin_role
 from api.tenant_config import validate_mail_config_update
 from services.tenant_config_scope import (
     get_scoped_tenant_config,
@@ -11,6 +11,10 @@ from services.tenant_config_scope import (
 )
 
 router = APIRouter(prefix="/api/accounts", tags=["accounts"])
+
+MAILBOX_ACCOUNT_SETTINGS_FORBIDDEN = (
+    "Mailbox account settings require a scoped user session"
+)
 
 class TenantConfigUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -74,11 +78,18 @@ def _empty_tenant_config_response(user_id: str) -> TenantConfigResponse:
     config = new_scoped_tenant_config(user_id=user_id, organization_id=None)
     return _tenant_config_response(config)
 
+
+def _ensure_mailbox_account_owner_session(auth_ctx: AuthContext) -> None:
+    if is_system_admin_role(auth_ctx.role):
+        raise HTTPException(status_code=403, detail=MAILBOX_ACCOUNT_SETTINGS_FORBIDDEN)
+
+
 @router.get("/config", response_model=TenantConfigResponse)
 async def get_tenant_config(
     db: AsyncSession = Depends(get_db),
     auth_ctx: AuthContext = Depends(get_auth_context)
 ):
+    _ensure_mailbox_account_owner_session(auth_ctx)
     config = await get_scoped_tenant_config(
         db,
         auth_ctx.user_id,
@@ -95,6 +106,7 @@ async def update_tenant_config(
     db: AsyncSession = Depends(get_db),
     auth_ctx: AuthContext = Depends(get_auth_context)
 ):
+    _ensure_mailbox_account_owner_session(auth_ctx)
     config = await get_scoped_tenant_config(
         db,
         auth_ctx.user_id,

--- a/backend/tests/test_accounts_api.py
+++ b/backend/tests/test_accounts_api.py
@@ -1,9 +1,20 @@
+import base64
+import hashlib
+import hmac
+import json
+import time
+
 import pytest
 from fastapi.testclient import TestClient
-from main import app
-from db.session import get_db
+from pydantic import SecretStr
 
-pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
+from api.auth import SESSION_AUDIENCE, SESSION_ISSUER
+from core.config import settings
+from db.session import get_db
+from main import app
+
+TEST_SESSION_HMAC_SECRET = "accounts-mailbox-owner-hmac-value-20260529"  # noqa: S105
+
 
 class MockTenantConfig:
     def __init__(self, user_id, organization_id=None):
@@ -35,6 +46,7 @@ class MockSession:
     def __init__(self):
         self.configs = {}
         self.commits = 0
+        self.execute_calls = 0
 
     def _query_key(self, stmt):
         params = dict(stmt.compile().params)
@@ -43,6 +55,7 @@ class MockSession:
         return user_id, organization_id
 
     async def execute(self, stmt):
+        self.execute_calls += 1
         return MockResult(self.configs.get(self._query_key(stmt)))
 
     def add(self, obj):
@@ -57,8 +70,73 @@ class MockSession:
 async def override_get_db():
     yield MockSession()
 
+
+def _base64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _signed_session_token(payload: dict[str, object]) -> str:
+    header_segment = _base64url_encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode()
+    )
+    payload_segment = _base64url_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature = hmac.new(
+        TEST_SESSION_HMAC_SECRET.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _valid_session_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ver": 1,
+        "iss": SESSION_ISSUER,
+        "aud": SESSION_AUDIENCE,
+        "sub": "mailbox-owner",
+        "role": "member",
+        "org": "org-acme",
+        "groups": [],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _request_with_signed_session(
+    method: str,
+    path: str,
+    db_session: MockSession,
+    payload: dict[str, object],
+    json_body: dict[str, object] | None = None,
+):
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+
+    async def scoped_db():
+        yield db_session
+
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    app.dependency_overrides[get_db] = scoped_db
+    try:
+        token = _signed_session_token(payload)
+        with TestClient(app) as c:
+            kwargs: dict[str, object] = {
+                "headers": {"Authorization": f"Bearer {token}"}
+            }
+            if json_body is not None:
+                kwargs["json"] = json_body
+            return c.request(method, path, **kwargs)
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        app.dependency_overrides.clear()
+
+
 @pytest.fixture
-def client():
+def client(dev_auth_dependency_overrides):
     app.dependency_overrides[get_db] = override_get_db
     with TestClient(app, headers={"X-User-Id": "testuser"}) as c:
         yield c
@@ -107,7 +185,9 @@ def test_get_and_update_tenant_config(client: TestClient, monkeypatch):
     assert data["has_pop3_password"] is True
 
 
-def test_accounts_config_uses_signed_session_organization_scope(monkeypatch):
+def test_accounts_config_uses_signed_session_organization_scope(
+    dev_auth_dependency_overrides, monkeypatch
+):
     monkeypatch.setattr(
         "api.tenant_config.validate_smtp_host",
         lambda host, *, resolve_host=True: host,
@@ -151,6 +231,54 @@ def test_accounts_config_uses_signed_session_organization_scope(monkeypatch):
     assert rival_read.json()["smtp_server"] == "smtp.other.com"
     assert ("shared-user", "org-acme") in session.configs
     assert ("shared-user", "org-rival") in session.configs
+
+
+@pytest.mark.parametrize("admin_role", ("system_admin", "platform_admin"))
+def test_accounts_config_rejects_system_admin_mailbox_owner_session(admin_role: str):
+    session = MockSession()
+    payload = _valid_session_payload(
+        sub="strix-admin",
+        role=admin_role,
+        org=None,
+        workspace="workspace-system",
+    )
+
+    read_response = _request_with_signed_session(
+        "GET",
+        "/api/accounts/config",
+        session,
+        payload,
+    )
+    write_response = _request_with_signed_session(
+        "PUT",
+        "/api/accounts/config",
+        session,
+        payload,
+        {"smtp_server": "smtp.example.com", "smtp_port": 587},
+    )
+
+    assert read_response.status_code == 403
+    assert write_response.status_code == 403
+    assert read_response.json()["detail"] == (
+        "Mailbox account settings require a scoped user session"
+    )
+    assert session.execute_calls == 0
+    assert session.configs == {}
+
+
+def test_accounts_config_preserves_scoped_signed_member_session():
+    session = MockSession()
+    response = _request_with_signed_session(
+        "GET",
+        "/api/accounts/config",
+        session,
+        _valid_session_payload(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "mailbox-owner"
+    assert response.json()["smtp_server"] is None
+    assert session.execute_calls == 1
 
 
 def test_accounts_config_rejects_private_imap_host(client: TestClient):

--- a/docs/plans/2026-05-29-accounts-mailbox-owner-auth-boundary.md
+++ b/docs/plans/2026-05-29-accounts-mailbox-owner-auth-boundary.md
@@ -1,0 +1,47 @@
+# 2026-05-29 Accounts Mailbox Owner Auth Boundary
+
+## Verified gap
+
+- Protected-branch Strix run `26613803845` reported a critical function-level
+  authorization issue on `GET /api/accounts/config`.
+- The reproduced pattern was a signed JWT with `role=system_admin` and no
+  organization scope being accepted by a user-owned mailbox/provider credential
+  endpoint.
+- This endpoint configures customer-owned SMTP, IMAP, POP3, and OAuth account
+  settings. Naruon may relay or proxy against customer-designated providers, but
+  it must not act as the customer's mailbox host, and operator roles must not be
+  treated as the mailbox owner.
+
+## Implemented slice
+
+- Keep `/api/accounts/config` on the default signed-session dependency.
+- Reject `system_admin` and `platform_admin` sessions before reading or writing
+  mailbox/provider settings.
+- Preserve scoped member and tenant sessions so normal customer account
+  configuration still works.
+- Add real signed bearer tests that cover the forged privileged JWT pattern and
+  the preserved scoped member path.
+- Record the review anti-pattern in `AGENTS.md`: elevated operators require
+  separate audited support flows, not implicit access to user-owned credential
+  APIs.
+
+## Verification
+
+- Targeted backend tests must cover `GET` and `PUT` denial before database
+  lookup for privileged operator sessions.
+- Existing account configuration tests must continue to cover organization
+  scoping and SMTP/IMAP/POP3 validation.
+- Security scanner reruns should confirm the Strix finding is gone for the PR
+  head before merge.
+
+## Remaining roadmap
+
+- Decide and implement the explicit B2C/SOHO signed-session model before
+  allowing orgless non-operator member tokens; the current shared auth layer
+  still rejects those sessions.
+- Design a separately audited support/impersonation flow only if product policy
+  requires operator-assisted mailbox troubleshooting.
+- Continue the next workspace phase after this gate fix: capture browser
+  screenshots for Security/Data responsive evidence and implement the next
+  source-backed operational surface gap found in `docs/plans` and
+  `frontend/branding`.


### PR DESCRIPTION
## Summary
- Reject `system_admin` and `platform_admin` signed sessions on `/api/accounts/config` before mailbox/provider credential lookup.
- Add real signed bearer tests for the Strix-forged privileged JWT pattern and the preserved scoped member path.
- Record the operator/user-owned credential anti-pattern in `AGENTS.md` and add the phase plan document.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests/test_accounts_api.py backend/tests/test_auth_real.py backend/tests/test_tenant_config_api.py -q` → 69 passed, 1 skipped
- `PYTHONDONTWRITEBYTECODE=1 python3 -m bandit -r backend/ -x backend/tests/ -q` → passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q` from `backend/` → 508 passed, 13 skipped
- `git diff --check` → passed

## Notes
- This is an API-only Strix gate remediation; responsive browser screenshots are not applicable to this PR.
- Subagent delegation was attempted for the parallel plans/branding audit, but the current agent thread limit was saturated. The follow-up workspace phase should resume that audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System admin and platform admin roles are now restricted from accessing user-owned mailbox and provider account configuration endpoints. Authorization validation now occurs earlier in the request flow to prevent unauthorized access before account configuration retrieval or modification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->