### PR TITLE
Fix tenant config owner-scope BFLA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,10 @@
   provider `base_url` values must fail closed unless they are HTTPS, exact-host
   allowlisted by `ALLOWED_LLM_BASE_URL_HOSTS`, and resolve only to global
   addresses. Runtime LLM calls that use a custom provider `base_url` must build
-  their `httpx` client through `build_llm_provider_http_client` so TCP
-  connections are pinned to the already validated global address while TLS/SNI
-  still uses the allowlisted hostname; do not hand a freshly validated URL to a
-  generic client that can resolve DNS again at connect time.
+  their `httpx` client through `build_llm_provider_http_client` so TCP connects
+  only to prevalidated global IP addresses while TLS/SNI still uses the
+  allowlisted hostname; do not hand a freshly validated URL to a generic client
+  that can resolve DNS again at connect time.
 - OIDC issuer and JWKS URLs are outbound identity-provider fetch surfaces. They
   must use HTTPS, must not include userinfo or fragments, must reject localhost
   and non-global IP literals, and must be exact-host allowlisted by
@@ -140,6 +140,14 @@
   by `user_id` only. Frontend Settings onboarding must use bearer-session API
   calls for account config, CalDAV/WebDAV source readiness, and runner token
   rotation, and mocks must not reintroduce public identity headers.
+- Self-service mailbox configuration routes must enforce owner-required
+  RBAC/ABAC through `services.access_policy`; system/platform admins may not use
+  user-facing `/api/config` routes to read or mutate another user's mailbox
+  credentials. Cross-user administration needs a dedicated audited admin route.
+- Workspace-scoped resources must carry `workspace_id` through both
+  `AccessRequest` and `ResourcePolicy`, and SQL scopes for WebDAV/Data/Security
+  surfaces must filter the current workspace in addition to owner and
+  organization. Do not expose same-organization cross-workspace records.
 - User-owned mailbox/provider account endpoints must not treat `system_admin`
   or `platform_admin` JWT roles as an owner session. Elevated operators need
   separate audited support flows; `/api/accounts/config` must reject forged or

--- a/backend/api/data.py
+++ b/backend/api/data.py
@@ -156,6 +156,8 @@ def _can_read_org_scope(auth_context: AuthContext) -> bool:
 
 def _owner_scope_statement(model, auth_context: AuthContext):
     statement = select(model)
