### PR TITLE
test: stabilize AI Hub source request evidence

### DIFF
--- a/frontend/tests/e2e/ai-hub-source-surface.spec.ts
+++ b/frontend/tests/e2e/ai-hub-source-surface.spec.ts
@@ -20,19 +20,21 @@ const viewports = [
 for (const viewport of viewports) {
   test(`renders source-backed AI Hub with scroll at ${viewport.name}`, async ({ page }, testInfo) => {
     const sessionToken = `signed-ai-hub-${viewport.name}`;
+    const surfaceRequestHeaders: Record<string, string>[] = [];
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
-    await mockDashboardApi(page);
+    await mockDashboardApi(page, (path, request) => {
+      if (path === '/api/ai-hub/surface' && request.method() === 'GET') {
+        surfaceRequestHeaders.push(request.headers());
+      }
+    });
     await page.addInitScript((token) => {
       window.localStorage.setItem('naruon_session_token', token);
     }, sessionToken);
 
-    const surfaceRequest = page.waitForRequest((request) => {
-      const url = new URL(request.url());
-      return url.pathname === '/api/ai-hub/surface' && request.method() === 'GET';
-    });
-
     await page.goto('/ai-hub');
-    const headers = (await surfaceRequest).headers();
+    await expect.poll(() => surfaceRequestHeaders.length).toBeGreaterThan(0);
+
+    const headers = surfaceRequestHeaders.at(-1) ?? {};
     expect(headers.authorization).toBe(`Bearer ${sessionToken}`);
     for (const headerName of publicIdentityHeaders) {
       expect(headers[headerName]).toBeUndefined();

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -401,7 +401,7 @@ case "${FAKE_STRIX_SCENARIO:?}" in
 		echo "scan ok with timeout disabled"
 		exit 0
 		;;
-	vertex-primary-notfound-fallback-success|github-models-fallback-success|github-models-fallback-requires-api-base|github-models-model-prefix-with-api-base-succeeds)
+	vertex-primary-notfound-fallback-success|github-models-fallback-success|github-models-fallback-success-nano|github-models-fallback-requires-api-base|github-models-model-prefix-with-api-base-succeeds)
 		case "${STRIX_LLM:-}" in
 		vertex_ai/missing-primary)
 			echo "Error: litellm.NotFoundError: Vertex_aiException - x"


### PR DESCRIPTION
## Summary
- stabilize AI Hub E2E request evidence capture by using the existing mockDashboardApi request hook
- avoid unhandled waitForRequest rejection warnings during source-surface browser checks

## Validation
- bash -n scripts/ci/strix_quick_gate.sh scripts/ci/test_strix_quick_gate.sh
- PYTHONWARNINGS='ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning,ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning,ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning' python3 -m pytest backend/tests/test_ai_hub_api.py backend/tests/test_release_governance.py -q
- npm run typecheck
- npm test -- src/app/ai-hub/page.test.tsx
- env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18087 npm run test:e2e -- tests/e2e/ai-hub-source-surface.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for improved request header capture and expanded scenario coverage in CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->