### PR TITLE
🎨 Palette: Calendar 화면의 일관된 UX를 위한 버튼 컴포넌트 표준화

### DIFF
--- a/frontend/.Jules/palette.md
+++ b/frontend/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-04 - Add loading state to SearchLayout button
 **Learning:** Users notice the little things. Missing loading states on async actions makes users unsure if their action registered. Adding a simple loading spinner provides immediate feedback and aligns with accessibility best practices when making dynamic state changes.
 **Action:** Always include a visual loading state like `Loader2` for async actions (like the '발신자 관계 캡처' button) to provide immediate feedback to the user.
+## 2024-06-07 - Refactoring CalendarLayout buttons
+**Learning:** Raw HTML `<button>` elements with complex Tailwind class strings were scattered throughout layout components, which led to inconsistent hover, focus-visible states, and accessibility properties compared to standard design system components.
+**Action:** Replace raw HTML `<button>` tags with the `@/components/ui/button` `Button` component using appropriate variants (`ghost`, `outline`) and sizes (`icon-sm`, `sm`) to instantly standardize accessible focus rings and interaction feedback.

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight, Settings, Plus, Users, Video, Paperclip, Clock, CalendarDays, X } from 'lucide-react';
+import { Button } from "@/components/ui/button";
 
 import { apiClient } from '@/lib/api-client';
 
@@ -164,9 +165,9 @@ export function CalendarLayout() {
     <div className="flex h-full min-h-0 bg-background text-foreground">
       {/* Left Sidebar - Calendar List */}
       <aside className="w-64 shrink-0 flex-col overflow-y-auto border-r border-border bg-card p-4 hidden lg:flex">
-        <button type="button" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">
+        <Button type="button" className="w-full h-10">
           <Plus className="size-4" />새 일정
-        </button>
+        </Button>
 
         <div className="mt-8">
           <div className="mb-4 flex items-center justify-between">
@@ -187,9 +188,9 @@ export function CalendarLayout() {
               </li>
             ))}
           </ul>
-          <button type="button" className="mt-4 flex items-center gap-2 text-sm font-semibold text-primary">
+          <Button variant="ghost" className="mt-4 w-full justify-start text-primary hover:text-primary">
             <Plus className="size-4" /> 캘린더 추가
-          </button>
+          </Button>
         </div>
       </aside>
 
@@ -197,10 +198,10 @@ export function CalendarLayout() {
       <main className="flex min-w-0 flex-1 flex-col bg-background">
         <header className="flex h-auto min-h-16 shrink-0 flex-col items-start gap-3 border-b border-border bg-card px-4 py-3 lg:px-6">
           <div className="flex min-w-0 flex-wrap items-center gap-3 lg:gap-4">
-            <button type="button" className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold">오늘</button>
+            <Button variant="outline" size="sm" className="h-8 rounded-md text-xs font-semibold">오늘</Button>
             <div className="flex items-center gap-1">
-              <button type="button" aria-label="이전 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"><ChevronLeft className="size-5" /></button>
-              <button type="button" aria-label="다음 달" className="grid size-8 place-items-center rounded-md hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"><ChevronRight className="size-5" /></button>
+              <Button variant="ghost" size="icon-sm" aria-label="이전 달" className="rounded-md"><ChevronLeft className="size-5" /></Button>
+              <Button variant="ghost" size="icon-sm" aria-label="다음 달" className="rounded-md"><ChevronRight className="size-5" /></Button>
             </div>
             <h1 className="text-xl font-bold">일정 관리</h1>
             <h2 className="text-sm font-bold text-muted-foreground lg:ml-2">2026년 5월</h2>
@@ -217,9 +218,9 @@ export function CalendarLayout() {
                 </button>
               ))}
             </div>
-            <button type="button" aria-label="설정" className="grid size-9 shrink-0 place-items-center rounded-md border border-border bg-background hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+            <Button variant="outline" size="icon-sm" className="size-9 rounded-md" aria-label="설정">
               <Settings className="size-5" />
-            </button>
+            </Button>
           </div>
         </header>
 
@@ -472,7 +473,7 @@ export function CalendarLayout() {
             <span className="rounded-md bg-secondary px-2 py-1 text-xs font-bold text-muted-foreground">공개</span>
           </div>
           <div className="flex items-center gap-2">
-            <button type="button" aria-label="닫기" className="grid size-8 place-items-center rounded-md hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"><X className="size-4" /></button>
+            <Button variant="ghost" size="icon-sm" aria-label="닫기" className="rounded-md"><X className="size-4" /></Button>
           </div>
         </div>
         


### PR DESCRIPTION
## 💡 UX 개선 사항 (What)
`CalendarLayout.tsx` 컴포넌트 내에 하드코딩되어 있던 여러 네이티브 `<button>` 태그들을 프로젝트의 표준 디자인 시스템 컴포넌트인 `@/components/ui/button` (`<Button>`)으로 교체했습니다.

## 🎯 해결한 문제 (Why)
- **일관성 부족**: 네이티브 버튼마다 각기 다른 hover 및 focus-visible 상태가 적용되어 있어 앱 전반의 통일성이 떨어졌습니다.
- **접근성(a11y)**: 표준 `Button` 컴포넌트를 사용함으로써 키보드 탐색 시 명확한 focus ring(`focus-visible`)이 기본적으로 보장됩니다.
- **코드 가독성**: 길고 복잡한 유틸리티 클래스(예: `hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40`)를 줄여 코드를 단순화했습니다.

## 📸 변경 화면 (Before/After)
UI의 레이아웃은 기존과 동일하게 유지되며, 키보드 네비게이션 시 포커스 링과 마우스 오버(hover) 시의 피드백이 디자인 시스템 표준에 맞게 깔끔하게 다듬어졌습니다.

## ♿ 접근성 (Accessibility)
- 아이콘 전용 버튼(이전 달, 다음 달, 설정 등)에 기존에 있던 `aria-label` 속성을 그대로 유지하여 스크린 리더 사용성을 보장했습니다.
- 시스템 공통의 키보드 포커스 스타일링이 일관되게 적용됩니다.

---
*PR created automatically by Jules for task [9961363152774985951](https://jules.google.com/task/9961363152774985951) started by @seonghobae*