### PR TITLE
🧹 Refactor complex schema_backfill_sql function in bootstrap_db.py

### DIFF
--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -1,7 +1,9 @@
 import asyncio
 import os
+from collections.abc import Sequence
 
-from sqlalchemy import text
+from sqlalchemy import Executable, text
+from sqlalchemy.engine import Connection
 
 from db.models import Base
 from db.session import engine
@@ -20,16 +22,70 @@ def _explicit_email_backfill_owner_ids() -> tuple[str | None, str | None]:
     return user_id, organization_id
 
 
-def schema_backfill_sql():
-    backfill_user_id, backfill_organization_id = _explicit_email_backfill_owner_ids()
-    statements = [
-        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS thread_id varchar"),
-        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS user_id varchar"),
-        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS organization_id varchar"),
-        text("ALTER TABLE llm_providers ADD COLUMN IF NOT EXISTS user_id varchar"),
+def _get_add_columns_statements() -> list[Executable]:
+    return [
+        text("ALTER TABLE emails " "ADD COLUMN IF NOT EXISTS thread_id varchar"),
+        text("ALTER TABLE emails " "ADD COLUMN IF NOT EXISTS user_id varchar"),
+        text("ALTER TABLE emails " "ADD COLUMN IF NOT EXISTS organization_id varchar"),
+        text("ALTER TABLE emails " "ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
+        text("ALTER TABLE emails " 'ADD COLUMN IF NOT EXISTS "references" varchar'),
+        text("ALTER TABLE emails " "ADD COLUMN IF NOT EXISTS reply_to varchar"),
+        text("ALTER TABLE llm_providers " "ADD COLUMN IF NOT EXISTS user_id varchar"),
         text(
-            "ALTER TABLE llm_providers ADD COLUMN IF NOT EXISTS organization_id varchar"
+            "ALTER TABLE llm_providers "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
         ),
+        text(
+            "ALTER TABLE webdav_accounts " "ADD COLUMN IF NOT EXISTS source_uid varchar"
+        ),
+        text(
+            "ALTER TABLE webdav_accounts "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
+        text(
+            "ALTER TABLE webdav_accounts "
+            "ADD COLUMN IF NOT EXISTS workspace_id varchar"
+        ),
+        text(
+            "ALTER TABLE webdav_accounts "
+            "ADD COLUMN IF NOT EXISTS writeback_enabled boolean "
+            "NOT NULL DEFAULT false"
+        ),
+        text(
+            "ALTER TABLE webdav_accounts " "ADD COLUMN IF NOT EXISTS etag_value varchar"
+        ),
+        text(
+            "ALTER TABLE project_folders " "ADD COLUMN IF NOT EXISTS folder_uid varchar"
+        ),
+        text(
+            "ALTER TABLE project_folders "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
+        text(
+            "ALTER TABLE tenant_configs "
+            "ADD COLUMN IF NOT EXISTS organization_id varchar"
+        ),
+        text(
+            "ALTER TABLE tenant_configs "
+            "ADD COLUMN IF NOT EXISTS pop3_username varchar"
+        ),
+        text(
+            "ALTER TABLE tenant_configs "
+            "ADD COLUMN IF NOT EXISTS pop3_password varchar"
+        ),
+        text(
+            "ALTER TABLE sender_relationships "
+            "ADD COLUMN IF NOT EXISTS source_message_id varchar"
+        ),
+        text(
+            "ALTER TABLE sender_relationships "
+            "ADD COLUMN IF NOT EXISTS source_thread_id varchar"
+        ),
+    ]
+
+
+def _get_create_tables_statements() -> list[Executable]:
+    return [
         text(
             "CREATE TABLE IF NOT EXISTS calendar_writeback_sources ("
             "source_uid varchar PRIMARY KEY, "
@@ -71,46 +127,12 @@ def schema_backfill_sql():
             "observed_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP"
             ")"
         ),
-        text("ALTER TABLE webdav_accounts ADD COLUMN IF NOT EXISTS source_uid varchar"),
-        text(
-            "ALTER TABLE webdav_accounts "
-            "ADD COLUMN IF NOT EXISTS organization_id varchar"
-        ),
-        text(
-            "ALTER TABLE webdav_accounts "
-            "ADD COLUMN IF NOT EXISTS workspace_id varchar"
-        ),
-        text(
-            "ALTER TABLE webdav_accounts "
-            "ADD COLUMN IF NOT EXISTS writeback_enabled boolean NOT NULL DEFAULT false"
-        ),
-        text(
-            "ALTER TABLE webdav_accounts "
-            "ADD COLUMN IF NOT EXISTS etag_value varchar"
-        ),
-        text("ALTER TABLE project_folders ADD COLUMN IF NOT EXISTS folder_uid varchar"),
-        text(
-            "ALTER TABLE project_folders "
-            "ADD COLUMN IF NOT EXISTS organization_id varchar"
-        ),
-        text(
-            "ALTER TABLE tenant_configs "
-            "ADD COLUMN IF NOT EXISTS organization_id varchar"
-        ),
-        text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_username varchar"),
-        text("ALTER TABLE tenant_configs ADD COLUMN IF NOT EXISTS pop3_password varchar"),
-        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS in_reply_to varchar"),
-        text('ALTER TABLE emails ADD COLUMN IF NOT EXISTS "references" varchar'),
-        text("ALTER TABLE emails ADD COLUMN IF NOT EXISTS reply_to varchar"),
-        text(
-            "ALTER TABLE sender_relationships "
-            "ADD COLUMN IF NOT EXISTS source_message_id varchar"
-        ),
-        text(
-            "ALTER TABLE sender_relationships "
-            "ADD COLUMN IF NOT EXISTS source_thread_id varchar"
-        ),
-        text("CREATE INDEX IF NOT EXISTS ix_emails_user_id ON emails (user_id)"),
+    ]
+
+
+def _get_create_indexes_statements() -> list[Executable]:
+    return [
+        text("CREATE INDEX IF NOT EXISTS ix_emails_user_id " "ON emails (user_id)"),
         text(
             "CREATE INDEX IF NOT EXISTS ix_emails_organization_id "
             "ON emails (organization_id)"
@@ -148,6 +170,11 @@ def schema_backfill_sql():
             "ON security_audit_events "
             "(actor_user_id, organization_id, workspace_id)"
         ),
+    ]
+
+
+def _get_update_webdav_accounts_statements() -> list[Executable]:
+    return [
         text(
             "UPDATE webdav_accounts "
             "SET source_uid = 'webdav_src_' || md5("
@@ -159,12 +186,13 @@ def schema_backfill_sql():
         text(
             "UPDATE webdav_accounts "
             "SET workspace_id = CASE "
-            "WHEN organization_id IS NOT NULL THEN 'workspace-' || organization_id "
+            "WHEN organization_id IS NOT NULL "
+            "THEN 'workspace-' || organization_id "
             "ELSE 'workspace-' || user_id END "
             "WHERE workspace_id IS NULL OR workspace_id = ''"
         ),
-        text("ALTER TABLE webdav_accounts ALTER COLUMN source_uid SET NOT NULL"),
-        text("ALTER TABLE webdav_accounts ALTER COLUMN workspace_id SET NOT NULL"),
+        text("ALTER TABLE webdav_accounts " "ALTER COLUMN source_uid SET NOT NULL"),
+        text("ALTER TABLE webdav_accounts " "ALTER COLUMN workspace_id SET NOT NULL"),
         text(
             "CREATE UNIQUE INDEX IF NOT EXISTS uq_webdav_accounts_source_uid "
             "ON webdav_accounts (source_uid)"
@@ -177,6 +205,11 @@ def schema_backfill_sql():
             "CREATE INDEX IF NOT EXISTS ix_webdav_accounts_workspace_scope "
             "ON webdav_accounts (user_id, organization_id, workspace_id)"
         ),
+    ]
+
+
+def _get_update_project_folders_statements() -> list[Executable]:
+    return [
         text(
             "UPDATE project_folders "
             "SET folder_uid = 'webdav_folder_' || md5("
@@ -185,7 +218,7 @@ def schema_backfill_sql():
             ") "
             "WHERE folder_uid IS NULL OR folder_uid = ''"
         ),
-        text("ALTER TABLE project_folders ALTER COLUMN folder_uid SET NOT NULL"),
+        text("ALTER TABLE project_folders " "ALTER COLUMN folder_uid SET NOT NULL"),
         text(
             "CREATE UNIQUE INDEX IF NOT EXISTS uq_project_folders_folder_uid "
             "ON project_folders (folder_uid)"
@@ -194,7 +227,12 @@ def schema_backfill_sql():
             "CREATE INDEX IF NOT EXISTS ix_project_folders_owner_scope "
             "ON project_folders (user_id, organization_id)"
         ),
-        text("ALTER TABLE emails DROP CONSTRAINT IF EXISTS emails_message_id_key"),
+    ]
+
+
+def _get_drop_constraints_and_indexes_statements() -> list[Executable]:
+    return [
+        text("ALTER TABLE emails " "DROP CONSTRAINT IF EXISTS emails_message_id_key"),
         text(
             "ALTER TABLE tenant_configs "
             "DROP CONSTRAINT IF EXISTS tenant_configs_user_id_key"
@@ -204,12 +242,20 @@ def schema_backfill_sql():
             "DROP CONSTRAINT IF EXISTS uq_sender_relationships_user_email"
         ),
         text(
-            "ALTER TABLE llm_providers DROP CONSTRAINT IF EXISTS llm_providers_name_key"
+            "ALTER TABLE llm_providers "
+            "DROP CONSTRAINT IF EXISTS llm_providers_name_key"
         ),
         text("DROP INDEX IF EXISTS ix_llm_providers_name"),
         text("DROP INDEX IF EXISTS ix_tenant_configs_user_id"),
         text("DROP INDEX IF EXISTS ix_emails_message_id"),
-        text("CREATE INDEX IF NOT EXISTS ix_emails_message_id ON emails (message_id)"),
+    ]
+
+
+def _get_create_new_indexes_statements() -> list[Executable]:
+    return [
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_emails_message_id " "ON emails (message_id)"
+        ),
         text(
             "CREATE INDEX IF NOT EXISTS ix_tenant_configs_user_id "
             "ON tenant_configs (user_id)"
@@ -223,126 +269,149 @@ def schema_backfill_sql():
             "ON tenant_configs (user_id, coalesce(organization_id, ''))"
         ),
     ]
+
+
+def _get_backfill_statements(
+    backfill_user_id: str, backfill_organization_id: str
+) -> list[Executable]:
+    return [
+        text(
+            "UPDATE emails "
+            "SET user_id = :user_id, "
+            "organization_id = :organization_id "
+            "WHERE user_id IS NULL AND organization_id IS NULL"
+        ).bindparams(
+            user_id=backfill_user_id,
+            organization_id=backfill_organization_id,
+        ),
+        text(
+            "UPDATE llm_providers "
+            "SET user_id = :user_id, "
+            "organization_id = :organization_id "
+            "WHERE user_id IS NULL AND organization_id IS NULL"
+        ).bindparams(
+            user_id=backfill_user_id,
+            organization_id=backfill_organization_id,
+        ),
+        text(
+            "UPDATE project_folders "
+            "SET organization_id = :organization_id "
+            "WHERE user_id = :user_id AND organization_id IS NULL"
+        ).bindparams(
+            user_id=backfill_user_id,
+            organization_id=backfill_organization_id,
+        ),
+        text(
+            "UPDATE tenant_configs "
+            "SET organization_id = :organization_id "
+            "WHERE user_id = :user_id AND organization_id IS NULL"
+        ).bindparams(
+            user_id=backfill_user_id,
+            organization_id=backfill_organization_id,
+        ),
+    ]
+
+
+def _get_validation_and_final_indexes_statements() -> list[Executable]:
+    return [
+        text(
+            "DO $$ "
+            "BEGIN "
+            "IF EXISTS ("
+            "SELECT 1 FROM emails "
+            "WHERE user_id IS NULL OR organization_id IS NULL"
+            ") THEN "
+            "RAISE EXCEPTION "
+            "'Existing emails require explicit non-default "
+            "NARUON_IMPORT_USER_ID and NARUON_IMPORT_ORGANIZATION_ID "
+            "before owner backfill'; "
+            "END IF; "
+            "END $$"
+        ),
+        text("ALTER TABLE emails ALTER COLUMN user_id SET NOT NULL"),
+        text("ALTER TABLE emails " "ALTER COLUMN organization_id SET NOT NULL"),
+        text(
+            "DO $$ "
+            "BEGIN "
+            "IF EXISTS ("
+            "SELECT 1 FROM llm_providers "
+            "WHERE user_id IS NULL OR organization_id IS NULL"
+            ") THEN "
+            "RAISE EXCEPTION "
+            "'Existing llm providers require explicit non-default "
+            "NARUON_IMPORT_USER_ID and NARUON_IMPORT_ORGANIZATION_ID "
+            "before owner backfill'; "
+            "END IF; "
+            "END $$"
+        ),
+        text("ALTER TABLE llm_providers " "ALTER COLUMN user_id SET NOT NULL"),
+        text("ALTER TABLE llm_providers " "ALTER COLUMN organization_id SET NOT NULL"),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_emails_owner_message_id "
+            "ON emails (user_id, organization_id, message_id)"
+        ),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_providers_org_name "
+            "ON llm_providers (organization_id, name)"
+        ),
+        text("CREATE INDEX IF NOT EXISTS ix_emails_thread_id " "ON emails (thread_id)"),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "uq_sender_relationships_scope_source "
+            "ON sender_relationships "
+            "(user_id, coalesce(organization_id, ''), sender_email, "
+            "coalesce(source_message_id, ''), coalesce(source_thread_id, ''))"
+        ),
+        text(
+            "WITH ranked_tasks AS ("
+            "SELECT ctid, row_number() OVER ("
+            "PARTITION BY user_id, coalesce(organization_id, ''), "
+            "source_type, email_id "
+            "ORDER BY updated_at DESC NULLS LAST, "
+            "created_at DESC NULLS LAST, task_id DESC"
+            ") AS row_rank "
+            "FROM ticket_tasks "
+            "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
+            ") "
+            "DELETE FROM ticket_tasks "
+            "USING ranked_tasks "
+            "WHERE ticket_tasks.ctid = ranked_tasks.ctid "
+            "AND ranked_tasks.row_rank > 1"
+        ),
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "uq_ticket_tasks_reply_sla_email "
+            "ON ticket_tasks "
+            "(user_id, coalesce(organization_id, ''), source_type, email_id) "
+            "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
+        ),
+    ]
+
+
+def schema_backfill_sql() -> list[Executable]:
+    statements: list[Executable] = []
+
+    statements.extend(_get_add_columns_statements())
+    statements.extend(_get_create_tables_statements())
+    statements.extend(_get_create_indexes_statements())
+    statements.extend(_get_update_webdav_accounts_statements())
+    statements.extend(_get_update_project_folders_statements())
+    statements.extend(_get_drop_constraints_and_indexes_statements())
+    statements.extend(_get_create_new_indexes_statements())
+
+    owner_ids = _explicit_email_backfill_owner_ids()
+    backfill_user_id, backfill_organization_id = owner_ids
     if backfill_user_id is not None and backfill_organization_id is not None:
         statements.extend(
-            [
-                text(
-                    "UPDATE emails "
-                    "SET user_id = :user_id, "
-                    "organization_id = :organization_id "
-                    "WHERE user_id IS NULL AND organization_id IS NULL"
-                ).bindparams(
-                    user_id=backfill_user_id,
-                    organization_id=backfill_organization_id,
-                ),
-                text(
-                    "UPDATE llm_providers "
-                    "SET user_id = :user_id, "
-                    "organization_id = :organization_id "
-                    "WHERE user_id IS NULL AND organization_id IS NULL"
-                ).bindparams(
-                    user_id=backfill_user_id,
-                    organization_id=backfill_organization_id,
-                ),
-                text(
-                    "UPDATE project_folders "
-                    "SET organization_id = :organization_id "
-                    "WHERE user_id = :user_id AND organization_id IS NULL"
-                ).bindparams(
-                    user_id=backfill_user_id,
-                    organization_id=backfill_organization_id,
-                ),
-                text(
-                    "UPDATE tenant_configs "
-                    "SET organization_id = :organization_id "
-                    "WHERE user_id = :user_id AND organization_id IS NULL"
-                ).bindparams(
-                    user_id=backfill_user_id,
-                    organization_id=backfill_organization_id,
-                ),
-            ]
+            _get_backfill_statements(backfill_user_id, backfill_organization_id)
         )
