### PR TITLE
Quarantine unstable Strix preview model

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_MODEL: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number == '')) && 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM == 'vertex_ai/gemini-3.1-pro-preview-customtools' && 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
           STRIX_VERTEX_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
         run: |
@@ -117,7 +117,7 @@ jobs:
                 exit 1
               fi
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+            vertex_ai/gemini-2.5-flash)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               echo 'provider_mode=vertex_ai' >> "$GITHUB_OUTPUT"
               sanitized_vertex_credentials="$(printf '%s' "$STRIX_VERTEX_CREDENTIALS" | tr -d '\r')"
@@ -203,7 +203,7 @@ jobs:
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_MODEL: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number == '')) && 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools' }}
+          STRIX_MODEL: ${{ secrets.STRIX_LLM == 'vertex_ai/gemini-3.1-pro-preview-customtools' && 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
@@ -215,7 +215,7 @@ jobs:
             gpt-*)
               printf 'openai/%s' "$strix_model" > "$strix_llm_file"
               ;;
-            vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+            vertex_ai/gemini-2.5-flash)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
             *)
@@ -249,7 +249,6 @@ jobs:
           STRIX_MEMORY_COMPRESSOR_TIMEOUT: 10
           STRIX_TRANSIENT_RETRY_PER_MODEL: 2
           STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
-          PYTHONWARNINGS: "ignore:Pydantic serializer warnings:UserWarning:pydantic.main"
           STRIX_PROCESS_TIMEOUT_SECONDS: ${{ (github.event_name == 'pull_request_target' || github.event.inputs.pr_number != '') && '1200' || '2400' }}
           STRIX_TOTAL_TIMEOUT_SECONDS: 4800
           STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,16 +16,17 @@
 - Strix Security Scan must not route through GitHub Models, `github.token`,
   generic `LLM_API_KEY`, GPT-4o, or GPT-4.1. The current organization-secret
   route is `STRIX_LLM` with `GCP_SA_KEY`;
-  `vertex_ai/gemini-3.1-pro-preview-customtools` is the configured PR-scoped
-  model after organization-secret visibility correction. Protected-branch full
-  scans must use `vertex_ai/gemini-2.5-flash` until 3.1 full-scan evidence
-  completes without timeout. Expose Google/Vertex credentials only for Vertex
-  provider mode. Direct OpenAI
+  `vertex_ai/gemini-3.1-pro-preview-customtools` must be quarantined to
+  `vertex_ai/gemini-2.5-flash` until it has no-timeout PR-scoped and
+  protected-branch full-scan evidence. Expose Google/Vertex credentials only for
+  Vertex provider mode. Direct OpenAI
   GPT-5.4-or-newer scans remain supported only when selected explicitly with
   `STRIX_OPENAI_API_KEY`. Do not silently fall back between providers, and
   record provider evidence in the PR. Known third-party Strix/Pydantic
-  serializer warnings must be filtered narrowly through the workflow/gate env
-  contract so Warn-class logs are not accepted as clean evidence. Keep
+  serializer warnings must be filtered narrowly inside the Strix gate child
+  process, not as a visible workflow env entry, so Warn-class logs are not
+  accepted as clean evidence and warning-filter variable names do not pollute
+  GitHub logs. Keep
   architecture docs and reusable Strix gate tests aligned with this rule so
   stale GitHub Models, OpenAI-only, unavailable-model, blanket-warning, or
   generic-key examples cannot re-enter copied workflow guidance.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ mail/calendar/file systems.
 - PR automation is metadata-only and uses current-head robot-review evidence plus
   required checks. Human approval is not awaited by default under repo policy.
 - Strix PR/security evidence uses the organization-secret provider selected by
