### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation to PromptCreate

### DIFF
--- a/backend/api/prompts.py
+++ b/backend/api/prompts.py
@@ -29,9 +29,9 @@ PROMPT_TEST_SYSTEM_MESSAGE = (
 
 
 class PromptCreate(BaseModel):
-    title: str
-    description: Optional[str] = None
-    content: str
+    title: str = Field(min_length=1, max_length=100)
+    description: Optional[str] = Field(default=None, max_length=1000)
+    content: str = Field(min_length=1, max_length=PROMPT_TEST_MAX_CONTENT_CHARS)
     is_shared: bool = False
 
 

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -106,6 +106,31 @@ def orgless_system_admin_client():
         yield c
 
 
+def test_prompt_crud_validation(auth_client):
+    # Missing required fields
+    resp = auth_client.post("/api/prompts", json={})
+    assert resp.status_code == 422
+
+    # Title too long
+    resp = auth_client.post(
+        "/api/prompts",
+        json={
+            "title": "A" * 101,
+            "content": "Summarize this: {{email}}",
+        },
+    )
+    assert resp.status_code == 422
+
+    # Content too long
+    resp = auth_client.post(
+        "/api/prompts",
+        json={
+            "title": "Test",
+            "content": "A" * 4001,
+        },
+    )
+    assert resp.status_code == 422
+
 def test_prompt_crud(auth_client):
     # Create
     resp = auth_client.post(


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add input validation to PromptCreate

🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length constraints on PromptCreate model allowed arbitrarily large payloads, posing a Denial of Service (DoS) risk and unnecessary resource consumption.
🎯 Impact: Attackers or unverified users could send multi-megabyte strings to the `title` or `content` fields, causing memory exhaustion or bloated database storage over time.
🔧 Fix: Implemented strict Pydantic `Field` bounds (`min_length` and `max_length`) on `title`, `description`, and `content`.
✅ Verification: Added `test_prompt_crud_validation` tests in `test_prompts_api.py` that successfully verify 422 Unprocessable Entity errors when limits are exceeded.

---
*PR created automatically by Jules for task [8299145276384621404](https://jules.google.com/task/8299145276384621404) started by @seonghobae*