### PR TITLE
fix: guard frontend API proxy query forwarding

### DIFF
--- a/frontend/src/app/api/[...path]/route.test.ts
+++ b/frontend/src/app/api/[...path]/route.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 const ORIGINAL_ENV = { ...process.env };
+const SIGNED_SESSION_TOKEN = "signed-session-token";
 
 describe("/api runtime proxy route", () => {
   beforeEach(() => {
@@ -37,7 +38,7 @@ describe("/api runtime proxy route", () => {
       {
         method: "POST",
         headers: {
-          Authorization: "Bearer signed-session-token",
+          Authorization: `Bearer ${SIGNED_SESSION_TOKEN}`,
           "Content-Type": "application/json",
           "X-User-Id": "public-user-id",
         },
@@ -63,7 +64,13 @@ describe("/api runtime proxy route", () => {
 
     const request = new NextRequest(
       "https://frontend.naruon.net/api/tasks?filename=../../../../etc/passwd",
-      { method: "POST", body: "{}" },
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${SIGNED_SESSION_TOKEN}`,
+        },
+        body: "{}",
+      },
     );
 
     const response = await POST(request, {
@@ -71,6 +78,7 @@ describe("/api runtime proxy route", () => {
     });
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
     await expect(response.json()).resolves.toEqual({
       error_code: "invalid_proxy_query",
       message: "Unsupported query parameter: filename",
@@ -88,7 +96,13 @@ describe("/api runtime proxy route", () => {
 
     const request = new NextRequest(
       "https://frontend.naruon.net/api/ontology/relationships?source_message_id=%3Cabc@example.com%3E&source_thread_id=thread/one",
-      { method: "POST", body: "{}" },
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${SIGNED_SESSION_TOKEN}`,
+        },
+        body: "{}",
+      },
     );
 
     const response = await POST(request, {

--- a/frontend/src/app/api/[...path]/route.test.ts
+++ b/frontend/src/app/api/[...path]/route.test.ts
@@ -56,4 +56,48 @@ describe("/api runtime proxy route", () => {
       request_body: '{"state":"open"}',
     });
   });
+
+  it("rejects unsupported query parameters before proxying", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest(
+      "https://frontend.naruon.net/api/tasks?filename=../../../../etc/passwd",
+      { method: "POST", body: "{}" },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["tasks"] }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error_code: "invalid_proxy_query",
+      message: "Unsupported query parameter: filename",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("re-encodes allowed query parameters instead of copying the raw search string", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo) =>
+        Response.json({ target_url: String(input) }),
+      ),
+    );
+
+    const request = new NextRequest(
+      "https://frontend.naruon.net/api/ontology/relationships?source_message_id=%3Cabc@example.com%3E&source_thread_id=thread/one",
+      { method: "POST", body: "{}" },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["ontology", "relationships"] }),
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      target_url:
+        "https://api.naruon.net/api/ontology/relationships?source_message_id=%3Cabc%40example.com%3E&source_thread_id=thread%2Fone",
+    });
+  });
 });

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -114,7 +114,12 @@ async function proxyApiRequest(
           error_code: "invalid_proxy_query",
           message: error.message,
         },
-        { status: 400 },
+        {
+          status: 400,
+          headers: {
+            "Referrer-Policy": "no-referrer",
+          },
+        },
       );
     }
     throw error;

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -26,9 +26,26 @@ const CLIENT_AUTHORITY_HEADERS = new Set([
   "x-user-role",
 ]);
 
+const ALLOWED_BACKEND_QUERY_PARAMS = new Set([
+  "folder",
+  "limit",
+  "source_message_id",
+  "source_thread_id",
+]);
+const MAX_QUERY_PARAM_COUNT = 12;
+const MAX_QUERY_PARAM_VALUE_LENGTH = 2048;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+
 type ApiRouteContext = {
   params: Promise<{ path?: string[] }> | { path?: string[] };
 };
+
+class InvalidProxyQueryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProxyQueryError";
+  }
+}
 
 function filteredRequestHeaders(request: NextRequest): Headers {
   const headers = new Headers();
@@ -50,6 +67,36 @@ function filteredResponseHeaders(response: Response): Headers {
   return headers;
 }
 
+function safeBackendQuery(searchParams: URLSearchParams): string {
+  const forwardedParams = new URLSearchParams();
+  const seenNames = new Set<string>();
+  let paramCount = 0;
+
+  for (const [name, value] of searchParams) {
+    paramCount += 1;
+    if (paramCount > MAX_QUERY_PARAM_COUNT) {
+      throw new InvalidProxyQueryError("Too many query parameters");
+    }
+    if (!ALLOWED_BACKEND_QUERY_PARAMS.has(name)) {
+      throw new InvalidProxyQueryError(`Unsupported query parameter: ${name}`);
+    }
+    if (seenNames.has(name)) {
+      throw new InvalidProxyQueryError(`Duplicate query parameter: ${name}`);
+    }
+    if (
+      value.length > MAX_QUERY_PARAM_VALUE_LENGTH ||
+      CONTROL_CHARACTER_PATTERN.test(value)
+    ) {
+      throw new InvalidProxyQueryError(`Invalid query parameter value: ${name}`);
+    }
+    seenNames.add(name);
+    forwardedParams.set(name, value);
+  }
+
+  const query = forwardedParams.toString();
+  return query ? `?${query}` : "";
+}
+
 async function proxyApiRequest(
   request: NextRequest,
   context: ApiRouteContext,
@@ -58,7 +105,20 @@ async function proxyApiRequest(
   const path = params.path ?? [];
   const target = backendApiBaseUrl();
   target.pathname = `/api/${path.map(encodeURIComponent).join("/")}`;
-  target.search = request.nextUrl.search;
+  try {
+    target.search = safeBackendQuery(request.nextUrl.searchParams);
+  } catch (error) {
+    if (error instanceof InvalidProxyQueryError) {
+      return NextResponse.json(
+        {
+          error_code: "invalid_proxy_query",
+          message: error.message,
+        },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
 
   const init: RequestInit = {
     method: request.method,


### PR DESCRIPTION
## Summary
- follow up on #318 Strix finding by rejecting unsupported frontend proxy query parameters before backend forwarding
- reconstruct allowed query strings via URLSearchParams instead of copying raw request.nextUrl.search
- keep signed-session proxy behavior and public identity header stripping intact

## Verification
- npm test -- 'src/app/api/[...path]/route.test.ts'
- npm run lint -- 'src/app/api/[...path]/route.ts' 'src/app/api/[...path]/route.test.ts'
- npm run typecheck
- env -u BACKEND_INTERNAL_URL NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for proxy route query parameter validation and error handling with edge cases.

* **Bug Fixes**
  * API proxy route now validates query parameters against an allowlist and returns detailed error responses for unsupported or malformed requests.
  * Query parameters are properly re-encoded before forwarding to the backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Seongho-Bae/naruon/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->