### PR TITLE
feat(auth): add browser OIDC PKCE session flow

### DIFF
--- a/docs/operations/auth-key-management.md
+++ b/docs/operations/auth-key-management.md
@@ -99,6 +99,20 @@
   code cannot reintroduce the development-header trust boundary.
 - Caller-provided `Authorization` is also discarded by the browser API client;
   only the stored `naruon_session_token` may populate the backend bearer session.
+- When `NEXT_PUBLIC_OIDC_ISSUER_URL` and `NEXT_PUBLIC_OIDC_CLIENT_ID` are set,
+  the browser can start an Authorization Code + PKCE login against the configured
+  Keycloak/Casdoor issuer, complete `/auth/callback`, store the returned OIDC
+  `access_token` as `naruon_session_token`, and send that token on private API
+  calls. Public endpoint overrides may be supplied with
+  `NEXT_PUBLIC_OIDC_AUTHORIZATION_ENDPOINT`, `NEXT_PUBLIC_OIDC_TOKEN_ENDPOINT`,
+  `NEXT_PUBLIC_OIDC_END_SESSION_ENDPOINT`, `NEXT_PUBLIC_OIDC_REDIRECT_URI`, and
+  `NEXT_PUBLIC_OIDC_SCOPE`; otherwise Keycloak's
+  `/protocol/openid-connect/{auth,token,logout}` endpoints are derived from the
+  issuer URL.
+- Browser-side OIDC support does not mint local roles. The IdP token must still
+  satisfy the backend's signed claim contract: verified issuer/audience, subject,
+  explicit non-platform role, organization, groups, workspace, expiry, and no
+  unsupported critical headers.
 
 ## Keycloak/Casdoor decision path
 
@@ -115,6 +129,6 @@
 
 - Compare Keycloak and Casdoor on OIDC support, operational complexity, admin UX,
   self-hosting footprint, backup/restore, and integration with gateway auth.
