### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection vulnerability in DAV handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The FastAPI application was missing standard HTTP security headers such as Strict-Transport-Security, X-Content-Type-Options, X-Frame-Options, and Content-Security-Policy in its default responses.
 **Learning:** By default, FastAPI does not automatically inject these defense-in-depth headers, leaving the application potentially more susceptible to MIME-sniffing, clickjacking, and injection downgrade paths. X-XSS-Protection is deprecated by major browsers and should not be the default XSS control.
 **Prevention:** Always add a global middleware (e.g., via `@app.middleware("http")` or dedicated security middleware plugins) early in the FastAPI application setup to enforce standard security headers across all endpoints, and use a configurable Content-Security-Policy as the modern XSS and framing control.
+## 2025-02-28 - DAV Log Injection
+**Vulnerability:** Log Injection / Terminal Escape Sequence Injection (CWE-117)
+**Learning:** Custom logic like `path.replace("\n", "").replace("\r", "")` is insufficient to prevent log injection and terminal escape sequence injection, as it leaves characters like ANSI color codes intact.
+**Prevention:** Use standard mechanisms like `repr()` or proper unicode escaping instead of custom string replacements.

--- a/backend/api/dav.py
+++ b/backend/api/dav.py
@@ -48,7 +48,8 @@ async def dav_handler(
     Naruon's Tasks and Events into DAV compliant responses.
     """
     _ensure_dav_owner_scope(path, auth_context)
-    safe_path = path.replace("\n", "").replace("\r", "")
+    # Use repr to safely escape control characters and prevent log injection (CWE-117)
+    safe_path = repr(path)[1:-1]
     logger.info("DAV Request: %s /%s", request.method, safe_path)
 
     if request.method == "OPTIONS":
@@ -87,7 +88,7 @@ async def dav_handler(
 
     if request.method == "PUT":
         body = await request.body()
-        safe_path = path.replace("\n", "").replace("\r", "")
+        safe_path = repr(path)[1:-1]
         logger.info("DAV PUT received %s bytes at /%s", len(body), safe_path)
         return Response(
             content=(

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -94,3 +94,62 @@ def test_dav_put(dev_auth_dependency_overrides):
         assert response.status_code == 501
         assert "Provider-backed DAV writeback is not implemented" in response.text
         assert "etag" not in {header.lower() for header in response.headers}
+
+def test_dav_log_injection_prevention(dev_auth_dependency_overrides, caplog):
+    """
+    Test that DAV handlers safely encode control characters in the requested path,
+    preventing log injection vulnerabilities.
+    """
+    import logging
+    from fastapi.testclient import TestClient
+    from main import app
+
+    caplog.set_level(logging.INFO)
+    # URL encode the payload so httpx doesn't reject it; FastAPI will decode it back to the raw control chars
+    malicious_path = "user123/projects/test%1B%5B31minjected%0A%0D"
+    with TestClient(app) as client:
+        # Pass raw path to simulate actual request if unquote fails; wait, TestClient accepts raw URL strings but they are parsed.
+        # Use simple printable characters for request, and we'll manually call the handler to verify logging logic
+        pass
+
+    # Since HTTP clients block raw control chars and starlette unquotes but might reject it before reaching our route,
+    # we test the handler directly to ensure the logger is using repr().
+    from api.dav import _ensure_dav_owner_scope
+
+    # We can invoke the route logic through the actual function or simply check the string formatting manually,
+    # but since this is an integration test, we can use the app but pass standard requests. Wait, the logger logic
+    # itself is the core fix. Let's just mock the request and call dav_handler directly.
+    import asyncio
+    from fastapi import Request
+
+    scope = {
+        "type": "http",
+        "method": "PROPFIND",
+        "headers": [],
+    }
+
+    async def run_handler():
+        req = Request(scope)
+        from api.auth import AuthContext
+        auth_ctx = AuthContext(user_id="user123", organization_id="org1", role="user", group_ids=[], workspace_id="ws1")
+
+        # pass raw unquoted path with escape sequences
+        from api.dav import dav_handler
+        await dav_handler(request=req, path="user123/projects/test\x1b[31minjected\n\r", auth_context=auth_ctx)
+
+    asyncio.run(run_handler())
+
+    # In some fastapi versions, returning an unexpected path might return 404. Let's just assert the log was captured.
+    # The vulnerability is about the logger.
+
+    # Assert that the raw ansi escape / newline was not logged, but encoded
+    raw_ansi = "\x1b[31m"
+    found_in_logs = False
+    for record in caplog.records:
+        if "DAV Request" in record.message:
+            assert raw_ansi not in record.message, "Raw ANSI escape sequence found in logs!"
+            assert "\n" not in record.message[12:], "Raw newline found in log message body!"
+            assert "\\x1b[31minjected\\n\\r" in record.message or "\\x1b[31minjected\\r\\n" in record.message, "Escaped characters missing from log message!"
+            found_in_logs = True
+
+    assert found_in_logs, "DAV Request log was not found"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection / Terminal Escape Sequence Injection (CWE-117)
🎯 **Impact:** Attackers could inject ANSI control characters or terminal escape sequences to obscure logs, forge log entries, or execute terminal injections by sending crafted `path` parameters in CalDAV/WebDAV endpoints. The existing sanitization (`replace("\n", "").replace("\r", "")`) failed to remove such characters.
🔧 **Fix:** Refactored the `safe_path` sanitization in `backend/api/dav.py` to use Python's built-in `repr()`. This securely converts all non-printable/control characters to their safe escape sequence equivalents before being formatted into the log string.
✅ **Verification:** A test case `test_dav_log_injection_prevention` was added to `backend/tests/test_dav_api.py`. The full test suite passed. Scratch test files that were causing regressions have been successfully removed.

---
*PR created automatically by Jules for task [1075642103241924423](https://jules.google.com/task/1075642103241924423) started by @seonghobae*