-  `STRIX_LLM` with `GCP_SA_KEY` for PR-scoped scans. The configured PR route is
-  `vertex_ai/gemini-3.1-pro-preview-customtools`; protected-branch full scans
-  use `vertex_ai/gemini-2.5-flash` until the 3.1 full-scan route has
-  no-timeout evidence. Direct OpenAI GPT-5.4-or-newer remains
+  `STRIX_LLM` with `GCP_SA_KEY`, but the
+  `vertex_ai/gemini-3.1-pro-preview-customtools` value is quarantined to
+  `vertex_ai/gemini-2.5-flash` until it has no-timeout PR and full-scan
+  evidence. Direct OpenAI GPT-5.4-or-newer remains
   supported only with an explicit `STRIX_OPENAI_API_KEY`. The workflow fails
   closed rather than falling back to GitHub Models, `github.token`, generic
   `LLM_API_KEY`, or GPT-4-era models. Known third-party Strix/Pydantic

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -196,25 +196,24 @@ def test_strix_workflow_uses_configured_vertex_model_and_narrow_warning_filter()
     assert "models: read" not in workflow
     assert "provider_mode=github_models" not in workflow
     assert "vertex_ai/gemini-3.1-pro-preview-customtools" in workflow
-    assert "github.event_name == 'push' || github.event_name == 'schedule'" in workflow
-    assert "github.event.inputs.pr_number == ''" in workflow
     assert (
-        "&& 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || "
-        "'vertex_ai/gemini-3.1-pro-preview-customtools'"
+        "secrets.STRIX_LLM == 'vertex_ai/gemini-3.1-pro-preview-customtools' "
+        "&& 'vertex_ai/gemini-2.5-flash'"
         in workflow
     )
+    assert "|| secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash'" in workflow
     assert (
-        "vertex_ai/gemini-3.1-pro-preview-customtools | "
-        "vertex_ai/gemini-2.5-flash"
-        in workflow
+        "vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash"
+        not in workflow
     )
     assert "vertex_ai/* | vertex_ai_beta/*" not in workflow
+    assert "PYTHONWARNINGS:" not in workflow
     assert (
-        'PYTHONWARNINGS: "ignore:Pydantic serializer warnings:UserWarning:pydantic.main"'
-        in workflow
+        'child_env["PYTHONWARNINGS"] = '
+        '"ignore:Pydantic serializer warnings:UserWarning:pydantic.main"'
+        in gate_script
     )
     assert "ignore::UserWarning" not in workflow
