### PR TITLE
fix: resolve standalone Dockerfile build and startup failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ COPY --from=frontend-builder /app/next.config.ts /app/frontend/next.config.ts
 
 # Create a startup script
 RUN echo '#!/bin/bash\n\
+if [ -z "$AUTH_SESSION_HMAC_SECRET" ]; then\n\
+  export AUTH_SESSION_HMAC_SECRET=$(python -c "import secrets; print(secrets.token_hex(32))")\n\
+fi\n\
 echo "Starting Naruon Backend and Frontend..."\n\
 python scripts/bootstrap_db.py\n\
 python scripts/start_backend.py --host 0.0.0.0 --port 8000 &\n\
@@ -58,7 +61,6 @@ USER appuser
 
 # Environment variables for Backend and Frontend
 ENV DATABASE_URL=sqlite+aiosqlite:///./naruon_standalone.db
-ENV AUTH_SESSION_HMAC_SECRET=local-dev-dummy-key-of-32-bytes-min-length-1234
 ENV NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV BACKEND_INTERNAL_URL=http://127.0.0.1:8000
 ENV ALLOW_DOCKER_BACKEND_INTERNAL_URL=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-slim AS frontend-builder
 WORKDIR /app
 COPY frontend/package*.json ./
-RUN npm ci --fetch-timeout=600000 --fetch-retries=5
+RUN npm install
 COPY frontend ./
 # Pass dummy URL for build if needed
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
@@ -56,7 +56,9 @@ exit $?\n\
 RUN useradd -m -s /bin/bash appuser && chown -R appuser:appuser /app
 USER appuser
 
-# Environment variables for Frontend
+# Environment variables for Backend and Frontend
+ENV DATABASE_URL=sqlite+aiosqlite:///./naruon_standalone.db
+ENV AUTH_SESSION_HMAC_SECRET=local-dev-dummy-key-of-32-bytes-min-length-1234
 ENV NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV BACKEND_INTERNAL_URL=http://127.0.0.1:8000
 ENV ALLOW_DOCKER_BACKEND_INTERNAL_URL=1


### PR DESCRIPTION
This PR fixes two issues with the standalone Dockerfile: 1) Changing npm ci to npm install because the project uses pnpm (no package-lock.json). 2) Supplying fallback ENV vars for DATABASE_URL and AUTH_SESSION_HMAC_SECRET so the backend doesn't crash on boot in standalone mode, allowing frontend and backend to stay up together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified frontend build installation in the container image.
  * Runtime now ensures an authentication session secret is present (auto-generated if missing) for startup.
  * Runtime environment now defaults to a local SQLite database URL for standalone use and merges backend/frontend environment notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->