-- Replace the HMAC session bridge with verified OIDC/JWT claims while keeping
-  regression tests that prove every email/search/network query path is scoped to
-  the authenticated mailbox owner and organization.
+- Complete production IdP onboarding runbooks and key rotation procedures while
+  keeping regression tests that prove every email/search/network query path is
+  scoped to the authenticated mailbox owner and organization.

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { completeOidcRedirect } from '@/lib/oidc-session';
+import { useEffect, useState } from 'react';
+
+export default function AuthCallbackPage() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    completeOidcRedirect()
+      .then(({ returnTo }) => {
+        if (!cancelled) window.location.replace(returnTo || '/');
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'OIDC callback failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-6">
+      <section aria-label="OIDC 로그인 콜백" className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-sm">
+        <h1 className="text-lg font-bold text-foreground">OIDC 로그인 확인</h1>
+        {error ? (
+          <p role="alert" className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-700">{error}</p>
+        ) : (
+          <p role="status" className="mt-3 text-sm font-semibold text-muted-foreground">세션을 확인하는 중입니다.</p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -17,6 +17,18 @@ vi.mock("lucide-react", () => ({
   User: () => <svg aria-hidden="true" />,
 }));
 
+const oidcMocks = vi.hoisted(() => ({
+  clearOidcSession: vi.fn(),
+  getOidcBrowserConfig: vi.fn(),
+  startOidcLogin: vi.fn(),
+}));
+
+vi.mock("@/lib/oidc-session", () => ({
+  clearOidcSession: oidcMocks.clearOidcSession,
+  getOidcBrowserConfig: oidcMocks.getOidcBrowserConfig,
+  startOidcLogin: oidcMocks.startOidcLogin,
+}));
+
 import { SettingsLayout } from "./SettingsLayout";
 
 function jsonResponse(body: unknown) {
@@ -26,12 +38,29 @@ function jsonResponse(body: unknown) {
   });
 }
 
+function sessionToken(payload: Record<string, unknown>) {
+  const encodedPayload = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `header.${encodedPayload}.signature`;
+}
+
 describe("SettingsLayout", () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
 
   beforeEach(() => {
     localStorage.setItem("naruon_session_token", "signed-runner-session-token");
+    oidcMocks.getOidcBrowserConfig.mockReturnValue({
+      issuerUrl: "https://login.example.com/realms/naruon",
+      clientId: "naruon-web",
+      redirectUri: "https://app.example.com/auth/callback",
+      scope: "openid profile email",
+      authorizationEndpoint: "https://login.example.com/realms/naruon/protocol/openid-connect/auth",
+      tokenEndpoint: "https://login.example.com/realms/naruon/protocol/openid-connect/token",
+      endSessionEndpoint: "https://login.example.com/realms/naruon/protocol/openid-connect/logout",
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -199,6 +228,7 @@ describe("SettingsLayout", () => {
     container?.remove();
     container = null;
     vi.unstubAllGlobals();
+    vi.clearAllMocks();
     localStorage.clear();
   });
 
@@ -322,6 +352,57 @@ describe("SettingsLayout", () => {
     for (const link of externalLinks) {
       expect(link.rel.split(/\s+/).sort()).toEqual(["noopener", "noreferrer"]);
     }
+  });
+
+  it("wires Keycloak OIDC login and logout controls to the stored bearer session", async () => {
+    window.history.pushState({}, "", "/settings");
+    localStorage.setItem(
+      "naruon_session_token",
+      sessionToken({ sub: "alice", org: "org-acme", workspace: "workspace-org-acme" }),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const developerTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "개발자",
+    );
+    expect(developerTab).toBeTruthy();
+    await act(async () => {
+      developerTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("OIDC 인증 세션");
+    expect(container.textContent).toContain("https://login.example.com/realms/naruon");
+    expect(container.textContent).toContain("naruon-web");
+    expect(container.textContent).toContain("alice / org-acme / workspace-org-acme");
+
+    const loginButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "OIDC 로그인");
+    const logoutButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "로그아웃");
+    expect(loginButton).toBeTruthy();
+    expect(logoutButton).toBeTruthy();
+
+    await act(async () => {
+      loginButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(oidcMocks.startOidcLogin).toHaveBeenCalledWith({ returnTo: "/settings" });
+
+    await act(async () => {
+      logoutButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(oidcMocks.clearOidcSession).toHaveBeenCalledWith({
+      postLogoutRedirectUri: "http://localhost:3000",
+    });
   });
 
   it("loads and saves source-backed mail account settings without public identity headers or secret replay", async () => {

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -2,6 +2,7 @@
 
 import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Monitor, AlertCircle, RefreshCw } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
+import { clearOidcSession, getOidcBrowserConfig, startOidcLogin } from '@/lib/oidc-session';
 import { useWorkspaceStartupView, setWorkspaceStartupView } from '@/lib/workspace-preferences';
 import { useEffect, useState } from 'react';
 
@@ -300,7 +301,10 @@ export function SettingsLayout() {
   const [webdavAccounts, setWebdavAccounts] = useState<WebdavAccount[]>([]);
   const [sourceReadinessLoading, setSourceReadinessLoading] = useState(true);
   const [sourceReadinessError, setSourceReadinessError] = useState<string | null>(null);
+  const [oidcSessionClaims, setOidcSessionClaims] = useState(() => apiClient.getSessionClaims());
+  const [oidcActionError, setOidcActionError] = useState<string | null>(null);
   const startupView = useWorkspaceStartupView();
+  const oidcBrowserConfig = getOidcBrowserConfig();
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
   const connectorEvents = operationalSignals?.connector.recent_events ?? [];
@@ -345,6 +349,25 @@ export function SettingsLayout() {
   const updateAccountField = (field: keyof AccountFormState, value: string) => {
     setAccountForm((current) => ({ ...current, [field]: value }));
     setAccountStatus(null);
+  };
+
+  const handleOidcLogin = async () => {
+    setOidcActionError(null);
+    try {
+      await startOidcLogin({ returnTo: window.location.pathname });
+    } catch (error) {
+      setOidcActionError(error instanceof Error ? error.message : 'OIDC login failed');
+    }
+  };
+
+  const handleOidcLogout = () => {
+    setOidcActionError(null);
+    try {
+      clearOidcSession({ postLogoutRedirectUri: window.location.origin });
+      setOidcSessionClaims(apiClient.getSessionClaims());
+    } catch (error) {
+      setOidcActionError(error instanceof Error ? error.message : 'OIDC logout failed');
+    }
   };
 
   const handleAccountSave = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -971,6 +994,59 @@ export function SettingsLayout() {
                       </div>
                     </div>
                   ) : null}
+                </section>
+
+                <section aria-label="OIDC 인증 세션" className="mt-6 rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <Shield className="size-5 text-blue-500" />
+                        <h3 className="font-bold text-lg">OIDC 인증 세션</h3>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        Keycloak/Casdoor OIDC 토큰을 브라우저 bearer 세션으로 연결합니다.
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={handleOidcLogin}
+                        disabled={!oidcBrowserConfig}
+                        className="rounded-lg bg-primary px-4 py-2 text-sm font-bold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        OIDC 로그인
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleOidcLogout}
+                        disabled={!oidcSessionClaims.userId}
+                        className="rounded-lg border border-border px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        로그아웃
+                      </button>
+                    </div>
+                  </div>
+                  {oidcActionError ? (
+                    <p role="alert" className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-700">{oidcActionError}</p>
+                  ) : null}
+                  <dl className="mt-5 grid gap-3 md:grid-cols-3">
+                    <div className="rounded-xl border border-border bg-background p-3">
+                      <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">issuer</dt>
+                      <dd className="mt-1 break-all font-mono text-sm font-semibold text-foreground">{oidcBrowserConfig?.issuerUrl ?? 'not_configured'}</dd>
+                    </div>
+                    <div className="rounded-xl border border-border bg-background p-3">
+                      <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">client_id</dt>
+                      <dd className="mt-1 break-all font-mono text-sm font-semibold text-foreground">{oidcBrowserConfig?.clientId ?? 'not_configured'}</dd>
+                    </div>
+                    <div className="rounded-xl border border-border bg-background p-3">
+                      <dt className="text-xs font-bold uppercase tracking-wide text-muted-foreground">session</dt>
+                      <dd className="mt-1 break-all font-mono text-sm font-semibold text-foreground">
+                        {oidcSessionClaims.userId
+                          ? `${oidcSessionClaims.userId} / ${oidcSessionClaims.organizationId ?? 'personal'} / ${oidcSessionClaims.workspaceId ?? 'workspace_unknown'}`
+                          : 'signed_session_absent'}
+                      </dd>
+                    </div>
+                  </dl>
                 </section>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">

--- a/frontend/src/lib/oidc-session.test.ts
+++ b/frontend/src/lib/oidc-session.test.ts
@@ -1,0 +1,120 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildOidcAuthorizationUrl,
+  clearOidcSession,
+  completeOidcRedirect,
+  getOidcBrowserConfig,
+  startOidcLogin,
+} from './oidc-session';
+
+function installCrypto() {
+  const cryptoMock = {
+    getRandomValues: (bytes: Uint8Array) => {
+      bytes.fill(7);
+      return bytes;
+    },
+    subtle: {
+      digest: vi.fn(async () => new Uint8Array([1, 2, 3, 4]).buffer),
+    },
+  };
+  Object.defineProperty(window, 'crypto', {
+    configurable: true,
+    value: cryptoMock,
+  });
+}
+
+describe('oidc-session', () => {
+  beforeEach(() => {
+    installCrypto();
+    vi.stubEnv('NEXT_PUBLIC_OIDC_ISSUER_URL', 'https://login.example.com/realms/naruon/');
+    vi.stubEnv('NEXT_PUBLIC_OIDC_CLIENT_ID', 'naruon-web');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('derives Keycloak endpoints from public OIDC settings', () => {
+    const config = getOidcBrowserConfig('https://app.example.com');
+
+    expect(config).toMatchObject({
+      issuerUrl: 'https://login.example.com/realms/naruon',
+      clientId: 'naruon-web',
+      redirectUri: 'https://app.example.com/auth/callback',
+      authorizationEndpoint: 'https://login.example.com/realms/naruon/protocol/openid-connect/auth',
+      tokenEndpoint: 'https://login.example.com/realms/naruon/protocol/openid-connect/token',
+      endSessionEndpoint: 'https://login.example.com/realms/naruon/protocol/openid-connect/logout',
+    });
+  });
+
+  it('builds a PKCE authorization request and stores transient login state', async () => {
+    const assignedUrls: string[] = [];
+
+    await startOidcLogin({
+      returnTo: '/settings',
+      navigate: (url) => assignedUrls.push(url),
+    });
+
+    expect(sessionStorage.getItem('naruon_oidc_state')).toBeTruthy();
+    expect(sessionStorage.getItem('naruon_oidc_pkce_verifier')).toBeTruthy();
+    expect(sessionStorage.getItem('naruon_oidc_return_to')).toBe('/settings');
+    const authorizationUrl = new URL(assignedUrls[0]);
+    expect(authorizationUrl.origin).toBe('https://login.example.com');
+    expect(authorizationUrl.searchParams.get('response_type')).toBe('code');
+    expect(authorizationUrl.searchParams.get('client_id')).toBe('naruon-web');
+    expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(authorizationUrl.searchParams.get('code_challenge')).toBe('AQIDBA');
+  });
+
+  it('exchanges a valid OIDC callback code and stores the bearer session token', async () => {
+    sessionStorage.setItem('naruon_oidc_state', 'state-123');
+    sessionStorage.setItem('naruon_oidc_pkce_verifier', 'verifier-123');
+    sessionStorage.setItem('naruon_oidc_return_to', '/security');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ access_token: 'oidc.jwt.token' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    const result = await completeOidcRedirect('?code=auth-code&state=state-123');
+
+    expect(result.returnTo).toBe('/security');
+    expect(localStorage.getItem('naruon_session_token')).toBe('oidc.jwt.token');
+    expect(sessionStorage.getItem('naruon_oidc_state')).toBeNull();
+    const tokenCall = vi.mocked(fetch).mock.calls[0];
+    expect(tokenCall[0]).toBe('https://login.example.com/realms/naruon/protocol/openid-connect/token');
+    expect(String(tokenCall[1]?.body)).toContain('grant_type=authorization_code');
+    expect(String(tokenCall[1]?.body)).toContain('code_verifier=verifier-123');
+  });
+
+  it('clears local session state and redirects to the provider logout endpoint', () => {
+    localStorage.setItem('naruon_session_token', 'oidc.jwt.token');
+    sessionStorage.setItem('naruon_oidc_state', 'state-123');
+    const assignedUrls: string[] = [];
+
+    clearOidcSession({
+      postLogoutRedirectUri: 'https://app.example.com',
+      navigate: (url) => assignedUrls.push(url),
+    });
+
+    expect(localStorage.getItem('naruon_session_token')).toBeNull();
+    expect(sessionStorage.getItem('naruon_oidc_state')).toBeNull();
+    const logoutUrl = new URL(assignedUrls[0]);
+    expect(logoutUrl.toString()).toContain('/protocol/openid-connect/logout');
+    expect(logoutUrl.searchParams.get('client_id')).toBe('naruon-web');
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe('https://app.example.com');
+  });
+
+  it('builds an authorization URL directly for deterministic callers', async () => {
+    const config = getOidcBrowserConfig('https://app.example.com');
+    expect(config).toBeTruthy();
+
+    const authorizationUrl = await buildOidcAuthorizationUrl(config!, 'state-123', 'verifier-123');
+
+    expect(new URL(authorizationUrl).searchParams.get('state')).toBe('state-123');
+  });
+});

--- a/frontend/src/lib/oidc-session.ts
+++ b/frontend/src/lib/oidc-session.ts
@@ -1,0 +1,197 @@
+export interface OidcBrowserConfig {
+  issuerUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  endSessionEndpoint: string;
+}
+
+export interface OidcLoginOptions {
+  returnTo?: string;
+  navigate?: (url: string) => void;
+}
+
+export interface OidcLogoutOptions {
+  postLogoutRedirectUri?: string;
+  navigate?: (url: string) => void;
+}
+
+const SESSION_TOKEN_KEY = 'naruon_session_token';
+const OIDC_STATE_KEY = 'naruon_oidc_state';
+const OIDC_VERIFIER_KEY = 'naruon_oidc_pkce_verifier';
+const OIDC_RETURN_TO_KEY = 'naruon_oidc_return_to';
+const DEFAULT_OIDC_SCOPE = 'openid profile email';
+
+export class OidcSessionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OidcSessionError';
+  }
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/, '');
+}
+
+function defaultBrowserOrigin() {
+  if (typeof window === 'undefined') return '';
+  return window.location.origin;
+}
+
+function defaultRedirectUri(origin: string) {
+  return origin ? `${origin}/auth/callback` : '/auth/callback';
+}
+
+export function getOidcBrowserConfig(origin = defaultBrowserOrigin()): OidcBrowserConfig | null {
+  const issuerUrl = envValue('NEXT_PUBLIC_OIDC_ISSUER_URL');
+  const clientId = envValue('NEXT_PUBLIC_OIDC_CLIENT_ID');
+  if (!issuerUrl || !clientId) return null;
+
+  const normalizedIssuer = trimTrailingSlash(issuerUrl);
+  const keycloakEndpointBase = `${normalizedIssuer}/protocol/openid-connect`;
+  return {
+    issuerUrl: normalizedIssuer,
+    clientId,
+    redirectUri: envValue('NEXT_PUBLIC_OIDC_REDIRECT_URI') ?? defaultRedirectUri(origin),
+    scope: envValue('NEXT_PUBLIC_OIDC_SCOPE') ?? DEFAULT_OIDC_SCOPE,
+    authorizationEndpoint: envValue('NEXT_PUBLIC_OIDC_AUTHORIZATION_ENDPOINT') ?? `${keycloakEndpointBase}/auth`,
+    tokenEndpoint: envValue('NEXT_PUBLIC_OIDC_TOKEN_ENDPOINT') ?? `${keycloakEndpointBase}/token`,
+    endSessionEndpoint: envValue('NEXT_PUBLIC_OIDC_END_SESSION_ENDPOINT') ?? `${keycloakEndpointBase}/logout`,
+  };
+}
+
+function requireBrowserStorage() {
+  if (typeof window === 'undefined') {
+    throw new OidcSessionError('OIDC browser session storage is unavailable');
+  }
+}
+
+function randomUrlSafeString(byteLength: number) {
+  requireBrowserStorage();
+  const bytes = new Uint8Array(byteLength);
+  window.crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function pkceChallenge(verifier: string) {
+  requireBrowserStorage();
+  const encoded = new TextEncoder().encode(verifier);
+  const digest = await window.crypto.subtle.digest('SHA-256', encoded);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export async function buildOidcAuthorizationUrl(config: OidcBrowserConfig, state: string, verifier: string) {
+  const challenge = await pkceChallenge(verifier);
+  const authorizationUrl = new URL(config.authorizationEndpoint);
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('client_id', config.clientId);
+  authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
+  authorizationUrl.searchParams.set('scope', config.scope);
+  authorizationUrl.searchParams.set('state', state);
+  authorizationUrl.searchParams.set('code_challenge', challenge);
+  authorizationUrl.searchParams.set('code_challenge_method', 'S256');
+  return authorizationUrl.toString();
+}
+
+export async function startOidcLogin(options: OidcLoginOptions = {}) {
+  requireBrowserStorage();
+  const config = getOidcBrowserConfig();
+  if (!config) {
+    throw new OidcSessionError('OIDC browser configuration is missing');
+  }
+
+  const state = randomUrlSafeString(32);
+  const verifier = randomUrlSafeString(64);
+  window.sessionStorage.setItem(OIDC_STATE_KEY, state);
+  window.sessionStorage.setItem(OIDC_VERIFIER_KEY, verifier);
+  window.sessionStorage.setItem(OIDC_RETURN_TO_KEY, options.returnTo ?? window.location.pathname);
+
+  const authorizationUrl = await buildOidcAuthorizationUrl(config, state, verifier);
+  const navigate = options.navigate ?? ((url: string) => window.location.assign(url));
+  navigate(authorizationUrl);
+}
+
+export async function completeOidcRedirect(search = window.location.search) {
+  requireBrowserStorage();
+  const config = getOidcBrowserConfig();
+  if (!config) {
+    throw new OidcSessionError('OIDC browser configuration is missing');
+  }
+
+  const params = new URLSearchParams(search);
+  const providerError = params.get('error');
+  if (providerError) {
+    throw new OidcSessionError(providerError);
+  }
+
+  const code = params.get('code');
+  const state = params.get('state');
+  const expectedState = window.sessionStorage.getItem(OIDC_STATE_KEY);
+  const verifier = window.sessionStorage.getItem(OIDC_VERIFIER_KEY);
+  if (!code || !state || !expectedState || state !== expectedState || !verifier) {
+    throw new OidcSessionError('OIDC callback state is invalid');
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.clientId,
+    code,
+    code_verifier: verifier,
+    redirect_uri: config.redirectUri,
+  });
+  const response = await fetch(config.tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!response.ok) {
+    throw new OidcSessionError('OIDC token exchange failed');
+  }
+  const tokenBody = await response.json() as { access_token?: unknown };
+  const accessToken = typeof tokenBody.access_token === 'string' ? tokenBody.access_token.trim() : '';
+  if (!accessToken) {
+    throw new OidcSessionError('OIDC token response did not include an access token');
+  }
+
+  window.localStorage.setItem(SESSION_TOKEN_KEY, accessToken);
+  const returnTo = window.sessionStorage.getItem(OIDC_RETURN_TO_KEY) || '/';
+  clearOidcTransientState();
+  return { returnTo };
+}
+
+export function clearOidcTransientState() {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(OIDC_STATE_KEY);
+  window.sessionStorage.removeItem(OIDC_VERIFIER_KEY);
+  window.sessionStorage.removeItem(OIDC_RETURN_TO_KEY);
+}
+
+export function clearOidcSession(options: OidcLogoutOptions = {}) {
+  requireBrowserStorage();
+  const config = getOidcBrowserConfig();
+  window.localStorage.removeItem(SESSION_TOKEN_KEY);
+  clearOidcTransientState();
+
+  if (!config) return;
+  const postLogoutRedirectUri = options.postLogoutRedirectUri ?? window.location.origin;
+  const logoutUrl = new URL(config.endSessionEndpoint);
+  logoutUrl.searchParams.set('client_id', config.clientId);
+  logoutUrl.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+  const navigate = options.navigate ?? ((url: string) => window.location.assign(url));
+  navigate(logoutUrl.toString());
+}


### PR DESCRIPTION
## Summary
- add browser OIDC Authorization Code + PKCE login, callback token exchange, and logout helpers
- surface Keycloak/Casdoor OIDC session controls in Settings using the stored bearer session claims
- document the frontend OIDC env contract and backend signed-claim boundary

Closes #198.

## Verification
- npm test -- oidc-session.test.ts SettingsLayout.test.tsx
- npm run typecheck
- npm run lint -- src/lib/oidc-session.ts src/lib/oidc-session.test.ts src/app/auth/callback/page.tsx src/components/SettingsLayout.tsx src/components/SettingsLayout.test.tsx
- git diff --check