-    assert '"PYTHONWARNINGS",' in gate_script
 
 
 def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge() -> (

--- a/docs/plans/2026-05-29-strix-full-scan-operational-model.md
+++ b/docs/plans/2026-05-29-strix-full-scan-operational-model.md
@@ -14,14 +14,14 @@
 
 ## Plan
 
-1. Keep PR-scoped Strix scans on the organization-secret `STRIX_LLM` route so
-   `vertex_ai/gemini-3.1-pro-preview-customtools` can be used after secret
-   visibility correction.
-2. Route protected-branch full scans (`push`, `schedule`, and manual
-   non-PR-scoped `workflow_dispatch`) to the previously validated exact Vertex
-   model `vertex_ai/gemini-2.5-flash`.
-3. Keep arbitrary Vertex model patterns disallowed; only the exact PR model and
-   exact full-scan model are accepted.
+1. Keep the organization-secret `STRIX_LLM` route, but quarantine the exact
+   `vertex_ai/gemini-3.1-pro-preview-customtools` value to
+   `vertex_ai/gemini-2.5-flash` until it has no-timeout evidence.
+2. Route PR-scoped and protected-branch scans to the previously validated exact
+   Vertex model `vertex_ai/gemini-2.5-flash` when the 3.1 preview value is
+   configured.
+3. Keep arbitrary Vertex model patterns disallowed; only the exact operational
+   Vertex model is accepted.
 4. Preserve the narrow Pydantic serializer warning filter and gate child-process
    forwarding from PR #303.
 5. Add regression assertions so later edits cannot accidentally send full-repo
@@ -32,4 +32,4 @@
 - This does not reintroduce GitHub Models or generic `LLM_API_KEY`.
 - This does not suppress scanner findings, timeouts, denied access, fatal
   errors, or application warnings.
-- This does not remove the 3.1 org-secret path for PR-scoped evidence.
+- This does not claim the 3.1 org-secret value is operational without evidence.

--- a/docs/plans/2026-05-29-strix-warning-filter-log-surface.md
+++ b/docs/plans/2026-05-29-strix-warning-filter-log-surface.md
@@ -1,0 +1,27 @@
+# Strix Warning Filter Log Surface Roadmap
+
+## Evidence
+
+- PR #303 moved the known third-party Pydantic serializer warning filter into
+  the Strix workflow environment.
+- GitHub Actions prints step environment names in the job log, so the literal
+  `PYTHONWARNINGS` name can trip broad `WARNING` log searches even when no
+  Python warning was emitted.
+- The filter still needs to reach the actual Strix Python child process.
+
+## Plan
+
+1. Remove the warning filter from the workflow `env` block.
+2. Set the same narrow `pydantic.main` serializer-warning filter inside
+   `scripts/ci/strix_quick_gate.sh` when constructing the child process
+   environment.
+3. Do not inherit a caller-provided warning filter for Strix; use the fixed
+   gate-owned value so CI cannot accidentally blanket-ignore warnings.
+4. Keep tests proving the workflow does not expose `PYTHONWARNINGS:` while the
+   gate still forwards the exact child filter.
+
+## Non-Goals
+
+- Do not suppress Strix findings, timeouts, fatal errors, denied access, or
+  application warnings.
+- Do not reintroduce GitHub Models or generic LLM credentials.

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1951,11 +1951,11 @@ for key in (
     "http_proxy",
     "https_proxy",
     "no_proxy",
-    "PYTHONWARNINGS",
 ):
     value = os.environ.get(key)
     if value:
         child_env[key] = value
+child_env["PYTHONWARNINGS"] = "ignore:Pydantic serializer warnings:UserWarning:pydantic.main"
 child_env["STRIX_LLM"] = os.environ["STRIX_CHILD_MODEL"]
 child_env["LLM_MODEL"] = os.environ["STRIX_CHILD_MODEL"]
 if os.environ.get("STRIX_CHILD_LLM_API_KEY"):

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -86,12 +86,12 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "timeout-minutes: 90" "strix workflow job budget covers PR-scoped Strix batches"
 	assert_file_contains "$workflow_file" "STRIX_TOTAL_TIMEOUT_SECONDS: 4800" "strix workflow total Strix budget covers PR-scoped batches"
 	assert_file_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH: 12" "strix workflow reduces PR batch startup overhead"
-	assert_file_contains "$workflow_file" "github.event_name == 'push' || github.event_name == 'schedule'" "strix workflow uses the stable Vertex model for protected-branch full scans"
-	assert_file_contains "$workflow_file" "github.event.inputs.pr_number == ''" "strix workflow treats manual non-PR scans as protected-branch full scans"
-	assert_file_contains "$workflow_file" "&& 'vertex_ai/gemini-2.5-flash' || secrets.STRIX_LLM || 'vertex_ai/gemini-3.1-pro-preview-customtools'" "strix workflow uses the organization STRIX_LLM model for PR-scoped scans"
+	assert_file_contains "$workflow_file" "secrets.STRIX_LLM == 'vertex_ai/gemini-3.1-pro-preview-customtools' && 'vertex_ai/gemini-2.5-flash'" "strix workflow quarantines the unavailable Vertex preview model to the stable operational model"
+	assert_file_contains "$workflow_file" "|| secrets.STRIX_LLM || 'vertex_ai/gemini-2.5-flash'" "strix workflow keeps explicit non-quarantined STRIX_LLM selections"
 	assert_file_contains "$workflow_file" "STRIX_LLM must select direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" "strix workflow rejects unsupported model inputs"
-	assert_file_contains "$workflow_file" "vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash" "strix workflow accepts exact approved organization Vertex AI operational models"
-	assert_file_contains "$workflow_file" 'PYTHONWARNINGS: "ignore:Pydantic serializer warnings:UserWarning:pydantic.main"' "strix workflow narrowly filters the known third-party Pydantic serializer warning"
+	assert_file_contains "$workflow_file" "vertex_ai/gemini-2.5-flash)" "strix workflow accepts the exact approved organization Vertex AI operational model"
+	assert_file_not_contains "$workflow_file" "PYTHONWARNINGS:" "strix workflow must not expose warning-filter env names in GitHub logs"
+	assert_file_contains "$GATE_SCRIPT" 'child_env["PYTHONWARNINGS"] = "ignore:Pydantic serializer warnings:UserWarning:pydantic.main"' "strix gate child env narrowly filters the known third-party Pydantic serializer warning"
 	assert_file_not_contains "$workflow_file" "ignore::UserWarning" "strix workflow must not blanket-suppress all UserWarning output"
 	assert_file_not_contains "$workflow_file" "vertex_ai/* | vertex_ai_beta/*" "strix workflow must not accept arbitrary Vertex models"
 	assert_file_contains "$workflow_file" "provider_mode=openai_direct" "strix workflow requires direct OpenAI GPT-5 credentials"
@@ -123,7 +123,7 @@ assert_strix_gpt54_model_guard_semantics() {
 	case "$model" in
 	gpt-5.[4-9]* | gpt-5.[1-9][0-9]* | gpt-[6-9]* | gpt-[1-9][0-9]* | \
 	openai/gpt-5.[4-9]* | openai/gpt-5.[1-9][0-9]* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-	vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)
+	vertex_ai/gemini-2.5-flash)
 		return 0
 		;;
 	*)
