### PR TITLE
🎨 Palette: 검색 입력 필드 접근성 개선 (ARIA label 및 id 추가)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-08 - Accessible Search Inputs Across Layouts
+**Learning:** Search inputs placed in complex dashboard layouts frequently miss explicitly associated labels and IDs, relying only on placeholders or visual icons, which creates barriers for screen reader users navigating the page landmarks.
+**Action:** Always provide a visually hidden `<label>` explicitly tied to the input via `htmlFor` and `id`, and ensure any adjacent decorative search icons have `aria-hidden="true"`.

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -355,10 +355,11 @@ export function DashboardLayout({
               <PrimaryNavLink key={item.href} {...item} />
             ))}
           </nav>
-          <label className="hidden min-w-0 flex-1 items-center rounded-2xl border border-border bg-background/80 px-4 py-2 text-sm text-muted-foreground shadow-inner shadow-slate-950/[0.02] xl:flex">
+          <label htmlFor="global-search-input" className="hidden min-w-0 flex-1 items-center rounded-2xl border border-border bg-background/80 px-4 py-2 text-sm text-muted-foreground shadow-inner shadow-slate-950/[0.02] xl:flex">
             <Search className="mr-2 size-4 text-primary" aria-hidden="true" />
             <span className="sr-only">맥락 검색</span>
             <input
+              id="global-search-input"
               className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
               placeholder="맥락, 사람, 파일, 판단 포인트 검색..."
               type="search"

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -448,11 +448,13 @@ export function SearchLayout() {
           className="mx-auto flex w-full max-w-4xl gap-2"
         >
           <div className="relative min-w-0 flex-1">
+            <label htmlFor="search-input" className="sr-only">맥락 검색</label>
             <Search
               className="absolute left-4 top-1/2 size-5 -translate-y-1/2 text-primary"
               aria-hidden="true"
             />
             <input
+              id="search-input"
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -271,8 +271,9 @@ export function TasksLayout() {
         </div>
         <div className="flex flex-wrap items-center gap-2 lg:gap-3">
           <div className="relative min-w-[180px] flex-1 sm:flex-none">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-            <input type="text" placeholder="작업 검색..." className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64" />
+            <label htmlFor="task-search-input" className="sr-only">작업 검색</label>
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" aria-hidden="true" />
+            <input id="task-search-input" type="text" placeholder="작업 검색..." className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64" />
           </div>
           <button type="button" className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
             <Filter className="size-4" /> 필터


### PR DESCRIPTION
🎨 Palette: 검색 입력 필드 접근성 개선 (ARIA label 및 id 추가)

💡 What:
- SearchLayout, TasksLayout, DashboardLayout 내 검색 input 필드에 고유 id와 명시적인 시각적 숨김 label 연결
- 장식용 Search 아이콘에 aria-hidden="true" 속성 부여

🎯 Why:
- 화면 판독기를 사용하는 사용자가 랜드마크 탐색 시 검색 입력 필드의 목적을 명확히 인지하도록 접근성(a11y) 기준을 준수하기 위함
- 아이콘으로만 유추해야 했던 기존 UI의 명확성 문제 해결

📸 Before/After:
- HTML 속성 추가로 시각적 변경은 없습니다.

♿ Accessibility:
- WAI-ARIA 규격에 맞춰 label태그와 input의 htmlFor, id 속성을 연결하여 스크린리더 친화성 향상

---
*PR created automatically by Jules for task [1927037391828393723](https://jules.google.com/task/1927037391828393723) started by @seonghobae*