### PR TITLE
⚡ 이메일 스레드 ID 조회 시 발생하는 N+1 쿼리 성능 개선

### DIFF
--- a/backend/services/threading_service.py
+++ b/backend/services/threading_service.py
@@ -1,7 +1,7 @@
 import uuid
 import re
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from db.models import Email
 from services.email_parser import EmailData
 
@@ -63,21 +63,41 @@ def email_owner_filters(user_id: str, organization_id: str | None):
     return (Email.user_id == user_id, organization_filter)
 
 
-async def _find_existing_thread_id(
+async def _find_existing_thread_ids(
     session: AsyncSession,
-    message_id: str,
+    message_ids: list[str],
     *,
     user_id: str,
     organization_id: str | None,
-) -> str | None:
-    bracketed = f"<{message_id}>"
+) -> dict[str, str]:
+    if not message_ids:
+        return {}
+
+    target_ids: list[str] = []
+    seen_target_ids: set[str] = set()
+    for message_id in message_ids:
+        for target_id in (message_id, f"<{message_id}>"):
+            if target_id not in seen_target_ids:
+                seen_target_ids.add(target_id)
+                target_ids.append(target_id)
+
     result = await session.execute(
-        select(Email.thread_id).where(
+        select(Email.message_id, Email.thread_id).where(
             *email_owner_filters(user_id, organization_id),
-            or_(Email.message_id == message_id, Email.message_id == bracketed),
+            Email.message_id.in_(target_ids),
         )
     )
-    return result.scalar_one_or_none()
+
+    thread_ids_by_message_id: dict[str, str] = {}
+    for message_id, thread_id in result.all():
+        if not thread_id:
+            continue
+        normalized_message_id = normalize_message_id(message_id)
+        if normalized_message_id:
+            thread_ids_by_message_id[normalized_message_id] = (
+                normalize_message_id(thread_id) or thread_id
+            )
+    return thread_ids_by_message_id
 
 
 async def assign_thread_id(
@@ -105,15 +125,17 @@ async def assign_thread_id(
             seen.add(ref)
             existing_candidates.append(ref)
 
-    for candidate in existing_candidates:
-        thread_id = await _find_existing_thread_id(
+    if existing_candidates:
+        thread_ids_by_message_id = await _find_existing_thread_ids(
             session,
-            candidate,
+            existing_candidates,
             user_id=user_id,
             organization_id=organization_id,
         )
-        if thread_id:
-            return normalize_message_id(thread_id) or thread_id
+        for candidate in existing_candidates:
+            thread_id = thread_ids_by_message_id.get(candidate)
+            if thread_id:
+                return thread_id
 
     # If the parent/root has not been imported yet, use the oldest known ancestor
     # as the deterministic thread root so later imports converge on one thread.

--- a/backend/tests/test_threading_perf.py
+++ b/backend/tests/test_threading_perf.py
@@ -1,0 +1,40 @@
+import pytest
+
+from services.threading_service import assign_thread_id
+
+
+class _Result:
+    def all(self):
+        return []
+
+
+class _CountingSession:
+    def __init__(self):
+        self.execute_count = 0
+        self.queries = []
+
+    async def execute(self, query):
+        self.execute_count += 1
+        self.queries.append(query)
+        return _Result()
+
+
+@pytest.mark.asyncio
+async def test_assign_thread_id_batches_many_reference_lookups():
+    session = _CountingSession()
+    references = " ".join(f"<ref{i}@example.com>" for i in range(100))
+
+    thread_id = await assign_thread_id(
+        session,
+        {
+            "message_id": "<reply@example.com>",
+            "in_reply_to": "<parent@example.com>",
+            "references": references,
+        },
+        user_id="testuser",
+        organization_id="org-acme",
+    )
+
+    assert thread_id == "ref0@example.com"
+    assert session.execute_count == 1
+    assert "emails.message_id" in str(session.queries[0]).lower()

--- a/backend/tests/test_threading_service.py
+++ b/backend/tests/test_threading_service.py
@@ -3,12 +3,12 @@ import pytest
 from services.threading_service import assign_thread_id
 
 
-class _ScalarResult:
-    def __init__(self, value):
-        self._value = value
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
 
-    def scalar_one_or_none(self):
-        return self._value
+    def all(self):
+        return self._rows
 
 
 class _SequentialSession:
@@ -18,8 +18,8 @@ class _SequentialSession:
 
     async def execute(self, _query):
         self.execute_count += 1
-        value = self._values.pop(0) if self._values else None
-        return _ScalarResult(value)
+        rows = self._values.pop(0) if self._values else []
+        return _Result(rows)
 
 
 class _QueryCapturingSession(_SequentialSession):
@@ -34,7 +34,7 @@ class _QueryCapturingSession(_SequentialSession):
 
 @pytest.mark.asyncio
 async def test_reply_before_root_uses_first_reference_as_deterministic_thread_id():
-    session = _SequentialSession([None, None, None])
+    session = _SequentialSession([[]])
 
     thread_id = await assign_thread_id(
         session,
@@ -52,7 +52,7 @@ async def test_reply_before_root_uses_first_reference_as_deterministic_thread_id
 
 @pytest.mark.asyncio
 async def test_reply_without_references_uses_in_reply_to_as_deterministic_thread_id():
-    session = _SequentialSession([None, None])
+    session = _SequentialSession([[]])
 
     thread_id = await assign_thread_id(
         session,
@@ -70,7 +70,7 @@ async def test_reply_without_references_uses_in_reply_to_as_deterministic_thread
 
 @pytest.mark.asyncio
 async def test_existing_parent_thread_id_wins_over_deterministic_fallback():
-    session = _SequentialSession(["thread-123"])
+    session = _SequentialSession([[("<parent@example.com>", "thread-123")]])
 
     thread_id = await assign_thread_id(
         session,
@@ -88,7 +88,7 @@ async def test_existing_parent_thread_id_wins_over_deterministic_fallback():
 
 @pytest.mark.asyncio
 async def test_existing_legacy_bracketed_thread_id_is_normalized():
-    session = _SequentialSession(["<root@example.com>"])
+    session = _SequentialSession([[("<root@example.com>", "<root@example.com>")]])
 
     thread_id = await assign_thread_id(
         session,
@@ -106,7 +106,7 @@ async def test_existing_legacy_bracketed_thread_id_is_normalized():
 
 @pytest.mark.asyncio
 async def test_forwarded_subject_alone_does_not_merge_unrelated_thread():
-    session = _SequentialSession(["unrelated-thread"])
+    session = _SequentialSession([[("unrelated@example.com", "unrelated-thread")]])
 
     thread_id = await assign_thread_id(
         session,
@@ -126,7 +126,7 @@ async def test_forwarded_subject_alone_does_not_merge_unrelated_thread():
 
 @pytest.mark.asyncio
 async def test_existing_thread_lookup_is_scoped_to_owner_and_organization():
-    session = _QueryCapturingSession(["thread-123"])
+    session = _QueryCapturingSession([[("<parent@example.com>", "thread-123")]])
 
     thread_id = await assign_thread_id(
         session,


### PR DESCRIPTION
💡 **What:** 
`assign_thread_id` 함수에서 수많은 참조(`references`)와 답변 대상(`in_reply_to`) ID들의 스레드 ID를 찾을 때 반복문 안에서 각각 DB 쿼리를 날리던 방식을 `in_()` 절을 이용해 하나의 Batch 쿼리로 한 번에 가져오도록 개선했습니다.

🎯 **Why:** 
기존에는 이메일 헤더의 참조(`references`) 목록이 길어질 경우(예: 100개의 참조) `_find_existing_thread_id` 함수가 반복문을 통해 호출되어 100번이 넘는 불필요한 N+1 쿼리 오버헤드가 발생했습니다. 이를 단일 쿼리 후 메모리 상의 딕셔너리를 활용해 매핑함으로써 대폭 속도를 향상했습니다.

📊 **Measured Improvement:**
로컬 벤치마크 테스트 결과(`tests/test_threading_perf.py`):
- 참조가 100개인 이메일 처리 시:
  - **기존 (Baseline):** 101 개의 쿼리 실행
  - **개선 후:** 단 1 개의 쿼리 실행

테스트 결과 모두 정상 통과하였으며 로직의 순위 결정 기준은 원본과 동일하게 유지했습니다.

---
*PR created automatically by Jules for task [1049894770745036613](https://jules.google.com/task/1049894770745036613) started by @seonghobae*