### PR TITLE
fix: include deployment context in Strix PR scopes

### DIFF
--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1111,6 +1111,7 @@ is_scannable_changed_file() {
 pull_request_scope_context_files() {
 	local needs_backend_python=0
 	local needs_frontend_email_api_context=0
+	local needs_deployment_context=0
 	local changed_file normalized_changed_file
 	for changed_file in "$@"; do
 		normalized_changed_file="$(normalize_changed_file_path "$changed_file")" || return 2
@@ -1122,6 +1123,13 @@ pull_request_scope_context_files() {
 		# shape frontend email retrieval flows; include backend auth context with them.
 		frontend/src/components/EmailDetail.tsx | frontend/src/components/EmailList.tsx | frontend/src/app/page.tsx | frontend/src/lib/api-client.ts | frontend/src/lib/email-threading.ts)
 			needs_frontend_email_api_context=1
+			;;
+		# Deployment and CI changes often reference build files that are not all
+		# changed in the PR. Include the trusted copies so Strix does not downgrade
+		# a clean finding to provider/failure-signal output due to missing Dockerfiles
+		# or VERSION context.
+		.github/workflows/* | Dockerfile | frontend/Dockerfile | frontend/next.config.ts | docker-compose*.yml | render.yaml)
+			needs_deployment_context=1
 			;;
 		esac
 	done
@@ -1181,6 +1189,20 @@ backend/core/config.py
 backend/db/models.py
 backend/main.py
 backend/services/threading_service.py
+EOF
+	fi
+
+	if [ "$needs_deployment_context" -eq 1 ]; then
+		cat <<'EOF'
+Dockerfile
+frontend/Dockerfile
+frontend/package.json
+frontend/package-lock.json
+frontend/next.config.ts
+frontend/postcss.config.mjs
+docker-compose.yml
+render.yaml
+VERSION
 EOF
 	fi
 }

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -50,6 +50,14 @@ assert_file_not_contains() {
 	fi
 }
 
+assert_strix_pr_scope_includes_deployment_context() {
+	assert_file_contains "$GATE_SCRIPT" "needs_deployment_context=0" "strix gate tracks deployment-context scoped PRs"
+	assert_file_contains "$GATE_SCRIPT" ".github/workflows/* | Dockerfile | frontend/Dockerfile | frontend/next.config.ts | docker-compose*.yml | render.yaml" "strix gate recognizes deployment and CI files"
+	assert_file_contains "$GATE_SCRIPT" "frontend/package-lock.json" "strix gate includes frontend dependency lock context"
+	assert_file_contains "$GATE_SCRIPT" "frontend/postcss.config.mjs" "strix gate includes frontend build config context"
+	assert_file_contains "$GATE_SCRIPT" "VERSION" "strix gate includes release version context for workflow scans"
+}
+
 assert_strix_workflow_pr_trigger_hardened() {
 	local workflow_file="$REPO_ROOT/.github/workflows/strix.yml"
 
@@ -4363,6 +4371,8 @@ EOF
 }
 
 assert_strix_workflow_pr_trigger_hardened
+
+assert_strix_pr_scope_includes_deployment_context
 
 assert_strix_gpt54_model_guard_cases
 


### PR DESCRIPTION
## Summary

Fix the Strix PR-scope gate so deployment and workflow changes include the build context files Strix needs for a clean assessment. This is a prerequisite for PR #318 because pull_request_target runs the trusted Strix gate from the base branch, so #318 cannot fix its own Strix scope from inside the PR.

## What changed

- When changed files include GitHub workflows, Dockerfiles, frontend Next config, docker-compose, or render.yaml, the isolated PR scan scope now includes trusted copies of:
  - `Dockerfile`
  - `frontend/Dockerfile`
  - `frontend/package.json`
  - `frontend/package-lock.json`
  - `frontend/next.config.ts`
  - `frontend/postcss.config.mjs`
  - `docker-compose.yml`
  - `render.yaml`
  - `VERSION`
- Added self-test assertions so this context cannot regress.

## Why

Strix was finding **0 vulnerabilities** on #318 but still failed closed because the scoped report said Dockerfiles and VERSION were missing. That is a gate/context bug, not an application vulnerability. This keeps the security posture strict while giving the scanner the files it explicitly needs.

## Test plan

- `bash scripts/ci/test_strix_quick_gate.sh` → PASS

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>