### PR TITLE
Add source-backed AI Hub workspace surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,10 @@
 - When reviews find inert navigation/dead-space controls, either wire them to an
   implemented workspace route/API or remove the control; do not leave
   high-traffic drawer/sidebar entries as permanent `준비 중` copy.
+- AI Hub tabs must be backed by signed source evidence from `/api/ai-hub/surface`
+  or a narrower signed API. Do not reintroduce static model-score fixtures,
+  fake workflow logs, or provider names that are not derived from prompt,
+  provider, or audit data.
 - Icon-only workspace controls must carry localized `aria-label` text matching
   the visible app language; do not rely on the SVG icon alone for Calendar,
   Tasks, drawer, modal, or toolbar actions.

--- a/backend/api/ai_hub.py
+++ b/backend/api/ai_hub.py
@@ -1,0 +1,356 @@
+import datetime
+import hashlib
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import desc, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import AuthContext, get_auth_context, is_admin_role
+from db.models import LLMProvider, PromptTemplate, SecurityAuditEvent
+from db.session import get_db
+
+router = APIRouter(prefix="/api/ai-hub", tags=["ai-hub"])
+
+
+class AiHubSummaryCard(BaseModel):
+    summary_key: str
+    label_text: str
+    value_text: str
+    detail_text: str
+    state_code: str
+
+
+class AiHubPromptCard(BaseModel):
+    prompt_key: str
+    prompt_title: str
+    description_text: str | None
+    shared_scope: bool
+    owner_label: str
+    updated_at: datetime.datetime | None
+
+
+class AiHubWorkflowCard(BaseModel):
+    workflow_key: str
+    workflow_title: str
+    trigger_source: str
+    state_code: str
+    evidence_text: str
+
+
+class AiHubAgentCard(BaseModel):
+    agent_key: str
+    agent_title: str
+    model_label: str
+    state_code: str
+    configured: bool
+    governance_text: str
+
+
+class AiHubEvaluationMetric(BaseModel):
+    metric_key: str
+    metric_label: str
+    score_value: int
+    trend_text: str
+
+
+class AiHubRunEvent(BaseModel):
+    event_key: str
+    event_title: str
+    state_code: str
+    evidence_source: str
+    observed_at: datetime.datetime | None
+    detail_text: str | None
+
+
+class AiHubSurfaceResponse(BaseModel):
+    summary_cards: list[AiHubSummaryCard]
+    prompt_cards: list[AiHubPromptCard]
+    workflow_cards: list[AiHubWorkflowCard]
+    agent_cards: list[AiHubAgentCard]
+    evaluation_metrics: list[AiHubEvaluationMetric]
+    run_events: list[AiHubRunEvent]
+
+
+def _stable_key(prefix: str, *parts: object) -> str:
+    digest = hashlib.sha256(
+        "|".join(str(part or "") for part in parts).encode("utf-8")
+    ).hexdigest()
+    return f"{prefix}_{digest[:16]}"
+
+
+def _prompt_card(prompt: PromptTemplate) -> AiHubPromptCard:
+    return AiHubPromptCard(
+        prompt_key=_stable_key("prompt", prompt.created_by, prompt.id, prompt.title),
+        prompt_title=prompt.title,
+        description_text=prompt.description,
+        shared_scope=bool(prompt.is_shared),
+        owner_label=prompt.created_by,
+        updated_at=prompt.updated_at,
+    )
+
+
+def _agent_card(provider: LLMProvider) -> AiHubAgentCard:
+    configured = bool(provider.api_key)
+    if provider.is_active and configured:
+        state_code = "active"
+    elif configured:
+        state_code = "configured"
+    else:
+        state_code = "needs_key"
+
+    return AiHubAgentCard(
+        agent_key=_stable_key(
+            "agent",
+            provider.organization_id,
+            provider.id,
+            provider.name,
+        ),
+        agent_title=provider.name,
+        model_label=provider.provider_type,
+        state_code=state_code,
+        configured=configured,
+        governance_text="organization llm provider registry",
+    )
+
+
+def _workflow_cards(
+    prompts: list[AiHubPromptCard],
+    active_provider_count: int,
+) -> list[AiHubWorkflowCard]:
+    workflow_state = "ready" if active_provider_count else "needs_provider"
+    evidence_text = (
+        "active organization provider is available"
+        if active_provider_count
+        else "active organization provider is required"
+    )
+    return [
+        AiHubWorkflowCard(
+            workflow_key=_stable_key("workflow", prompt.prompt_key),
+            workflow_title=f"{prompt.prompt_title} 실행 흐름",
+            trigger_source="prompt_template",
+            state_code=workflow_state,
+            evidence_text=evidence_text,
+        )
+        for prompt in prompts[:5]
+    ]
+
+
+def _run_events(
+    prompts: list[PromptTemplate],
+    audit_events: list[SecurityAuditEvent],
+) -> list[AiHubRunEvent]:
+    events = [
+        AiHubRunEvent(
+            event_key=_stable_key("event", event.event_uid),
+            event_title=f"{event.resource_type} {event.event_action}",
+            state_code="recorded",
+            evidence_source=event.evidence_source,
+            observed_at=event.observed_at,
+            detail_text=event.detail_text,
+        )
+        for event in audit_events
+    ]
+    if events:
+        return events
+
+    return [
+        AiHubRunEvent(
+            event_key=_stable_key("event", prompt.created_by, prompt.id, prompt.title),
+            event_title=f"prompt template updated: {prompt.title}",
+            state_code="recorded",
+            evidence_source="prompt_templates",
+            observed_at=prompt.updated_at,
+            detail_text=prompt.description,
+        )
+        for prompt in prompts[:5]
+    ]
+
+
+def _score(active_provider_count: int, prompt_count: int, audit_count: int) -> int:
+    provider_score = 40 if active_provider_count else 0
+    prompt_score = min(40, prompt_count * 10)
+    audit_score = min(20, audit_count * 5)
+    return provider_score + prompt_score + audit_score
+
+
+def _evaluation_metrics(
+    prompt_count: int,
+    provider_count: int,
+    active_provider_count: int,
+    audit_count: int,
+) -> list[AiHubEvaluationMetric]:
+    return [
+        AiHubEvaluationMetric(
+            metric_key="prompt_coverage",
+            metric_label="프롬프트 커버리지",
+            score_value=min(100, prompt_count * 20),
+            trend_text=f"{prompt_count} source-backed prompt templates",
+        ),
+        AiHubEvaluationMetric(
+            metric_key="provider_readiness",
+            metric_label="Provider 준비도",
+            score_value=100 if active_provider_count else 0,
+            trend_text=f"{active_provider_count}/{provider_count} active providers",
+        ),
+        AiHubEvaluationMetric(
+            metric_key="audit_evidence",
+            metric_label="운영 증거",
+            score_value=min(100, audit_count * 20),
+            trend_text=f"{audit_count} scoped audit events",
+        ),
+        AiHubEvaluationMetric(
+            metric_key="execution_readiness",
+            metric_label="실행 준비도",
+            score_value=_score(active_provider_count, prompt_count, audit_count),
+            trend_text="derived from provider, prompt, and audit evidence",
+        ),
+    ]
+
+
+def _summary_cards(
+    prompt_count: int,
+    workflow_count: int,
+    provider_count: int,
+    active_provider_count: int,
+    run_event_count: int,
+    readiness_score: int,
+) -> list[AiHubSummaryCard]:
+    return [
+        AiHubSummaryCard(
+            summary_key="prompt_templates",
+            label_text="프롬프트",
+            value_text=str(prompt_count),
+            detail_text="source-backed templates",
+            state_code="ready" if prompt_count else "empty",
+        ),
+        AiHubSummaryCard(
+            summary_key="workflow_blueprints",
+            label_text="워크플로우",
+            value_text=str(workflow_count),
+            detail_text="prompt-derived execution flows",
+            state_code="ready" if workflow_count else "empty",
+        ),
+        AiHubSummaryCard(
+            summary_key="ai_providers",
+            label_text="AI 에이전트",
+            value_text=f"{active_provider_count}/{provider_count}",
+            detail_text="active organization providers",
+            state_code="ready" if active_provider_count else "needs_provider",
+        ),
+        AiHubSummaryCard(
+            summary_key="evaluation_readiness",
+            label_text="평가",
+            value_text=f"{readiness_score}%",
+            detail_text="derived operational readiness",
+            state_code="ready" if readiness_score >= 60 else "attention",
+        ),
+        AiHubSummaryCard(
+            summary_key="run_events",
+            label_text="실행 이력",
+            value_text=str(run_event_count),
+            detail_text="scoped source evidence",
+            state_code="ready" if run_event_count else "empty",
+        ),
+    ]
+
+
+async def _list_prompts(
+    db: AsyncSession,
+    auth_context: AuthContext,
+) -> list[PromptTemplate]:
+    result = await db.execute(
+        select(PromptTemplate)
+        .where(
+            or_(
+                PromptTemplate.created_by == auth_context.user_id,
+                PromptTemplate.is_shared.is_(True),
+            )
+        )
+        .order_by(desc(PromptTemplate.updated_at))
+        .limit(8)
+    )
+    return list(result.scalars().all())
+
+
+async def _list_providers(
+    db: AsyncSession,
+    auth_context: AuthContext,
+) -> list[LLMProvider]:
+    if auth_context.organization_id is None:
+        return []
+    result = await db.execute(
+        select(LLMProvider)
+        .where(LLMProvider.organization_id == auth_context.organization_id)
+        .order_by(desc(LLMProvider.updated_at))
+        .limit(8)
+    )
+    return list(result.scalars().all())
+
+
+async def _list_audit_events(
+    db: AsyncSession,
+    auth_context: AuthContext,
+) -> list[SecurityAuditEvent]:
+    if auth_context.organization_id is None:
+        return []
+    statement = (
+        select(SecurityAuditEvent)
+        .where(
+            SecurityAuditEvent.organization_id == auth_context.organization_id,
+            SecurityAuditEvent.workspace_id == auth_context.workspace_id,
+            SecurityAuditEvent.resource_type == "llm_provider",
+        )
+        .order_by(desc(SecurityAuditEvent.observed_at))
+        .limit(8)
+    )
+    if not is_admin_role(auth_context.role):
+        statement = statement.where(
+            SecurityAuditEvent.actor_user_id == auth_context.user_id
+        )
+    result = await db.execute(statement)
+    return list(result.scalars().all())
+
+
+@router.get("/surface", response_model=AiHubSurfaceResponse)
+async def get_ai_hub_surface(
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: AsyncSession = Depends(get_db),
+) -> AiHubSurfaceResponse:
+    prompts = await _list_prompts(db, auth_context)
+    providers = await _list_providers(db, auth_context)
+    audit_events = await _list_audit_events(db, auth_context)
+
+    prompt_cards = [_prompt_card(prompt) for prompt in prompts]
+    active_provider_count = sum(
+        1 for provider in providers if provider.is_active and provider.api_key
+    )
+    workflow_cards = _workflow_cards(prompt_cards, active_provider_count)
+    agent_cards = [_agent_card(provider) for provider in providers]
+    run_events = _run_events(prompts, audit_events)
+    readiness_score = _score(
+        active_provider_count,
+        len(prompt_cards),
+        len(audit_events),
+    )
+
+    return AiHubSurfaceResponse(
+        summary_cards=_summary_cards(
+            len(prompt_cards),
+            len(workflow_cards),
+            len(providers),
+            active_provider_count,
+            len(run_events),
+            readiness_score,
+        ),
+        prompt_cards=prompt_cards,
+        workflow_cards=workflow_cards,
+        agent_cards=agent_cards,
+        evaluation_metrics=_evaluation_metrics(
+            len(prompt_cards),
+            len(providers),
+            active_provider_count,
+            len(audit_events),
+        ),
+        run_events=run_events,
+    )

