### PR TITLE
Reject platform admin HMAC sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@
   separate audited support flows; `/api/accounts/config` must reject forged or
   orgless privileged sessions before credential lookup, and tests must exercise
   the real signed bearer path rather than only dev public-header overrides.
+- HMAC fallback sessions must not authorize `system_admin` or `platform_admin`
+  roles. Platform-wide operators require the OIDC/JWKS path or a separately
+  audited support flow so compromise of an HMAC session secret cannot mint
+  platform administrator claims.
 - Reply-wait task escalation must reuse the server-authoritative pending reply
   path, create or update source-linked `reply_sla` ticket tasks by opaque task
   id, and sanitize generated task titles from email subjects before persistence.

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -233,7 +233,14 @@ def _verify_signed_session_payload(authorization: str | None) -> dict[str, Any]:
     if not hmac.compare_digest(expected_signature, provided_signature):
         raise _authentication_error()
 
-    return _json_object_from_base64url_segment(payload_segment)
+    payload = _json_object_from_base64url_segment(payload_segment)
+    _reject_hmac_system_admin_payload(payload)
+    return payload
+
+
+def _reject_hmac_system_admin_payload(payload: dict[str, Any]) -> None:
+    if payload.get("role") in SYSTEM_ADMIN_ROLES:
+        raise _authentication_error()
 
 
 def _required_string_claim(payload: dict[str, Any], name: str) -> str:

--- a/backend/tests/test_accounts_api.py
+++ b/backend/tests/test_accounts_api.py
@@ -257,11 +257,9 @@ def test_accounts_config_rejects_system_admin_mailbox_owner_session(admin_role: 
         {"smtp_server": "smtp.example.com", "smtp_port": 587},
     )
 
-    assert read_response.status_code == 403
-    assert write_response.status_code == 403
-    assert read_response.json()["detail"] == (
-        "Mailbox account settings require a scoped user session"
-    )
+    assert read_response.status_code == 401
+    assert write_response.status_code == 401
+    assert read_response.json()["detail"] == "Authentication required"
     assert session.execute_calls == 0
     assert session.configs == {}
 

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -474,7 +474,7 @@ async def test_admin_subject_does_not_imply_system_admin_role():
 
 
 @pytest.mark.asyncio
-async def test_system_admin_requires_explicit_signed_role_claim():
+async def test_hmac_session_rejects_platform_system_admin_role_claim():
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     token = _signed_session_token(
         _valid_session_payload(
@@ -482,12 +482,25 @@ async def test_system_admin_requires_explicit_signed_role_claim():
         )
     )
 
-    context = await get_auth_context(authorization=f"Bearer {token}")
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
 
-    assert context.user_id == "alice"
-    assert context.role == "system_admin"
-    assert context.organization_id is None
-    assert context.workspace_id == "workspace-root"
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_hmac_session_rejects_platform_admin_role_claim():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(
+            role="platform_admin", org=None, workspace="workspace-root"
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
 
 
 def test_http_route_accepts_signed_bearer_and_ignores_forged_identity_headers():

--- a/docs/plans/2026-05-29-hmac-system-admin-boundary.md
+++ b/docs/plans/2026-05-29-hmac-system-admin-boundary.md
@@ -1,0 +1,29 @@
+# HMAC System Admin Boundary Roadmap
+
+## Evidence
+
+- Master Strix run `26641767705` reported a critical JWT authentication bypass:
+  if an attacker learns `AUTH_SESSION_HMAC_SECRET`, they can forge a
+  `system_admin` token.
+- The runtime already validates HMAC secret length, fixture values, issuer,
+  audience, expiration, role names, and unsupported critical headers.
+- The remaining high-impact path is platform-wide role minting through the
+  legacy HMAC fallback.
+
+## Plan
+
+1. Keep OIDC/JWKS verification authoritative when `OIDC_ISSUER_URL` is
+   configured.
+2. Reject `system_admin` and `platform_admin` role claims on the legacy HMAC
+   fallback path.
+3. Keep tenant-scoped HMAC sessions working for existing workspace flows.
+4. Add signed bearer regression tests proving HMAC platform-admin claims fail.
+5. Record the anti-pattern in `AGENTS.md` so future admin endpoints do not
+   reintroduce platform-wide HMAC sessions.
+
+## Non-Goals
+
+- This does not remove HMAC sessions for tenant-scoped local development or
+  existing non-platform workspace flows.
+- This does not weaken OIDC; platform-wide roles should come from an external
+  IdP or an audited support flow.


### PR DESCRIPTION
## Summary
- reject `system_admin` and `platform_admin` claims on the legacy HMAC fallback session path
- keep OIDC/JWKS verification authoritative for platform-wide roles
- update signed bearer regression tests and the accounts boundary test to expect auth failure before mailbox-owner authorization
- document the anti-pattern in AGENTS and a plan note

## Evidence
- Master Strix run `26641767705` reported `JWT Authentication Bypass via HMAC Secret Disclosure`, specifically forged `system_admin` claims when `AUTH_SESSION_HMAC_SECRET` is known.
- Tracked files do not include `backend/.env`; the remaining defensible fix is to reduce HMAC fallback blast radius so platform-wide roles cannot be minted through a symmetric session secret.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests/test_auth_real.py backend/tests/test_accounts_api.py backend/tests/test_observability_api.py backend/tests/test_security_api.py backend/tests/test_data_api.py backend/tests/test_ai_hub_api.py backend/tests/test_tasks_api.py -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m bandit -r backend/ -x backend/tests/ -q`
- `git diff --check`

## Notes
- This does not remove tenant-scoped HMAC sessions.
- Platform-wide roles must come through OIDC/JWKS or a separately audited support flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secured HMAC fallback authentication by preventing system_admin and platform_admin role assignment. Authentication now properly rejects unauthorized claims with HTTP 401. Platform-wide operators must use OIDC/JWKS authentication path.

* **Documentation**
  * Added security roadmap documenting JWT authentication hardening measures and anti-patterns to prevent privilege escalation vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->