-    statements.extend(
-        [
-            text(
-                "DO $$ "
-                "BEGIN "
-                "IF EXISTS ("
-                "SELECT 1 FROM emails "
-                "WHERE user_id IS NULL OR organization_id IS NULL"
-                ") THEN "
-                "RAISE EXCEPTION "
-                "'Existing emails require explicit non-default "
-                "NARUON_IMPORT_USER_ID and NARUON_IMPORT_ORGANIZATION_ID "
-                "before owner backfill'; "
-                "END IF; "
-                "END $$"
-            ),
-            text("ALTER TABLE emails ALTER COLUMN user_id SET NOT NULL"),
-            text("ALTER TABLE emails ALTER COLUMN organization_id SET NOT NULL"),
-            text(
-                "DO $$ "
-                "BEGIN "
-                "IF EXISTS ("
-                "SELECT 1 FROM llm_providers "
-                "WHERE user_id IS NULL OR organization_id IS NULL"
-                ") THEN "
-                "RAISE EXCEPTION "
-                "'Existing llm providers require explicit non-default "
-                "NARUON_IMPORT_USER_ID and NARUON_IMPORT_ORGANIZATION_ID "
-                "before owner backfill'; "
-                "END IF; "
-                "END $$"
-            ),
-            text("ALTER TABLE llm_providers ALTER COLUMN user_id SET NOT NULL"),
-            text("ALTER TABLE llm_providers ALTER COLUMN organization_id SET NOT NULL"),
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_emails_owner_message_id "
-                "ON emails (user_id, organization_id, message_id)"
-            ),
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_providers_org_name "
-                "ON llm_providers (organization_id, name)"
-            ),
-            text(
-                "CREATE INDEX IF NOT EXISTS ix_emails_thread_id ON emails (thread_id)"
-            ),
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS "
-                "uq_sender_relationships_scope_source "
-                "ON sender_relationships "
-                "(user_id, coalesce(organization_id, ''), sender_email, "
-                "coalesce(source_message_id, ''), coalesce(source_thread_id, ''))"
-            ),
-            text(
-                "WITH ranked_tasks AS ("
-                "SELECT ctid, row_number() OVER ("
-                "PARTITION BY user_id, coalesce(organization_id, ''), "
-                "source_type, email_id "
-                "ORDER BY updated_at DESC NULLS LAST, "
-                "created_at DESC NULLS LAST, task_id DESC"
-                ") AS row_rank "
-                "FROM ticket_tasks "
-                "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
-                ") "
-                "DELETE FROM ticket_tasks "
-                "USING ranked_tasks "
-                "WHERE ticket_tasks.ctid = ranked_tasks.ctid "
-                "AND ranked_tasks.row_rank > 1"
-            ),
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS "
-                "uq_ticket_tasks_reply_sla_email "
-                "ON ticket_tasks "
-                "(user_id, coalesce(organization_id, ''), source_type, email_id) "
-                "WHERE source_type = 'reply_sla' AND email_id IS NOT NULL"
-            ),
-        ]
-    )
+
+    statements.extend(_get_validation_and_final_indexes_statements())
+
     return statements
 
 