--- a/backend/api/ai_hub.py
+++ b/backend/api/ai_hub.py
@@ -3,7 +3,7 @@ import hashlib
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlalchemy import desc, or_, select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import AuthContext, get_auth_context, is_admin_role
@@ -261,13 +261,8 @@ async def _list_prompts(
 ) -> list[PromptTemplate]:
     result = await db.execute(
         select(PromptTemplate)
-        .where(
-            or_(
-                PromptTemplate.created_by == auth_context.user_id,
-                PromptTemplate.is_shared.is_(True),
-            )
-        )
-        .order_by(desc(PromptTemplate.updated_at))
+        .where(PromptTemplate.created_by == auth_context.user_id)
+        .order_by(desc(PromptTemplate.updated_at), desc(PromptTemplate.id))
         .limit(8)
     )
     return list(result.scalars().all())
@@ -277,12 +272,12 @@ async def _list_providers(
     db: AsyncSession,
     auth_context: AuthContext,
 ) -> list[LLMProvider]:
-    if auth_context.organization_id is None:
+    if auth_context.organization_id is None or not is_admin_role(auth_context.role):
         return []
     result = await db.execute(
         select(LLMProvider)
         .where(LLMProvider.organization_id == auth_context.organization_id)
-        .order_by(desc(LLMProvider.updated_at))
+        .order_by(desc(LLMProvider.updated_at), desc(LLMProvider.id))
         .limit(8)
     )
     return list(result.scalars().all())
@@ -294,20 +289,23 @@ async def _list_audit_events(
 ) -> list[SecurityAuditEvent]:
     if auth_context.organization_id is None:
         return []
