### PR TITLE
Require authoritative security surface workspace scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@
   architecture docs and reusable Strix gate tests aligned with this rule so
   stale GitHub Models, OpenAI-only, unavailable-model, blanket-warning, or
   generic-key examples cannot re-enter copied workflow guidance.
+- HMAC fallback sessions are local/control-plane compatibility credentials, not
+  authoritative workspace-membership evidence. Sensitive tenant security posture
+  surfaces must require OIDC/JWKS-backed membership or an explicit dependency
+  override in tests; do not allow a signed HMAC `workspace` claim alone to open
+  cross-workspace security data.
 
 ## PR automation and review defaults
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ mail/calendar/file systems.
   connector evidence plus durable `security_audit_events`, reuses the deny-first
   RBAC/ABAC policy engine, and returns no sequential account ids, raw
   credentials, legacy unscoped audit rows, or fake security posture claims.
+  HMAC fallback sessions are not accepted as authoritative workspace-membership
+  evidence for this security posture surface; enterprise OIDC/JWKS or an
+  explicit server-side membership path must establish the workspace boundary.
 - Data quality is source-backed through signed `/api/data/quality-surface`.
   The endpoint summarizes scoped repositories, recent email-attachment file
   assets, ingestion inventory, embedding coverage, quality checks, and connector

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -6,7 +6,7 @@ import json
 import logging
 import math
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, cast
 
 import jwt
@@ -35,6 +35,7 @@ RoleName = Literal[
     "group_admin",
     "member",
 ]
+SessionVerifier = Literal["hmac", "oidc", "override"]
 ALLOWED_ROLES: set[str] = {
     "system_admin",
     "tenant_admin",
@@ -59,6 +60,7 @@ class AuthContext:
     organization_id: str | None
     group_ids: tuple[str, ...]
     workspace_id: str
+    session_verifier: SessionVerifier = field(default="override", compare=False)
 
 
 def ensure_organization_access(auth_context: AuthContext, organization_id: str) -> None:
@@ -209,6 +211,7 @@ def _verify_signed_session_payload(authorization: str | None) -> dict[str, Any]:
                 audience=settings.OIDC_CLIENT_ID,
                 issuer=settings.OIDC_ISSUER_URL
             )
+            payload["_session_verifier"] = "oidc"
             return payload
         except Exception:
             raise _authentication_error() from None
@@ -235,6 +238,7 @@ def _verify_signed_session_payload(authorization: str | None) -> dict[str, Any]:
 
     payload = _json_object_from_base64url_segment(payload_segment)
     _reject_hmac_system_admin_payload(payload)
+    payload["_session_verifier"] = "hmac"
     return payload
 
 
@@ -293,6 +297,9 @@ def _validate_session_metadata(payload: dict[str, Any]) -> None:
 
 def _auth_context_from_session_payload(payload: dict[str, Any]) -> AuthContext:
     _validate_session_metadata(payload)
+    session_verifier = payload.get("_session_verifier", "override")
+    if session_verifier not in ("hmac", "oidc", "override"):
+        raise _authentication_error()
     role_value = _required_string_claim(payload, "role")
     if role_value not in ALLOWED_ROLES:
         raise _authentication_error()
@@ -306,6 +313,7 @@ def _auth_context_from_session_payload(payload: dict[str, Any]) -> AuthContext:
         organization_id=organization_id,
         group_ids=_tuple_string_claim(payload, "groups"),
         workspace_id=_required_string_claim(payload, "workspace"),
+        session_verifier=cast(SessionVerifier, session_verifier),
     )
 
 

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Literal
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -472,11 +472,20 @@ def _policy_order() -> list[PolicyOrderStep]:
     ]
 
 
+def _require_authoritative_workspace_scope(auth_context: AuthContext) -> None:
+    if auth_context.session_verifier == "hmac":
+        raise HTTPException(
+            status_code=403,
+            detail="Authoritative workspace membership is required for security access surface",
+        )
+
+
 @router.get("/access-surface", response_model=SecurityAccessSurfaceResponse)
 async def get_access_surface(
     auth_context: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ) -> SecurityAccessSurfaceResponse:
+    _require_authoritative_workspace_scope(auth_context)
     webdav_result = await db.execute(_webdav_scope_statement(auth_context))
     calendar_result = await db.execute(_calendar_scope_statement(auth_context))
     audit_result = await db.execute(_durable_audit_scope_statement(auth_context))

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -243,6 +243,7 @@ async def test_get_auth_context_accepts_signed_bearer_session():
         group_ids=("group-1", "group-2"),
         workspace_id="workspace-org-acme",
     )
