### PR TITLE
⚡ Bolt: 이메일 중복 제거 로직 반복 해시 연산 캐싱

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-06-06 - Refactoring repetitive assert any loops
 **Learning:** Repetitive single-statement `assert any(...)` calls can be cleanly refactored into an `expected_substrings` list that loops over assertions. When extracting strings to build the list, it's very helpful to use `re.sub()` to simultaneously capture strings via a replacer function while replacing the matches with placeholders, and then substitute the newly generated list block into the code.
 **Action:** Always prefer lists and loops over repeated code structures when possible, maintaining test readability.
+
+## 2026-06-07 - Redundant SHA256 Hashing during UniqueThread Deduplication
+**Learning:** `create_unique_thread_intent` iterates over candidates twice to first extract lookups and fingerprint sets, and then iterates over them a second time inside `_find_matches_for_candidates` to match those lookups. This caused `candidate_strong_fingerprint(candidate)` (which performs a SHA256 encoding) to be redundantly executed twice per candidate.
+**Action:** Extract expensive lookups (`candidate_strong_fingerprint` and regex normalizations) into dictionaries mapped by `candidate_key` during the first iteration to prevent redundant processing.

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -6,7 +6,12 @@ from db.models import Email
 from pydantic import BaseModel, EmailStr, Field
 import datetime
 from typing import Literal
-from services.email_client import EmailMessageParams, SmtpConfig, send_email, validate_smtp_destination
+from services.email_client import (
+    EmailMessageParams,
+    SmtpConfig,
+    send_email,
+    validate_smtp_destination,
+)
 from services.reply_tracking_service import (
     check_missing_replies,
     configured_email_addresses,
@@ -183,9 +188,7 @@ class UniqueThreadCandidateRequest(BaseModel):
 
 
 class UniqueThreadIntentRequest(BaseModel):
-    candidates: list[UniqueThreadCandidateRequest] = Field(
-        min_length=1, max_length=20
-    )
+    candidates: list[UniqueThreadCandidateRequest] = Field(min_length=1, max_length=20)
 
 
 class UniqueThreadUpdate(BaseModel):
@@ -296,16 +299,33 @@ async def get_pending_replies(
     return {"emails": items}
 
 
-
-def _extract_candidate_lookups(candidates: list[EmailDedupeCandidate]) -> tuple[set[str], set[str]]:
+def _extract_candidate_lookups(
+    candidates: list[EmailDedupeCandidate],
+) -> tuple[set[str], set[str], dict[str, set[str]], dict[str, str | None]]:
     message_lookup_values: set[str] = set()
     fingerprint_values: set[str] = set()
+
+    # ⚡ Bolt: Cache expensive lookup generation and SHA-256 fingerprinting
+    # Mapping by candidate_key to prevent redundant processing in downstream dedupe logic
+    candidate_lookups: dict[str, set[str]] = {}
+    candidate_fingerprints: dict[str, str | None] = {}
+
     for candidate in candidates:
-        message_lookup_values.update(candidate_message_lookup_values(candidate))
+        lookups = candidate_message_lookup_values(candidate)
+        candidate_lookups[candidate.candidate_key] = lookups
+        message_lookup_values.update(lookups)
+
         candidate_fingerprint = candidate_strong_fingerprint(candidate)
+        candidate_fingerprints[candidate.candidate_key] = candidate_fingerprint
         if candidate_fingerprint:
             fingerprint_values.add(candidate_fingerprint)
-    return message_lookup_values, fingerprint_values
+
+    return (
+        message_lookup_values,
+        fingerprint_values,
+        candidate_lookups,
+        candidate_fingerprints,
+    )
 
 
 async def _fetch_existing_emails_for_candidates(
@@ -352,6 +372,8 @@ def _find_matches_for_candidates(
     candidates: list[EmailDedupeCandidate],
     by_message_id: dict[str, Email],
     by_fingerprint: dict[str, Email],
+    candidate_lookups: dict[str, set[str]],
+    candidate_fingerprints: dict[str, str | None],
 ) -> list[UniqueThreadUpdate]:
     updates: list[UniqueThreadUpdate] = []
     for candidate in candidates:
@@ -359,7 +381,7 @@ def _find_matches_for_candidates(
         match_reason: Literal["message_id", "fingerprint"] | None = None
         dedupe_key: str | None = None
 
-        for lookup_value in candidate_message_lookup_values(candidate):
+        for lookup_value in candidate_lookups.get(candidate.candidate_key, set()):
             if lookup_value in by_message_id:
                 matched_email = by_message_id[lookup_value]
                 match_reason = "message_id"
@@ -367,7 +389,7 @@ def _find_matches_for_candidates(
                 break
 
         if matched_email is None:
-            candidate_fingerprint = candidate_strong_fingerprint(candidate)
+            candidate_fingerprint = candidate_fingerprints.get(candidate.candidate_key)
             if candidate_fingerprint and candidate_fingerprint in by_fingerprint:
                 matched_email = by_fingerprint[candidate_fingerprint]
                 match_reason = "fingerprint"
@@ -396,12 +418,23 @@ async def create_unique_thread_intent(
     auth_context: AuthContext = Depends(get_auth_context),
 ):
     candidates = [_to_dedupe_candidate(candidate) for candidate in request.candidates]
-    message_lookup_values, fingerprint_values = _extract_candidate_lookups(candidates)
+    (
+        message_lookup_values,
+        fingerprint_values,
+        candidate_lookups,
+        candidate_fingerprints,
+    ) = _extract_candidate_lookups(candidates)
     existing_emails = await _fetch_existing_emails_for_candidates(
         db, auth_context, message_lookup_values, fingerprint_values
     )
     by_message_id, by_fingerprint = _build_email_lookup_dicts(existing_emails)
-    updates = _find_matches_for_candidates(candidates, by_message_id, by_fingerprint)
+    updates = _find_matches_for_candidates(
+        candidates,
+        by_message_id,
+        by_fingerprint,
+        candidate_lookups,
+        candidate_fingerprints,
+    )
 
     return UniqueThreadIntentResponse(
         status="intent_ready",


### PR DESCRIPTION
💡 What: 캐싱을 통해 이메일 스레드 후보들의 룩업 및 지문 값을 반복적으로 생성하지 않도록 최적화했습니다.

🎯 Why: `UniqueThreadIntentRequest` 처리 과정에서 `_extract_candidate_lookups`와 `_find_matches_for_candidates` 두 곳 모두 후보 리스트를 반복하며 동일한 룩업 데이터와 SHA-256 해시를 생성하고 있었습니다. 이는 불필요한 계산 비용을 발생시키는 병목 지점(N번 반복)이었습니다.

📊 Impact: 각각의 이메일 후보마다 고비용의 SHA-256 해시 연산 및 정규식 정규화 과정이 두 번 실행되는 것을 방지하여, 대용량 스레드 데이터 처리 속도를 크게 향상시킵니다. 

🔬 Measurement: `backend/api/emails.py` 관련 모든 pytest가 성공적으로 통과했으며 로직 상의 일관성이 유지됨을 확인했습니다.

---
*PR created automatically by Jules for task [4244851696120861847](https://jules.google.com/task/4244851696120861847) started by @seonghobae*