### PR TITLE
🧹 코드 건강 향상: create_reply_sla_escalations 함수 리팩토링

### DIFF
--- a/.jules/plan.md
+++ b/.jules/plan.md
@@ -1,0 +1,14 @@
+1. **Analyze `backend/api/tasks.py:131`**:
+   The function `create_reply_sla_escalations` is too long, mostly due to duplication of fetching logic, task updating logic, and complex error handling (IntegrityError with a fallback path).
+
+2. **Extract common operations**:
+   - Create `_fetch_existing_sla_tasks` to fetch and index existing SLA tasks by `related_email_id`.
+   - Create `_update_sla_task` to handle updating an existing task.
+   - Create `_build_new_sla_task` to encapsulate the creation of a new `TicketTask`.
+
+3. **Extract Fallback Logic**:
+   - Extract the entire `IntegrityError` fallback block into a new function: `_process_sla_escalations_fallback`. This makes the main function's happy path clearer and separates the complex nested retry logic.
+
+4. **Verify**:
+   - Run tests and ensure no functionality is broken.
+   - Run linter/formatting (`black`, `ruff`, etc., based on the project's setup).

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -127,6 +127,127 @@ def _task_response(task: TicketTask, source_email_id: str | None) -> TicketTaskR
     )
 
 
+
+async def _get_existing_tasks(
+    db: AsyncSession,
+    user_id: str,
+    organization_id: str | None,
+    email_ids: list[int],
+) -> dict[int, TicketTask]:
+    result = await db.execute(
+        select(TicketTask)
+        .where(
+            TicketTask.user_id == user_id,
+            TicketTask.organization_id == organization_id,
+            TicketTask.related_email_id.in_(email_ids),
+            TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
+        )
+        .order_by(TicketTask.updated_at.desc())
+    )
+    existing_tasks_by_email = {}
+    for task in result.scalars().all():
+        if task.related_email_id not in existing_tasks_by_email:
+            existing_tasks_by_email[task.related_email_id] = task
+    return existing_tasks_by_email
+
+
+async def _handle_fallback(
+    db: AsyncSession,
+    auth_context: AuthContext,
+    overdue_replies: list[Email],
+    email_ids: list[int],
+    now: datetime.datetime,
+) -> tuple[list[tuple[TicketTask, str | None]], int]:
+    await db.rollback()
+
+    existing_tasks_by_email_fallback = await _get_existing_tasks(
+        db, auth_context.user_id, auth_context.organization_id, email_ids
+    )
+
+    fallback_entries: list[tuple[Email, TicketTask | None]] = []
+    conflicted_email_ids: list[int] = []
+    created_count = 0
+
+    for email in overdue_replies:
+        if email.id in existing_tasks_by_email_fallback:
+            task = existing_tasks_by_email_fallback[email.id]
+            if task.status != "done":
+                task.title = _reply_sla_task_title(email)
+                task.status = "blocked"
+                task.priority = "urgent"
+                task.related_thread_id = canonical_thread_key(email)
+                task.updated_at = now
+        else:
+            task = TicketTask(
+                user_id=auth_context.user_id,
+                organization_id=auth_context.organization_id,
+                title=_reply_sla_task_title(email),
+                status="blocked",
+                priority="urgent",
+                source_type=REPLY_SLA_SOURCE_TYPE,
+                related_email_id=email.id,
+                related_thread_id=canonical_thread_key(email),
+            )
+            try:
+                async with db.begin_nested():
+                    db.add(task)
+                    await db.flush()
+                created_count += 1
+            except IntegrityError:
+                conflicted_email_ids.append(email.id)
+                task = None
+        fallback_entries.append((email, task))
+
+    if conflicted_email_ids:
+        conflicted_tasks_by_email = await _get_existing_tasks(
+            db, auth_context.user_id, auth_context.organization_id, conflicted_email_ids
+        )
+
+        for index, (email, task) in enumerate(fallback_entries):
+            if task is not None or email.id not in conflicted_email_ids:
+                continue
+            task = conflicted_tasks_by_email.get(email.id)
+            if task is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error_code": "reply_sla_task_conflict",
+                        "message": "Reply SLA task conflict",
+                    },
+                ) from None
+
+            if task.status != "done":
+                task.title = _reply_sla_task_title(email)
+                task.status = "blocked"
+                task.priority = "urgent"
+                task.related_thread_id = canonical_thread_key(email)
+                task.updated_at = now
+            fallback_entries[index] = (email, task)
+
+    escalated_tasks = [
+        (task, email.message_id)
+        for email, task in fallback_entries
+        if task is not None
+    ]
+
+    if created_count > 0 or any(t.status != "done" for t, _ in escalated_tasks):
+        await db.commit()
+
+        refreshed_tasks_by_email = await _get_existing_tasks(
+            db, auth_context.user_id, auth_context.organization_id, email_ids
+        )
+
+        for i in range(len(escalated_tasks)):
+            task, message_id = escalated_tasks[i]
+            if task.related_email_id in refreshed_tasks_by_email:
+                escalated_tasks[i] = (
+                    refreshed_tasks_by_email[task.related_email_id],
+                    message_id,
+                )
+
+    return escalated_tasks, created_count
+
+
 @router.post("/reply-sla-escalations", response_model=ReplySlaEscalationResponse)
 async def create_reply_sla_escalations(
     request: ReplySlaEscalationRequest,
@@ -157,21 +278,9 @@ async def create_reply_sla_escalations(
 
     email_ids = [email.id for email in overdue_replies]
 
-    existing_result = await db.execute(
-        select(TicketTask)
-        .where(
-            TicketTask.user_id == auth_context.user_id,
-            TicketTask.organization_id == auth_context.organization_id,
-            TicketTask.related_email_id.in_(email_ids),
-            TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-        )
-        .order_by(TicketTask.updated_at.desc())
+    existing_tasks_by_email = await _get_existing_tasks(
+        db, auth_context.user_id, auth_context.organization_id, email_ids
     )
-
-    existing_tasks_by_email = {}
-    for task in existing_result.scalars().all():
-        if task.related_email_id not in existing_tasks_by_email:
-            existing_tasks_by_email[task.related_email_id] = task
 
     created_count = 0
     escalated_tasks: list[tuple[TicketTask, str | None]] = []
@@ -207,23 +316,11 @@ async def create_reply_sla_escalations(
         ):
             await db.commit()
 
-            # Fetch updated values efficiently instead of looping db.refresh.
             if created_count > 0:
-                refreshed_result = await db.execute(
-                    select(TicketTask)
-                    .where(
-                        TicketTask.user_id == auth_context.user_id,
-                        TicketTask.organization_id == auth_context.organization_id,
-                        TicketTask.related_email_id.in_(email_ids),
-                        TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                    )
-                    .order_by(TicketTask.updated_at.desc())
+                refreshed_tasks_by_email = await _get_existing_tasks(
+                    db, auth_context.user_id, auth_context.organization_id, email_ids
                 )
-                refreshed_tasks_by_email = {
-                    t.related_email_id: t for t in refreshed_result.scalars().all()
-                }
 
-                # Replace un-refreshed tasks to avoid validation errors.
                 for i in range(len(escalated_tasks)):
                     task, message_id = escalated_tasks[i]
                     if task.related_email_id in refreshed_tasks_by_email:
@@ -232,127 +329,9 @@ async def create_reply_sla_escalations(
                             message_id,
                         )
     except IntegrityError:
-        await db.rollback()
-        created_count = 0
-        escalated_tasks.clear()
-
-        # Re-fetch the existing tasks to find the newly inserted ones
-        existing_result = await db.execute(
-            select(TicketTask)
-            .where(
-                TicketTask.user_id == auth_context.user_id,
-                TicketTask.organization_id == auth_context.organization_id,
-                TicketTask.related_email_id.in_(email_ids),
-                TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-            )
-            .order_by(TicketTask.updated_at.desc())
+        escalated_tasks, created_count = await _handle_fallback(
+            db, auth_context, overdue_replies, email_ids, now
         )
-        existing_tasks_by_email_fallback = {}
-        for t in existing_result.scalars().all():
-            if t.related_email_id not in existing_tasks_by_email_fallback:
-                existing_tasks_by_email_fallback[t.related_email_id] = t
-
-        fallback_entries: list[tuple[Email, TicketTask | None]] = []
-        conflicted_email_ids: list[int] = []
-        for email in overdue_replies:
-            if email.id in existing_tasks_by_email_fallback:
-                task = existing_tasks_by_email_fallback[email.id]
-                if task.status != "done":
-                    task.title = _reply_sla_task_title(email)
-                    task.status = "blocked"
-                    task.priority = "urgent"
-                    task.related_thread_id = canonical_thread_key(email)
-                    task.updated_at = now
-            else:
-                task = TicketTask(
-                    user_id=auth_context.user_id,
-                    organization_id=auth_context.organization_id,
-                    title=_reply_sla_task_title(email),
-                    status="blocked",
-                    priority="urgent",
-                    source_type=REPLY_SLA_SOURCE_TYPE,
-                    related_email_id=email.id,
-                    related_thread_id=canonical_thread_key(email),
-                )
-                try:
-                    async with db.begin_nested():
-                        db.add(task)
-                        await db.flush()
-                    created_count += 1
-                except IntegrityError:
-                    conflicted_email_ids.append(email.id)
-                    task = None
-            fallback_entries.append((email, task))
-
-        if conflicted_email_ids:
-            conflicted_result = await db.execute(
-                select(TicketTask)
-                .where(
-                    TicketTask.user_id == auth_context.user_id,
-                    TicketTask.organization_id == auth_context.organization_id,
-                    TicketTask.related_email_id.in_(conflicted_email_ids),
-                    TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                )
-                .order_by(TicketTask.updated_at.desc())
-            )
-            conflicted_tasks_by_email = {}
-            for task in conflicted_result.scalars().all():
-                if task.related_email_id not in conflicted_tasks_by_email:
-                    conflicted_tasks_by_email[task.related_email_id] = task
-
-            for index, (email, task) in enumerate(fallback_entries):
-                if task is not None or email.id not in conflicted_email_ids:
-                    continue
-                task = conflicted_tasks_by_email.get(email.id)
-                if task is None:
-                    raise HTTPException(
-                        status_code=409,
-                        detail={
-                            "error_code": "reply_sla_task_conflict",
-                            "message": "Reply SLA task conflict",
-                        },
-                    ) from None
-
-                if task.status != "done":
-                    task.title = _reply_sla_task_title(email)
-                    task.status = "blocked"
-                    task.priority = "urgent"
-                    task.related_thread_id = canonical_thread_key(email)
-                    task.updated_at = now
-                fallback_entries[index] = (email, task)
-
-        escalated_tasks.extend(
-            (task, email.message_id)
-            for email, task in fallback_entries
-            if task is not None
-        )
-
-        if created_count > 0 or any(t.status != "done" for t, _ in escalated_tasks):
-            await db.commit()
-
-            # Refetch updated values efficiently
-            refreshed_result = await db.execute(
-                select(TicketTask)
-                .where(
-                    TicketTask.user_id == auth_context.user_id,
-                    TicketTask.organization_id == auth_context.organization_id,
-                    TicketTask.related_email_id.in_(email_ids),
-                    TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                )
-                .order_by(TicketTask.updated_at.desc())
-            )
-            refreshed_tasks_by_email = {
-                t.related_email_id: t for t in refreshed_result.scalars().all()
-            }
-
-            # Replace un-refreshed tasks to avoid validation errors.
-            for i in range(len(escalated_tasks)):
-                task, message_id = escalated_tasks[i]
-                if task.related_email_id in refreshed_tasks_by_email:
-                    escalated_tasks[i] = (
-                        refreshed_tasks_by_email[task.related_email_id],
-                        message_id,
-                    )
 
     return ReplySlaEscalationResponse(
         evaluated=len(pending_replies),
@@ -363,6 +342,7 @@ async def create_reply_sla_escalations(
             for task, source_email_id in escalated_tasks
         ],
     )
+
 
 
 @router.get("", response_model=list[TicketTaskResponse])


### PR DESCRIPTION
🎯 **What:** 
- `backend/api/tasks.py` 파일 내의 `create_reply_sla_escalations` 함수가 지나치게 길고 복잡하여 단일 책임 원칙(SRP)을 위반하는 코드 건강(Code Health) 문제를 해결했습니다.
- 중복되는 데이터베이스 조회 로직을 `_get_existing_tasks` 헬퍼 함수로 추출했습니다.
- `IntegrityError` 발생 시 복잡하게 중첩된 fallback 로직을 `_handle_fallback` 헬퍼 함수로 추출하여 가독성을 높였습니다.

💡 **Why:** 
함수가 수행하는 역할을 분리하여 코드를 더 쉽게 읽고 유지보수할 수 있게 만들기 위함입니다. 핵심 로직과 예외 처리 및 데이터 조회를 분리하면 각 부분의 독립적인 테스트가 쉬워집니다.

✅ **Verification:** 
- `cd backend && python3 -m pytest tests/test_tasks_api.py -q` 테스트를 실행하여 모든 엔드포인트 테스트(30개)가 정상적으로 통과됨을 확인했습니다.
- Code Review 피드백을 수용하여 `_handle_fallback` 반환 타입 오류를 수정하고 불필요하게 생성된 임시 스크립트를 삭제했습니다.

✨ **Result:** 
- `create_reply_sla_escalations` 함수의 길이가 절반 이하로 줄어들었으며 로직의 복잡도가 크게 낮아졌습니다. 기존 동작은 전혀 바뀌지 않으면서 코드 품질과 유지보수성이 대폭 향상되었습니다.

---
*PR created automatically by Jules for task [12617763050497149749](https://jules.google.com/task/12617763050497149749) started by @seonghobae*