+    assert context.session_verifier == "hmac"
 
 
 @pytest.mark.asyncio
@@ -748,6 +749,7 @@ async def test_signed_bearer_session_with_oidc(monkeypatch):
     assert context.user_id == "alice"
     assert context.role == "tenant_admin"
     assert context.organization_id == "org-acme"
+    assert context.session_verifier == "oidc"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_security_api.py
+++ b/backend/tests/test_security_api.py
@@ -328,14 +328,18 @@ def test_access_surface_rejects_public_identity_headers_without_signed_session(m
     assert response.json() == {"detail": "Authentication required"}
 
 
-def test_access_surface_accepts_signed_bearer_session(mock_db):
+def test_access_surface_rejects_hmac_bearer_session_without_authoritative_workspace(
+    mock_db,
+):
     async def override_get_db():
         yield mock_db
 
     previous_secret = settings.AUTH_SESSION_HMAC_SECRET
     original_overrides = dict(app.dependency_overrides)
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
-    token = _signed_session_token(_valid_session_payload())
+    token = _signed_session_token(
+        _valid_session_payload(workspace="another_workspace_id")
+    )
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides.pop(get_auth_context, None)
     app.dependency_overrides.pop(get_current_user, None)
@@ -350,8 +354,10 @@ def test_access_surface_accepts_signed_bearer_session(mock_db):
         app.dependency_overrides.clear()
         app.dependency_overrides.update(original_overrides)
 
-    assert response.status_code == 200, response.text
-    assert response.json()["viewer"]["user_id"] == "admin"
+    assert response.status_code == 403, response.text
+    assert response.json() == {
+        "detail": "Authoritative workspace membership is required for security access surface"
+    }
 
 
 @pytest.mark.asyncio

--- a/docs/plans/2026-05-29-hmac-security-access-surface-boundary.md
+++ b/docs/plans/2026-05-29-hmac-security-access-surface-boundary.md
@@ -1,0 +1,28 @@
+# HMAC Security Access Surface Boundary
+
+## Evidence
+
+- Protected-branch Strix run `26643294848` reported a medium IDOR finding on
+  `/api/security/access-surface`.
+- The exploit path was a forged HMAC-signed JWT with a manipulated `workspace`
+  claim. PR #306 rejected platform/system admin HMAC roles, but tenant-scoped
+  HMAC workspace claims were still accepted by the security posture endpoint.
+
+## Plan
+
+1. Mark verified runtime sessions with their verifier: `hmac`, `oidc`, or
+   dependency-override test context.
+2. Keep HMAC fallback usable for non-security compatibility paths, but reject it
+   for `/api/security/access-surface` because it is not authoritative
+   workspace-membership evidence.
+3. Preserve OIDC/JWKS as the production membership authority and preserve test
+   dependency overrides for scoped security-surface fixtures.
+4. Add regression coverage for forged HMAC workspace claims against the security
+   surface.
+
+## Non-goals
+
+- Do not weaken scanner gates or classify timeout, denied, fatal, or finding
+  output as passing evidence.
+- Do not invent a database membership registry in this slice; that belongs to
+  the broader RBAC/ABAC identity-provider integration plan.


### PR DESCRIPTION
## Summary
- mark runtime auth contexts with the verifier that produced them: HMAC, OIDC, or test override
- reject HMAC fallback sessions for `/api/security/access-surface` because a signed workspace claim is not authoritative membership evidence
- document the Strix finding and the recurrence rule in README, AGENTS, and a dated plan note

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests/test_auth_real.py backend/tests/test_security_api.py -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests/test_auth_real.py backend/tests/test_security_api.py backend/tests/test_observability_api.py backend/tests/test_data_api.py backend/tests/test_ai_hub_api.py backend/tests/test_runner_config_api.py backend/tests/test_accounts_api.py -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest backend/tests -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m bandit -r backend/ -x backend/tests/ -q`
- `git diff --check`

## Strix Evidence
- Protected-branch Strix run `26643294848` failed on a medium `/api/security/access-surface` IDOR finding plus LLM timeout/incomplete scan evidence.
- This PR addresses the reported HMAC workspace-forgery path by requiring an authoritative workspace-membership verifier for the security posture surface.