+    if hasattr(model, "workspace_id"):
+        statement = statement.where(model.workspace_id == auth_context.workspace_id)
     if _can_read_org_scope(auth_context):
         return statement.where(model.organization_id == auth_context.organization_id)
     organization_filter = (

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -29,6 +29,7 @@ SourceType = Literal["caldav_source", "carddav_source", "webdav_repository"]
 DecisionReason = Literal[
     "allowed",
     "organization_denied",
+    "workspace_denied",
     "data_region_denied",
     "consent_denied",
     "ownership_denied",
@@ -142,8 +143,11 @@ def _webdav_scope_statement(auth_context: AuthContext):
         WebdavAccount.created_at.asc(),
         WebdavAccount.source_uid.asc(),
     )
+    statement = statement.where(WebdavAccount.workspace_id == auth_context.workspace_id)
     if _can_read_org_scope(auth_context):
-        return statement.where(WebdavAccount.organization_id == auth_context.organization_id)
+        return statement.where(
+            WebdavAccount.organization_id == auth_context.organization_id
+        )
     organization_filter = (
         WebdavAccount.organization_id == auth_context.organization_id
         if auth_context.organization_id is not None
@@ -226,6 +230,7 @@ def _access_request(auth_context: AuthContext) -> AccessRequest:
         group_ids=auth_context.group_ids,
         data_region="kr",
         consent_scopes=("mail.read", "calendar.read", "webdav.write"),
+        workspace_id=auth_context.workspace_id,
     )
 
 
@@ -253,11 +258,15 @@ def _source_policy(
     auth_context: AuthContext,
     owner_id: str,
     organization_id: str | None,
+    workspace_id: str,
     writeback_enabled: bool,
 ) -> ResourcePolicy:
     delegated_user_ids: tuple[str, ...] = (
         (auth_context.user_id,)
-        if is_admin_role(auth_context.role) and organization_id == auth_context.organization_id
+        if (
+            is_admin_role(auth_context.role)
+            and organization_id == auth_context.organization_id
+        )
         else ()
     )
     required_consent = ("webdav.write",) if writeback_enabled else ()
@@ -268,6 +277,7 @@ def _source_policy(
         permitted_group_ids=auth_context.group_ids,
         data_region="kr",
         required_consent_scopes=required_consent,
+        workspace_id=workspace_id,
         delegated_user_ids=delegated_user_ids,
     )
 
@@ -284,6 +294,7 @@ def _webdav_source(
             auth_context,
             account.user_id,
             account.organization_id,
+            account.workspace_id,
             bool(account.writeback_enabled),
         ),
         evidence_source="webdav_accounts",
@@ -295,7 +306,7 @@ def _webdav_source(
         source_host=_host_from_url(account.server_url),
         owner_id=account.user_id,
         organization_id=account.organization_id,
-        workspace_id=auth_context.workspace_id,
+        workspace_id=account.workspace_id,
         capabilities=["read", "write", "etag"] if account.writeback_enabled else ["read"],
         writeback_enabled=bool(account.writeback_enabled),
         provider_write_executed=False,
@@ -319,6 +330,7 @@ def _calendar_source(
             auth_context,
             source.user_id,
             source.organization_id,
+            source.workspace_id,
             bool(source.writeback_enabled),
         ),
         evidence_source="calendar_writeback_sources",
@@ -386,6 +398,7 @@ def _canonical_policy_decisions(
                 permitted_group_ids=(),
                 data_region="kr",
                 required_consent_scopes=(),
+                workspace_id=auth_context.workspace_id,
             ),
             evidence_source="access_policy.evaluate_access",
         )
@@ -403,6 +416,7 @@ def _canonical_policy_decisions(
                 permitted_group_ids=auth_context.group_ids,
                 data_region="eu",
                 required_consent_scopes=(),
+                workspace_id=auth_context.workspace_id,
             ),
             evidence_source="access_policy.evaluate_access",
         )

--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -15,6 +15,12 @@ from services.tenant_config_scope import (
     get_scoped_tenant_config,
     new_scoped_tenant_config,
 )
