### PR TITLE
fix: route home dashboard actions

### DIFF
--- a/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
+++ b/docs/plans/2026-05-19-branding-menu-task-tracking-gap-closure.md
@@ -54,6 +54,16 @@
   reply-tracking notifications, ETag-aware WebDAV/Notes provider execution for
   self-sent knowledge, and source-id filtered sender DAG views.
 
+## 2026-05-31 dashboard dead-control closure
+
+- The Today dashboard task and calendar controls now route to implemented
+  `/tasks` and `/calendar` workspaces instead of inert buttons.
+- The Home quick-action grid links only to implemented workspace routes:
+  `/mail`, `/mail?folder=sent`, `/calendar`, `/tasks`, `/projects`, `/ai-hub`,
+  `/data`, and `/security`.
+- Header notification, help, and profile icons route to existing Security and
+  Settings surfaces so branded chrome controls are no longer decorative.
+
 ## Task 1: Governance wait-state correction
 
 **Files:**

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -69,8 +69,9 @@ describe("DashboardLayout", () => {
     expect(primaryNav?.querySelector<HTMLAnchorElement>('a[href="/security"]')?.textContent).toContain("보안");
     expect(primaryNav?.querySelector<HTMLAnchorElement>('a[href="/settings"]')?.textContent).toContain("설정");
     expect(mobileNav).not.toBeNull();
-    expect(banner?.querySelector('button[aria-label="알림 보기"]')).not.toBeNull();
-    expect(banner?.querySelector('button[aria-label="프로필 메뉴"]')).not.toBeNull();
+    expect(banner?.querySelector<HTMLAnchorElement>('a[aria-label="알림 보기"]')?.getAttribute("href")).toBe("/security");
+    expect(banner?.querySelector<HTMLAnchorElement>('a[aria-label="도움말 보기"]')?.getAttribute("href")).toBe("/settings#help");
+    expect(banner?.querySelector<HTMLAnchorElement>('a[aria-label="프로필 메뉴"]')?.getAttribute("href")).toBe("/settings#profile");
     expect(mobileMenuButton?.getAttribute("aria-expanded")).toBe("false");
     expect(mobileMenuButton?.getAttribute("aria-controls")).toBe("mobile-workspace-menu");
     expect(mobileNavLinks).toEqual(["받은편지함", "맥락 검색", "일정", "더보기"]);

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -401,16 +401,16 @@ export function DashboardLayout({
             ))}
           </div>
           <div className="ml-auto flex items-center gap-2 xl:ml-0">
-            <button type="button" aria-label="알림 보기" className="hidden size-10 place-items-center rounded-xl border border-border text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 md:grid">
+            <Link href="/security" aria-label="알림 보기" className="hidden size-10 place-items-center rounded-xl border border-border text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 md:grid">
               <Bell className="size-4" aria-hidden="true" />
-            </button>
-            <button type="button" aria-label="도움말 보기" className="hidden size-10 place-items-center rounded-xl border border-border text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 md:grid">
+            </Link>
+            <Link href="/settings#help" aria-label="도움말 보기" className="hidden size-10 place-items-center rounded-xl border border-border text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 md:grid">
               <HelpCircle className="size-4" aria-hidden="true" />
-            </button>
-            <button type="button" aria-label="프로필 메뉴" className="hidden h-10 items-center gap-2 rounded-xl border border-border bg-background/80 px-3 text-xs font-bold text-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 xl:inline-flex">
+            </Link>
+            <Link href="/settings#profile" aria-label="프로필 메뉴" className="hidden h-10 items-center gap-2 rounded-xl border border-border bg-background/80 px-3 text-xs font-bold text-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 xl:inline-flex">
               <UserCircle className="size-4 text-primary" aria-hidden="true" />
               Seongho
-            </button>
+            </Link>
             <span className="hidden rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary xl:inline-flex">
               답장 추적
             </span>

--- a/frontend/src/components/WorkspaceHome.dashboard.test.tsx
+++ b/frontend/src/components/WorkspaceHome.dashboard.test.tsx
@@ -235,4 +235,84 @@ describe("WorkspaceHome Today dashboard", () => {
     }
     expect(container.textContent).toContain("1개 SLA 티켓 생성, 2개 답변 대기 확인");
   });
