### PR TITLE
feat: Add support for Gemma4 and EmbeddingGemma models

### DIFF
--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,0 +1,8 @@
+FROM ollama/ollama:latest
+
+# We pull the models during build time.
+# To ensure the server is up to receive the pull requests, we start it in the background.
+RUN nohup bash -c "ollama serve &" && \
+    sleep 5 && \
+    ollama pull gemma4 && \
+    ollama pull embeddinggemma

--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,8 +1,14 @@
 FROM ollama/ollama:latest
 
-# We pull the models during build time.
-# To ensure the server is up to receive the pull requests, we start it in the background.
+# Pull model weights at build time so the container is ready without network
+# access at runtime.  We start the server in the background, wait for it to be
+# ready with a readiness poll, pull the models, then stop the server.  A
+# fixed sleep is fragile on slow/constrained runners, so we use a loop instead.
 RUN nohup bash -c "ollama serve &" && \
-    sleep 5 && \
+    until curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; do sleep 1; done && \
     ollama pull gemma4 && \
     ollama pull embeddinggemma
+
+# Run as non-root for security (DS-0002).
+# The ollama base image ships with an 'ollama' user.
+USER ollama

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     ALLOWED_POP3_HOSTS: str = ""
     ALLOWED_POP3_PORTS: str = "995"
     ALLOWED_LLM_BASE_URL_HOSTS: str = ""
+    ALLOW_LOCAL_LLM_PROVIDERS: bool = False
     ALLOWED_CORS_ORIGINS: str = "http://localhost:3000,http://127.0.0.1:3000,http://localhost:8000,http://127.0.0.1:8000"
     ENABLE_PROMETHEUS_METRICS: bool = False
     SECURITY_CONTENT_SECURITY_POLICY: str = (

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -54,16 +54,17 @@ def _validate_global_address(address: str) -> str:
         ip_address = ipaddress.ip_address(address)
     except ValueError as exc:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
-    if (
-        ip_address.is_private
-        or ip_address.is_loopback
-        or ip_address.is_link_local
-        or ip_address.is_reserved
-        or ip_address.is_unspecified
-        or ip_address.is_multicast
-        or not ip_address.is_global
-    ):
-        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+    if not settings.DEBUG:
+        if (
+            ip_address.is_private
+            or ip_address.is_loopback
+            or ip_address.is_link_local
+            or ip_address.is_reserved
+            or ip_address.is_unspecified
+            or ip_address.is_multicast
+            or not ip_address.is_global
+        ):
+            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
     return str(ip_address)
 
 
@@ -110,28 +111,36 @@ def _normalize_llm_provider_base_url(value: str | None):
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
 
     hostname = (parsed.hostname or "").lower().rstrip(".")
+    is_localhost = hostname in {"localhost", "localhost.localdomain", "127.0.0.1", "ollama"}
+    
+    # Allow http for local development or if explicitly allowed
+    if parsed.scheme.lower() not in {"http", "https"}:
+        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+        
+    if parsed.scheme.lower() == "http" and not is_localhost and not settings.DEBUG:
+        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+
     if (
-        parsed.scheme.lower() != "https"
-        or not hostname
+        not hostname
         or parsed.username is not None
         or parsed.password is not None
         or parsed.query
         or parsed.fragment
-        or port != 443
-        or hostname in {"localhost", "localhost.localdomain"}
     ):
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
     allowed_hosts = _parse_allowed_hosts()
-    if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
-        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
-    if hostname not in allowed_hosts:
-        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
-    if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
-        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+    # If not localhost, must be in allowed hosts
+    if not is_localhost:
+        if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
+            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+        if hostname not in allowed_hosts:
+            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+        if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
+            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
     netloc = hostname if parsed.port is None else f"{hostname}:{port}"
-    return urlunsplit(("https", netloc, parsed.path or "", "", "")), hostname, port
+    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path or "", "", "")), hostname, port
 
 
 def validate_llm_provider_base_url_details(

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -49,14 +49,28 @@ def _looks_like_ip_literal(candidate: str) -> bool:
     )
 
 
-def _validate_global_address(address: str) -> str:
+def _validate_global_address(address: str, *, hostname: str | None = None) -> str:
+    """Validate that an IP address is globally routable, or explicitly allowed.
+
+    When ``ALLOW_LOCAL_LLM_PROVIDERS`` is enabled the address is accepted if:
+    - the IP is a loopback address, **or**
+    - the *original* hostname (before DNS resolution) is present in
+      ``ALLOWED_LLM_BASE_URL_HOSTS``.
+
+    This second condition is necessary because Docker container names (e.g.
+    ``ollama``) resolve to RFC-1918 private IPs that would otherwise be
+    rejected by the global-address check.
+    """
     try:
         ip_address = ipaddress.ip_address(address)
     except ValueError as exc:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
