### PR TITLE
Document CodeGraph init and memoize task lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,14 @@
 - Strix Security Scan uses GitHub Models by default through
   `STRIX_GITHUB_MODELS_TOKEN`, `STRIX_LLM=openai/gpt-5`, and
   `LLM_API_BASE_FILE` pointing at a trusted file containing
-  `https://models.github.ai/inference`; GitHub Models fallbacks use
-  `openai/gpt-5-mini` and `openai/gpt-5-nano`. Keep the GitHub Models endpoint
-  in a trusted input file and pass the token only through the provider-scoped
-  Strix child-process key path. Legacy `STRIX_LLM` secrets must not override PR,
-  push, or scheduled Strix defaults. Vertex remains available only for manual
+  `https://models.github.ai/inference`; GitHub Models scans must try the
+  configured GPT-5-or-newer model first and may fall back to the explicit
+  workflow fallback list, currently `openai/gpt-4.1`, when GitHub Models
+  provider capacity or model availability blocks the primary run. Keep the
+  GitHub Models endpoint in a trusted input file and pass the token only through
+  the provider-scoped Strix child-process key path. Legacy `STRIX_LLM` secrets
+  must not override PR, push, or scheduled Strix defaults. Vertex remains
+  available only for manual
   `workflow_dispatch` evidence when the `strix_llm` input
   explicitly selects `vertex_ai/gemini-3.1-pro-preview-customtools` or
   `vertex_ai/gemini-2.5-flash` with `GCP_SA_KEY`; expose Google/Vertex
@@ -352,6 +355,10 @@
 
 ## Development environment and tooling defaults
 
+- If CodeGraph is not initialized for this repository, agents may ask the user
+  to approve initialization and then run `codegraph init -i`; keep the generated
+  `.codegraph/` index local unless a future repository policy explicitly says to
+  commit it.
 - StepSecurity `harden-runner` will trigger false-positive `suspicious_file_access` lockouts on Next.js build and dev server executions (e.g., `router_init.js` checksum matches). Configure `disable-file-monitoring: true` in the `harden-runner` step rather than disabling the workflow or using `continue-on-error`.
 - Next.js 15+ Turbopack resolves workspace roots by scanning upward for `package-lock.json`. Do not create or leave a `package-lock.json` in the user's home directory (`~/`), as it will cause Turbopack to spawn infinite background worker node processes attempting to compile the entire home directory.
 - `pydantic-settings` strictly rejects unexpected environment variables by default. When sharing a common `.env` file between frontend and backend services, you must explicitly set `extra="ignore"` in the `SettingsConfigDict` to prevent fatal startup crashes.

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -231,6 +231,10 @@ export function TasksLayout() {
     { id: 'done', title: '완료', count: tasks.done.length, color: 'bg-green-100 text-green-700' },
   ];
 
+  const allTasks = useMemo(() => Object.values(tasks).flat(), [tasks]);
+  const myTasks = useMemo(() => allTasks.filter((task) => task.assignee === '김나루'), [allTasks]);
+  const delegatedTasks = useMemo(() => allTasks.filter((task) => task.assignee !== '김나루'), [allTasks]);
+
   const liveBoardCounts = useMemo(() => {
     return ticketTasks.reduce<Record<TicketTask['status'], number>>(
       (acc, task) => {
@@ -544,7 +548,7 @@ export function TasksLayout() {
         {viewMode === '내 작업' && (
           <div className="space-y-4 max-w-4xl mx-auto">
             <h2 className="font-bold text-lg mb-4">내 작업 (My Tasks)</h2>
-            {Object.values(tasks).flat().filter(t => t.assignee === '김나루').map(task => (
+            {myTasks.map(task => (
               <div key={task.id} className="flex items-center justify-between p-4 rounded-xl border border-border bg-card shadow-sm hover:border-primary/50 transition-colors cursor-pointer" onClick={() => { setSelectedTaskId(task.id); setViewMode('작업 상세'); }}>
                 <div className="flex items-center gap-4">
                   <div className={`size-3 rounded-full ${task.priority === 'urgent' ? 'bg-red-500' : task.priority === 'high' ? 'bg-orange-500' : 'bg-blue-500'}`}></div>
@@ -562,7 +566,7 @@ export function TasksLayout() {
         {viewMode === '위임한 작업' && (
           <div className="space-y-4 max-w-4xl mx-auto">
             <h2 className="font-bold text-lg mb-4">위임한 작업 (Delegation)</h2>
-            {Object.values(tasks).flat().filter(t => t.assignee !== '김나루').map(task => (
+            {delegatedTasks.map(task => (
               <div key={task.id} className="flex items-center justify-between p-4 rounded-xl border border-border bg-card shadow-sm hover:border-primary/50 transition-colors cursor-pointer" onClick={() => { setSelectedTaskId(task.id); setViewMode('작업 상세'); }}>
                 <div className="flex items-center gap-4">
                   <div className="size-8 rounded-full bg-primary/10 text-primary grid place-items-center text-xs font-bold">{task.assignee.charAt(0)}</div>
@@ -578,7 +582,7 @@ export function TasksLayout() {
         )}
 
         {viewMode === '작업 상세' && (() => {
-          const task = Object.values(tasks).flat().find(t => t.id === selectedTaskId);
+          const task = allTasks.find(t => t.id === selectedTaskId);
           if (!task) return <div className="p-6 text-center text-muted-foreground">작업을 선택해주세요.</div>;
           
           const priorityText = task.priority === 'urgent' ? '긴급' : task.priority === 'high' ? '우선순위 높음' : task.priority === 'normal' ? '보통' : '낮음';


### PR DESCRIPTION
## Summary\n- document that agents may ask for approval and run `codegraph init -i` when CodeGraph is missing\n- align AGENTS Strix fallback wording with the current GitHub Models workflow fallback list\n- memoize flattened task collections in `TasksLayout` so the render path reuses the same flattened task list for my tasks, delegated tasks, and detail lookup\n\n## Validation\n- `git diff --check`\n- `npm test -- src/components/DashboardLayout.test.tsx src/app/page.test.tsx src/app/calendar/page.test.tsx src/app/tasks/page.test.tsx src/app/projects/page.test.tsx src/app/search/page.test.tsx src/app/data/page.test.tsx src/app/ai-hub/page.test.tsx src/app/security/page.test.tsx src/components/SettingsLayout.test.tsx` (10 files, 59 tests)\n- `npm run typecheck`\n\n## Prior PR handling\n- Closed #353 because it targeted `master`; its endpoint diff against `develop` would remove current governance/design assets including OpenCode workflow files and `docs/ui-ux/mockups/*`. This branch reapplies only the valid task memoization on `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance guidance for AI agent model selection and CodeGraph initialization requirements.

* **Refactor**
  * Optimized task list filtering and display logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->