-def _execute_statements(conn, statements) -> None:
+def _execute_statements(conn: Connection, statements: Sequence[Executable]) -> None:
     for statement in statements:
         conn.execute(statement)
 

--- a/backend/tests/test_imap_worker.py
+++ b/backend/tests/test_imap_worker.py
@@ -44,7 +44,7 @@ async def test_imap_worker_sync_tenant_raises_when_connection_fails(monkeypatch)
     )
     monkeypatch.setattr(
         "services.imap_worker.aioimaplib.IMAP4_SSL",
-        lambda host, port: FailingImapClient(),
+        lambda host, port, **kwargs: FailingImapClient(),
     )
 
     with pytest.raises(Exception, match="IMAP Sync failed for user testuser"):


### PR DESCRIPTION
🎯 **What:** 
- Refactored `schema_backfill_sql` in `backend/scripts/bootstrap_db.py` to break out huge lists of raw SQL queries into smaller, specific functions based on their responsibilities (e.g. `_get_add_columns_statements`, `_get_create_tables_statements`, `_get_create_indexes_statements`, etc).
- Also addressed an unrelated, failing test mock in `test_imap_worker.py` to allow the test suite to fully pass.

💡 **Why:**
- The `schema_backfill_sql` function violated the Single Responsibility Principle as it did multiple distinct migrations sequentially. It was excessively long and harder to digest/maintain. Breaking it down helps with code modularity and maintainability.

✅ **Verification:** 
- Ensured formatting passes via `black` and `flake8` (`--ignore=E501`).
- Ran all relevant tests. Confirmed `cd backend && python3 -m pytest -q` passes without regressions.
- Code logic behaves entirely identical to previous sequential state.

✨ **Result:**
- A more maintainable and readable `bootstrap_db.py` backend script ready for further modifications.

---
*PR created automatically by Jules for task [8257411735822284316](https://jules.google.com/task/8257411735822284316) started by @seonghobae*