+
+  it("routes Today dashboard task calendar and quick actions to implemented workspaces", async () => {
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })));
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/emails/pending-replies?limit=3")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ emails: [] }),
+        });
+      }
+      if (url.endsWith("/api/emails")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            emails: [
+              {
+                id: 101,
+                subject: "고객 계약 승인 대기",
+                sender: "legal@example.com",
+                date: "2026-05-17T09:00:00Z",
+                snippet: "오늘 승인해야 하는 계약 검토 요청",
+                unread: true,
+              },
+            ],
+          }),
+        });
+      }
+      if (url.endsWith("/api/tasks")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ([
+            {
+              id: "task-home-route",
+              title: "계약 승인 확인",
+              status: "open",
+              priority: "high",
+              created_at: "2026-05-17T09:00:00Z",
+              updated_at: "2026-05-17T09:00:00Z",
+            },
+          ]),
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<WorkspaceHome forcedStartupView="dashboard" />);
+    });
+    await waitForCondition(() => container?.textContent?.includes("계약 승인 확인") ?? false);
+
+    const linkHrefByText = (label: string) =>
+      Array.from(container?.querySelectorAll<HTMLAnchorElement>("a") ?? [])
+        .find((link) => link.textContent?.includes(label))
+        ?.getAttribute("href");
+
+    expect(linkHrefByText("작업 바로가기")).toBe("/tasks");
+    expect(linkHrefByText("전체 작업 보기")).toBe("/tasks");
+    expect(linkHrefByText("일정 조정하기")).toBe("/calendar");
+
+    const quickActions = container.querySelector<HTMLElement>('[aria-label="홈 빠른 실행"]');
+    expect(quickActions).not.toBeNull();
+    expect(Array.from(quickActions?.querySelectorAll("button") ?? [])).toHaveLength(0);
+    expect(linkHrefByText("메일함 열기")).toBe("/mail");
+    expect(linkHrefByText("보낸 메일 답변 추적")).toBe("/mail?folder=sent");
+    expect(linkHrefByText("일정 후보 검토")).toBe("/calendar");
+    expect(linkHrefByText("작업 보드")).toBe("/tasks");
+    expect(linkHrefByText("프로젝트 의사결정")).toBe("/projects");
+    expect(linkHrefByText("AI 허브")).toBe("/ai-hub");
+    expect(linkHrefByText("데이터 품질 점검")).toBe("/data");
+    expect(linkHrefByText("보안 감사 로그")).toBe("/security");
+  });
 });

--- a/frontend/src/components/WorkspaceHome.tsx
+++ b/frontend/src/components/WorkspaceHome.tsx
@@ -71,6 +71,17 @@ type ReplySlaEscalationResponse = {
   };
 };
 
+const dashboardQuickActions = [
+  { label: '메일함 열기', href: '/mail', icon: Inbox, color: 'text-blue-500' },
+  { label: '보낸 메일 답변 추적', href: '/mail?folder=sent', icon: Send, color: 'text-rose-500' },
+  { label: '일정 후보 검토', href: '/calendar', icon: CalendarDays, color: 'text-blue-500' },
+  { label: '작업 보드', href: '/tasks', icon: CheckCircle2, color: 'text-green-500' },
+  { label: '프로젝트 의사결정', href: '/projects', icon: Network, color: 'text-purple-500' },
+  { label: 'AI 허브', href: '/ai-hub', icon: Network, color: 'text-purple-500' },
+  { label: '데이터 품질 점검', href: '/data', icon: Network, color: 'text-blue-500' },
+  { label: '보안 감사 로그', href: '/security', icon: CheckCircle2, color: 'text-emerald-500' },
+];
+
 interface EmailItem {
   id: number;
   subject: string | null;
@@ -295,7 +306,7 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
               <div>
                 <p className="break-keep font-bold">완료 가능 작업 {loading ? '-' : pendingTasks.length}건</p>
                 <p className="text-xs text-muted-foreground mt-1">오늘 마감 전 완료해보세요.</p>
-                <button className="mt-2 text-xs font-semibold text-primary hover:underline">작업 바로가기</button>
+                <a href="/tasks" className="mt-2 inline-flex text-xs font-semibold text-primary hover:underline">작업 바로가기</a>
               </div>
             </div>
           </div>
@@ -358,7 +369,7 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
                 );
               })}
             </div>
-            <button className="mt-4 w-full text-center text-sm font-semibold text-primary hover:underline">전체 작업 보기</button>
+            <a href="/tasks" className="mt-4 block w-full text-center text-sm font-semibold text-primary hover:underline">전체 작업 보기</a>
           </div>
 
           <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
@@ -382,7 +393,7 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
                 </div>
               ))}
             </div>
-            <button className="mt-4 w-full text-center text-sm font-semibold text-primary hover:underline">일정 조정하기</button>
+            <a href="/calendar" className="mt-4 block w-full text-center text-sm font-semibold text-primary hover:underline">일정 조정하기</a>
           </div>
         </div>
 
