### PR TITLE
🎨 Palette: Add loading spinner to capture relationship button

### DIFF
--- a/frontend/.Jules/palette.md
+++ b/frontend/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-04 - Add loading state to SearchLayout button
+**Learning:** Users notice the little things. Missing loading states on async actions makes users unsure if their action registered. Adding a simple loading spinner provides immediate feedback and aligns with accessibility best practices when making dynamic state changes.
+**Action:** Always include a visual loading state like `Loader2` for async actions (like the '발신자 관계 캡처' button) to provide immediate feedback to the user.

--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -12,6 +12,7 @@ vi.mock("lucide-react", () => ({
   CheckCircle2: () => <svg aria-hidden="true" />,
   AlertCircle: () => <svg aria-hidden="true" />,
   CornerDownRight: () => <svg aria-hidden="true" />,
+  Loader2: () => <svg aria-hidden="true" className="lucide-loader-2" />,
 }));
 
 vi.mock("vis-network", () => ({

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   Clock,
   CornerDownRight,
+  Loader2,
   Mail,
   Network,
   Search,
@@ -146,8 +147,11 @@ function SenderDagPanel({
               type="button"
               onClick={onCapture}
               disabled={captureStatus === "loading"}
-              className="w-full rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto"
+              className="w-full rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto inline-flex items-center justify-center"
             >
+              {captureStatus === "loading" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              )}
               {captureStatus === "loading" ? "캡처 중" : "발신자 관계 캡처"}
             </button>
           </div>


### PR DESCRIPTION
Added a Loader2 spinning icon to the "발신자 관계 캡처" (Capture relationship) button in SearchLayout.tsx when captureStatus is loading. Also added a learning to the palette journal. Provides immediate visual feedback for an async operation, preventing users from being unsure if their action registered.

---
*PR created automatically by Jules for task [303915303184814792](https://jules.google.com/task/303915303184814792) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sender relationship capture button in SearchLayout now displays an animated loading spinner during async operations, providing users with clear visual feedback that their action is being processed.

* **Tests**
  * Test infrastructure was updated to include the new loading indicator component mock, ensuring proper rendering and validation of the spinner functionality during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->