+
     is_allowed_local = False
     if settings.ALLOW_LOCAL_LLM_PROVIDERS:
-        if ip_address.is_loopback or address in _parse_allowed_hosts():
+        if ip_address.is_loopback:
+            is_allowed_local = True
+        elif hostname and hostname.lower().rstrip(".") in _parse_allowed_hosts():
             is_allowed_local = True
 
     if not is_allowed_local:
@@ -84,7 +98,9 @@ def _resolve_all_global_addresses(hostname: str, port: int) -> tuple[str, ...]:
     addresses: list[str] = []
     seen_addresses: set[str] = set()
     for address_info in address_infos:
-        address = _validate_global_address(str(address_info[4][0]))
+        # Pass the original hostname so that Docker container names listed in
+        # ALLOWED_LLM_BASE_URL_HOSTS are matched before checking the resolved IP.
+        address = _validate_global_address(str(address_info[4][0]), hostname=hostname)
         if address not in seen_addresses:
             seen_addresses.add(address)
             addresses.append(address)
@@ -191,8 +207,10 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
             raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
         self._hostname = hostname
         self._port = port
+        # Re-validate each address; pass the hostname so Docker-container names
+        # in ALLOWED_LLM_BASE_URL_HOSTS are accepted.
         self._addresses = tuple(
-            _validate_global_address(address) for address in addresses
+            _validate_global_address(address, hostname=hostname) for address in addresses
         )
         self._backend = AutoBackend()
 
@@ -204,7 +222,7 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
         local_address: str | None,
         socket_options,
     ):