@@ -423,21 +434,12 @@ function StartupDashboard({ onOpenView }: { onOpenView: (view: WorkspaceStartupV
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-base font-bold">빠른 실행</h2>
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              {[
-                { label: '새 메일 작성', icon: Inbox, color: 'text-blue-500' },
-                { label: '일정 추가', icon: CalendarDays, color: 'text-blue-500' },
-                { label: '새 프로젝트', icon: Network, color: 'text-purple-500' },
-                { label: '작업 만들기', icon: CheckCircle2, color: 'text-green-500' },
-                { label: 'AI 허브로 이동', icon: Network, color: 'text-purple-500' },
-                { label: '데이터 대시보드', icon: Network, color: 'text-purple-500' },
-                { label: '문서 작성', icon: CheckCircle2, color: 'text-blue-500' },
-                { label: '파일 업로드', icon: Network, color: 'text-blue-500' },
-              ].map((action, i) => (
-                <button key={i} className="flex items-center justify-start gap-3 rounded-xl border border-border bg-card px-4 py-3 text-xs font-bold hover:bg-secondary transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40">
+            <div aria-label="홈 빠른 실행" className="grid grid-cols-2 gap-3">
+              {dashboardQuickActions.map((action) => (
+                <a key={action.href} href={action.href} className="flex items-center justify-start gap-3 rounded-xl border border-border bg-card px-4 py-3 text-xs font-bold transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40">
                   <action.icon className={`size-5 shrink-0 ${action.color}`} />
                   <span className="truncate">{action.label}</span>
-                </button>
+                </a>
               ))}
             </div>
           </div>

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -30,8 +30,9 @@ test('renders the desktop Naruon shell with local brand assets', async ({ page }
   await expect(primaryNav.getByRole('link', { name: '데이터', exact: true })).toHaveAttribute('href', '/data');
   await expect(primaryNav.getByRole('link', { name: '보안', exact: true })).toHaveAttribute('href', '/security');
   await expect(primaryNav.getByRole('link', { name: '설정', exact: true })).toHaveAttribute('href', '/settings');
-  await expect(header.getByRole('button', { name: '알림 보기' })).toBeVisible();
-  await expect(header.getByRole('button', { name: '프로필 메뉴' })).toBeVisible();
+  await expect(header.getByRole('link', { name: '알림 보기' })).toHaveAttribute('href', '/security');
+  await expect(header.getByRole('link', { name: '도움말 보기' })).toHaveAttribute('href', '/settings#help');
+  await expect(header.getByRole('link', { name: '프로필 메뉴' })).toHaveAttribute('href', '/settings#profile');
   await expect(header.getByRole('button', { name: '캘린더 반영' })).toBeVisible();
   await expect(header.getByRole('button', { name: '답장 초안' })).toBeVisible();
   await expect(header.getByRole('button', { name: '할 일 만들기' })).toBeVisible();
@@ -41,6 +42,11 @@ test('renders the desktop Naruon shell with local brand assets', async ({ page }
   await expect(header.getByText('메일 상세 패널에서 답장 초안을 생성합니다.')).toBeVisible();
 
   await expect(page.getByRole('region', { name: '홈 개요 대시보드' }).first()).toBeVisible();
+  const homeQuickActions = page.getByLabel('홈 빠른 실행');
+  await expect(homeQuickActions.getByRole('link', { name: '메일함 열기' })).toHaveAttribute('href', '/mail');
+  await expect(homeQuickActions.getByRole('link', { name: '보낸 메일 답변 추적' })).toHaveAttribute('href', '/mail?folder=sent');
+  await expect(homeQuickActions.getByRole('link', { name: '일정 후보 검토' })).toHaveAttribute('href', '/calendar');
+  await expect(homeQuickActions.getByRole('link', { name: '작업 보드' })).toHaveAttribute('href', '/tasks');
   await expect(page.getByRole('button', { name: '메일함 바로가기' }).first()).toBeVisible();
   await expect(page.getByRole('button', { name: '일정 확인하기' }).first()).toBeVisible();
   await page.getByRole('button', { name: '메일함 바로가기' }).first().click();


### PR DESCRIPTION
## Summary
- Route Today dashboard task, calendar, notification, help, and profile controls to implemented workspace routes.
- Replace the Home quick-action inert buttons with links to Mail, sent-mail reply tracking, Calendar, Tasks, Projects, AI Hub, Data, and Security.
- Record the dashboard dead-control closure in the branding gap plan.

## Verification
- npm test -- src/components/WorkspaceHome.dashboard.test.tsx
- npm test -- src/components/DashboardLayout.test.tsx
- npm test -- src/app/page.test.tsx
- npm run lint -- src/components/DashboardLayout.tsx src/components/DashboardLayout.test.tsx src/components/WorkspaceHome.tsx src/components/WorkspaceHome.dashboard.test.tsx tests/e2e/dashboard-branding.spec.ts
- npm run typecheck
- env -u BACKEND_INTERNAL_URL NEXT_BUILD_CPUS=2 POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run build
- env -u NO_COLOR PLAYWRIGHT_PORT=18133 LIVE_BASE_URL=http://127.0.0.1:18133 NEXT_TELEMETRY_DISABLED=1 npm run test:e2e -- dashboard-branding.spec.ts --project=desktop -g "renders the desktop Naruon shell|renders Today dashboard pending reply lane|renders compact mobile navigation|keeps the branded workspace usable without horizontal overflow|validates mobile hamburger composition" (10 passed)

## Visual evidence reviewed
- today-pending-replies-desktop.png
- today-pending-replies-mobile-pending-list.png
- today-pending-replies-mobile-scroll.png
- mobile-workspace-menu.png

## Notes
- A full dashboard-branding.spec.ts run still includes unrelated pre-existing failures in settings/data/AI Hub strict locators and used the dev server path that emits local warning output. The focused production-server run above covers this PR scope and completed without warning output.