+    conditions = [
+        SecurityAuditEvent.organization_id == auth_context.organization_id,
+        SecurityAuditEvent.workspace_id == auth_context.workspace_id,
+        SecurityAuditEvent.resource_type == "llm_provider",
+    ]
+    if not is_admin_role(auth_context.role):
+        conditions.append(SecurityAuditEvent.actor_user_id == auth_context.user_id)
+
     statement = (
         select(SecurityAuditEvent)
-        .where(
-            SecurityAuditEvent.organization_id == auth_context.organization_id,
-            SecurityAuditEvent.workspace_id == auth_context.workspace_id,
-            SecurityAuditEvent.resource_type == "llm_provider",
+        .where(*conditions)
+        .order_by(
+            desc(SecurityAuditEvent.observed_at),
+            desc(SecurityAuditEvent.event_uid),
         )
-        .order_by(desc(SecurityAuditEvent.observed_at))
         .limit(8)
     )
-    if not is_admin_role(auth_context.role):
-        statement = statement.where(
-            SecurityAuditEvent.actor_user_id == auth_context.user_id
-        )
     result = await db.execute(statement)
     return list(result.scalars().all())
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from api.accounts import router as accounts_router
 from api.webdav import router as webdav_router
 from api.security import router as security_router
 from api.data import router as data_router
+from api.ai_hub import router as ai_hub_router
 from core.config import settings
 from core.telemetry import setup_telemetry
 from services.imap_worker import ImapSyncWorker
@@ -103,6 +104,7 @@ app.include_router(accounts_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(webdav_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(security_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(data_router, dependencies=PRIVATE_API_DEPENDENCIES)
+app.include_router(ai_hub_router, dependencies=PRIVATE_API_DEPENDENCIES)
 
 
 @app.get("/")

--- a/backend/tests/test_ai_hub_api.py
+++ b/backend/tests/test_ai_hub_api.py
@@ -4,13 +4,20 @@ import hashlib
 import hmac
 import json
 import time
+import uuid
 
+import asyncpg
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api.auth import SESSION_AUDIENCE, SESSION_ISSUER
 from core.config import settings
-from db.models import LLMProvider, PromptTemplate, SecurityAuditEvent
+from db.models import Base, LLMProvider, PromptTemplate, SecurityAuditEvent
 from db.session import get_db
 from main import app
 
@@ -46,11 +53,7 @@ class MockSession:
         if entity is PromptTemplate:
             owner_id = params.get("created_by_1")
             return MockResult(
-                [
-                    prompt
-                    for prompt in self.prompts
-                    if prompt.created_by == owner_id or prompt.is_shared
-                ]
+                [prompt for prompt in self.prompts if prompt.created_by == owner_id]
             )
         if entity is LLMProvider:
             organization_id = params.get("organization_id_1")
@@ -162,7 +165,10 @@ def _audit_event() -> SecurityAuditEvent:
     )
 
 
-def _request_with_signed_session(db_session: MockSession):
+def _request_with_signed_session(
+    db_session: MockSession,
+    **payload_overrides: object,
+):
     previous_secret = settings.AUTH_SESSION_HMAC_SECRET
 
     async def scoped_db():
@@ -171,7 +177,7 @@ def _request_with_signed_session(db_session: MockSession):
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     app.dependency_overrides[get_db] = scoped_db
     try:
-        token = _signed_session_token(_valid_session_payload())
+        token = _signed_session_token(_valid_session_payload(**payload_overrides))
         with TestClient(app) as client:
             return client.get(
                 "/api/ai-hub/surface",
@@ -196,8 +202,9 @@ def test_ai_hub_surface_uses_signed_source_evidence():
 
     assert response.status_code == 200
     data = response.json()
-    assert data["summary_cards"][0]["value_text"] == "2"
+    assert data["summary_cards"][0]["value_text"] == "1"
     assert data["prompt_cards"][0]["prompt_title"] == "의사결정 로그 요약"
+    assert all(card["owner_label"] == "alice" for card in data["prompt_cards"])
     assert data["prompt_cards"][0]["prompt_key"].startswith("prompt_")
     assert "id" not in data["prompt_cards"][0]
     assert data["workflow_cards"][0]["state_code"] == "ready"
@@ -206,6 +213,20 @@ def test_ai_hub_surface_uses_signed_source_evidence():
     assert data["evaluation_metrics"][1]["score_value"] == 100
     assert data["run_events"][0]["evidence_source"] == "api.llm_providers"
     assert "credential material" not in response.text
+
+
+def test_ai_hub_surface_hides_provider_metadata_for_members():
+    session = MockSession()
+    session.prompts = [_prompt(1, "멤버 프롬프트")]
+    session.providers = [_provider(1)]
+
+    response = _request_with_signed_session(session, role="member")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["prompt_cards"][0]["prompt_title"] == "멤버 프롬프트"
+    assert data["agent_cards"] == []
+    assert data["summary_cards"][2]["value_text"] == "0/0"
 
 
 def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session():
@@ -230,3 +251,122 @@ def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session()
 
     assert response.status_code == 401
     assert response.json() == {"detail": "Authentication required"}
+
+
+@pytest.mark.postgres
+@pytest.mark.asyncio
+async def test_ai_hub_surface_postgres_smoke_uses_signed_scope():
+    user_id = f"ai_hub_user_{uuid.uuid4().hex[:12]}"
+    organization_id = f"ai_hub_org_{uuid.uuid4().hex[:12]}"
+    workspace_id = f"workspace_{organization_id}"
+    event_uid = f"audit_evt_ai_hub_{uuid.uuid4().hex[:18]}"
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    session_factory = None
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            prompt = PromptTemplate(
+                title="Postgres AI Hub prompt",
+                description="source-backed postgres smoke prompt",
+                content="Summarize {{email}}",
+                is_shared=False,
+                created_by=user_id,
+            )
+            provider = LLMProvider(
+                user_id=user_id,
+                organization_id=organization_id,
+                name="Postgres Provider",
+                provider_type="openai",
+                api_key=None,
+                is_active=True,
+            )
+            audit_event = SecurityAuditEvent(
+                event_uid=event_uid,
+                actor_user_id=user_id,
+                actor_role="tenant_admin",
+                organization_id=organization_id,
+                workspace_id=workspace_id,
+                event_action="update",
+                resource_type="llm_provider",
+                resource_uid="llm_provider:postgres",
+                evidence_source="api.llm_providers",
+                detail_text="Postgres provider evidence",
+                observed_at=_now(),
+            )
+            session.add_all([prompt, provider, audit_event])
+            await session.commit()
+    except (
+        ConnectionRefusedError,
+        OSError,
+        OperationalError,
+        asyncpg.CannotConnectNowError,
+        asyncpg.InvalidAuthorizationSpecificationError,
+        asyncpg.InvalidCatalogNameError,
+        asyncpg.InvalidPasswordError,
+    ) as exc:
+        await engine.dispose()
+        pytest.skip(f"PostgreSQL smoke path unavailable: {exc}")
+    except Exception:
+        await engine.dispose()
+        raise
+
+    assert session_factory is not None
+
+    async def override_real_db():
+        async with session_factory() as session:
+            yield session
+
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    original_overrides = dict(app.dependency_overrides)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(
+            sub=user_id,
+            org=organization_id,
+            workspace=workspace_id,
+        )
+    )
+    app.dependency_overrides[get_db] = override_real_db
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as client:
+            response = await client.get("/api/ai-hub/surface")
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DELETE FROM security_audit_events WHERE event_uid = :event_uid"),
+                {"event_uid": event_uid},
+            )
+            await conn.execute(
+                text(
+                    """
+                    DELETE FROM llm_providers
+                    WHERE user_id = :user_id AND organization_id = :organization_id
+                    """
+                ),
+                {"user_id": user_id, "organization_id": organization_id},
+            )
+            await conn.execute(
+                text("DELETE FROM prompt_templates WHERE created_by = :user_id"),
+                {"user_id": user_id},
+            )
+        await engine.dispose()
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["prompt_cards"][0]["prompt_title"] == "Postgres AI Hub prompt"
+    assert data["agent_cards"][0]["agent_title"] == "Postgres Provider"
+    assert data["agent_cards"][0]["configured"] is False
+    assert data["run_events"][0]["evidence_source"] == "api.llm_providers"

--- a/backend/tests/test_ai_hub_api.py
+++ b/backend/tests/test_ai_hub_api.py
@@ -1,0 +1,232 @@
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+import time
+
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from api.auth import SESSION_AUDIENCE, SESSION_ISSUER
+from core.config import settings
+from db.models import LLMProvider, PromptTemplate, SecurityAuditEvent
+from db.session import get_db
+from main import app
+
+TEST_SESSION_HMAC_SECRET = "ai-hub-surface-hmac-value-20260529-32"  # noqa: S105
+
+
+class MockScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class MockResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return MockScalars(self._rows)
+
+
+class MockSession:
+    def __init__(self):
+        self.prompts: list[PromptTemplate] = []
+        self.providers: list[LLMProvider] = []
+        self.audit_events: list[SecurityAuditEvent] = []
+
+    async def execute(self, stmt):
+        descriptions = getattr(stmt, "column_descriptions", [])
+        entity = descriptions[0].get("entity") if descriptions else None
+        params = stmt.compile().params
+        if entity is PromptTemplate:
+            owner_id = params.get("created_by_1")
+            return MockResult(
+                [
+                    prompt
+                    for prompt in self.prompts
+                    if prompt.created_by == owner_id or prompt.is_shared
+                ]
+            )
+        if entity is LLMProvider:
+            organization_id = params.get("organization_id_1")
+            return MockResult(
+                [
+                    provider
+                    for provider in self.providers
+                    if provider.organization_id == organization_id
+                ]
+            )
+        if entity is SecurityAuditEvent:
+            organization_id = params.get("organization_id_1")
+            workspace_id = params.get("workspace_id_1")
+            actor_user_id = params.get("actor_user_id_1")
+            rows = [
+                event
+                for event in self.audit_events
+                if event.organization_id == organization_id
+                and event.workspace_id == workspace_id
+                and event.resource_type == "llm_provider"
+            ]
+            if actor_user_id:
+                rows = [event for event in rows if event.actor_user_id == actor_user_id]
+            return MockResult(rows)
+        return MockResult([])
+
+
+def _base64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _signed_session_token(payload: dict[str, object]) -> str:
+    header_segment = _base64url_encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode()
+    )
+    payload_segment = _base64url_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature = hmac.new(
+        TEST_SESSION_HMAC_SECRET.encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _valid_session_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ver": 1,
+        "iss": SESSION_ISSUER,
+        "aud": SESSION_AUDIENCE,
+        "sub": "alice",
+        "role": "tenant_admin",
+        "org": "org-acme",
+        "groups": ["group-ai"],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime(2026, 5, 29, 9, 30, tzinfo=datetime.timezone.utc)
+
+
+def _prompt(prompt_id: int, title: str, owner_id: str = "alice") -> PromptTemplate:
+    prompt = PromptTemplate(
+        title=title,
+        description="메일에서 판단 포인트를 추출합니다.",
+        content="Summarize {{email}}",
+        is_shared=False,
+        created_by=owner_id,
+    )
+    prompt.id = prompt_id
+    prompt.created_at = _now()
+    prompt.updated_at = _now()
+    return prompt
+
+
+def _provider(provider_id: int, *, active: bool = True) -> LLMProvider:
+    provider = LLMProvider(
+        user_id="alice",
+        organization_id="org-acme",
+        name="Primary OpenAI",
+        provider_type="openai",
+        api_key="credential material",
+        is_active=active,
+    )
+    provider.id = provider_id
+    provider.updated_at = _now()
+    return provider
+
+
+def _audit_event() -> SecurityAuditEvent:
+    return SecurityAuditEvent(
+        event_uid="audit_evt_provider_update",
+        actor_user_id="alice",
+        actor_role="tenant_admin",
+        organization_id="org-acme",
+        workspace_id="workspace-org-acme",
+        event_action="update",
+        resource_type="llm_provider",
+        resource_uid="llm_provider:abc123",
+        evidence_source="api.llm_providers",
+        detail_text="Updated provider configuration",
+        observed_at=_now(),
+    )
+
+
+def _request_with_signed_session(db_session: MockSession):
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+
+    async def scoped_db():
+        yield db_session
+
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    app.dependency_overrides[get_db] = scoped_db
+    try:
+        token = _signed_session_token(_valid_session_payload())
+        with TestClient(app) as client:
+            return client.get(
+                "/api/ai-hub/surface",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        app.dependency_overrides.clear()
+
+
+def test_ai_hub_surface_uses_signed_source_evidence():
+    session = MockSession()
+    session.prompts = [
+        _prompt(1, "의사결정 로그 요약"),
+        _prompt(2, "공유 프롬프트", owner_id="other-user"),
+    ]
+    session.prompts[1].is_shared = True
+    session.providers = [_provider(1)]
+    session.audit_events = [_audit_event()]
+
+    response = _request_with_signed_session(session)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["summary_cards"][0]["value_text"] == "2"
+    assert data["prompt_cards"][0]["prompt_title"] == "의사결정 로그 요약"
+    assert data["prompt_cards"][0]["prompt_key"].startswith("prompt_")
+    assert "id" not in data["prompt_cards"][0]
+    assert data["workflow_cards"][0]["state_code"] == "ready"
+    assert data["agent_cards"][0]["configured"] is True
+    assert data["agent_cards"][0]["state_code"] == "active"
+    assert data["evaluation_metrics"][1]["score_value"] == 100
+    assert data["run_events"][0]["evidence_source"] == "api.llm_providers"
+    assert "credential material" not in response.text
+
+
+def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session():
+    session = MockSession()
+
+    async def scoped_db():
+        yield session
+
+    app.dependency_overrides[get_db] = scoped_db
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get(
+                "/api/ai-hub/surface",
+                headers={
+                    "X-User-Id": "alice",
+                    "X-User-Role": "tenant_admin",
+                    "X-Organization-Id": "org-acme",
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}

--- a/backend/tests/test_ai_hub_api.py
+++ b/backend/tests/test_ai_hub_api.py
@@ -85,9 +85,16 @@ def _base64url_encode(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
-def _signed_session_token(payload: dict[str, object]) -> str:
+def _signed_session_token(
+    payload: dict[str, object],
+    *,
+    header: dict[str, object] | None = None,
+) -> str:
     header_segment = _base64url_encode(
-        json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode()
+        json.dumps(
+            header or {"alg": "HS256", "typ": "JWT"},
+            separators=(",", ":"),
+        ).encode()
     )
     payload_segment = _base64url_encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
@@ -167,9 +174,11 @@ def _audit_event() -> SecurityAuditEvent:
 
 def _request_with_signed_session(
     db_session: MockSession,
+    header: dict[str, object] | None = None,
     **payload_overrides: object,
 ):
     previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    original_overrides = dict(app.dependency_overrides)
 
     async def scoped_db():
         yield db_session
@@ -177,7 +186,10 @@ def _request_with_signed_session(
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     app.dependency_overrides[get_db] = scoped_db
     try:
-        token = _signed_session_token(_valid_session_payload(**payload_overrides))
+        token = _signed_session_token(
+            _valid_session_payload(**payload_overrides),
+            header=header,
+        )
         with TestClient(app) as client:
             return client.get(
                 "/api/ai-hub/surface",
@@ -186,6 +198,7 @@ def _request_with_signed_session(
     finally:
         settings.AUTH_SESSION_HMAC_SECRET = previous_secret
         app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
 
 
 def test_ai_hub_surface_uses_signed_source_evidence():
@@ -231,6 +244,7 @@ def test_ai_hub_surface_hides_provider_metadata_for_members():
 
 def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session():
     session = MockSession()
+    original_overrides = dict(app.dependency_overrides)
 
     async def scoped_db():
         yield session
@@ -248,6 +262,24 @@ def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session()
             )
     finally:
         app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+def test_ai_hub_surface_rejects_unsupported_signed_session_crit_header():
+    session = MockSession()
+
+    response = _request_with_signed_session(
+        session,
+        header={
+            "alg": "HS256",
+            "typ": "JWT",
+            "crit": ["x-custom-policy"],
+            "x-custom-policy": "require-mfa",
+        },
+    )
 
     assert response.status_code == 401
     assert response.json() == {"detail": "Authentication required"}
@@ -256,11 +288,15 @@ def test_ai_hub_surface_rejects_public_identity_headers_without_signed_session()
 @pytest.mark.postgres
 @pytest.mark.asyncio
 async def test_ai_hub_surface_postgres_smoke_uses_signed_scope():
+    database_url = getattr(settings, "DATABASE_URL", None)
+    if not database_url:
+        pytest.skip("PostgreSQL smoke path unavailable: DATABASE_URL is not set")
+
     user_id = f"ai_hub_user_{uuid.uuid4().hex[:12]}"
     organization_id = f"ai_hub_org_{uuid.uuid4().hex[:12]}"
     workspace_id = f"workspace_{organization_id}"
     event_uid = f"audit_evt_ai_hub_{uuid.uuid4().hex[:18]}"
-    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    engine = create_async_engine(database_url, echo=False)
     session_factory = None
     try:
         async with engine.begin() as conn:

--- a/docs/plans/2026-05-29-ai-hub-source-backed-surface.md
+++ b/docs/plans/2026-05-29-ai-hub-source-backed-surface.md
@@ -16,8 +16,11 @@
 
 - Add signed `GET /api/ai-hub/surface`.
 - Build the surface from existing source-backed objects:
-  - `PromptTemplate` rows visible to the user or shared in the workspace;
-  - organization-scoped `LLMProvider` rows, exposing only non-secret metadata;
+  - `PromptTemplate` rows owned by the signed user. Global `is_shared` prompts
+    are intentionally excluded until prompt rows have durable tenant/workspace
+    scope;
+  - organization-scoped `LLMProvider` rows for admin roles only, exposing only
+    non-secret metadata;
   - durable `SecurityAuditEvent` rows for provider governance events.
 - Return opaque stable keys for prompt, workflow, agent, and event cards instead
   of exposing sequential database identifiers.
@@ -29,7 +32,9 @@
 ## Verification
 
 - Backend tests cover signed-session AI Hub reads, source evidence rendering,
-  secret redaction, opaque keys, and public identity header rejection.
+  secret redaction, opaque keys, member provider redaction, shared prompt leak
+  prevention, public identity header rejection, and PostgreSQL smoke behavior
+  when a local test database is available.
 - Frontend tests cover bearer fetch headers and all five operational AI Hub tabs.
 - Browser evidence must capture desktop, tablet/mobile scroll, and hamburger
   navigation after this route is included in the responsive E2E pass.
@@ -37,6 +42,8 @@
 ## Remaining roadmap
 
 - Add a durable workflow registry before allowing workflow edits in AI Hub.
+- Add tenant/workspace scope columns to prompt templates before returning shared
+  prompt rows from AI Hub.
 - Add a real evaluation result store before presenting model benchmark trends as
   historical evaluation data.
 - Connect run history to actual agent execution rows once workflow execution is

--- a/docs/plans/2026-05-29-ai-hub-source-backed-surface.md
+++ b/docs/plans/2026-05-29-ai-hub-source-backed-surface.md
@@ -1,0 +1,44 @@
+# 2026-05-29 AI Hub Source-Backed Surface
+
+## Verified gap
+
+- `frontend/branding/naruon-ux-mockup-8.png` defines AI Hub as five
+  operational surfaces: Prompt Studio, Workflow, AI Agent, Evaluation, and Run
+  History.
+- The current `AIHubLayout` rendered static prompt, workflow, provider, score,
+  and log examples. It did not call a signed backend API and could not prove
+  whether the UI was backed by real prompt/provider/audit evidence.
+- `docs/plans/2026-05-29-security-durable-audit-surface.md` already added
+  durable provider audit events, so AI Hub can now use those scoped events
+  instead of fake execution logs.
+
+## Implemented slice
+
+- Add signed `GET /api/ai-hub/surface`.
+- Build the surface from existing source-backed objects:
+  - `PromptTemplate` rows visible to the user or shared in the workspace;
+  - organization-scoped `LLMProvider` rows, exposing only non-secret metadata;
+  - durable `SecurityAuditEvent` rows for provider governance events.
+- Return opaque stable keys for prompt, workflow, agent, and event cards instead
+  of exposing sequential database identifiers.
+- Replace static AI Hub UI fixtures with API-wired tabs and empty/error/loading
+  states.
+- Preserve the stored `naruon_session_token` bearer path and keep public
+  identity headers out of frontend requests.
+
+## Verification
+
+- Backend tests cover signed-session AI Hub reads, source evidence rendering,
+  secret redaction, opaque keys, and public identity header rejection.
+- Frontend tests cover bearer fetch headers and all five operational AI Hub tabs.
+- Browser evidence must capture desktop, tablet/mobile scroll, and hamburger
+  navigation after this route is included in the responsive E2E pass.
+
+## Remaining roadmap
+
+- Add a durable workflow registry before allowing workflow edits in AI Hub.
+- Add a real evaluation result store before presenting model benchmark trends as
+  historical evaluation data.
+- Connect run history to actual agent execution rows once workflow execution is
+  persisted; until then the surface must label prompt/provider/audit evidence as
+  operational evidence, not completed agent runs.

--- a/frontend/src/app/ai-hub/page.test.tsx
+++ b/frontend/src/app/ai-hub/page.test.tsx
@@ -5,20 +5,82 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('lucide-react', () => ({
   Activity: () => <svg aria-hidden="true" />,
-  Cpu: () => <svg aria-hidden="true" />,
-  Zap: () => <svg aria-hidden="true" />,
-  Key: () => <svg aria-hidden="true" />,
-  FileCode2: () => <svg aria-hidden="true" />,
-  MessageSquare: () => <svg aria-hidden="true" />,
-  Sparkles: () => <svg aria-hidden="true" />,
   Bot: () => <svg aria-hidden="true" />,
-  Database: () => <svg aria-hidden="true" />,
-  Network: () => <svg aria-hidden="true" />,
+  CheckCircle2: () => <svg aria-hidden="true" />,
+  FileCode2: () => <svg aria-hidden="true" />,
+  GitBranch: () => <svg aria-hidden="true" />,
   RefreshCw: () => <svg aria-hidden="true" />,
-  ShieldAlert: () => <svg aria-hidden="true" />,
+  ShieldCheck: () => <svg aria-hidden="true" />,
+  Sparkles: () => <svg aria-hidden="true" />,
 }));
 
 import AIHubPage from './page';
+
+const aiHubSurface = {
+  summary_cards: [
+    {
+      summary_key: 'prompt_templates',
+      label_text: '프롬프트',
+      value_text: '2',
+      detail_text: 'source-backed templates',
+      state_code: 'ready',
+    },
+    {
+      summary_key: 'ai_providers',
+      label_text: 'AI 에이전트',
+      value_text: '1/1',
+      detail_text: 'active organization providers',
+      state_code: 'ready',
+    },
+  ],
+  prompt_cards: [
+    {
+      prompt_key: 'prompt_safe',
+      prompt_title: '의사결정 로그 요약',
+      description_text: '메일에서 판단 포인트를 추출합니다.',
+      shared_scope: false,
+      owner_label: 'alice',
+      updated_at: '2026-05-29T09:30:00Z',
+    },
+  ],
+  workflow_cards: [
+    {
+      workflow_key: 'workflow_prompt_safe',
+      workflow_title: '의사결정 로그 요약 실행 흐름',
+      trigger_source: 'prompt_template',
+      state_code: 'ready',
+      evidence_text: 'active organization provider is available',
+    },
+  ],
+  agent_cards: [
+    {
+      agent_key: 'agent_primary',
+      agent_title: 'Primary OpenAI',
+      model_label: 'openai',
+      state_code: 'active',
+      configured: true,
+      governance_text: 'organization llm provider registry',
+    },
+  ],
+  evaluation_metrics: [
+    {
+      metric_key: 'provider_readiness',
+      metric_label: 'Provider 준비도',
+      score_value: 100,
+      trend_text: '1/1 active providers',
+    },
+  ],
+  run_events: [
+    {
+      event_key: 'event_provider',
+      event_title: 'llm_provider update',
+      state_code: 'recorded',
+      evidence_source: 'api.llm_providers',
+      observed_at: '2026-05-29T09:30:00Z',
+      detail_text: 'Updated provider configuration',
+    },
+  ],
+};
 
 function jsonResponse(body: unknown, ok = true) {
   return {
@@ -36,6 +98,16 @@ async function flushAsyncWork() {
   });
 }
 
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((node) =>
+    node.textContent?.includes(label),
+  );
+  expect(button).not.toBeUndefined();
+  act(() => {
+    button?.click();
+  });
+}
+
 describe('AIHubPage', () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
@@ -47,13 +119,14 @@ describe('AIHubPage', () => {
     root = null;
     container?.remove();
     container = null;
+    localStorage.clear();
     vi.unstubAllGlobals();
   });
 
-  it('renders the three functional AI workspace sections from API data', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse([
-      { id: 1, title: 'Q2 출시 판단', description: '출시 일정과 파트너 리스크를 함께 검토합니다.' },
-    ])));
+  it('fetches the signed AI Hub surface and renders every operational tab', async () => {
+    localStorage.setItem('naruon_session_token', 'signed-session-token');
+    const fetchMock = vi.fn(async () => jsonResponse(aiHubSurface));
+    vi.stubGlobal('fetch', fetchMock);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -63,11 +136,44 @@ describe('AIHubPage', () => {
     });
     await flushAsyncWork();
 
-    expect(container.querySelector('h1')?.textContent).toContain('AI 허브');
-    expect(container.querySelector('h1')?.textContent).toContain('AI 허브');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/ai-hub/surface',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer signed-session-token',
+        }),
+      }),
+    );
+    const firstFetchCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.stringify(firstFetchCall[1]?.headers)).not.toContain('X-User-Id');
+    expect(container.textContent).toContain('AI 허브');
+    expect(container.textContent).toContain('의사결정 로그 요약');
+
+    clickButton(container, '워크플로우');
+    expect(container.textContent).toContain('의사결정 로그 요약 실행 흐름');
+
+    clickButton(container, 'AI 에이전트');
+    expect(container.textContent).toContain('Primary OpenAI');
+
+    clickButton(container, '평가');
+    expect(container.textContent).toContain('Provider 준비도');
+    expect(container.textContent).toContain('1/1 active providers');
+
+    clickButton(container, '실행 이력');
+    expect(container.textContent).toContain('api.llm_providers');
   });
 
