### PR TITLE
🎨 Palette: Search accessibility and loading UX improvement

### DIFF
--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -450,6 +450,7 @@ export function SearchLayout() {
             />
             <input
               type="search"
+              aria-label="맥락 검색어 입력"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="메일, 일정, 파일, 사람, 의사결정 로그 검색..."
@@ -458,9 +459,10 @@ export function SearchLayout() {
           </div>
           <button
             type="submit"
-            className="h-12 shrink-0 rounded-lg bg-primary px-4 text-sm font-bold text-primary-foreground hover:bg-primary/90"
+            disabled={loading}
+            className="h-12 shrink-0 rounded-lg bg-primary px-4 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            검색
+            {loading ? "검색 중..." : "검색"}
           </button>
         </form>
       </header>


### PR DESCRIPTION
### 💡 What
Added `aria-label="맥락 검색어 입력"` to the main search `<input>` in `SearchLayout.tsx`. Also updated the search `<button>` to disable and show "검색 중..." while the search is loading.

### 🎯 Why
- **Accessibility:** Screen readers previously had no explicit label for the search input, relying only on the placeholder. The `aria-label` makes the input explicitly identifiable.
- **UX/Feedback:** The submit button lacked a clear disabled state during API calls, allowing duplicate clicks and providing poor visual feedback when users submitted a search.

### ♿ Accessibility
- Improved keyboard and screen reader accessibility for the primary search interaction.

### 📸 Before/After
*(See Playwright screenshot submitted in thread demonstrating disabled state and aria-label presence)*

---
*PR created automatically by Jules for task [13903676271293196787](https://jules.google.com/task/13903676271293196787) started by @seonghobae*