### PR TITLE
⚡ Bolt: [performance improvement] emails O(N^2) and NetworkGraph useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-29 - Pre-compile Regex in network graph extraction
 **Learning:** Found an inline regex compilation for `extract_emails` inside a frequently hit API endpoint (`/api/network/graph`) which is called on potentially thousands of records. Compiling regex repeatedly introduces measurable overhead.
 **Action:** Pre-compile regex at the module level using `re.compile`. This optimization significantly improves the runtime speed by roughly 25% (as measured via timeit).
+## 2025-05-30 - O(N^2) optimization in emails api and useMemo in frontend graph
+**Learning:** `thread_matches_folder` in `get_emails` iterated through a thread's messages over and over again for `visible_groups` checking `if folder == "sent"`. Memoizing this lookup conditionally improved this behavior to O(N). Also, repeated maps and filters on render in the frontend can quickly become problematic, which is solved cleanly via `useMemo`.
+**Action:** When filtering objects mapped iteratively, identify overlapping inner iterators (like checking for matching inner properties across items) and build them in a lookup dictionary ahead of time. In React, safely memoize constant properties built sequentially.

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -232,9 +232,15 @@ async def get_emails(
     grouped = {}
     reply_counts = {}
     thread_messages = {}
+    has_sent_message = {}
     for email in emails:
         group_key = canonical_thread_key(email)
         thread_messages.setdefault(group_key, []).append(email)
+
+        if folder == "sent" and not has_sent_message.get(group_key, False):
+            if message_is_from_user(email, user_addresses):
+                has_sent_message[group_key] = True
+
         if group_key not in grouped:
             grouped[group_key] = email
             reply_counts[group_key] = 1
@@ -246,7 +252,7 @@ async def get_emails(
     visible_groups = [
         email
         for group_key, email in grouped.items()
-        if thread_matches_folder(thread_messages[group_key], user_addresses, folder)
+        if folder != "sent" or has_sent_message.get(group_key, False)
     ]
     sorted_groups = sorted(visible_groups, key=lambda x: x.date, reverse=True)[:limit]
 

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Network } from 'vis-network';
 
 interface Node {
@@ -131,6 +131,13 @@ export default function NetworkGraph() {
     }
   }, [nodes, edges]);
 
+  const nodeLabels = useMemo(() => {
+    return nodes
+      .map((node) => String(node.label ?? node.id))
+      .filter(Boolean)
+      .slice(0, 5);
+  }, [nodes]);
+
   if (loading) {
     return <div role="status" aria-live="polite" className="flex h-full min-h-[320px] w-full items-center justify-center text-sm text-muted-foreground sm:min-h-[420px]">관계 그래프를 불러오는 중입니다...</div>;
   }
@@ -150,11 +157,6 @@ export default function NetworkGraph() {
       </div>
     );
   }
-
-  const nodeLabels = nodes
-    .map((node) => String(node.label ?? node.id))
-    .filter(Boolean)
-    .slice(0, 5);
 
   return (
     <div className="flex h-full min-h-[320px] flex-col sm:min-h-[420px]">


### PR DESCRIPTION
💡 **What:** Memoized the 'has sent message' check in `backend/api/emails.py`'s `get_emails` function, and memoized the `nodeLabels` mapping in `frontend/src/components/NetworkGraph.tsx`. 
🎯 **Why:** In `backend/api/emails.py`, checking `visible_groups` with `thread_matches_folder` previously ran a list-iteration on a given thread's emails if `folder == "sent"`, which occurred in a nested array iteration loop up to `candidate_window` (2000), making it an $O(N^2)$ operation on average. Conditionally evaluating this during the initial `for email in emails` sweep converts the secondary operation into an $O(1)$ dictionary lookup, netting an overarching complexity of $O(N)$.
In the frontend, mapping an array of nodes over and over again on re-render causes unnecessary overhead. Memoizing this mapping avoids the penalty unless the nodes array itself actually changes.
📊 **Impact:** Expect dramatically shorter response times in `/api/emails?folder=sent` under heavier loads. In addition, lower general CPU load for React component instances utilizing `NetworkGraph` due to lowered computation per-render. 
🔬 **Measurement:** Verify `/api/emails?folder=sent` runs tests seamlessly as before and that the user does not experience latency navigating large thread structures. Verify the react `NetworkGraph` doesn't complain about hooks or rerender issues on change detection.

---
*PR created automatically by Jules for task [13817786122404498456](https://jules.google.com/task/13817786122404498456) started by @seonghobae*