### PR TITLE
🧪 [Testing] POP3 와일드카드 호스트 정책 거부 테스트 추가

### DIFF
--- a/backend/tests/test_email_client_smtp.py
+++ b/backend/tests/test_email_client_smtp.py
@@ -261,6 +261,19 @@ def test_pop3_destination_rejects_non_pop3_port(monkeypatch):
         )
 
 
+def test_pop3_host_policy_rejects_wildcard_allowlist_entry(monkeypatch):
+    monkeypatch.setattr(
+        email_client.settings,
+        "ALLOWED_POP3_HOSTS",
+        "pop3.example.com,*",
+    )
+
+    with pytest.raises(ValueError, match=email_client.POP3_HOST_NOT_ALLOWED):
+        email_client.validate_pop3_destination(
+            "pop3.example.com", 995, resolve_host=False
+        )
+
+
 def test_pop3_destination_rejects_private_dns_answer(monkeypatch):
     monkeypatch.setattr(email_client.settings, "ALLOWED_POP3_HOSTS", "pop3.example.com")
     monkeypatch.setattr(email_client.settings, "ALLOWED_POP3_PORTS", "995")

--- a/backend/tests/test_imap_worker.py
+++ b/backend/tests/test_imap_worker.py
@@ -44,7 +44,7 @@ async def test_imap_worker_sync_tenant_raises_when_connection_fails(monkeypatch)
     )
     monkeypatch.setattr(
         "services.imap_worker.aioimaplib.IMAP4_SSL",
-        lambda host, port: FailingImapClient(),
+        lambda host, port, **kwargs: FailingImapClient(),
     )
 
     with pytest.raises(Exception, match="IMAP Sync failed for user testuser"):


### PR DESCRIPTION
🎯 **목적:** POP3 호스트 검증 정책(와일드카드 거부)에 대한 누락된 테스트를 추가하여 테스트 커버리지 및 코드 신뢰성을 개선합니다.

📊 **적용 내용:**
- `ALLOWED_POP3_HOSTS` 설정에 와일드카드(`*`)가 포함될 경우, `validate_pop3_destination` 함수가 `ValueError`를 올바르게 발생시키는지 확인하는 `test_pop3_host_policy_rejects_wildcard_allowlist_entry` 테스트 케이스를 `backend/tests/test_email_client_smtp.py`에 추가했습니다.
- 기존 IMAP 관련 모의(Mock) 테스트(`test_imap_worker_sync_tenant_raises_when_connection_fails`)가 `ssl_context`와 같은 추가 인자로 인해 실패하던 문제를 해결했습니다.

✨ **결과:**
- POP3 호스트 검증 로직의 예외 처리(에지 케이스)에 대한 테스트 커버리지가 확보되었습니다.
- 전체 백엔드 테스트 스위트가 오류 없이 성공적으로 통과합니다.

---
*PR created automatically by Jules for task [742242031811720724](https://jules.google.com/task/742242031811720724) started by @seonghobae*