### PR TITLE
🧹 Remove unused import is_tenant_admin_role

### DIFF
--- a/backend/api/calendar.py
+++ b/backend/api/calendar.py
@@ -10,7 +10,6 @@ from api.auth import (
     AuthContext,
     get_auth_context,
     is_system_admin_role,
-    is_tenant_admin_role,
 )
 from db.models import CalendarWritebackSource
 from db.session import get_db


### PR DESCRIPTION
🎯 **What:** Removed the unused import `is_tenant_admin_role` from `backend/api/calendar.py`.
💡 **Why:** It cleans up the imports and removes dead code, which improves code readability and maintainability.
✅ **Verification:** Verified by using `sed` and `cat` to safely remove the import without affecting surrounding code. Executed tests via `cd backend && python3 -m pytest tests/test_calendar_api.py`, which passed. The full test suite was run and confirmed no issues resulted from this change.
✨ **Result:** A cleaner import block in `backend/api/calendar.py` and overall better code health.

---
*PR created automatically by Jules for task [16391743957787310348](https://jules.google.com/task/16391743957787310348) started by @seonghobae*