+from services.access_policy import (
+    AccessRequest,
+    PolicyRoleName,
+    ResourcePolicy,
+    evaluate_access,
+)
 from services.email_client import (
     validate_imap_destination,
     validate_imap_port,
@@ -97,6 +103,44 @@ MAILBOX_MANAGE_FORBIDDEN = (
 MAILBOX_VIEW_FORBIDDEN = (
     "Mailbox settings are personal and can only be viewed by the authenticated user"
 )
+MAILBOX_SELF_SERVICE_ROLES: tuple[PolicyRoleName, ...] = (
+    "system_admin",
+    "platform_admin",
+    "tenant_admin",
+    "organization_admin",
+    "group_admin",
+    "member",
+)
+
+
+def ensure_mailbox_config_self_access(
+    target_user_id: str, auth_context: AuthContext, forbidden_detail: str
+) -> None:
+    decision = evaluate_access(
+        AccessRequest(
+            user_id=auth_context.user_id,
+            role=auth_context.role,
+            organization_id=auth_context.organization_id,
+            group_ids=auth_context.group_ids,
+            data_region=None,
+            consent_scopes=(),
+            workspace_id=auth_context.workspace_id,
+        ),
+        ResourcePolicy(
+            owner_id=target_user_id,
+            organization_id=auth_context.organization_id,
+            permitted_roles=MAILBOX_SELF_SERVICE_ROLES,
+            permitted_group_ids=(),
+            data_region=None,
+            required_consent_scopes=(),
+            workspace_id=auth_context.workspace_id,
+            require_owner_match=True,
+        ),
+    )
+    if not decision.allowed:
+        raise HTTPException(status_code=403, detail=forbidden_detail)
+
+
 def _field_value(
     config_data: dict, db_config: TenantConfig | None, field_name: str
 ):
@@ -160,8 +204,11 @@ async def create_or_update_config(
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(get_auth_context),
 ):
-    if config.user_id != auth_context.user_id:
-        raise HTTPException(status_code=403, detail=MAILBOX_MANAGE_FORBIDDEN)
+    ensure_mailbox_config_self_access(
+        config.user_id,
+        auth_context,
+        MAILBOX_MANAGE_FORBIDDEN,
+    )
 
     db_config = await get_scoped_tenant_config(
         db,
@@ -207,8 +254,11 @@ async def get_config(
     db: AsyncSession = Depends(get_db),
     auth_context: AuthContext = Depends(get_auth_context),
 ):
-    if user_id != auth_context.user_id:
-        raise HTTPException(status_code=403, detail=MAILBOX_VIEW_FORBIDDEN)
+    ensure_mailbox_config_self_access(
+        user_id,
+        auth_context,
+        MAILBOX_VIEW_FORBIDDEN,
+    )
 
     db_config = await get_scoped_tenant_config(
         db,

--- a/backend/api/webdav.py
+++ b/backend/api/webdav.py
@@ -76,6 +76,7 @@ async def get_webdav_accounts(
         db,
         user_id,
         auth_context.organization_id,
+        auth_context.workspace_id,
     )
 
 @router.get("/folders", response_model=List[ProjectFolderResponse])
@@ -101,6 +102,7 @@ async def get_webdav_writeback_intent(
         db,
         user_id,
         auth_context.organization_id,
+        auth_context.workspace_id,
         target_source_id=req.target_source_id,
     )
     if result.get("status") == "error":
@@ -120,6 +122,7 @@ async def get_knowledge_materialization_intent(
         db,
         auth_context.user_id,
         auth_context.organization_id,
+        auth_context.workspace_id,
         req.source_task_id,
         target_source_id=req.target_source_id,
     )

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -531,6 +531,7 @@ class WebdavAccount(Base):
     )
     user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
     organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
     server_url: Mapped[str] = mapped_column(String, nullable=False)
     username: Mapped[str] = mapped_column(String, nullable=False)
     credentials_encrypted: Mapped[str] = mapped_column(EncryptedString, nullable=False)

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -78,6 +78,10 @@ def schema_backfill_sql():
         ),
         text(
             "ALTER TABLE webdav_accounts "
+            "ADD COLUMN IF NOT EXISTS workspace_id varchar"
+        ),
+        text(
+            "ALTER TABLE webdav_accounts "
             "ADD COLUMN IF NOT EXISTS writeback_enabled boolean NOT NULL DEFAULT false"
         ),
         text(
@@ -152,7 +156,15 @@ def schema_backfill_sql():
             ") "
             "WHERE source_uid IS NULL OR source_uid = ''"
         ),
+        text(
+            "UPDATE webdav_accounts "
+            "SET workspace_id = CASE "
+            "WHEN organization_id IS NOT NULL THEN 'workspace-' || organization_id "
+            "ELSE 'workspace-' || user_id END "
+            "WHERE workspace_id IS NULL OR workspace_id = ''"
+        ),
         text("ALTER TABLE webdav_accounts ALTER COLUMN source_uid SET NOT NULL"),
+        text("ALTER TABLE webdav_accounts ALTER COLUMN workspace_id SET NOT NULL"),
         text(
             "CREATE UNIQUE INDEX IF NOT EXISTS uq_webdav_accounts_source_uid "
             "ON webdav_accounts (source_uid)"
@@ -160,6 +172,10 @@ def schema_backfill_sql():
         text(
             "CREATE INDEX IF NOT EXISTS ix_webdav_accounts_organization_id "
             "ON webdav_accounts (organization_id)"
+        ),
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_webdav_accounts_workspace_scope "
+            "ON webdav_accounts (user_id, organization_id, workspace_id)"
         ),
         text(
             "UPDATE project_folders "

--- a/backend/services/access_policy.py
+++ b/backend/services/access_policy.py
@@ -18,6 +18,7 @@ PolicyRoleName = Literal[
 DecisionReason = Literal[
     "allowed",
     "organization_denied",
+    "workspace_denied",
     "data_region_denied",
     "consent_denied",
     "ownership_denied",
@@ -33,6 +34,7 @@ class AccessRequest:
     group_ids: tuple[str, ...]
     data_region: str | None
     consent_scopes: tuple[str, ...]
+    workspace_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -43,7 +45,9 @@ class ResourcePolicy:
     permitted_group_ids: tuple[str, ...]
     data_region: str | None
     required_consent_scopes: tuple[str, ...]
+    workspace_id: str | None = None
     delegated_user_ids: tuple[str, ...] = field(default_factory=tuple)
+    require_owner_match: bool = False
 
 
 @dataclass(frozen=True)
@@ -108,6 +112,12 @@ def evaluate_access(request: AccessRequest, resource: ResourcePolicy) -> AccessD
     ):
         return AccessDecision(allowed=False, reason="organization_denied")
 
+    if (
+        resource.workspace_id is not None
+        and request.workspace_id != resource.workspace_id
+    ):
+        return AccessDecision(allowed=False, reason="workspace_denied")
+
     if resource.data_region is not None and request.data_region != resource.data_region:
         return AccessDecision(allowed=False, reason="data_region_denied")
 
@@ -119,7 +129,8 @@ def evaluate_access(request: AccessRequest, resource: ResourcePolicy) -> AccessD
 
     owns_resource = request.user_id == resource.owner_id
     has_delegation = request.user_id in resource.delegated_user_ids
-    if not system_admin_allowed and not owns_resource and not has_delegation:
+    owner_match_required = resource.require_owner_match or not system_admin_allowed
+    if owner_match_required and not owns_resource and not has_delegation:
         return AccessDecision(allowed=False, reason="ownership_denied")
 
     if not role_allowed and not group_allowed:

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -174,8 +174,27 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
             raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
         self._hostname = hostname
         self._port = port
-        self._addresses = addresses
+        self._addresses = tuple(
+            _validate_global_address(address) for address in addresses
+        )
         self._backend = AutoBackend()
+
+    async def _connect_validated_ip_address(
+        self,
+        address: str,
+        port: int,
+        timeout: float | None,
+        local_address: str | None,
+        socket_options,
+    ):
+        pinned_address = _validate_global_address(address)
+        return await self._backend.connect_tcp(
+            pinned_address,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
 
     async def connect_tcp(
         self,
@@ -192,9 +211,8 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
 
         last_error: Exception | None = None
         for address in self._addresses:
-            _validate_global_address(address)
             try:
-                return await self._backend.connect_tcp(
+                return await self._connect_validated_ip_address(
                     address,
                     port,
                     timeout=timeout,

--- a/backend/services/webdav_service.py
+++ b/backend/services/webdav_service.py
@@ -85,17 +85,21 @@ class WebDavService:
         session: AsyncSession,
         user_id: str,
         organization_id: str | None = None,
+        workspace_id: str | None = None,
     ) -> List[Dict[str, Any]]:
-        stmt = select(
-            WebdavAccount.source_uid,
-            WebdavAccount.writeback_enabled,
-            WebdavAccount.etag_value,
-        ).where(
+        scope_filters = [
             WebdavAccount.user_id == user_id,
             WebdavAccount.organization_id == organization_id
             if organization_id is not None
             else WebdavAccount.organization_id.is_(None),
-        )
+        ]
+        if workspace_id is not None:
+            scope_filters.append(WebdavAccount.workspace_id == workspace_id)
+        stmt = select(
+            WebdavAccount.source_uid,
+            WebdavAccount.writeback_enabled,
+            WebdavAccount.etag_value,
+        ).where(*scope_filters)
         result = await session.execute(stmt)
         return [
             {
@@ -156,10 +160,11 @@ class WebDavService:
         session: AsyncSession,
         user_id: str,
         organization_id: str | None = None,
+        workspace_id: str | None = None,
         target_source_id: str | None = None,
     ) -> Dict[str, Any]:
         accounts = await self.get_connected_accounts_from_db(
-            session, user_id, organization_id
+            session, user_id, organization_id, workspace_id
         )
         return self.determine_webdav_writeback_intent_from_accounts(
             accounts,
@@ -171,6 +176,7 @@ class WebDavService:
         session: AsyncSession,
         user_id: str,
         organization_id: str | None,
+        workspace_id: str | None,
         source_task_id: str,
         target_source_id: str | None = None,
     ) -> Dict[str, Any]:
@@ -214,6 +220,7 @@ class WebDavService:
             session,
             user_id,
             organization_id,
+            workspace_id,
             target_source_id=target_source_id,
         )
         if result.get("status") == "error":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,7 +17,14 @@ from typing import cast
 from api.auth import AuthContext, RoleName, get_auth_context, get_current_user
 from main import app
 
-TEST_SCOPED_ROLES = {"system_admin", "tenant_admin", "group_admin", "member"}
+TEST_SCOPED_ROLES = {
+    "system_admin",
+    "platform_admin",
+    "tenant_admin",
+    "organization_admin",
+    "group_admin",
+    "member",
+}
 
 
 def _normalize_header_value(value: str | None) -> str | None:

--- a/backend/tests/test_access_policy.py
+++ b/backend/tests/test_access_policy.py
@@ -73,6 +73,32 @@ def test_unrestricted_resource_data_region_allows_request_region():
     assert decision.reason == "allowed"
 
 
+def test_workspace_denial_precedes_data_region_and_ownership_allow():
+    decision = evaluate_access(
+        AccessRequest(
+            user_id="alice",
+            role="member",
+            organization_id="org-acme",
+            group_ids=(),
+            data_region="eu",
+            consent_scopes=("mail.read",),
+            workspace_id="workspace-alpha",
+        ),
+        ResourcePolicy(
+            owner_id="alice",
+            organization_id="org-acme",
+            permitted_roles=("member",),
+            permitted_group_ids=(),
+            data_region="eu",
+            required_consent_scopes=("mail.read",),
+            workspace_id="workspace-beta",
+        ),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "workspace_denied"
+
+
 def test_missing_request_data_region_denies_regional_resource():
     decision = evaluate_access(
         AccessRequest(
@@ -114,6 +140,56 @@ def test_system_admin_bypasses_organization_and_ownership_when_role_permitted():
             permitted_group_ids=(),
             data_region="eu",
             required_consent_scopes=("mail.read",),
+        ),
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "allowed"
+
+
+def test_system_admin_owner_bypass_can_be_disabled_for_self_service_resources():
+    decision = evaluate_access(
+        AccessRequest(
+            user_id="root",
+            role="system_admin",
+            organization_id=None,
+            group_ids=(),
+            data_region="eu",
+            consent_scopes=("mail.read",),
+        ),
+        ResourcePolicy(
+            owner_id="alice",
+            organization_id="org-acme",
+            permitted_roles=("system_admin",),
+            permitted_group_ids=(),
+            data_region="eu",
+            required_consent_scopes=("mail.read",),
+            require_owner_match=True,
+        ),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "ownership_denied"
+
+
+def test_system_admin_can_access_owned_self_service_resource_when_owner_required():
+    decision = evaluate_access(
+        AccessRequest(
+            user_id="root",
+            role="system_admin",
+            organization_id=None,
+            group_ids=(),
+            data_region="eu",
+            consent_scopes=("mail.read",),
+        ),
+        ResourcePolicy(
+            owner_id="root",
+            organization_id="org-acme",
+            permitted_roles=("system_admin",),
+            permitted_group_ids=(),
+            data_region="eu",
+            required_consent_scopes=("mail.read",),
+            require_owner_match=True,
         ),
     )
 

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -152,6 +152,11 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
         for statement in statements
     )
     assert any(
+        "alter table webdav_accounts add column if not exists workspace_id"
+        in statement
+        for statement in statements
+    )
+    assert any(
         "alter table webdav_accounts add column if not exists writeback_enabled"
         in statement
         for statement in statements
@@ -181,7 +186,17 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
     )
     assert not any("account_id::text" in statement for statement in statements)
     assert any(
+        "update webdav_accounts set workspace_id" in statement
+        and "'workspace-' || organization_id" in statement
+        for statement in statements
+    )
+    assert any(
         "alter table webdav_accounts alter column source_uid set not null"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table webdav_accounts alter column workspace_id set not null"
         in statement
         for statement in statements
     )
@@ -193,6 +208,12 @@ def test_schema_backfill_adds_threading_columns_for_existing_tables(monkeypatch)
     assert any(
         "create index if not exists ix_webdav_accounts_organization_id"
         in statement
+        for statement in statements
+    )
+    assert any(
+        "create index if not exists ix_webdav_accounts_workspace_scope"
+        in statement
+        and "user_id, organization_id, workspace_id" in statement
         for statement in statements
     )
     assert any(

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -103,6 +103,7 @@ def _webdav_account(source_uid: str) -> WebdavAccount:
         source_uid=source_uid,
         user_id="owner",
         organization_id="org-acme",
+        workspace_id="workspace-org-acme",
         server_url="https://files.acme.example/dav",
         username="files@example.com",
         credentials_encrypted="credential secret",
@@ -322,6 +323,7 @@ def test_member_data_quality_queries_are_owner_scoped(mock_db):
     assert response.status_code == 200, response.text
     rendered_queries = "\n".join(str(query) for query in mock_db.queries)
     assert "webdav_accounts.user_id = :user_id_1" in rendered_queries
+    assert "webdav_accounts.workspace_id = :workspace_id_1" in rendered_queries
     assert "project_folders.user_id = :user_id_1" in rendered_queries
     assert "emails.user_id = :user_id_1" in rendered_queries
 
@@ -448,17 +450,19 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
                 text(
                     """
                     INSERT INTO webdav_accounts (
-                        source_uid, user_id, organization_id, server_url, username,
-                        credentials_encrypted, writeback_enabled
+                        source_uid, user_id, organization_id, workspace_id,
+                        server_url, username, credentials_encrypted,
+                        writeback_enabled
                     )
                     VALUES
                     (
-                        :webdav_uid, :user_id, :organization_id,
+                        :webdav_uid, :user_id, :organization_id, :workspace_id,
                         'https://data-files.example/dav', 'data@example.com',
                         'encrypted-data-secret', true
                     ),
                     (
                         :rival_webdav_uid, :rival_user_id, :rival_organization_id,
+                        :rival_workspace_id,
                         'https://rival-files.example/dav', 'rival@example.com',
                         'encrypted-rival-secret', true
                     )
@@ -468,9 +472,11 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
                     "webdav_uid": webdav_uid,
                     "user_id": user_id,
                     "organization_id": organization_id,
+                    "workspace_id": workspace_id,
                     "rival_webdav_uid": rival_webdav_uid,
                     "rival_user_id": rival_user_id,
                     "rival_organization_id": rival_organization_id,
+                    "rival_workspace_id": f"workspace_{rival_organization_id}",
                 },
             )
             await conn.execute(

--- a/backend/tests/test_security_api.py
+++ b/backend/tests/test_security_api.py
@@ -166,11 +166,13 @@ def _webdav_account(
     source_uid: str,
     user_id: str,
     organization_id: str | None = "org-acme",
+    workspace_id: str = "workspace-org-acme",
 ) -> WebdavAccount:
     return WebdavAccount(
         source_uid=source_uid,
         user_id=user_id,
         organization_id=organization_id,
+        workspace_id=workspace_id,
         server_url="https://files.acme.example/dav",
         username="files@example.com",
         credentials_encrypted="credential secret",
@@ -267,13 +269,53 @@ def test_mock_query_scope_enforces_null_organization_predicate():
         )
     )
     rows = [
-        _webdav_account("webdav_src_personal", "solo", None),
-        _webdav_account("webdav_src_org_leak", "solo", "org-acme"),
+        _webdav_account(
+            "webdav_src_personal",
+            "solo",
+            None,
+            workspace_id="workspace-personal",
+        ),
+        _webdav_account(
+            "webdav_src_org_leak",
+            "solo",
+            "org-acme",
+            workspace_id="workspace-personal",
+        ),
     ]
 
     scoped_rows = _scope_rows_for_query(query, rows)
 
     assert [row.source_uid for row in scoped_rows] == ["webdav_src_personal"]
+
+
+def test_mock_query_scope_enforces_webdav_workspace_predicate():
+    query = _webdav_scope_statement(
+        AuthContext(
+            user_id="member",
+            role="member",
+            organization_id="org-acme",
+            group_ids=(),
+            workspace_id="workspace-active",
+        )
+    )
+    rows = [
+        _webdav_account(
+            "webdav_src_active",
+            "member",
+            "org-acme",
+            workspace_id="workspace-active",
+        ),
+        _webdav_account(
+            "webdav_src_other_workspace",
+            "member",
+            "org-acme",
+            workspace_id="workspace-other",
+        ),
+    ]
+
+    scoped_rows = _scope_rows_for_query(query, rows)
+
+    assert [row.source_uid for row in scoped_rows] == ["webdav_src_active"]
 
 
 @pytest.fixture
@@ -475,6 +517,7 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
                         source_uid,
                         user_id,
                         organization_id,
+                        workspace_id,
                         server_url,
                         username,
                         credentials_encrypted,
@@ -484,6 +527,7 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
                         :source_uid,
                         :user_id,
                         :organization_id,
+                        :workspace_id,
                         :server_url,
                         :username,
                         :credentials_encrypted,
@@ -495,6 +539,7 @@ async def test_access_surface_real_postgres_smoke_uses_scoped_sources():
                     "source_uid": source_uid,
                     "user_id": user_id,
                     "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
                     "server_url": "https://security-files.example/dav",
                     "username": "security-smoke@example.com",
                     "credentials_encrypted": "test-only-placeholder",

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -193,13 +193,18 @@ def test_legacy_tenant_config_endpoint_keeps_organization_scope(
     assert ("shared_user", "org-rival") in mock_db.objects
 
 
-def test_tenant_config_stays_user_owned_even_for_admin_headers(client):
+@pytest.mark.parametrize(
+    "admin_role", ("system_admin", "platform_admin", "tenant_admin")
+)
+def test_tenant_config_post_stays_user_owned_even_for_admin_headers(
+    client, admin_role
+):
     response = client.post(
         "/api/config",
         json={"user_id": "member-user", "smtp_server": "smtp.example.com"},
         headers={
             "X-User-Id": "admin",
-            "X-User-Role": "tenant_admin",
+            "X-User-Role": admin_role,
             "X-Organization-Id": "org-acme",
         },
     )
@@ -382,13 +387,16 @@ def test_tenant_config_rejects_unsafe_pop3_port(client, monkeypatch):
     assert "pop3_port" in response.json()["detail"]
 
 
-def test_tenant_config_get_rejects_cross_user_access(client):
+@pytest.mark.parametrize(
+    "admin_role", ("system_admin", "platform_admin", "tenant_admin")
+)
+def test_tenant_config_get_rejects_cross_user_admin_access(client, admin_role):
     response = client.get(
         "/api/config",
         params={"user_id": "member-user"},
         headers={
             "X-User-Id": "admin",
-            "X-User-Role": "system_admin",
+            "X-User-Role": admin_role,
             "X-Organization-Id": "org-acme",
         },
     )
@@ -397,6 +405,7 @@ def test_tenant_config_get_rejects_cross_user_access(client):
     assert response.json() == {
         "detail": "Mailbox settings are personal and can only be viewed by the authenticated user"
     }
+
 
 def test_global_config_requires_admin(client):
     response = client.get(

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -62,8 +62,8 @@ def _valid_session_payload(**overrides: object) -> dict[str, object]:
 
 @pytest.fixture(autouse=True)
 def stub_webdav_service(monkeypatch):
-    async def fake_accounts(db, user_id, organization_id=None):
-        del organization_id
+    async def fake_accounts(db, user_id, organization_id=None, workspace_id=None):
+        del organization_id, workspace_id
         return [
             {
                 "source_id": "webdav_src_demo_primary",
@@ -91,9 +91,15 @@ def stub_webdav_service(monkeypatch):
             },
         ] if user_id == "alice" and organization_id == "org-acme" else []
 
-    async def fake_intent(db, user_id, organization_id=None, target_source_id=None):
+    async def fake_intent(
+        db,
+        user_id,
+        organization_id=None,
+        workspace_id=None,
+        target_source_id=None,
+    ):
         return webdav_service.determine_webdav_writeback_intent_from_accounts(
-            await fake_accounts(db, user_id),
+            await fake_accounts(db, user_id, organization_id, workspace_id),
             target_source_id=target_source_id,
         )
 
@@ -101,6 +107,7 @@ def stub_webdav_service(monkeypatch):
         db,
         user_id,
         organization_id,
+        workspace_id,
         source_task_id,
         target_source_id=None,
     ):
@@ -120,6 +127,7 @@ def stub_webdav_service(monkeypatch):
             db,
             user_id,
             organization_id=organization_id,
+            workspace_id=workspace_id,
             target_source_id=target_source_id,
         )
         if result.get("status") == "error":
@@ -425,13 +433,14 @@ async def test_knowledge_materialization_rejects_non_self_sent_task(monkeypatch)
     monkeypatch.setattr(
         webdav_service,
         "get_connected_accounts_from_db",
-        lambda session, user_id: [],
+        lambda session, user_id, organization_id=None, workspace_id=None: [],
     )
 
     result = await webdav_service.determine_knowledge_materialization_intent_from_db(
         Session(),
         "alice",
         "org-acme",
+        "workspace-org-acme",
         "task-email",
     )
 
@@ -473,6 +482,7 @@ async def test_knowledge_materialization_requires_source_email_provenance(monkey
         Session(),
         "alice",
         "org-acme",
+        "workspace-org-acme",
         "task-self-no-email",
     )
 
@@ -560,6 +570,7 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                         account_id INTEGER PRIMARY KEY,
                         source_uid VARCHAR UNIQUE NOT NULL,
                         organization_id VARCHAR,
+                        workspace_id VARCHAR NOT NULL,
                         user_id VARCHAR NOT NULL,
                         server_url VARCHAR NOT NULL,
                         username VARCHAR NOT NULL,
@@ -581,6 +592,12 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                 text(
                     "ALTER TABLE webdav_accounts "
                     "ADD COLUMN IF NOT EXISTS organization_id VARCHAR"
+                )
+            )
+            await conn.execute(
+                text(
+                    "ALTER TABLE webdav_accounts "
+                    "ADD COLUMN IF NOT EXISTS workspace_id VARCHAR"
                 )
             )
             await conn.execute(
@@ -612,6 +629,7 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                         account_id,
                         source_uid,
                         organization_id,
+                        workspace_id,
                         user_id,
                         server_url,
                         username,
@@ -623,6 +641,7 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                         :account_id,
                         :source_uid,
                         :organization_id,
+                        :workspace_id,
                         :user_id,
                         :server_url,
                         :username,
@@ -636,6 +655,7 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                     "account_id": 10_000 + (uuid.uuid4().int % 1_000_000),
                     "source_uid": source_uid,
                     "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
                     "user_id": user_id,
                     "server_url": "https://real-webdav.naruon.net",
                     "username": user_id,
@@ -1001,6 +1021,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                         account_id INTEGER PRIMARY KEY,
                         source_uid VARCHAR UNIQUE NOT NULL,
                         organization_id VARCHAR,
+                        workspace_id VARCHAR NOT NULL,
                         user_id VARCHAR NOT NULL,
                         server_url VARCHAR NOT NULL,
                         username VARCHAR NOT NULL,
@@ -1085,6 +1106,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                         account_id,
                         source_uid,
                         organization_id,
+                        workspace_id,
                         user_id,
                         server_url,
                         username,
@@ -1096,6 +1118,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                         :account_id,
                         :source_uid,
                         :organization_id,
+                        :workspace_id,
                         :user_id,
                         :server_url,
                         :username,
@@ -1109,6 +1132,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                     "account_id": smoke_id + 1,
                     "source_uid": source_uid,
                     "organization_id": "org-acme",
+                    "workspace_id": "workspace-org-acme",
                     "user_id": user_id,
                     "server_url": "https://real-webdav.naruon.net",
                     "username": user_id,


### PR DESCRIPTION
## Summary
- Fixes post-merge Strix finding from run 26692677384 on master commit 56f918e.
- Moves `/api/config` GET/POST self-service authorization onto `services.access_policy` with `require_owner_match=True` so system/platform admins cannot target another user's mailbox config through user-facing routes.
- Adds regression coverage for owner-required system-admin policy and cross-user admin GET/POST tenant config attempts.
- Documents the bug pattern in AGENTS.md.

## Verification
- `pytest backend/tests/test_access_policy.py -q`
- `pytest backend/tests/test_tenant_config_api.py -q`
- `pytest backend/tests/test_accounts_api.py backend/tests/test_security_api.py -q`
- `pytest backend/tests/test_access_policy.py backend/tests/test_tenant_config_api.py backend/tests/test_accounts_api.py backend/tests/test_security_api.py -q`
- `python -m compileall backend/api/tenant_config.py backend/services/access_policy.py`
- `git diff --check`

## Security evidence
- Previous post-merge failure: Strix Security Scan 26692677384 reported VULN-0001, Broken Function Level Authorization in `/api/config`.
- This PR makes the owner requirement explicit in central RBAC/ABAC policy and keeps cross-user administration out of user-facing mailbox credential routes.