### PR TITLE
fix: harden referrer policy and settings external links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,10 @@
   be stored in artificially short `varchar(n)` columns; use opaque source UIDs
   that fit seeded smoke data and provider evidence without truncation.
 - When reviews find public/private identifier leaks, stale API fixture shapes, or recurring bug patterns, update tests, frontend mocks, E2E mocks, README examples, architecture docs, and explicitly record the anti-pattern in `AGENTS.md` so the same bug pattern does not reappear in copied examples.
+- When reviews find missing browser security headers or tabnabbing hardening,
+  update both backend header tests and frontend link tests. Global backend
+  responses must include `Referrer-Policy`, and `target="_blank"` links must
+  use explicit `rel="noopener noreferrer"`.
 - When robot review cites an obsolete Strix provider policy, update the docs and
   tests to the current secret contract before accepting a rollback suggestion;
   do not reintroduce generic `LLM_API_KEY`, GitHub Models, or cross-provider

--- a/backend/main.py
+++ b/backend/main.py
@@ -66,6 +66,7 @@ async def add_security_headers(request: Request, call_next):
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     if settings.SECURITY_CONTENT_SECURITY_POLICY:
         response.headers["Content-Security-Policy"] = (
             settings.SECURITY_CONTENT_SECURITY_POLICY

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -18,6 +18,7 @@ def test_root_response_has_security_headers():
     )
     assert response.headers["x-content-type-options"] == "nosniff"
     assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
     assert response.headers["content-security-policy"] == (
         "default-src 'self'; "
         "object-src 'none'; "

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -287,6 +287,43 @@ describe("SettingsLayout", () => {
     expect(container.textContent).toContain("nrn_one_time_connector_token");
   });
 
+  it("marks external operational console links with explicit noopener", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const developerTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "개발자",
+    );
+    expect(developerTab).toBeTruthy();
+    await act(async () => {
+      developerTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const externalLinks = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a[target="_blank"]'),
+    );
+    expect(externalLinks.map((link) => link.textContent)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Grafana"),
+        expect.stringContaining("Keycloak"),
+        expect.stringContaining("Loki"),
+        expect.stringContaining("Tempo"),
+      ]),
+    );
+    for (const link of externalLinks) {
+      expect(link.rel.split(/\s+/).sort()).toEqual(["noopener", "noreferrer"]);
+    }
+  });
+
   it("loads and saves source-backed mail account settings without public identity headers or secret replay", async () => {
     container = document.createElement("div");
     document.body.appendChild(container);

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -974,22 +974,22 @@ export function SettingsLayout() {
                 </section>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-                  <a href="http://localhost:3000" target="_blank" rel="noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
+                  <a href="http://localhost:3000" target="_blank" rel="noopener noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
                     <Monitor className="size-8 text-orange-500 mb-2" />
                     <h3 className="font-bold text-lg">Grafana 대시보드</h3>
                     <p className="text-sm text-muted-foreground">OpenTelemetry 기반의 APM, 트래픽 메트릭 및 시스템 자원 모니터링을 확인합니다.</p>
                   </a>
-                  <a href="http://localhost:8080" target="_blank" rel="noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
+                  <a href="http://localhost:8080" target="_blank" rel="noopener noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
                     <Shield className="size-8 text-blue-500 mb-2" />
                     <h3 className="font-bold text-lg">Keycloak 관리 콘솔</h3>
                     <p className="text-sm text-muted-foreground">OIDC 프로바이더, SSO 인증, 역할 기반 접근 제어(RBAC)를 구성합니다.</p>
                   </a>
-                  <a href="http://localhost:3100" target="_blank" rel="noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
+                  <a href="http://localhost:3100" target="_blank" rel="noopener noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
                     <AlertCircle className="size-8 text-slate-500 mb-2" />
                     <h3 className="font-bold text-lg">Loki 로그 서버</h3>
                     <p className="text-sm text-muted-foreground">분산 아키텍처 환경의 컨테이너 로그 및 어플리케이션 에러 로그를 검색합니다.</p>
                   </a>
-                  <a href="http://localhost:3200" target="_blank" rel="noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
+                  <a href="http://localhost:3200" target="_blank" rel="noopener noreferrer" className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6 shadow-sm hover:border-primary/50 transition-colors">
                     <RefreshCw className="size-8 text-teal-500 mb-2" />
                     <h3 className="font-bold text-lg">Tempo 분산 추적</h3>
                     <p className="text-sm text-muted-foreground">FastAPI의 엔드포인트 지연율 및 MSA 구성요소 간의 호출 트레이스를 시각화합니다.</p>


### PR DESCRIPTION
## Summary
- Add `Referrer-Policy: strict-origin-when-cross-origin` to global FastAPI security headers.
- Require explicit `rel="noopener noreferrer"` on Settings external operational console links.
- Record the recurring review pattern in `AGENTS.md` and add backend/frontend regression tests.

## Verification
- `python -m pytest backend/tests/test_main.py -q`
- `npm test -- src/components/SettingsLayout.test.tsx`
- `npm run lint -- src/components/SettingsLayout.tsx src/components/SettingsLayout.test.tsx`
- `npm run typecheck`
- `git diff --check`

Supersedes the security-header slice of #317 without carrying its stale Strix quick-gate changes.