-  it('renders an accessible loading state while the AI hub loads', async () => {
+  it('renders a loading state while the AI Hub surface is pending', async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      ),
+    );
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -76,20 +182,30 @@ describe('AIHubPage', () => {
       root?.render(<AIHubPage />);
     });
 
-    expect(container).not.toBeNull();
+    expect(container.textContent).toContain('AI Hub source evidence를 불러오는 중입니다.');
+
+    await act(async () => {
+      resolveFetch(jsonResponse(aiHubSurface));
+    });
+    await flushAsyncWork();
   });
 
-  it('renders an accessible error state with retry', async () => {
+  it('renders a retryable error state when the source surface fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ message: 'Internal Server Error' }, false)));
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root?.render(<AIHubPage />);
     });
     await flushAsyncWork();
 
-    expect(container).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'AI Hub source evidence를 불러오지 못했습니다.',
+    );
+    expect(container.textContent).toContain('다시 시도');
+    expect(consoleError).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/ai-hub/page.test.tsx
+++ b/frontend/src/app/ai-hub/page.test.tsx
@@ -16,6 +16,15 @@ vi.mock('lucide-react', () => ({
 
 import AIHubPage from './page';
 
+const forbiddenIdentityHeaders = [
+  'x-user-id',
+  'x-organization-id',
+  'x-group-id',
+  'x-group-ids',
+  'x-user-role',
+  'x-dev-auth-token',
+];
+
 const aiHubSurface = {
   summary_cards: [
     {
@@ -145,7 +154,15 @@ describe('AIHubPage', () => {
       }),
     );
     const firstFetchCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    expect(JSON.stringify(firstFetchCall[1]?.headers)).not.toContain('X-User-Id');
+    const sentHeaders = firstFetchCall[1]?.headers;
+    const headerNames =
+      sentHeaders && !Array.isArray(sentHeaders) && !(sentHeaders instanceof Headers)
+        ? Object.keys(sentHeaders)
+        : [];
+    const lowerHeaderNames = new Set(headerNames.map((name) => name.toLowerCase()));
+    for (const headerName of forbiddenIdentityHeaders) {
+      expect(lowerHeaderNames.has(headerName)).toBe(false);
+    }
     expect(container.textContent).toContain('AI 허브');
     expect(container.textContent).toContain('의사결정 로그 요약');
 

--- a/frontend/src/components/AIHubLayout.tsx
+++ b/frontend/src/components/AIHubLayout.tsx
@@ -1,253 +1,400 @@
 "use client";
 
-import { useState } from 'react';
-import { Sparkles, Zap, Activity, Cpu, Key, FileCode2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  Bot,
+  FileCode2,
+  GitBranch,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react';
 
-const EXECUTION_SECTIONS = [
-  {
-    id: 'context',
-    title: '맥락 종합',
-    status: '7개 근거 연결',
-    primary: '메일 thread-892, 회사 CalDAV 일정, WebDAV 산출물을 하나의 실행 후보로 묶었습니다.',
-    secondary: '중복 메일과 전달본은 원본 메시지 식별자 기준으로 thread에 귀속됩니다.',
-    action: '근거 열기',
-  },
-  {
-    id: 'decisions',
-    title: '판단 포인트',
-    status: '3건 검토 대기',
-    primary: '발신자 DAG와 프로젝트 의사결정 로그를 비교해 승인자, 위임자, 참조자를 분리합니다.',
-    secondary: '조직, 개인, SOHO 계정의 RBAC/ABAC 경계를 함께 평가합니다.',
-    action: '판단 기록',
-  },
-  {
-    id: 'actions',
-    title: '실행 항목',
-    status: '5개 워크플로우',
-    primary: '일정 후보, 티켓형 작업, 답장 추적을 원본 계정 writeback 대상과 함께 큐에 올립니다.',
-    secondary: 'Naruon 저장소만 남기는 항목은 만들지 않고 원본 CalDAV/WebDAV/메일 계정을 우선합니다.',
-    action: '큐 확인',
-  },
+import { apiClient } from '@/lib/api-client';
+
+type SurfaceStatus = 'loading' | 'ready' | 'error';
+type TabId = 'prompts' | 'workflows' | 'agents' | 'evaluation' | 'runs';
+
+type SummaryCard = {
+  summary_key: string;
+  label_text: string;
+  value_text: string;
+  detail_text: string;
+  state_code: string;
+};
+
+type PromptCard = {
+  prompt_key: string;
+  prompt_title: string;
+  description_text: string | null;
+  shared_scope: boolean;
+  owner_label: string;
+  updated_at: string | null;
+};
+
+type WorkflowCard = {
+  workflow_key: string;
+  workflow_title: string;
+  trigger_source: string;
+  state_code: string;
+  evidence_text: string;
+};
+
+type AgentCard = {
+  agent_key: string;
+  agent_title: string;
+  model_label: string;
+  state_code: string;
+  configured: boolean;
+  governance_text: string;
+};
+
+type EvaluationMetric = {
+  metric_key: string;
+  metric_label: string;
+  score_value: number;
+  trend_text: string;
+};
+
+type RunEvent = {
+  event_key: string;
+  event_title: string;
+  state_code: string;
+  evidence_source: string;
+  observed_at: string | null;
+  detail_text: string | null;
+};
+
+type AiHubSurfaceResponse = {
+  summary_cards: SummaryCard[];
+  prompt_cards: PromptCard[];
+  workflow_cards: WorkflowCard[];
+  agent_cards: AgentCard[];
+  evaluation_metrics: EvaluationMetric[];
+  run_events: RunEvent[];
+};
+
+const tabs = [
+  { id: 'prompts', label: '프롬프트 스튜디오', icon: FileCode2 },
+  { id: 'workflows', label: '워크플로우', icon: GitBranch },
+  { id: 'agents', label: 'AI 에이전트', icon: Bot },
+  { id: 'evaluation', label: '평가', icon: ShieldCheck },
+  { id: 'runs', label: '실행 이력', icon: Activity },
 ] as const;
 
+function getSafeErrorSummary(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return 'unknown error';
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) return '기록 없음';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '기록 없음';
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(parsed);
+}
+
+function stateLabel(stateCode: string) {
+  const labels: Record<string, string> = {
+    active: '활성',
+    attention: '점검',
+    configured: '구성됨',
+    empty: '없음',
+    needs_key: '키 필요',
+    needs_provider: 'Provider 필요',
+    ready: '준비됨',
+    recorded: '기록됨',
+  };
+  return labels[stateCode] ?? stateCode;
+}
+
+function stateClassName(stateCode: string) {
+  if (stateCode === 'active' || stateCode === 'ready' || stateCode === 'recorded') {
+    return 'border-green-200 bg-green-50 text-green-700';
+  }
+  if (stateCode === 'attention' || stateCode.startsWith('needs_')) {
+    return 'border-amber-200 bg-amber-50 text-amber-700';
+  }
+  return 'border-border bg-secondary text-muted-foreground';
+}
+
+function StatusBadge({ stateCode }: { stateCode: string }) {
+  return (
+    <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[11px] font-bold ${stateClassName(stateCode)}`}>
+      {stateLabel(stateCode)}
+    </span>
+  );
+}
+
+function EmptyState({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+      <p className="font-bold text-foreground">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function SummaryGrid({ cards }: { cards: SummaryCard[] }) {
+  return (
+    <section aria-label="AI Hub source-backed summary" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+      {cards.map((card) => (
+        <article key={card.summary_key} className="rounded-lg border border-border bg-card p-4 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <p className="text-sm font-bold text-muted-foreground">{card.label_text}</p>
+            <StatusBadge stateCode={card.state_code} />
+          </div>
+          <p className="mt-4 text-3xl font-black text-foreground">{card.value_text}</p>
+          <p className="mt-1 text-xs font-semibold text-muted-foreground">{card.detail_text}</p>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function PromptPanel({ prompts }: { prompts: PromptCard[] }) {
+  if (prompts.length === 0) {
+    return <EmptyState title="등록된 프롬프트가 없습니다." detail="프롬프트 스튜디오에서 저장된 템플릿이 생기면 이 화면에 연결됩니다." />;
+  }
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {prompts.map((prompt) => (
+        <article key={prompt.prompt_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="truncate text-base font-black">{prompt.prompt_title}</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{prompt.description_text ?? '설명 없음'}</p>
+            </div>
+            <StatusBadge stateCode={prompt.shared_scope ? 'ready' : 'configured'} />
+          </div>
+          <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="font-bold text-muted-foreground">소유자</dt>
+              <dd className="mt-1 font-semibold">{prompt.owner_label}</dd>
+            </div>
+            <div>
+              <dt className="font-bold text-muted-foreground">업데이트</dt>
+              <dd className="mt-1 font-semibold">{formatDateTime(prompt.updated_at)}</dd>
+            </div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function WorkflowPanel({ workflows }: { workflows: WorkflowCard[] }) {
+  if (workflows.length === 0) {
+    return <EmptyState title="실행 흐름으로 만들 프롬프트가 없습니다." detail="저장된 프롬프트와 활성 Provider가 연결되면 실행 후보가 생성됩니다." />;
+  }
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {workflows.map((workflow) => (
+        <article key={workflow.workflow_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-base font-black">{workflow.workflow_title}</h2>
+            <StatusBadge stateCode={workflow.state_code} />
+          </div>
+          <p className="mt-4 text-sm font-bold text-primary">{workflow.trigger_source}</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">{workflow.evidence_text}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function AgentsPanel({ agents }: { agents: AgentCard[] }) {
+  if (agents.length === 0) {
+    return <EmptyState title="조직 Provider가 없습니다." detail="설정의 LLM Provider registry가 구성되면 AI 에이전트 실행 후보로 표시됩니다." />;
+  }
+  return (
+    <div className="grid gap-4 lg:grid-cols-3">
+      {agents.map((agent) => (
+        <article key={agent.agent_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-base font-black">{agent.agent_title}</h2>
+            <StatusBadge stateCode={agent.state_code} />
+          </div>
+          <dl className="mt-5 space-y-3 text-sm">
+            <div className="flex items-center justify-between gap-3">
+              <dt className="font-bold text-muted-foreground">Provider</dt>
+              <dd className="font-semibold">{agent.model_label}</dd>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <dt className="font-bold text-muted-foreground">Credential</dt>
+              <dd className="font-semibold">{agent.configured ? 'configured' : 'missing'}</dd>
+            </div>
+          </dl>
+          <p className="mt-4 text-xs leading-5 text-muted-foreground">{agent.governance_text}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function EvaluationPanel({ metrics }: { metrics: EvaluationMetric[] }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {metrics.map((metric) => (
+        <article key={metric.metric_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-base font-black">{metric.metric_label}</h2>
+            <span className="text-2xl font-black text-primary">{metric.score_value}</span>
+          </div>
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-secondary">
+            <div className="h-full rounded-full bg-primary" style={{ width: `${Math.max(0, Math.min(metric.score_value, 100))}%` }} />
+          </div>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">{metric.trend_text}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function RunHistoryPanel({ events }: { events: RunEvent[] }) {
+  if (events.length === 0) {
+    return <EmptyState title="기록된 실행 증거가 없습니다." detail="프롬프트 변경 또는 Provider 감사 이벤트가 생기면 실행 이력으로 정렬됩니다." />;
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
+      <div className="grid grid-cols-[minmax(0,1fr)_9rem_8rem] gap-4 border-b border-border px-4 py-3 text-xs font-black text-muted-foreground max-md:hidden">
+        <span>이벤트</span>
+        <span>증거</span>
+        <span>시간</span>
+      </div>
+      <div className="divide-y divide-border">
+        {events.map((event) => (
+          <article key={event.event_key} className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(0,1fr)_9rem_8rem] md:items-center">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-black">{event.event_title}</h2>
+                <StatusBadge stateCode={event.state_code} />
+              </div>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">{event.detail_text ?? '상세 증거 없음'}</p>
+            </div>
+            <p className="text-sm font-semibold text-primary">{event.evidence_source}</p>
+            <p className="text-sm font-semibold text-muted-foreground">{formatDateTime(event.observed_at)}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function AIHubLayout() {
-  const [activeTab, setActiveTab] = useState<'프롬프트 스튜디오' | '워크플로우' | 'AI 에이전트' | '평가' | '실행 이력'>('워크플로우');
+  const [activeTab, setActiveTab] = useState<TabId>('prompts');
+  const [surfaceStatus, setSurfaceStatus] = useState<SurfaceStatus>('loading');
+  const [surface, setSurface] = useState<AiHubSurfaceResponse | null>(null);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const requestRefresh = () => {
+    setSurfaceStatus('loading');
+    setErrorText(null);
+    setRefreshNonce((value) => value + 1);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient
+      .get<AiHubSurfaceResponse>('/api/ai-hub/surface')
+      .then((data) => {
+        if (cancelled) return;
+        setSurface(data);
+        setSurfaceStatus('ready');
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        console.error('AI Hub surface fetch error', getSafeErrorSummary(error));
+        setSurface(null);
+        setErrorText('AI Hub source evidence를 불러오지 못했습니다.');
+        setSurfaceStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshNonce]);
+
+  const activeTabLabel = useMemo(
+    () => tabs.find((tab) => tab.id === activeTab)?.label ?? 'AI 허브',
+    [activeTab],
+  );
 
   return (
-    <div className="flex h-full min-h-0 bg-background text-foreground flex-col">
-      <header className="flex h-20 shrink-0 items-center border-b border-border bg-card px-8">
-        <h1 className="text-2xl font-bold flex items-center gap-3">
-          <Sparkles className="size-6 text-primary" /> AI 허브
-        </h1>
-        <div className="ml-8 flex gap-2 overflow-x-auto no-scrollbar">
-          {['프롬프트 스튜디오', '워크플로우', 'AI 에이전트', '평가', '실행 이력'].map((tab) => (
+    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      <header className="shrink-0 border-b border-border bg-card px-4 py-4 md:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="flex items-center gap-3 text-xl font-black md:text-2xl">
+            <Sparkles className="size-6 text-primary" aria-hidden="true" />
+            AI 허브
+          </h1>
+          <button
+            type="button"
+            onClick={requestRefresh}
+            className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-bold hover:bg-secondary"
+          >
+            <RefreshCw className="size-4" aria-hidden="true" />
+            새로고침
+          </button>
+        </div>
+        <nav aria-label="AI 허브 섹션" className="mt-4 flex gap-2 overflow-x-auto pb-1">
+          {tabs.map((tab) => (
             <button
-              key={tab}
-              onClick={() => setActiveTab(tab as '프롬프트 스튜디오' | '워크플로우' | 'AI 에이전트' | '평가' | '실행 이력')}
-              className={`whitespace-nowrap px-4 py-2 text-sm font-bold rounded-lg transition-colors ${activeTab === tab ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`inline-flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-bold transition-colors ${
+                activeTab === tab.id
+                  ? 'bg-primary text-primary-foreground'
+                  : 'border border-border bg-background text-muted-foreground hover:bg-secondary'
+              }`}
             >
-              {tab}
+              <tab.icon className="size-4" aria-hidden="true" />
+              {tab.label}
             </button>
           ))}
-        </div>
+        </nav>
       </header>
 
-      <main className="flex-1 overflow-y-auto p-8">
-        <div className="max-w-5xl mx-auto space-y-8">
-          <nav aria-label="AI hub execution checkpoints" className="flex scroll-smooth gap-2 overflow-x-auto pb-1">
-            {EXECUTION_SECTIONS.map((section) => (
-              <a
-                key={section.id}
-                href={`#${section.id}`}
-                className="shrink-0 rounded-lg border border-border bg-card px-3 py-2 text-sm font-bold text-foreground hover:border-primary hover:text-primary"
-              >
-                {section.title}
-              </a>
-            ))}
-          </nav>
+      <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-background p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-8">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+          {surfaceStatus === 'loading' && (
+            <div role="status" className="rounded-lg border border-border bg-card p-6 font-bold text-primary">
+              AI Hub source evidence를 불러오는 중입니다.
+            </div>
+          )}
 
-          <div className="grid gap-4 lg:grid-cols-3">
-            {EXECUTION_SECTIONS.map((section) => (
-              <section
-                id={section.id}
-                key={section.id}
-                aria-label={section.title}
-                className="scroll-mt-24 rounded-2xl border border-border bg-card p-5 shadow-sm"
+          {surfaceStatus === 'error' && (
+            <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-700">
+              <p className="font-black">{errorText}</p>
+              <button
+                type="button"
+                onClick={requestRefresh}
+                className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white"
               >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h2 className="text-lg font-bold">{section.title}</h2>
-                    <p className="mt-1 text-xs font-bold text-primary">{section.status}</p>
-                  </div>
-                  <button type="button" className="shrink-0 rounded-lg border border-border bg-background px-3 py-1.5 text-xs font-bold hover:bg-secondary">
-                    {section.action}
-                  </button>
-                </div>
-                <p className="mt-4 text-sm leading-6 text-foreground">{section.primary}</p>
-                <p className="mt-3 text-xs leading-5 text-muted-foreground">{section.secondary}</p>
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {surfaceStatus === 'ready' && surface && (
+            <>
+              <SummaryGrid cards={surface.summary_cards} />
+              <section aria-label={activeTabLabel} className="min-h-[24rem]">
+                {activeTab === 'prompts' && <PromptPanel prompts={surface.prompt_cards} />}
+                {activeTab === 'workflows' && <WorkflowPanel workflows={surface.workflow_cards} />}
+                {activeTab === 'agents' && <AgentsPanel agents={surface.agent_cards} />}
+                {activeTab === 'evaluation' && <EvaluationPanel metrics={surface.evaluation_metrics} />}
+                {activeTab === 'runs' && <RunHistoryPanel events={surface.run_events} />}
               </section>
-            ))}
-          </div>
-          
-          {activeTab === '평가' && (
-            <div className="space-y-6">
-              {/* Token Usage Stats */}
-              <div className="grid grid-cols-4 gap-6">
-                {[
-                  { label: '이번 달 호출 수', value: '4,208', icon: Activity, color: 'text-blue-500' },
-                  { label: '사용된 토큰', value: '1.2M', icon: Cpu, color: 'text-purple-500' },
-                  { label: '평균 응답 시간', value: '1.4s', icon: Zap, color: 'text-orange-500' },
-                  { label: '토큰당 비용', value: '$0.002', icon: Key, color: 'text-green-500' },
-                ].map((stat, i) => (
-                  <div key={i} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-                    <stat.icon className={`size-5 ${stat.color} mb-3`} />
-                    <p className="text-sm font-bold text-muted-foreground">{stat.label}</p>
-                    <p className="text-2xl font-black mt-1">{stat.value}</p>
-                  </div>
-                ))}
-              </div>
-
-              {/* Usage Graph Mock */}
-              <div className="rounded-2xl border border-border bg-card shadow-sm p-6">
-                <h2 className="font-bold text-lg mb-6">모델별 평가 지표 (LLM Evaluation)</h2>
-                <div className="h-64 flex items-end gap-4 justify-between border-b border-border pb-2 px-4 relative">
-                  {/* Grid Lines */}
-                  <div className="absolute inset-x-0 bottom-1/4 border-b border-dashed border-border z-0"></div>
-                  <div className="absolute inset-x-0 bottom-2/4 border-b border-dashed border-border z-0"></div>
-                  <div className="absolute inset-x-0 bottom-3/4 border-b border-dashed border-border z-0"></div>
-                  
-                  {[60, 80, 40, 90, 50, 70, 30].map((h, i) => (
-                    <div key={i} className="w-full relative z-10 group flex flex-col justify-end items-center h-full">
-                      <div className="w-12 bg-primary/20 rounded-t-sm hover:bg-primary/40 transition-colors" style={{ height: `${h}%` }}>
-                        <div className="w-full bg-primary rounded-t-sm" style={{ height: `${h * 0.4}%` }}></div>
-                      </div>
-                      <span className="text-xs text-muted-foreground mt-2 font-semibold">5/{18 + i}</span>
-                    </div>
-                  ))}
-                </div>
-                <div className="flex gap-4 justify-center mt-4">
-                  <div className="flex items-center gap-2"><div className="size-3 rounded-sm bg-primary"></div><span className="text-xs font-semibold">GPT-4o 정확도</span></div>
-                  <div className="flex items-center gap-2"><div className="size-3 rounded-sm bg-primary/20"></div><span className="text-xs font-semibold">Claude 3.5 정확도</span></div>
-                </div>
-              </div>
-            </div>
+            </>
           )}
-
-          {activeTab === '프롬프트 스튜디오' && (
-            <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-border bg-secondary/30 flex justify-between items-center">
-                <h2 className="font-bold text-lg">시스템 프롬프트 관리</h2>
-                <button className="bg-primary text-primary-foreground text-sm font-bold px-4 py-2 rounded-lg">새 프롬프트</button>
-              </div>
-              <div className="divide-y divide-border">
-                {[
-                  { name: '일정 추출 시스템', id: 'prompt-calendar-v2', desc: '이메일 본문에서 회의 시간, 장소, 참석자를 파싱합니다.', active: true },
-                  { name: '의사결정 로그 요약', id: 'prompt-decision-v1', desc: '스레드 내에서 최종 승인자와 결정 사항을 요약합니다.', active: true },
-                  { name: '자동 답장 초안 (톤앤매너)', id: 'prompt-reply-v4', desc: '이전 발신 메일을 바탕으로 어조를 맞춰 답장을 작성합니다.', active: false },
-                ].map((prompt) => (
-                  <div key={prompt.id} className="p-5 flex items-start justify-between">
-                    <div className="flex gap-4">
-                      <div className="p-3 bg-secondary rounded-xl h-fit"><FileCode2 className="size-5 text-primary" /></div>
-                      <div>
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-bold text-base">{prompt.name}</h3>
-                          {prompt.active ? 
-                            <span className="bg-green-100 text-green-700 text-[10px] px-2 py-0.5 rounded font-bold">Active</span> :
-                            <span className="bg-slate-100 text-slate-700 text-[10px] px-2 py-0.5 rounded font-bold">Draft</span>
-                          }
-                        </div>
-                        <p className="text-sm text-muted-foreground">{prompt.desc}</p>
-                        <p className="text-xs text-muted-foreground mt-2 font-mono">{prompt.id}</p>
-                      </div>
-                    </div>
-                    <button className="text-sm font-semibold text-primary hover:underline">편집</button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {activeTab === '워크플로우' && (
-            <div className="rounded-2xl border border-border bg-card shadow-sm p-6 h-[600px] flex flex-col">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="font-bold text-lg">DAG 노드 캔버스 (Agent Workflow)</h2>
-                <button className="text-sm border border-border bg-background px-4 py-2 rounded-lg font-semibold hover:bg-secondary">새 노드 추가</button>
-              </div>
-              <div className="flex-1 border border-border rounded-xl bg-secondary/10 relative overflow-hidden flex items-center justify-center">
-                <svg className="absolute inset-0 w-full h-full pointer-events-none z-0">
-                  <path d="M 150 200 C 300 200, 300 100, 450 100" stroke="var(--naruon-border)" strokeWidth="3" fill="none" />
-                  <path d="M 150 200 C 300 200, 300 300, 450 300" stroke="var(--naruon-border)" strokeWidth="3" fill="none" />
-                </svg>
-                <div className="absolute left-[50px] top-[160px] w-48 rounded-lg bg-card border-2 border-primary p-3 shadow-md z-10">
-                  <p className="text-xs font-bold text-primary mb-1">Trigger</p>
-                  <p className="text-sm font-semibold">새 이메일 수신</p>
-                </div>
-                <div className="absolute left-[450px] top-[60px] w-48 rounded-lg bg-card border-2 border-border p-3 shadow-sm z-10">
-                  <p className="text-xs font-bold text-muted-foreground mb-1">Action</p>
-                  <p className="text-sm font-semibold">일정 추출 (LLM)</p>
-                </div>
-                <div className="absolute left-[450px] top-[260px] w-48 rounded-lg bg-card border-2 border-border p-3 shadow-sm z-10">
-                  <p className="text-xs font-bold text-muted-foreground mb-1">Action</p>
-                  <p className="text-sm font-semibold">지식 그래프 저장</p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {activeTab === 'AI 에이전트' && (
-            <div className="space-y-6">
-              <div className="flex justify-between items-center">
-                <h2 className="text-lg font-bold">등록된 에이전트</h2>
-                <button className="bg-primary text-primary-foreground px-4 py-2 rounded-lg text-sm font-bold">새 에이전트 등록</button>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                {[
-                  { name: '일정 조율 에이전트', model: 'GPT-4o', status: '활성' },
-                  { name: '의사결정 추출 에이전트', model: 'Claude 3.5 Sonnet', status: '활성' },
-                  { name: '티켓 분류 에이전트', model: 'Gemini 1.5 Pro', status: '대기 중' },
-                ].map((agent, i) => (
-                  <div key={i} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-                    <div className="flex justify-between items-start mb-3">
-                      <h3 className="font-bold">{agent.name}</h3>
-                      <span className={`px-2 py-0.5 rounded text-xs font-bold ${agent.status === '활성' ? 'bg-green-100 text-green-700' : 'bg-slate-100 text-slate-700'}`}>{agent.status}</span>
-                    </div>
-                    <p className="text-sm text-muted-foreground mb-4">사용 모델: <span className="font-semibold text-foreground">{agent.model}</span></p>
-                    <div className="flex gap-2">
-                      <button className="flex-1 border border-border rounded-lg py-1.5 text-xs font-bold hover:bg-secondary">설정</button>
-                      <button className="flex-1 border border-border rounded-lg py-1.5 text-xs font-bold hover:bg-secondary">테스트</button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {activeTab === '실행 이력' && (
-            <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-border bg-secondary/30 flex justify-between items-center">
-                <h2 className="font-bold text-lg">최근 실행 로그</h2>
-              </div>
-              <div className="divide-y divide-border">
-                {[
-                  { id: 'LOG-001', agent: '일정 조율 에이전트', trigger: '새 이메일', time: '5분 전', status: '성공' },
-                  { id: 'LOG-002', agent: '의사결정 추출 에이전트', trigger: '스레드 업데이트', time: '12분 전', status: '성공' },
-                  { id: 'LOG-003', agent: '티켓 분류 에이전트', trigger: '수동 실행', time: '1시간 전', status: '실패' },
-                ].map((log, i) => (
-                  <div key={i} className="p-4 flex items-center justify-between hover:bg-secondary/10">
-                    <div>
-                      <p className="font-bold text-sm">{log.agent} <span className="text-xs text-muted-foreground ml-2">{log.id}</span></p>
-                      <p className="text-xs text-muted-foreground mt-1">트리거: {log.trigger}</p>
-                    </div>
-                    <div className="text-right">
-                      <span className={`text-xs font-bold px-2 py-1 rounded-full ${log.status === '성공' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'}`}>{log.status}</span>
-                      <p className="text-xs text-muted-foreground mt-1">{log.time}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
         </div>
       </main>
     </div>

--- a/frontend/tests/e2e/ai-hub-source-surface.spec.ts
+++ b/frontend/tests/e2e/ai-hub-source-surface.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+import { mockDashboardApi } from './helpers';
+
+const publicIdentityHeaders = [
+  'x-user-id',
+  'x-organization-id',
+  'x-group-id',
+  'x-group-ids',
+  'x-user-role',
+  'x-dev-auth-token',
+];
+
+const viewports = [
+  { name: 'desktop', width: 1280, height: 720 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 390, height: 844 },
+] as const;
+
+for (const viewport of viewports) {
+  test(`renders source-backed AI Hub with scroll at ${viewport.name}`, async ({ page }, testInfo) => {
+    const sessionToken = `signed-ai-hub-${viewport.name}`;
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockDashboardApi(page);
+    await page.addInitScript((token) => {
+      window.localStorage.setItem('naruon_session_token', token);
+    }, sessionToken);
+
+    const surfaceRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname === '/api/ai-hub/surface' && request.method() === 'GET';
+    });
+
+    await page.goto('/ai-hub');
+    const headers = (await surfaceRequest).headers();
+    expect(headers.authorization).toBe(`Bearer ${sessionToken}`);
+    for (const headerName of publicIdentityHeaders) {
+      expect(headers[headerName]).toBeUndefined();
+    }
+
+    await expect(page.getByRole('heading', { name: 'AI 허브' })).toBeVisible();
+    await expect(page.getByText('의사결정 로그 요약')).toBeVisible();
+    await page.getByRole('button', { name: /워크플로우/ }).click();
+    await expect(page.getByText('의사결정 로그 요약 실행 흐름')).toBeVisible();
+    await page.getByRole('button', { name: /AI 에이전트/ }).click();
+    await expect(page.getByText('Primary OpenAI')).toBeVisible();
+    await page.getByRole('button', { name: /평가/ }).click();
+    await expect(page.getByText('Provider 준비도')).toBeVisible();
+    await page.getByRole('button', { name: /실행 이력/ }).click();
+    await expect(page.getByText('api.llm_providers')).toBeVisible();
+
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(horizontalOverflow).toBeLessThanOrEqual(1);
+
+    const aiHubScroller = page.locator('main').last();
+    const scrollMetrics = await aiHubScroller.evaluate((node) => {
+      const element = node as HTMLElement;
+      element.scrollTop = 0;
+      const before = element.scrollTop;
+      element.scrollTop = element.scrollHeight;
+      return {
+        before,
+        after: element.scrollTop,
+        maxScroll: element.scrollHeight - element.clientHeight,
+      };
+    });
+    expect(scrollMetrics.maxScroll).toBeGreaterThan(0);
+    expect(scrollMetrics.after).toBeGreaterThan(scrollMetrics.before);
+
+    await page.screenshot({ path: testInfo.outputPath(`ai-hub-${viewport.name}-scrolled.png`), fullPage: false });
+
+    if (viewport.name === 'mobile') {
+      await page.getByRole('button', { name: '워크스페이스 메뉴 열기' }).click();
+      const mobileMenu = page.locator('#mobile-workspace-menu');
+      await expect(mobileMenu).toBeVisible();
+      await expect(mobileMenu.getByRole('link', { name: /AI 허브/ })).toBeVisible();
+      await page.screenshot({ path: testInfo.outputPath('ai-hub-mobile-hamburger.png'), fullPage: false });
+    }
+  });
+}

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -132,10 +132,107 @@ const calendarCandidate = {
 };
 
 const aiHubPrompts = [
-  { id: 101, title: 'Q2 출시 판단', description: '출시 일정과 파트너 리스크를 함께 검토합니다.' },
+  { id: 101, title: '의사결정 로그 요약', description: '출시 일정과 파트너 리스크를 함께 검토합니다.' },
   { id: 102, title: '계약 리스크 점검', description: '계약서, 첨부, 메일 스레드를 판단 포인트로 정리합니다.' },
   { id: 103, title: '후속 실행 항목', description: '답장, 일정, 할 일을 담당자별 실행 흐름으로 나눕니다.' },
 ];
+
+const aiHubSurface = {
+  summary_cards: [
+    {
+      summary_key: 'prompt_templates',
+      label_text: '프롬프트',
+      value_text: '3',
+      detail_text: 'source-backed templates',
+      state_code: 'ready',
+    },
+    {
+      summary_key: 'workflow_blueprints',
+      label_text: '워크플로우',
+      value_text: '3',
+      detail_text: 'prompt-derived execution flows',
+      state_code: 'ready',
+    },
+    {
+      summary_key: 'ai_providers',
+      label_text: 'AI 에이전트',
+      value_text: '1/1',
+      detail_text: 'active organization providers',
+      state_code: 'ready',
+    },
+    {
+      summary_key: 'evaluation_readiness',
+      label_text: '평가',
+      value_text: '85%',
+      detail_text: 'derived operational readiness',
+      state_code: 'ready',
+    },
+    {
+      summary_key: 'run_events',
+      label_text: '실행 이력',
+      value_text: '2',
+      detail_text: 'scoped source evidence',
+      state_code: 'ready',
+    },
+  ],
+  prompt_cards: aiHubPrompts.map((prompt) => ({
+    prompt_key: `prompt_${prompt.id}`,
+    prompt_title: prompt.title,
+    description_text: prompt.description,
+    shared_scope: prompt.id === 102,
+    owner_label: prompt.id === 102 ? 'shared-template' : 'admin',
+    updated_at: '2026-05-29T09:30:00Z',
+  })),
+  workflow_cards: aiHubPrompts.map((prompt) => ({
+    workflow_key: `workflow_${prompt.id}`,
+    workflow_title: `${prompt.title} 실행 흐름`,
+    trigger_source: 'prompt_template',
+    state_code: 'ready',
+    evidence_text: 'active organization provider is available',
+  })),
+  agent_cards: [
+    {
+      agent_key: 'agent_primary',
+      agent_title: 'Primary OpenAI',
+      model_label: 'openai',
+      state_code: 'active',
+      configured: true,
+      governance_text: 'organization llm provider registry',
+    },
+  ],
+  evaluation_metrics: [
+    {
+      metric_key: 'provider_readiness',
+      metric_label: 'Provider 준비도',
+      score_value: 100,
+      trend_text: '1/1 active providers',
+    },
+    {
+      metric_key: 'execution_readiness',
+      metric_label: '실행 준비도',
+      score_value: 85,
+      trend_text: 'derived from provider, prompt, and audit evidence',
+    },
+  ],
+  run_events: [
+    {
+      event_key: 'event_provider_update',
+      event_title: 'llm_provider update',
+      state_code: 'recorded',
+      evidence_source: 'api.llm_providers',
+      observed_at: '2026-05-29T09:30:00Z',
+      detail_text: 'Updated provider configuration',
+    },
+    {
+      event_key: 'event_prompt_update',
+      event_title: 'prompt template updated: Q2 출시 판단',
+      state_code: 'recorded',
+      evidence_source: 'prompt_templates',
+      observed_at: '2026-05-29T09:31:00Z',
+      detail_text: '출시 일정과 파트너 리스크를 함께 검토합니다.',
+    },
+  ],
+};
 
 const runnerConfig = {
   workspace_id: 'workspace-org-acme',
@@ -599,6 +696,11 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
 
     if (path === '/api/prompts' && request.method() === 'GET') {
       await fulfillJson(route, aiHubPrompts);
+      return;
+    }
+
+    if (path === '/api/ai-hub/surface' && request.method() === 'GET') {
+      await fulfillJson(route, aiHubSurface);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add signed `GET /api/ai-hub/surface` backed by prompt templates, organization LLM provider metadata, and durable provider audit events.
- Replace static AI Hub fixture cards with API-wired Prompt Studio, Workflow, AI Agent, Evaluation, and Run History tabs.
- Add backend, frontend, and Playwright coverage for signed bearer headers, no public identity headers, responsive scroll, and mobile hamburger sanity.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q` from `backend/` → 510 passed, 13 skipped
- `PYTHONDONTWRITEBYTECODE=1 python3 -m bandit -r backend/ -x backend/tests/ -q` → passed
- `npm run lint` → passed
- `npm run typecheck` → passed
- `npm test` → 103 passed
- `env -u FORCE_COLOR -u NO_COLOR PLAYWRIGHT_PORT=18130 npm run test:e2e -- --project=desktop tests/e2e/ai-hub-source-surface.spec.ts tests/e2e/mobile-hamburger.spec.ts` → 4 passed
- `git diff --check` → passed

## Browser screenshots inspected
- `frontend/test-results/ai-hub-source-surface-rend-39496--Hub-with-scroll-at-desktop-desktop/ai-hub-desktop-scrolled.png`
- `frontend/test-results/ai-hub-source-surface-rend-32190-I-Hub-with-scroll-at-tablet-desktop/ai-hub-tablet-scrolled.png`
- `frontend/test-results/ai-hub-source-surface-rend-73ede-I-Hub-with-scroll-at-mobile-desktop/ai-hub-mobile-scrolled.png`
- `frontend/test-results/ai-hub-source-surface-rend-73ede-I-Hub-with-scroll-at-mobile-desktop/ai-hub-mobile-hamburger.png`
- `frontend/test-results/mobile-hamburger-Mobile-Wo-024c1-gles-and-displays-correctly-desktop/mobile-hamburger-open-scrolled.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Hub now renders a source-backed surface from a signed backend API, showing real prompts, workflows, agents, evaluation metrics, and run history with opaque stable card keys; manual refresh, loading, error/retry states included.
  * Role-based visibility: provider/agent metadata redacted for non-admins; secrets not exposed.

* **Tests**
  * Expanded backend/unit/integration and Postgres smoke tests for signed evidence, auth rules, redaction, and rejection of unsupported session headers.
  * Added Playwright e2e coverage across viewports.

* **Documentation**
  * Added spec/plan for the source-backed AI Hub surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->