### PR TITLE
🎨 Palette: 탭 내비게이션 일관성을 위한 버튼 focus-visible 스타일 추가

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-04 - Semantic Buttons for Task Interactions
 **Learning:** Interactive areas that trigger actions (like opening a task detail view or navigating to a source) should be semantic `<button>` elements rather than `<div>`s with `onClick` handlers. `div`s lack native keyboard accessibility, focus rings, and proper screen reader roles. Also, `aria-label`s should be context-aware (e.g., "접수 더보기" instead of just "더보기").
 **Action:** When creating new components that function as clickable cards or icon triggers, always wrap them in `<button type="button">` and ensure they have `focus-visible` styles and contextually descriptive `aria-label`s.
+## 2026-06-08 - Focus-visible styles on interactive elements
+**Learning:** Keyboard accessibility relies on visual indicators when elements receive focus. Standard focus-visible rings (e.g. `focus-visible:ring-2 focus-visible:ring-ring/40`) must be applied globally to all interactive elements like buttons and tabs, instead of randomly missing them in different pages.
+**Action:** Audit all interactive elements (buttons, links, custom inputs) across components and standardise on `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40` to provide predictable tab navigation feedback.

--- a/frontend/src/components/AIHubLayout.tsx
+++ b/frontend/src/components/AIHubLayout.tsx
@@ -349,7 +349,7 @@ export function AIHubLayout() {
               key={tab.id}
               type="button"
               onClick={() => setActiveTab(tab.id)}
-              className={`inline-flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-bold transition-colors ${
+              className={`inline-flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${
                 activeTab === tab.id
                   ? 'bg-primary text-primary-foreground'
                   : 'border border-border bg-background text-muted-foreground hover:bg-secondary'
@@ -376,7 +376,7 @@ export function AIHubLayout() {
               <button
                 type="button"
                 onClick={requestRefresh}
-                className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white"
+                className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 다시 시도
               </button>

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -122,7 +122,7 @@ export function CalendarLayout() {
     <div className="flex h-full min-h-0 bg-background text-foreground">
       {/* Left Sidebar - Calendar List */}
       <aside className="w-64 shrink-0 flex-col overflow-y-auto border-r border-border bg-card p-4 hidden lg:flex">
-        <button type="button" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">
+        <button type="button" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
           <Plus className="size-4" />새 일정
         </button>
 
@@ -145,7 +145,7 @@ export function CalendarLayout() {
               </li>
             ))}
           </ul>
-          <button type="button" className="mt-4 flex items-center gap-2 text-sm font-semibold text-primary">
+          <button type="button" className="mt-4 flex items-center gap-2 text-sm font-semibold text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
             <Plus className="size-4" /> 캘린더 추가
           </button>
         </div>
@@ -155,7 +155,7 @@ export function CalendarLayout() {
       <main className="flex min-w-0 flex-1 flex-col bg-background">
         <header className="flex h-auto min-h-16 shrink-0 flex-col items-start gap-3 border-b border-border bg-card px-4 py-3 lg:px-6">
           <div className="flex min-w-0 flex-wrap items-center gap-3 lg:gap-4">
-            <button type="button" className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold">오늘</button>
+            <button type="button" className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">오늘</button>
             <div className="flex items-center gap-1">
               <button type="button" aria-label="이전 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"><ChevronLeft className="size-5" /></button>
               <button type="button" aria-label="다음 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"><ChevronRight className="size-5" /></button>
@@ -169,7 +169,7 @@ export function CalendarLayout() {
                 <button type="button"
                   key={mode}
                   onClick={() => setViewMode(mode as '월간 캘린더' | '주간 캘린더' | '일정 상세' | '회의 조율' | '일정 후보')}
-                  className={`shrink-0 px-4 py-1.5 text-sm font-semibold transition-colors ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
+                  className={`shrink-0 px-4 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
                 >
                   {mode}
                 </button>
@@ -198,7 +198,7 @@ export function CalendarLayout() {
                   type="button"
                   onClick={() => void requestWritebackIntent('create')}
                   disabled={isWritebackActionDisabled}
-                  className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60"
+                  className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                 >
                   새 일정 intent 점검
                 </button>
@@ -375,7 +375,7 @@ export function CalendarLayout() {
                 <h3 className="text-lg font-bold mb-4">회의 조율 (Coordination)</h3>
                 <p className="text-sm text-muted-foreground mb-4">참석자들의 캘린더(CalDAV)를 종합 분석하여 최적의 시간을 제안합니다.</p>
                 <div className="grid gap-3 max-w-lg">
-                  <button type="button" className="flex items-center justify-between rounded-xl border border-primary/20 bg-primary/5 p-4 hover:bg-primary/10 transition-colors">
+                  <button type="button" className="flex items-center justify-between rounded-xl border border-primary/20 bg-primary/5 p-4 hover:bg-primary/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
                     <div className="flex items-center gap-3">
                       <span className="grid size-8 place-items-center rounded-lg bg-primary/20 text-primary font-bold">1안</span>
                       <div className="text-left">
@@ -493,7 +493,7 @@ export function CalendarLayout() {
         <div className="mt-8 flex gap-3">
           <button type="button" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">삭제</button>
           <button type="button" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">복사</button>
-          <button type="button" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">수정</button>
+          <button type="button" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">수정</button>
         </div>
       </aside>
     </div>

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -146,7 +146,7 @@ function SenderDagPanel({
               type="button"
               onClick={onCapture}
               disabled={captureStatus === "loading"}
-              className="w-full rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto"
+              className="w-full rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 sm:w-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
             >
               {captureStatus === "loading" ? "캡처 중" : "발신자 관계 캡처"}
             </button>
@@ -391,7 +391,7 @@ export function SearchLayout() {
               type="button"
               onClick={() => setActiveResultId(result.id)}
               aria-current={isActive ? "true" : undefined}
-              className={`w-full border-l-4 p-4 text-left transition-colors ${
+              className={`w-full border-l-4 p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${
                 isActive
                   ? "border-primary bg-secondary/50"
                   : "border-transparent hover:bg-secondary/20"
@@ -460,7 +460,7 @@ export function SearchLayout() {
           <button
             type="submit"
             disabled={loading}
-            className="h-12 shrink-0 rounded-lg bg-primary px-4 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="h-12 shrink-0 rounded-lg bg-primary px-4 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           >
             {loading ? "검색 중..." : "검색"}
           </button>
@@ -481,7 +481,7 @@ export function SearchLayout() {
                 key={filter.key}
                 type="button"
                 onClick={() => setActiveFilter(filter.key)}
-                className={`shrink-0 rounded-full px-3 py-1 text-xs font-bold ${
+                className={`shrink-0 rounded-full px-3 py-1 text-xs font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${
                   activeFilter === filter.key
                     ? "bg-primary text-primary-foreground"
                     : "bg-secondary text-muted-foreground hover:bg-secondary/80"

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -258,7 +258,7 @@ export function TasksLayout() {
               <button type="button"
                 key={mode}
                 onClick={() => setViewMode(mode as '내 작업' | '위임한 작업' | '칸반' | '작업 상세')}
-                className={`shrink-0 px-4 py-1.5 text-sm font-semibold transition-colors ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
+                className={`shrink-0 px-4 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${viewMode === mode ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-secondary'}`}
               >
                 {mode}
               </button>
@@ -273,7 +273,7 @@ export function TasksLayout() {
           <button type="button" className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
             <Filter className="size-4" /> 필터
           </button>
-          <button type="button" className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90">
+          <button type="button" className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
             <Plus className="size-4" /> 새 작업
           </button>
         </div>
@@ -320,7 +320,7 @@ export function TasksLayout() {
                 aria-label="보낸 메일 답변 SLA 티켓 생성"
                 disabled={replySlaStatus === 'loading'}
                 onClick={() => void handleReplySlaEscalation()}
-                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 <Plus className="size-3.5" />
                 {replySlaStatus === 'loading' ? '확인 중' : 'SLA 티켓 생성'}
@@ -370,7 +370,7 @@ export function TasksLayout() {
                         aria-label={`${task.title} 상태를 ${taskStatusChangeLabels[status]} 변경`}
                         aria-pressed={task.status === status}
                         onClick={() => void handleTicketStatusChange(task.id, status)}
-                        className={`rounded-md border px-2.5 py-1 text-xs font-bold transition-colors ${
+                        className={`rounded-md border px-2.5 py-1 text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${
                           task.status === status
                             ? 'border-primary bg-primary text-primary-foreground'
                             : 'border-border bg-card text-foreground hover:border-primary/60 hover:bg-secondary'
@@ -417,7 +417,7 @@ export function TasksLayout() {
                           aria-label={`${task.title} WebDAV 지식 노트 intent 생성`}
                           disabled={currentKnowledgeIntent.state === 'loading'}
                           onClick={() => void handleKnowledgeIntentCreate(task.id)}
-                          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+                          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                         >
                           <Plus className="size-3.5" />
                           {currentKnowledgeIntent.state === 'loading' ? '생성 중' : 'intent 생성'}
@@ -594,7 +594,7 @@ export function TasksLayout() {
                 </div>
                 <h2 className="text-2xl font-bold">{task.title}</h2>
               </div>
-              <button type="button" className="px-4 py-2 bg-primary text-primary-foreground text-sm font-bold rounded-lg hover:bg-primary/90">상태 변경</button>
+              <button type="button" className="px-4 py-2 bg-primary text-primary-foreground text-sm font-bold rounded-lg hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">상태 변경</button>
             </div>
             
             <div className="grid grid-cols-3 gap-6 mb-6">


### PR DESCRIPTION
## 💡 What
`TasksLayout`, `CalendarLayout`, `SearchLayout`, `AIHubLayout` 등의 주요 컴포넌트에 존재하는 여러 버튼 요소에 `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40` 클래스를 추가했습니다.

## 🎯 Why
일부 버튼은 `hover` 스타일만 있고 `focus-visible` 스타일이 없어서 키보드로(Tab 키) 탭 내비게이션 시 포커스가 이동했는지 시각적으로 확인하기 어려웠습니다. 산업 표준 및 기존 시스템의 포커스 링 패턴(`ring-2`)을 모든 인터랙티브 요소에 일관되게 적용하여 스크린 리더 및 키보드 사용자의 접근성을 크게 향상시킵니다.

## 📸 Before/After
(로컬에서 Playwright 영상/스크린샷으로 검증 완료)

## ♿ Accessibility
키보드 사용자 경험 개선 (WCAG 2.1 - 2.4.7 Focus Visible 준수)

---
*PR created automatically by Jules for task [16630240717663858833](https://jules.google.com/task/16630240717663858833) started by @seonghobae*