### PR TITLE
🧪 테스트 개선: email_parser.py 내의 _sanitize_nul 함수 테스트 추가

### DIFF
--- a/backend/tests/test_email_parser.py
+++ b/backend/tests/test_email_parser.py
@@ -2,7 +2,7 @@ import tempfile
 import os
 import datetime
 import pytest
-from services.email_parser import parse_eml
+from services.email_parser import parse_eml, _sanitize_nul
 from services.exceptions import EmailParseError
 
 
@@ -233,3 +233,26 @@ Test"""
         assert parsed["reply_to"] == "Reply Target <reply-target@test.com>"
     finally:
         os.unlink(temp_path)
+
+
+def test_sanitize_nul():
+    # Normal string
+    assert _sanitize_nul("hello world") == "hello world"
+
+    # Strings with NUL characters
+    assert _sanitize_nul("hello\x00world") == "helloworld"
+    assert _sanitize_nul("\x00hello world") == "hello world"
+    assert _sanitize_nul("hello world\x00") == "hello world"
+    assert _sanitize_nul("hello\x00\x00world") == "helloworld"
+    assert _sanitize_nul("\x00") == ""
+
+    # Empty string
+    assert _sanitize_nul("") == ""
+
+    # None value
+    assert _sanitize_nul(None) == ""
+
+    # Non-string types (should be cast to string representations without NUL)
+    assert _sanitize_nul(123) == "123"
+    assert _sanitize_nul(12.3) == "12.3"
+    assert _sanitize_nul(True) == "True"


### PR DESCRIPTION
## 🧪 개선 사항

이 PR은 `backend/services/email_parser.py` 파일 내의 `_sanitize_nul` 함수에 대한 테스트를 추가하여 테스트 커버리지 및 안정성을 높입니다.

🎯 **무엇을 해결했는가:**
`_sanitize_nul` 함수는 문자열을 입력받아 PostgreSQL 텍스트 필드에서 유효하지 않은 NUL 문자(`\x00`)를 제거하는 함수입니다. 이 함수는 순수 함수임에도 불구하고 테스트 코드가 없었습니다.

📊 **테스트 범위 (Coverage):**
`backend/tests/test_email_parser.py` 에 다음 시나리오에 대한 테스트 케이스를 추가했습니다:
- 정상적인 문자열
- 시작, 중간, 끝, 여러개의 NUL 문자가 포함된 문자열
- 빈 문자열
- `None` 값 처리
- 정수, 실수, 부울 등 문자열이 아닌 타입의 처리

✨ **결과 (Result):**
`_sanitize_nul` 함수의 동작을 보장하는 테스트가 추가되어, 이메일 파서의 안정성 및 테스트 커버리지가 향상되었습니다.

---
*PR created automatically by Jules for task [6554076563066885346](https://jules.google.com/task/6554076563066885346) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for NUL character handling in email parsing. Tests verify that embedded null characters are properly sanitized while preserving valid content and handling edge cases including None values and non-string inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->