### PR TITLE
fix(ci): preserve above-threshold vulnerabilities when models fail mid-stream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,5 @@
 - **UI/Browser Testing**: Use a real browser for testing (do not rely on assumptions).
 - **Strict Errors**: Treat `Timeout`, `Fatal`, `Warn`, and `Denied` outputs as hard failures.
 - **Goal**: Actively manage tasks to ensure open PR counts converge to 0.
+
+- When the gate exhausts fallbacks after the primary model produces a finding at or above threshold and then fails with a retryable error (like `NOT_FOUND`), ensure the final output explicitly reports `Strix quick scan failed with a non-recoverable error.` to prevent downgrading the finding to pass or misleadingly reporting an unavailability error.

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -2301,6 +2301,7 @@ has_only_below_threshold_vulnerabilities() {
 
 	local found_any_vuln_file=0
 	local global_max_rank=-1
+	STRIX_MAX_SEVERITY_RANK=-1
 	local saw_any_severity=0
 
 	update_max_severity_from_stream() {
@@ -2323,6 +2324,7 @@ has_only_below_threshold_vulnerabilities() {
 			saw_any_severity=1
 			if [ "$rank" -gt "$global_max_rank" ]; then
 				global_max_rank="$rank"
+				STRIX_MAX_SEVERITY_RANK="$rank"
 			fi
 		done < <(grep -Ei 'severity[[:space:]]*:' "$source_path" || true)
 	}
@@ -2850,6 +2852,13 @@ run_current_target_scan() {
 		else
 			echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in $fallback_config_name." >&2
 		fi
+	fi
+
+	local threshold_rank
+	threshold_rank="$(severity_rank "$STRIX_FAIL_ON_MIN_SEVERITY")"
+	if [ "${STRIX_MAX_SEVERITY_RANK:--1}" -ge "$threshold_rank" ]; then
+		echo "Strix quick scan failed with a non-recoverable error." >&2
+		return 1
 	fi
 
 	if is_vertex_model "$PRIMARY_MODEL"; then

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -4997,7 +4997,7 @@ run_gate_case "model-disagreement-critical-in-earlier-report" \
 	"vertex_ai/model-a" \
 	"vertex_ai/model-b" \
 	"1" \
-	"Configured Vertex model and fallback models were unavailable." \
+	"Strix quick scan failed with a non-recoverable error." \
 	"2" \
 	"vertex_ai/model-a|vertex_ai/model-b" \
 	"<unset>|<unset>"


### PR DESCRIPTION
When a primary model generates a finding that is at or above the threshold (e.g. `CRITICAL`), but then the model process crashes mid-stream with a retryable error such as `NOT_FOUND`, the gate begins the fallback loop. If the fallback models also fail or complete without overriding the finding, the pipeline used to exhaust fallbacks and exit with the generic message `"Configured Vertex model and fallback models were unavailable."`.

Because this exit message overwrote the detection message, the user would not be alerted to the critical vulnerability discovered before the infrastructure issue occurred.

This PR fixes this by verifying the maximum severity detected across all generated reports thus far (saved in `STRIX_MAX_SEVERITY_RANK`). If the rank meets or exceeds the threshold, the script will output `"Strix quick scan failed with a non-recoverable error."` and exit with `1`, explicitly preventing the critical finding from being ignored or hidden behind an unavailability error. I also updated the corresponding test (`model-disagreement-critical-in-earlier-report`) and documented this in `AGENTS.md`.

---
*PR created automatically by Jules for task [10548847571812843222](https://jules.google.com/task/10548847571812843222) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when Strix gate scans encounter non-recoverable errors to avoid misreporting as availability issues.
  * Enhanced severity tracking during vulnerability scanning to better handle scan failures.

* **Tests**
  * Updated test expectations for error messaging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->