### PR TITLE
🧹 [Code Health] Use icalendar library for VTODO generation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,4 @@ opentelemetry-exporter-otlp==1.25.0
 setuptools==78.1.1
 websockets==14.1
 PyJWT==2.13.0
+icalendar==7.1.2

--- a/backend/services/calendar_sync.py
+++ b/backend/services/calendar_sync.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Optional
+from icalendar import Calendar, Todo
 
 def generate_ics_from_task(
     task_uid: str,
@@ -12,9 +13,6 @@ def generate_ics_from_task(
     """
     Generates a basic CalDAV-compatible .ics (iCalendar) string for a TicketTask (VTODO).
     """
-    dtstamp = updated_at.strftime("%Y%m%dT%H%M%SZ")
-    
-    # Map status
     ics_status = "NEEDS-ACTION"
     if status == "in_progress":
         ics_status = "IN-PROCESS"
@@ -23,23 +21,19 @@ def generate_ics_from_task(
     elif status == "blocked":
         ics_status = "NEEDS-ACTION"
 
-    lines = [
-        "BEGIN:VCALENDAR",
-        "VERSION:2.0",
-        "PRODID:-//Naruon//AI Workspace//EN",
-        "BEGIN:VTODO",
-        f"UID:{task_uid}",
-        f"DTSTAMP:{dtstamp}",
-        f"SUMMARY:{title}",
-        f"STATUS:{ics_status}"
-    ]
+    cal = Calendar()
+    cal.add('VERSION', '2.0')
+    cal.add('PRODID', '-//Naruon//AI Workspace//EN')
+
+    todo = Todo()
+    todo.add('UID', task_uid)
+    todo.add('DTSTAMP', updated_at)
+    todo.add('SUMMARY', title)
+    todo.add('STATUS', ics_status)
 
     if due_date:
-        lines.append(f"DUE:{due_date.strftime('%Y%m%dT%H%M%SZ')}")
+        todo.add('DUE', due_date)
 
-    lines.extend([
-        "END:VTODO",
-        "END:VCALENDAR"
-    ])
+    cal.add_component(todo)
 
-    return "\r\n".join(lines) + "\r\n"
+    return cal.to_ical().decode("utf-8")


### PR DESCRIPTION
🎯 **What:** Replaced manual string concatenation with the `icalendar` library for generating CalDAV VTODO (iCalendar) strings in `backend/services/calendar_sync.py`.
💡 **Why:** Manually building VCALENDAR/VTODO strings with list appends and joins is error prone and hard to maintain. Using a dedicated library like `icalendar` is safer, standard-compliant, and improves code readability.
✅ **Verification:** Verified by checking the generated iCalendar strings and successfully running `backend/tests/test_calendar_sync.py` and the backend tests suite.
✨ **Result:** A safer, more robust implementation of CalDAV task generation that avoids manual string formatting.

---
*PR created automatically by Jules for task [7531697833047027898](https://jules.google.com/task/7531697833047027898) started by @seonghobae*