@@ -148,11 +148,11 @@ assert_strix_gpt54_model_guard_cases() {
 	if assert_strix_gpt54_model_guard_semantics "openai/openai/gpt-5.4"; then
 		record_failure "strix GPT-5.4 guard must reject GitHub Models openai/openai/gpt-5.4"
 	fi
-	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-3.1-pro-preview-customtools"; then
-		record_failure "strix guard must accept the configured organization Vertex AI operational model"
+	if assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-3.1-pro-preview-customtools"; then
+		record_failure "strix guard must reject the Vertex preview model until it has no-timeout evidence"
 	fi
 	if ! assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-flash"; then
-		record_failure "strix guard must accept the fallback approved organization Vertex AI model"
+		record_failure "strix guard must accept the approved organization Vertex AI operational model"
 	fi
 	if assert_strix_gpt54_model_guard_semantics "vertex_ai/gemini-2.5-pro"; then
 		record_failure "strix guard must reject arbitrary Vertex models"
@@ -1972,7 +1972,6 @@ EOS
 			STRIX_REASONING_EFFORT="minimal"
 			STRIX_LLM_MAX_RETRIES="1"
 			GEMINI_LOCATION="GLOBAL"
-			PYTHONWARNINGS="ignore:Pydantic serializer warnings:UserWarning:pydantic.main"
 			UNRELATED_SECRET="should-not-forward"
 		)
 	fi


### PR DESCRIPTION
## Summary
- quarantine `vertex_ai/gemini-3.1-pro-preview-customtools` to `vertex_ai/gemini-2.5-flash` until it has no-timeout PR and full-scan evidence
- remove the visible workflow-level `PYTHONWARNINGS` env entry and set the same narrow Pydantic serializer warning filter inside the Strix child process environment
- update release-governance tests and docs so preview models and warning-filter env names cannot silently re-enter the workflow

## Evidence
- Master Strix run `26639599107` passed after PR #304 routed full scans through `vertex_ai/gemini-2.5-flash`.
- PR #304 Strix run `26639062495` failed on the `STRIX_LLM` 3.1 route after a 1200s timeout and an unmapped high finding, so 3.1 cannot be treated as operational evidence yet.
- GitHub Actions logs printed the workflow env key `PYTHONWARNINGS`, which can trip broad Warning/WARN scans even when the Pydantic warning is filtered.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests/test_release_governance.py -q`
- `bash scripts/ci/test_strix_quick_gate.sh`
- `git diff --check`

## Notes
- GitHub Models remains disabled.
- This does not suppress Strix findings, timeouts, fatal errors, denied access, or application warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance policies for LLM model selection in security scanning workflows
  * Added roadmap documentation for Strix operational model stability requirements
  * Clarified restrictions on preview model variants

* **Chores**
  * Updated Strix model selection to default to stable variant
  * Restricted preview model pending timeout evidence verification
  * Refined environment configuration handling in CI processes
  * Updated test expectations to match new governance behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->