### PR TITLE
ci: cover GitHub Models connection retry self-test

### DIFF
--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -680,7 +680,7 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 			;;
 		esac
 		;;
-	vertex-primary-api-connection-retry-same-model-success)
+	vertex-primary-api-connection-retry-same-model-success|github-models-internal-server-connection-retry-same-model-success)
 		case "${STRIX_LLM:-}" in
 		gemini/retry-api-connection-primary|vertex_ai/retry-api-connection-primary|openai/openai/retry-api-connection-primary)
 			attempt="0"


### PR DESCRIPTION
## Summary\n- map the GitHub Models InternalServerError retry scenario to the fake Strix scenario handler\n- keep the current GitHub Models same-model retry self-test aligned with the gate behavior\n\n## Verification\n- bash -n scripts/ci/test_strix_quick_gate.sh scripts/ci/strix_quick_gate.sh\n- python3 -m pytest -p no:warnings backend/tests/test_release_governance.py -q\n- single-case runner for github-models-internal-server-connection-retry-same-model-success\n- git diff --check HEAD~1 HEAD