-        pinned_address = _validate_global_address(address)
+        pinned_address = _validate_global_address(address, hostname=self._hostname)
         return await self._backend.connect_tcp(
             pinned_address,
             port,

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -54,7 +54,12 @@ def _validate_global_address(address: str) -> str:
         ip_address = ipaddress.ip_address(address)
     except ValueError as exc:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
-    if not settings.DEBUG:
+    is_allowed_local = False
+    if settings.ALLOW_LOCAL_LLM_PROVIDERS:
+        if ip_address.is_loopback or address in _parse_allowed_hosts():
+            is_allowed_local = True
+
+    if not is_allowed_local:
         if (
             ip_address.is_private
             or ip_address.is_loopback
@@ -106,19 +111,22 @@ def _normalize_llm_provider_base_url(value: str | None):
 
     try:
         parsed = urlsplit(candidate)
-        port = parsed.port or 443
+        default_port = 443 if parsed.scheme.lower() == "https" else 80
+        port = parsed.port or default_port
     except ValueError as exc:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
 
     hostname = (parsed.hostname or "").lower().rstrip(".")
-    is_localhost = hostname in {"localhost", "localhost.localdomain", "127.0.0.1", "ollama"}
+    # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
+    is_local_dev_host = hostname in {"localhost", "localhost.localdomain", "127.0.0.1"}
     
     # Allow http for local development or if explicitly allowed
     if parsed.scheme.lower() not in {"http", "https"}:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
         
-    if parsed.scheme.lower() == "http" and not is_localhost and not settings.DEBUG:
-        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+    if parsed.scheme.lower() == "http" and not is_local_dev_host:
+        if not (settings.ALLOW_LOCAL_LLM_PROVIDERS and hostname in _parse_allowed_hosts()):
+            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
     if (
         not hostname
@@ -131,7 +139,7 @@ def _normalize_llm_provider_base_url(value: str | None):
 
     allowed_hosts = _parse_allowed_hosts()
     # If not localhost, must be in allowed hosts
-    if not is_localhost:
+    if not is_local_dev_host:
         if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
             raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
         if hostname not in allowed_hosts:

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -153,11 +153,11 @@ def test_frontend_dockerfile_builds_and_starts_production_artifact() -> None:
     dockerfile = read_repo_text("frontend/Dockerfile")
 
     assert dockerfile.index("ARG NEXT_PUBLIC_API_URL") < dockerfile.index(
-        "RUN npm run build"
+        "RUN pnpm run build"
     )
-    assert "npm run build" in dockerfile
-    assert 'CMD ["npm", "run", "start"' in dockerfile or "npm run start" in dockerfile
-    assert "npm run dev" not in dockerfile
+    assert "pnpm run build" in dockerfile
+    assert 'CMD ["pnpm", "run", "start"' in dockerfile or "pnpm run start" in dockerfile
+    assert "pnpm run dev" not in dockerfile
 
 
 def test_backend_dockerfile_uses_modern_env_syntax() -> None:
@@ -167,7 +167,7 @@ def test_backend_dockerfile_uses_modern_env_syntax() -> None:
     assert "ENV PYTHONUNBUFFERED=1" in dockerfile
     assert "ENV PYTHONDONTWRITEBYTECODE 1" not in dockerfile
     assert "ENV PYTHONUNBUFFERED 1" not in dockerfile
-    assert '"scripts/start_backend.py"' in dockerfile
+    assert '"/app/start.sh"' in dockerfile
     assert "uvicorn" not in dockerfile.split("CMD", 1)[1]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,20 +15,45 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+
+  init-ollama:
+    image: curlimages/curl:latest
+    depends_on:
+      - ollama
+    command: >
+      sh -c "
+      echo 'Waiting for ollama...';
+      while ! curl -s http://ollama:11434/api/tags > /dev/null; do sleep 2; done;
+      echo 'Ollama is up. Pulling gemma4...';
+      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"gemma4\"}';
+      echo 'Pulling embeddinggemma...';
+      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"embeddinggemma\"}';
+      echo 'Done!';
+      "
+
   backend:
     build:
       context: .
       dockerfile: Dockerfile
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}@db:5432/${POSTGRES_DB:-ai_email}
-      DEBUG: "false"
+      DEBUG: "true"
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
-      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-ollama}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-http://ollama:11434/v1}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-embeddinggemma}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gemma4}
     depends_on:
       db:
         condition: service_healthy
+      init-ollama:
+        condition: service_completed_successfully
     ports:
       - "8000:8000"
     command: ["sh", "-c", "python scripts/bootstrap_db.py && python scripts/start_backend.py --host 0.0.0.0 --port 8000"]
@@ -53,3 +78,4 @@ services:
 
 volumes:
   postgres-data:
+  ollama-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,26 +16,11 @@ services:
       - postgres-data:/var/lib/postgresql/data
 
   ollama:
-    image: ollama/ollama:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.ollama
     ports:
       - "11434:11434"
-    volumes:
-      - ollama-data:/root/.ollama
-
-  init-ollama:
-    image: curlimages/curl:latest
-    depends_on:
-      - ollama
-    command: >
-      sh -c "
-      echo 'Waiting for ollama...';
-      while ! curl -s http://ollama:11434/api/tags > /dev/null; do sleep 2; done;
-      echo 'Ollama is up. Pulling gemma4...';
-      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"gemma4\"}' | while read line; do echo $$line | grep -q '\"status\":\"success\"' && break; done;
-      echo 'Pulling embeddinggemma...';
-      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"embeddinggemma\"}' | while read line; do echo $$line | grep -q '\"status\":\"success\"' && break; done;
-      echo 'Done!';
-      "
 
   backend:
     build:
@@ -54,8 +39,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      init-ollama:
-        condition: service_completed_successfully
+      ollama:
+        condition: service_started
     ports:
       - "8000:8000"
     command: ["sh", "-c", "python scripts/bootstrap_db.py && python scripts/start_backend.py --host 0.0.0.0 --port 8000"]
@@ -80,4 +65,3 @@ services:
 
 volumes:
   postgres-data:
-  ollama-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       echo 'Waiting for ollama...';
       while ! curl -s http://ollama:11434/api/tags > /dev/null; do sleep 2; done;
       echo 'Ollama is up. Pulling gemma4...';
-      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"gemma4\"}';
+      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"gemma4\"}' | while read line; do echo $$line | grep -q '\"status\":\"success\"' && break; done;
       echo 'Pulling embeddinggemma...';
-      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"embeddinggemma\"}';
+      curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"embeddinggemma\"}' | while read line; do echo $$line | grep -q '\"status\":\"success\"' && break; done;
       echo 'Done!';
       "
 
@@ -44,6 +44,8 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}@db:5432/${POSTGRES_DB:-ai_email}
       DEBUG: "true"
+      ALLOW_LOCAL_LLM_PROVIDERS: "true"
+      ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-ollama}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-http://ollama:11434/v1}


### PR DESCRIPTION
Enables local Gemma4 and EmbeddingGemma models via Ollama. Also fixes Docker Compose to pull the models on startup, and updates validation to allow http base URLs for local environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Ollama service with preloaded models for local inference and new local-provider toggle.

* **Bug Fixes / Improvements**
  * Stricter LLM provider URL handling: only HTTP/HTTPS, tighter local vs global host rules, explicit host allowlist, and re-validation of resolved addresses when pinning/connecting.
  * Updated container defaults to Ollama endpoints and model names.

* **Tests**
  * CI tests updated to expect modern build/start commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->