### PR TITLE
Implement source-backed model settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 # Stage 1: Build Frontend
 FROM node:22-slim AS frontend-builder
 WORKDIR /app
-COPY frontend/package*.json ./
-RUN npm install
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false
+RUN corepack enable pnpm
+COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml frontend/.pnpmfile.cjs ./
+RUN pnpm install --frozen-lockfile
 COPY frontend ./
 # Pass dummy URL for build if needed
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+ENV POSTCSS_WORKERS=1
+ENV DISABLE_POSTCSS_WORKERS=true
+RUN pnpm run build
 
 # Stage 2: Final Image (Python + Node.js)
 FROM python:3.11-slim
@@ -18,12 +22,15 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
-# Install system dependencies & Node.js
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libpq-dev curl \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
+# Install system dependencies. Runtime Node is copied from the frontend builder
+# so apt does not install a distro Node package with noisy alternatives output.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gcc \
+      libpq-dev \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=frontend-builder /usr/local/bin/node /usr/local/bin/node
 
 # Install Backend dependencies
 COPY backend/requirements.txt /app/requirements.txt
@@ -40,27 +47,25 @@ COPY --from=frontend-builder /app/node_modules /app/frontend/node_modules
 COPY --from=frontend-builder /app/package.json /app/frontend/package.json
 COPY --from=frontend-builder /app/next.config.ts /app/frontend/next.config.ts
 
-# Create a startup script
+# Create a startup script. DATABASE_URL and AUTH_SESSION_HMAC_SECRET must be
+# supplied by the operator or orchestrator; do not generate runtime secrets here.
 RUN echo '#!/bin/bash\n\
-if [ -z "$AUTH_SESSION_HMAC_SECRET" ]; then\n\
-  export AUTH_SESSION_HMAC_SECRET=$(python -c "import secrets; print(secrets.token_hex(32))")\n\
-fi\n\
+set -euo pipefail\n\
 echo "Starting Naruon Backend and Frontend..."\n\
 python scripts/bootstrap_db.py\n\
 python scripts/start_backend.py --host 0.0.0.0 --port 8000 &\n\
 BACKEND_PID=$!\n\
-cd frontend && npm run start -- --hostname 0.0.0.0 --port 3000 &\n\
+cd frontend && ./node_modules/.bin/next start --hostname 0.0.0.0 --port 3000 &\n\
 FRONTEND_PID=$!\n\
-wait -n\n\
-exit $?\n\
+trap "kill $BACKEND_PID $FRONTEND_PID 2>/dev/null || true" EXIT\n\
+wait -n "$BACKEND_PID" "$FRONTEND_PID"\n\
 ' > /app/start.sh && chmod +x /app/start.sh
 
 # Create non-root user
 RUN useradd -m -s /bin/bash appuser && chown -R appuser:appuser /app
 USER appuser
 
-# Environment variables for Backend and Frontend
-ENV DATABASE_URL=sqlite+aiosqlite:///./naruon_standalone.db
+# Environment variables for Frontend proxying inside the combined image
 ENV NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV BACKEND_INTERNAL_URL=http://127.0.0.1:8000
 ENV ALLOW_DOCKER_BACKEND_INTERNAL_URL=1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ mail/calendar/file systems.
 cp .env.example .env
 python3 - <<'PY'
 from pathlib import Path
+import base64
+import os
 import secrets
 
 env_path = Path(".env")
@@ -126,6 +128,10 @@ env_text = env_path.read_text()
 env_text = env_text.replace(
     "AUTH_SESSION_HMAC_SECRET=\n",
     f"AUTH_SESSION_HMAC_SECRET={secrets.token_urlsafe(48)}\n",
+)
+env_text = env_text.replace(
+    "ENCRYPTION_KEY=\n",
+    f"ENCRYPTION_KEY={base64.urlsafe_b64encode(os.urandom(32)).decode()}\n",
 )
 env_path.write_text(env_text)
 PY
@@ -146,8 +152,8 @@ set. With the default empty key it writes local zero-vector embeddings so the
 threading proof path works offline.
 
 Backend settings read environment variables first, then `.env`, `../.env`, and
-`~/.env`. `DATABASE_URL` and `AUTH_SESSION_HMAC_SECRET` still have no code
-defaults; Compose and Kubernetes must inject them explicitly. For Compose,
+`~/.env`. `DATABASE_URL`, `AUTH_SESSION_HMAC_SECRET`, and `ENCRYPTION_KEY` still
+have no code defaults; Compose and Kubernetes must inject them explicitly. For Compose,
 `./scripts/naruon_compose.sh` reads `${NARUON_ENV_FILE}` when set, otherwise
 uses `~/.env` if present, and falls back to the project `.env`. It passes that
 file to Docker Compose only as an interpolation source so the backend service

--- a/backend/api/ai_hub.py
+++ b/backend/api/ai_hub.py
@@ -9,6 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.auth import AuthContext, get_auth_context, is_admin_role
 from db.models import LLMProvider, PromptTemplate, SecurityAuditEvent
 from db.session import get_db
+from services.llm_provider_readiness import (
+    is_llm_provider_configured,
+    llm_provider_model_label,
+)
 
 router = APIRouter(prefix="/api/ai-hub", tags=["ai-hub"])
 
@@ -91,7 +95,7 @@ def _prompt_card(prompt: PromptTemplate) -> AiHubPromptCard:
 
 
 def _agent_card(provider: LLMProvider) -> AiHubAgentCard:
-    configured = bool(provider.api_key)
+    configured = is_llm_provider_configured(provider)
     if provider.is_active and configured:
         state_code = "active"
     elif configured:
@@ -107,7 +111,7 @@ def _agent_card(provider: LLMProvider) -> AiHubAgentCard:
             provider.name,
         ),
         agent_title=provider.name,
-        model_label=provider.provider_type,
+        model_label=llm_provider_model_label(provider),
         state_code=state_code,
         configured=configured,
         governance_text="organization llm provider registry",
@@ -321,7 +325,9 @@ async def get_ai_hub_surface(
 
     prompt_cards = [_prompt_card(prompt) for prompt in prompts]
     active_provider_count = sum(
-        1 for provider in providers if provider.is_active and provider.api_key
+        1
+        for provider in providers
+        if provider.is_active and is_llm_provider_configured(provider)
     )
     workflow_cards = _workflow_cards(prompt_cards, active_provider_count)
     agent_cards = [_agent_card(provider) for provider in providers]

--- a/backend/api/llm_providers.py
+++ b/backend/api/llm_providers.py
@@ -15,6 +15,7 @@ from services.llm_provider_urls import (
     LLM_BASE_URL_NOT_ALLOWED,
     validate_llm_provider_base_url_async,
 )
+from services.llm_provider_readiness import is_llm_provider_configured
 
 router = APIRouter(prefix="/api/llm-providers", tags=["llm-providers"])
 
@@ -23,6 +24,8 @@ class LLMProviderCreate(BaseModel):
     name: str
     provider_type: str
     base_url: Optional[str] = None
+    model_identifier: Optional[str] = None
+    embedding_model: Optional[str] = None
     api_key: Optional[str] = None
     is_active: bool = False
 
@@ -31,6 +34,8 @@ class LLMProviderUpdate(BaseModel):
     name: Optional[str] = None
     provider_type: Optional[str] = None
     base_url: Optional[str] = None
+    model_identifier: Optional[str] = None
+    embedding_model: Optional[str] = None
     api_key: Optional[str] = None
     is_active: Optional[bool] = None
 
@@ -40,6 +45,8 @@ class LLMProviderResponse(BaseModel):
     name: str
     provider_type: str
     base_url: Optional[str] = None
+    model_identifier: Optional[str] = None
+    embedding_model: Optional[str] = None
     is_active: bool
     configured: bool
     fingerprint: Optional[str] = None
@@ -61,6 +68,28 @@ async def _validated_base_url(value: str | None) -> str | None:
         return await validate_llm_provider_base_url_async(value)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=LLM_BASE_URL_NOT_ALLOWED) from exc
+
+
+def _optional_stripped_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _provider_response(provider: LLMProvider) -> LLMProviderResponse:
+    return LLMProviderResponse(
+        id=provider.id,
+        name=provider.name,
+        provider_type=provider.provider_type,
+        base_url=provider.base_url,
+        model_identifier=provider.model_identifier,
+        embedding_model=provider.embedding_model,
+        is_active=provider.is_active,
+        configured=is_llm_provider_configured(provider),
+        fingerprint=_get_fingerprint(provider.api_key),
+        updated_at=provider.updated_at,
+    )
 
 
 async def check_admin_access(
@@ -121,18 +150,7 @@ async def list_providers(
 
     responses = []
     for p in providers:
-        responses.append(
-            LLMProviderResponse(
-                id=p.id,
-                name=p.name,
-                provider_type=p.provider_type,
-                base_url=p.base_url,
-                is_active=p.is_active,
-                configured=bool(p.api_key),
-                fingerprint=_get_fingerprint(p.api_key),
-                updated_at=p.updated_at,
-            )
-        )
+        responses.append(_provider_response(p))
     return responses
 
 
@@ -148,6 +166,8 @@ async def create_provider(
         name=data.name,
         provider_type=data.provider_type,
         base_url=await _validated_base_url(data.base_url),
+        model_identifier=_optional_stripped_text(data.model_identifier),
+        embedding_model=_optional_stripped_text(data.embedding_model),
         api_key=data.api_key,
         is_active=data.is_active,
     )
@@ -180,16 +200,7 @@ async def create_provider(
         await db.rollback()
         raise HTTPException(status_code=409, detail="Provider name already exists")
 
-    return LLMProviderResponse(
-        id=provider.id,
-        name=provider.name,
-        provider_type=provider.provider_type,
-        base_url=provider.base_url,
-        is_active=provider.is_active,
-        configured=bool(provider.api_key),
-        fingerprint=_get_fingerprint(provider.api_key),
-        updated_at=provider.updated_at,
-    )
+    return _provider_response(provider)
 
 
 @router.put("/{provider_id}", response_model=LLMProviderResponse)
@@ -219,6 +230,12 @@ async def update_provider(
     if data.base_url is not None:
         provider.base_url = await _validated_base_url(data.base_url)
         updated = True
+    if data.model_identifier is not None:
+        provider.model_identifier = _optional_stripped_text(data.model_identifier)
+        updated = True
+    if data.embedding_model is not None:
+        provider.embedding_model = _optional_stripped_text(data.embedding_model)
+        updated = True
     if data.api_key is not None:
         provider.api_key = data.api_key
         updated = True
@@ -246,16 +263,7 @@ async def update_provider(
         await db.commit()
         await db.refresh(provider)
 
-    return LLMProviderResponse(
-        id=provider.id,
-        name=provider.name,
-        provider_type=provider.provider_type,
-        base_url=provider.base_url,
-        is_active=provider.is_active,
-        configured=bool(provider.api_key),
-        fingerprint=_get_fingerprint(provider.api_key),
-        updated_at=provider.updated_at,
-    )
+    return _provider_response(provider)
 
 
 @router.delete("/{provider_id}", status_code=204)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -136,6 +136,8 @@ class LLMProvider(Base):
         String
     )  # e.g. openai, anthropic, gemini, ollama
     base_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    model_identifier: Mapped[str | None] = mapped_column(String, nullable=True)
+    embedding_model: Mapped[str | None] = mapped_column(String, nullable=True)
     api_key: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=False)
     updated_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/scripts/bootstrap_db.py
+++ b/backend/scripts/bootstrap_db.py
@@ -36,6 +36,14 @@ def _get_add_columns_statements() -> list[Executable]:
             "ADD COLUMN IF NOT EXISTS organization_id varchar"
         ),
         text(
+            "ALTER TABLE llm_providers "
+            "ADD COLUMN IF NOT EXISTS model_identifier varchar"
+        ),
+        text(
+            "ALTER TABLE llm_providers "
+            "ADD COLUMN IF NOT EXISTS embedding_model varchar"
+        ),
+        text(
             "ALTER TABLE webdav_accounts " "ADD COLUMN IF NOT EXISTS source_uid varchar"
         ),
         text(

--- a/backend/services/llm_provider_readiness.py
+++ b/backend/services/llm_provider_readiness.py
@@ -1,0 +1,23 @@
+from db.models import LLMProvider
+
+LOCAL_PROVIDER_TYPES = frozenset({"local", "ollama", "vllm", "openai-compatible-local"})
+
+
+def _has_value(value: str | None) -> bool:
+    return bool(value and value.strip())
+
+
+def is_llm_provider_configured(provider: LLMProvider) -> bool:
+    if _has_value(provider.api_key):
+        return True
+
+    provider_type = (provider.provider_type or "").strip().lower()
+    if provider_type not in LOCAL_PROVIDER_TYPES:
+        return False
+
+    return _has_value(provider.base_url) and _has_value(provider.model_identifier)
+
+
+def llm_provider_model_label(provider: LLMProvider) -> str:
+    model_identifier = (provider.model_identifier or "").strip()
+    return model_identifier or provider.provider_type

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -14,6 +14,8 @@ from core.config import settings
 
 LLM_BASE_URL_NOT_ALLOWED = "LLM provider base URL is not allowed"
 _DNS_RESOLUTION_TIMEOUT_SECONDS = 5.0
+_LOCAL_DEV_HOSTNAMES = {"localhost", "localhost.localdomain"}
+_LOCAL_DEV_IP_LITERALS = {"127.0.0.1", "::1"}
 
 
 @dataclass(frozen=True)
@@ -47,6 +49,23 @@ def _looks_like_ip_literal(candidate: str) -> bool:
         or compact_candidate.isdigit()
         or compact_candidate.startswith("0x")
     )
+
+
+def _is_local_dev_host(hostname: str) -> bool:
+    normalized_hostname = hostname.lower().rstrip(".")
+    return (
+        normalized_hostname in _LOCAL_DEV_HOSTNAMES
+        or normalized_hostname in _LOCAL_DEV_IP_LITERALS
+    )
+
+
+def _format_normalized_netloc(
+    hostname: str, port: int, *, explicit_port: bool
+) -> str:
+    host_part = f"[{hostname}]" if ":" in hostname else hostname
+    if not explicit_port:
+        return host_part
+    return f"{host_part}:{port}"
 
 
 def _validate_global_address(address: str, *, hostname: str | None = None) -> str:
@@ -134,12 +153,12 @@ def _normalize_llm_provider_base_url(value: str | None):
 
     hostname = (parsed.hostname or "").lower().rstrip(".")
     # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
-    is_local_dev_host = hostname in {"localhost", "localhost.localdomain", "127.0.0.1"}
-    
+    is_local_dev_host = _is_local_dev_host(hostname)
+
     # Allow http for local development or if explicitly allowed
     if parsed.scheme.lower() not in {"http", "https"}:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
-        
+
     if parsed.scheme.lower() == "http" and not is_local_dev_host:
         if not (settings.ALLOW_LOCAL_LLM_PROVIDERS and hostname in _parse_allowed_hosts()):
             raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
@@ -163,7 +182,9 @@ def _normalize_llm_provider_base_url(value: str | None):
         if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
             raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
-    netloc = hostname if parsed.port is None else f"{hostname}:{port}"
+    netloc = _format_normalized_netloc(
+        hostname, port, explicit_port=parsed.port is not None
+    )
     return urlunsplit((parsed.scheme.lower(), netloc, parsed.path or "", "", "")), hostname, port
 
 

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -134,6 +134,16 @@ def test_schema_backfill_adds_llm_provider_columns_and_indexes(monkeypatch):
         for statement in statements
     )
     assert any(
+        "alter table llm_providers add column if not exists model_identifier"
+        in statement
+        for statement in statements
+    )
+    assert any(
+        "alter table llm_providers add column if not exists embedding_model"
+        in statement
+        for statement in statements
+    )
+    assert any(
         "create index if not exists ix_llm_providers_organization_id" in statement
         for statement in statements
     )

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -137,12 +137,16 @@ def test_llm_provider_crud_admin(admin_client):
         json={
             "name": "Primary OpenAI",
             "provider_type": "openai",
+            "model_identifier": "gpt-5.4",
+            "embedding_model": "text-embedding-3-small",
             "api_key": "sk-12345",
         },
     )
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["name"] == "Primary OpenAI"
+    assert data["model_identifier"] == "gpt-5.4"
+    assert data["embedding_model"] == "text-embedding-3-small"
     assert data["configured"] is True
     assert data["fingerprint"] is not None
     assert "api_key" not in data
@@ -154,6 +158,7 @@ def test_llm_provider_crud_admin(admin_client):
     response = admin_client.get("/api/llm-providers")
     assert response.status_code == 200
     assert len(response.json()) == 1
+    assert response.json()[0]["model_identifier"] == "gpt-5.4"
 
     response = admin_client.put(
         f"/api/llm-providers/{provider_id}", json={"is_active": True}
@@ -278,6 +283,48 @@ def test_llm_provider_accepts_allowlisted_external_https_base_url(
     assert response.json()["base_url"] == "https://llm-gateway.example.com/v1"
 
 
+def test_llm_provider_accepts_configured_local_gemma_without_fake_secret(
+    admin_client, monkeypatch
+):
+    previous_allowed_hosts = settings.ALLOWED_LLM_BASE_URL_HOSTS
+    previous_allow_local = settings.ALLOW_LOCAL_LLM_PROVIDERS
+    settings.ALLOWED_LLM_BASE_URL_HOSTS = "ollama"
+    settings.ALLOW_LOCAL_LLM_PROVIDERS = True
+
+    def fake_getaddrinfo(host, port, type=0):
+        assert host == "ollama"
+        assert port == 11434
+        return [(2, 1, 6, "", ("172.20.0.10", port))]
+
+    monkeypatch.setattr(
+        "services.llm_provider_urls.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    try:
+        response = admin_client.post(
+            "/api/llm-providers",
+            json={
+                "name": "Local Gemma4",
+                "provider_type": "ollama",
+                "base_url": "http://ollama:11434/v1",
+                "model_identifier": "gemma4",
+                "embedding_model": "embeddinggemma",
+                "is_active": True,
+            },
+        )
+    finally:
+        settings.ALLOWED_LLM_BASE_URL_HOSTS = previous_allowed_hosts
+        settings.ALLOW_LOCAL_LLM_PROVIDERS = previous_allow_local
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["configured"] is True
+    assert data["fingerprint"] is None
+    assert data["model_identifier"] == "gemma4"
+    assert data["embedding_model"] == "embeddinggemma"
+    assert mock_session.providers[0].api_key is None
+
+
 def test_llm_provider_member_rejected(member_client):
     response = member_client.get("/api/llm-providers")
     assert response.status_code == 403
@@ -292,7 +339,12 @@ def test_llm_provider_member_rejected(member_client):
 def test_llm_provider_model_declares_owner_scope_columns():
     column_names = {column.name for column in LLMProvider.__table__.columns}
 
-    assert {"user_id", "organization_id"}.issubset(column_names)
+    assert {
+        "user_id",
+        "organization_id",
+        "model_identifier",
+        "embedding_model",
+    }.issubset(column_names)
     assert any(
         constraint.name == "uq_llm_providers_org_name"
         for constraint in LLMProvider.__table__.constraints

--- a/backend/tests/test_llm_providers_api.py
+++ b/backend/tests/test_llm_providers_api.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,6 +10,10 @@ from core.config import settings
 from db.models import AuditLog, LLMProvider, SecurityAuditEvent
 from db.session import get_db
 from main import app
+from services.llm_provider_readiness import (
+    is_llm_provider_configured,
+    llm_provider_model_label,
+)
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
@@ -323,6 +328,86 @@ def test_llm_provider_accepts_configured_local_gemma_without_fake_secret(
     assert data["model_identifier"] == "gemma4"
     assert data["embedding_model"] == "embeddinggemma"
     assert mock_session.providers[0].api_key is None
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        (
+            SimpleNamespace(
+                api_key="sk-live",
+                provider_type="openai",
+                base_url=None,
+                model_identifier=None,
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                api_key=None,
+                provider_type="openai",
+                base_url="https://api.openai.com/v1",
+                model_identifier="gpt-5.4",
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                api_key=None,
+                provider_type="ollama",
+                base_url="http://ollama:11434/v1",
+                model_identifier="gemma4",
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                api_key=None,
+                provider_type="vllm",
+                base_url="http://vllm:8000/v1",
+                model_identifier="local-rag",
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                api_key=None,
+                provider_type="ollama",
+                base_url="http://ollama:11434/v1",
+                model_identifier=" ",
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                api_key=None,
+                provider_type="ollama",
+                base_url=" ",
+                model_identifier="gemma4",
+            ),
+            False,
+        ),
+    ],
+)
+def test_llm_provider_readiness_requires_secret_or_complete_local_model(
+    provider, expected
+):
+    assert is_llm_provider_configured(provider) is expected
+
+
+def test_llm_provider_model_label_prefers_configured_model_identifier():
+    assert (
+        llm_provider_model_label(
+            SimpleNamespace(provider_type="ollama", model_identifier=" gemma4 ")
+        )
+        == "gemma4"
+    )
+    assert (
+        llm_provider_model_label(
+            SimpleNamespace(provider_type="openai", model_identifier=None)
+        )
+        == "openai"
+    )
 
 
 def test_llm_provider_member_rejected(member_client):

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -153,6 +153,37 @@ async def test_extract_todos_and_summary_disables_redirect_following_for_custom_
     mock_client.close.assert_awaited_once()
 
 
+def test_validate_llm_provider_base_url_accepts_allowlisted_local_provider(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "ollama")
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+
+    def fake_getaddrinfo(host, port, type=0):
+        assert host == "ollama"
+        assert port == 11434
+        return [(2, 1, 6, "", ("172.20.0.10", port))]
+
+    monkeypatch.setattr(
+        "services.llm_provider_urls.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    assert (
+        provider_urls.validate_llm_provider_base_url("http://ollama:11434/v1")
+        == "http://ollama:11434/v1"
+    )
+
+
+def test_validate_llm_provider_base_url_rejects_local_provider_without_local_mode(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "ollama")
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", False)
+
+    with pytest.raises(ValueError, match=provider_urls.LLM_BASE_URL_NOT_ALLOWED):
+        provider_urls.validate_llm_provider_base_url("http://ollama:11434/v1")
+
+
 @pytest.mark.asyncio
 async def test_draft_reply_success(mock_openai):
     # Setup mock response

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -174,6 +174,77 @@ def test_validate_llm_provider_base_url_accepts_allowlisted_local_provider(
     )
 
 
+def test_normalize_llm_provider_base_url_handles_local_development_hosts():
+    assert provider_urls._normalize_llm_provider_base_url(
+        "HTTP://LOCALHOST:11434/v1"
+    ) == ("http://localhost:11434/v1", "localhost", 11434)
+    assert provider_urls._normalize_llm_provider_base_url(
+        "http://[::1]:11434/v1"
+    ) == ("http://[::1]:11434/v1", "::1", 11434)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://localhost:11434/v1",
+        "http://user:pass@localhost:11434/v1",
+        "http://localhost:11434/v1?token=secret",
+        "http://localhost:11434/v1#fragment",
+        "http://0x7f000001:11434/v1",
+    ],
+)
+def test_normalize_llm_provider_base_url_rejects_unsafe_shapes(url):
+    with pytest.raises(ValueError, match=provider_urls.LLM_BASE_URL_NOT_ALLOWED):
+        provider_urls._normalize_llm_provider_base_url(url)
+
+
+def test_validate_llm_provider_base_url_details_accepts_localhost_only_in_local_mode(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "")
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+
+    def fake_getaddrinfo(host, port, type=0):
+        assert host == "localhost"
+        assert port == 11434
+        return [(2, 1, 6, "", ("127.0.0.1", port))]
+
+    monkeypatch.setattr(
+        "services.llm_provider_urls.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    details = provider_urls.validate_llm_provider_base_url_details(
+        "http://localhost:11434/v1"
+    )
+
+    assert details is not None
+    assert details.normalized_url == "http://localhost:11434/v1"
+    assert details.hostname == "localhost"
+    assert details.port == 11434
+    assert details.addresses == ("127.0.0.1",)
+
+
+def test_validate_llm_provider_base_url_details_rejects_localhost_without_local_mode(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "")
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", False)
+
+    def fake_getaddrinfo(host, port, type=0):
+        assert host == "localhost"
+        assert port == 11434
+        return [(2, 1, 6, "", ("127.0.0.1", port))]
+
+    monkeypatch.setattr(
+        "services.llm_provider_urls.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    with pytest.raises(ValueError, match=provider_urls.LLM_BASE_URL_NOT_ALLOWED):
+        provider_urls.validate_llm_provider_base_url_details(
+            "http://localhost:11434/v1"
+        )
+
+
 def test_validate_llm_provider_base_url_rejects_local_provider_without_local_mode(
     monkeypatch,
 ):

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -165,8 +165,14 @@ def test_backend_dockerfile_uses_modern_env_syntax() -> None:
 
     assert "ENV PYTHONDONTWRITEBYTECODE=1" in dockerfile
     assert "ENV PYTHONUNBUFFERED=1" in dockerfile
+    assert "pnpm install --frozen-lockfile" in dockerfile
+    assert "pnpm run build" in dockerfile
+    assert "COPY --from=frontend-builder /usr/local/bin/node" in dockerfile
+    assert "nodejs" not in dockerfile
     assert "ENV PYTHONDONTWRITEBYTECODE 1" not in dockerfile
     assert "ENV PYTHONUNBUFFERED 1" not in dockerfile
+    assert "secrets.token_hex" not in dockerfile
+    assert "ENV DATABASE_URL=" not in dockerfile
     assert '"/app/start.sh"' in dockerfile
     assert "uvicorn" not in dockerfile.split("CMD", 1)[1]
 

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -36,6 +36,8 @@ def test_compose_externalizes_postgres_credentials():
     assert "${POSTGRES_PASSWORD" in compose
     assert "AUTH_SESSION_HMAC_SECRET" in compose
     assert "${AUTH_SESSION_HMAC_SECRET:?" in compose
+    assert "ENCRYPTION_KEY" in compose
+    assert "${ENCRYPTION_KEY:?" in compose
 
 
 def test_compose_wrapper_uses_operator_env_file_without_bulk_secret_injection():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       ALLOW_LOCAL_LLM_PROVIDERS: "true"
       ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-ollama}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-http://ollama:11434/v1}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-embeddinggemma}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 RUN corepack enable pnpm
 
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
+COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml frontend/.pnpmfile.cjs ./
 ARG TARGETARCH
 RUN pnpm install --frozen-lockfile \
     && if [ "$TARGETARCH" = "arm64" ] \

--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -229,7 +229,8 @@ describe("SearchPage", () => {
   it("renders search snippets as escaped text instead of executable HTML", async () => {
     const maliciousSnippet =
       '검토 필요 <img src=x onerror="window.__naruonSearchXss = true"><script>window.__naruonSearchXss = true</script>';
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    const fetchMock = vi.fn((...args: [RequestInfo | URL, RequestInit?]) => {
+      const [input] = args;
       const url = String(input);
       if (url.endsWith("/api/search")) {
         return Promise.resolve(

--- a/frontend/src/components/SettingsLayout.test.tsx
+++ b/frontend/src/components/SettingsLayout.test.tsx
@@ -7,8 +7,12 @@ vi.mock("lucide-react", () => ({
   Activity: () => <svg aria-hidden="true" />,
   AlertCircle: () => <svg aria-hidden="true" />,
   Bell: () => <svg aria-hidden="true" />,
+  Bot: () => <svg aria-hidden="true" />,
+  CheckCircle2: () => <svg aria-hidden="true" />,
+  Cpu: () => <svg aria-hidden="true" />,
   Mail: () => <svg aria-hidden="true" />,
   Monitor: () => <svg aria-hidden="true" />,
+  Network: () => <svg aria-hidden="true" />,
   Plus: () => <svg aria-hidden="true" />,
   RefreshCw: () => <svg aria-hidden="true" />,
   Settings: () => <svg aria-hidden="true" />,
@@ -173,6 +177,52 @@ describe("SettingsLayout", () => {
               source_id: "webdav_src_primary",
               display_label: "WebDAV source webdav_src_primary",
               writeback_enabled: true,
+            },
+          ]);
+        }
+        if (String(input) === "/api/llm-providers" && init?.method === "POST") {
+          const body = JSON.parse(String(init.body));
+          return jsonResponse({
+            id: 2,
+            name: body.name,
+            provider_type: body.provider_type,
+            base_url: body.base_url,
+            model_identifier: body.model_identifier,
+            embedding_model: body.embedding_model,
+            is_active: body.is_active,
+            configured: true,
+            fingerprint: body.api_key ? "***1234" : null,
+            updated_at: "2026-06-11T04:00:00Z",
+          });
+        }
+        if ((String(input) === "/api/llm-providers/1" || String(input) === "/api/llm-providers/2") && init?.method === "PUT") {
+          const body = JSON.parse(String(init.body));
+          return jsonResponse({
+            id: String(input).endsWith("/2") ? 2 : 1,
+            name: String(input).endsWith("/2") ? "Local Gemma4" : "Primary OpenAI",
+            provider_type: String(input).endsWith("/2") ? "ollama" : "openai",
+            base_url: String(input).endsWith("/2") ? "http://ollama:11434/v1" : "https://api.openai.com/v1",
+            model_identifier: String(input).endsWith("/2") ? "gemma4" : "gpt-5.4",
+            embedding_model: body.embedding_model,
+            is_active: true,
+            configured: true,
+            fingerprint: String(input).endsWith("/2") ? null : "***1234",
+            updated_at: "2026-06-11T05:00:00Z",
+          });
+        }
+        if (String(input) === "/api/llm-providers") {
+          return jsonResponse([
+            {
+              id: 1,
+              name: "Primary OpenAI",
+              provider_type: "openai",
+              base_url: "https://api.openai.com/v1",
+              model_identifier: "gpt-5.4",
+              embedding_model: "text-embedding-3-small",
+              is_active: true,
+              configured: true,
+              fingerprint: "***1234",
+              updated_at: "2026-06-11T03:00:00Z",
             },
           ]);
         }
@@ -529,6 +579,86 @@ describe("SettingsLayout", () => {
     expect(putBody).not.toHaveProperty("pop3_password");
     expect(putBody).not.toHaveProperty("oauth_client_secret");
     expect(container.textContent).toContain("계정 설정을 저장했습니다");
+  });
+
+  it("loads and saves AI model registry entries without public identity headers or secret replay", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<SettingsLayout />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const modelButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "AI 모델");
+    expect(modelButton).toBeTruthy();
+    await act(async () => {
+      modelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const providerListCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/llm-providers" && init?.method !== "POST");
+    expect(providerListCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-Group-Id");
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-Group-Ids");
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-User-Role");
+    expect(providerListCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+    expect(container.textContent).toContain("등록된 모델 레지스트리");
+    expect(container.textContent).toContain("Primary OpenAI");
+    expect(container.textContent).toContain("gpt-5.4");
+    expect(container.textContent).toContain("text-embedding-3-small");
+    expect(container.textContent).toContain("Gemma4 로컬 모델 등록");
+    expect(container.textContent).not.toContain("sk-");
+
+    const localRegisterButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Gemma4 로컬 모델 등록"));
+    expect(localRegisterButton).toBeTruthy();
+    await act(async () => {
+      localRegisterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const providerPostCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/llm-providers" && init?.method === "POST");
+    expect(providerPostCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    expect(providerPostCall?.[1]?.headers).not.toHaveProperty("X-User-Id");
+    expect(providerPostCall?.[1]?.headers).not.toHaveProperty("X-Organization-Id");
+    expect(providerPostCall?.[1]?.headers).not.toHaveProperty("X-Dev-Auth-Token");
+    const providerPostBody = JSON.parse(String(providerPostCall?.[1]?.body));
+    expect(providerPostBody).toMatchObject({
+      name: "Local Gemma4",
+      provider_type: "ollama",
+      base_url: "http://ollama:11434/v1",
+      model_identifier: "gemma4",
+      embedding_model: "embeddinggemma",
+      is_active: true,
+    });
+    expect(providerPostBody).not.toHaveProperty("api_key");
+    expect(container.textContent).toContain("Gemma4 로컬 모델을 등록했습니다");
+
+    const embeddingSaveButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("임베딩 모델 저장"));
+    expect(embeddingSaveButton).toBeTruthy();
+    await act(async () => {
+      embeddingSaveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const embeddingPutCall = vi.mocked(fetch).mock.calls.find(([input, init]) => String(input) === "/api/llm-providers/2" && init?.method === "PUT");
+    expect(embeddingPutCall?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer signed-runner-session-token",
+    });
+    const embeddingPutBody = JSON.parse(String(embeddingPutCall?.[1]?.body));
+    expect(embeddingPutBody).toEqual({ embedding_model: "embeddinggemma" });
+    expect(container.textContent).toContain("임베딩 모델 지정을 저장했습니다");
   });
 
   it("renders settings tabs as detail surfaces instead of placeholder dead space", async () => {

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Monitor, AlertCircle, RefreshCw, Bot, Cpu, Network } from 'lucide-react';
+import { Activity, Settings, User, Mail, Bell, Shield, Smartphone, Monitor, AlertCircle, RefreshCw, Bot, Cpu, Network, Plus, CheckCircle2 } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { clearOidcSession, getOidcBrowserConfig, startOidcLogin } from '@/lib/oidc-session';
 import { useWorkspaceStartupView, setWorkspaceStartupView } from '@/lib/workspace-preferences';
 import { useEffect, useState } from 'react';
 
-type SettingsTab = '워크스페이스' | '멤버' | 'AI 모델' | '연결 계정' | '알림' | '자동화' | '결제' | '개발자';
+export type SettingsTab = '워크스페이스' | '멤버' | 'AI 모델' | '연결 계정' | '알림' | '자동화' | '결제' | '개발자';
 
 interface RunnerConfig {
   workspace_id: string;
@@ -126,6 +126,19 @@ interface WebdavAccount {
   writeback_enabled: boolean;
 }
 
+interface LLMProviderConfig {
+  id: number;
+  name: string;
+  provider_type: string;
+  base_url: string | null;
+  model_identifier: string | null;
+  embedding_model: string | null;
+  is_active: boolean;
+  configured: boolean;
+  fingerprint: string | null;
+  updated_at: string;
+}
+
 interface AccountFormState {
   smtpServer: string;
   smtpPort: string;
@@ -142,6 +155,16 @@ interface AccountFormState {
   oauthClientId: string;
   oauthClientSecret: string;
   oauthRedirectUri: string;
+}
+
+interface ModelProviderFormState {
+  name: string;
+  providerType: string;
+  baseUrl: string;
+  modelIdentifier: string;
+  embeddingModel: string;
+  apiKey: string;
+  isActive: boolean;
 }
 
 const emptyAccountForm: AccountFormState = {
@@ -161,6 +184,33 @@ const emptyAccountForm: AccountFormState = {
   oauthClientSecret: '',
   oauthRedirectUri: '',
 };
+
+const commercialModelFormDefaults: ModelProviderFormState = {
+  name: '상용 API 기본 모델',
+  providerType: 'openai',
+  baseUrl: 'https://api.openai.com/v1',
+  modelIdentifier: 'gpt-5.4',
+  embeddingModel: 'text-embedding-3-small',
+  apiKey: '',
+  isActive: true,
+};
+
+const localModelFormDefaults: ModelProviderFormState = {
+  name: 'Local Gemma4',
+  providerType: 'ollama',
+  baseUrl: 'http://ollama:11434/v1',
+  modelIdentifier: 'gemma4',
+  embeddingModel: 'embeddinggemma',
+  apiKey: '',
+  isActive: true,
+};
+
+const embeddingModelOptions = [
+  { value: 'text-embedding-3-small', label: 'text-embedding-3-small', detail: 'OpenAI (1536차원)' },
+  { value: 'text-embedding-3-large', label: 'text-embedding-3-large', detail: 'OpenAI (3072차원)' },
+  { value: 'nomic-embed-text', label: 'nomic-embed-text', detail: '로컬 Ollama' },
+  { value: 'embeddinggemma', label: 'embeddinggemma', detail: 'Gemma 임베딩 · 로컬 Ollama' },
+];
 
 // Note: Passwords and secrets are intentionally cleared here and never stored in plain text client-side.
 // We only collect them from the user temporarily when updating credentials, sending them directly via HTTPS.
@@ -222,6 +272,29 @@ function buildAccountUpdate(form: AccountFormState): AccountConfigUpdate {
   if (oauthClientSecret) update.oauth_client_secret = oauthClientSecret;
 
   return update;
+}
+
+function buildProviderCreate(form: ModelProviderFormState) {
+  const payload: {
+    name: string;
+    provider_type: string;
+    base_url: string | null;
+    model_identifier: string | null;
+    embedding_model: string | null;
+    api_key?: string;
+    is_active: boolean;
+  } = {
+    name: optionalText(form.name) ?? form.modelIdentifier,
+    provider_type: optionalText(form.providerType) ?? 'openai',
+    base_url: optionalText(form.baseUrl),
+    model_identifier: optionalText(form.modelIdentifier),
+    embedding_model: optionalText(form.embeddingModel),
+    is_active: form.isActive,
+  };
+
+  const apiKey = optionalText(form.apiKey);
+  if (apiKey) payload.api_key = apiKey;
+  return payload;
 }
 
 function formatEndpoint(host: string | null | undefined, port: number | null | undefined) {
@@ -332,6 +405,28 @@ function getOperationalSignalDetail(signal: OperationalSignal) {
   return signal.detail ? '운영 신호 상태를 확인합니다.' : '상세 근거가 아직 기록되지 않았습니다.';
 }
 
+function getProviderTypeLabel(providerType: string) {
+  switch (providerType.toLowerCase()) {
+    case 'openai':
+      return 'OpenAI 호환';
+    case 'anthropic':
+      return 'Anthropic';
+    case 'gemini':
+      return 'Google Gemini';
+    case 'ollama':
+      return '로컬 Ollama';
+    case 'vllm':
+      return '로컬 vLLM';
+    default:
+      return 'OpenAI-compatible';
+  }
+}
+
+function getProviderEndpointLabel(provider: LLMProviderConfig) {
+  if (provider.base_url) return provider.base_url;
+  return provider.provider_type === 'openai' ? '기본 OpenAI API endpoint' : 'Provider 기본 endpoint';
+}
+
 const settingsDetailSurfaces: Partial<Record<SettingsTab, {
   heading: string;
   copy: string;
@@ -396,6 +491,17 @@ export function SettingsLayout() {
   const [webdavAccounts, setWebdavAccounts] = useState<WebdavAccount[]>([]);
   const [sourceReadinessLoading, setSourceReadinessLoading] = useState(true);
   const [sourceReadinessError, setSourceReadinessError] = useState<string | null>(null);
+  const [modelProviders, setModelProviders] = useState<LLMProviderConfig[]>([]);
+  const [modelProvidersLoading, setModelProvidersLoading] = useState(true);
+  const [modelProvidersError, setModelProvidersError] = useState<string | null>(null);
+  const [modelProviderStatus, setModelProviderStatus] = useState<string | null>(null);
+  const [commercialModelForm, setCommercialModelForm] = useState<ModelProviderFormState>(commercialModelFormDefaults);
+  const [localModelForm, setLocalModelForm] = useState<ModelProviderFormState>(localModelFormDefaults);
+  const [commercialModelSaving, setCommercialModelSaving] = useState(false);
+  const [localModelSaving, setLocalModelSaving] = useState(false);
+  const [selectedEmbeddingProviderId, setSelectedEmbeddingProviderId] = useState<number | null>(null);
+  const [selectedEmbeddingModel, setSelectedEmbeddingModel] = useState('embeddinggemma');
+  const [embeddingSaving, setEmbeddingSaving] = useState(false);
   const [oidcSessionClaims, setOidcSessionClaims] = useState(() => apiClient.getSessionClaims());
   const [oidcActionError, setOidcActionError] = useState<string | null>(null);
   const startupView = useWorkspaceStartupView();
@@ -403,6 +509,8 @@ export function SettingsLayout() {
   const connectorManifest = runnerConfig?.connector_manifest;
   const detailSurface = settingsDetailSurfaces[activeTab];
   const connectorEvents = operationalSignals?.connector.recent_events ?? [];
+  const activeModelProvider = modelProviders.find((provider) => provider.is_active) ?? modelProviders[0] ?? null;
+  const selectedEmbeddingProvider = modelProviders.find((provider) => provider.id === selectedEmbeddingProviderId) ?? activeModelProvider;
   const accountReady = !accountLoading && !accountError && accountConfig !== null;
   const oauthAppConfigured = Boolean(
     accountConfig?.oauth_client_id
@@ -482,6 +590,67 @@ export function SettingsLayout() {
       setAccountError(message);
     } finally {
       setAccountSaving(false);
+    }
+  };
+
+  const updateCommercialModelField = (field: keyof ModelProviderFormState, value: string | boolean) => {
+    setCommercialModelForm((current) => ({ ...current, [field]: value }));
+    setModelProviderStatus(null);
+  };
+
+  const updateLocalModelField = (field: keyof ModelProviderFormState, value: string | boolean) => {
+    setLocalModelForm((current) => ({ ...current, [field]: value }));
+    setModelProviderStatus(null);
+  };
+
+  const createModelProvider = async (
+    event: React.FormEvent<HTMLFormElement>,
+    form: ModelProviderFormState,
+    options: {
+      setSaving: (saving: boolean) => void;
+      resetApiKey: () => void;
+      successMessage: string;
+    },
+  ) => {
+    event.preventDefault();
+    options.setSaving(true);
+    setModelProvidersError(null);
+    setModelProviderStatus(null);
+
+    try {
+      const created = await apiClient.post<LLMProviderConfig>('/api/llm-providers', buildProviderCreate(form));
+      setModelProviders((current) => [created, ...current.filter((provider) => provider.id !== created.id)]);
+      setSelectedEmbeddingProviderId(created.id);
+      setSelectedEmbeddingModel(created.embedding_model ?? form.embeddingModel);
+      options.resetApiKey();
+      setModelProviderStatus(options.successMessage);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'AI 모델 설정을 저장할 수 없습니다.';
+      setModelProvidersError(message);
+    } finally {
+      options.setSaving(false);
+    }
+  };
+
+  const handleEmbeddingModelSave = async () => {
+    const providerId = selectedEmbeddingProvider?.id;
+    if (!providerId) return;
+
+    setEmbeddingSaving(true);
+    setModelProvidersError(null);
+    setModelProviderStatus(null);
+
+    try {
+      const updated = await apiClient.put<LLMProviderConfig>(`/api/llm-providers/${providerId}`, {
+        embedding_model: selectedEmbeddingModel,
+      });
+      setModelProviders((current) => current.map((provider) => (provider.id === updated.id ? updated : provider)));
+      setModelProviderStatus('임베딩 모델 지정을 저장했습니다.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '임베딩 모델 지정을 저장할 수 없습니다.';
+      setModelProvidersError(message);
+    } finally {
+      setEmbeddingSaving(false);
     }
   };
 
@@ -574,6 +743,24 @@ export function SettingsLayout() {
       })
       .finally(() => {
         if (!cancelled) setSourceReadinessLoading(false);
+      });
+
+    void apiClient
+      .get<LLMProviderConfig[]>('/api/llm-providers')
+      .then((providers) => {
+        if (cancelled) return;
+        setModelProviders(providers);
+        const activeProvider = providers.find((provider) => provider.is_active) ?? providers[0] ?? null;
+        setSelectedEmbeddingProviderId(activeProvider?.id ?? null);
+        setSelectedEmbeddingModel(activeProvider?.embedding_model ?? 'embeddinggemma');
+        setModelProvidersError(null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setModelProvidersError(error.message || 'AI 모델 설정을 불러오지 못했습니다.');
+      })
+      .finally(() => {
+        if (!cancelled) setModelProvidersLoading(false);
       });
 
     return () => {
@@ -676,12 +863,94 @@ export function SettingsLayout() {
                 <div className="flex flex-wrap items-start justify-between gap-4">
                   <div>
                     <h2 className="font-bold text-xl">AI 모델 설정</h2>
-                    <p className="text-sm text-muted-foreground mt-1">대규모 언어 모델(LLM), 로컬 모델, 임베딩 모델을 등록하고 관리합니다.</p>
+                    <p className="text-sm text-muted-foreground mt-1">대규모 언어 모델(LLM), 로컬 모델, 임베딩 모델을 signed provider registry에 등록하고 관리합니다.</p>
                   </div>
+                  <span className="rounded-full border border-border bg-card px-3 py-1 font-mono text-xs font-bold text-foreground">
+                    /api/llm-providers
+                  </span>
                 </div>
 
+                {modelProvidersLoading ? (
+                  <p className="rounded-xl bg-secondary/60 p-3 text-sm font-semibold text-muted-foreground">AI 모델 설정을 불러오는 중입니다.</p>
+                ) : null}
+                {modelProvidersError ? (
+                  <p className="rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-900">{modelProvidersError}</p>
+                ) : null}
+                {modelProviderStatus ? (
+                  <p className="rounded-xl border border-emerald-300 bg-emerald-50 p-3 text-sm font-semibold text-emerald-900">{modelProviderStatus}</p>
+                ) : null}
+
+                <section aria-label="등록된 AI 모델" className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-bold text-lg">등록된 모델 레지스트리</h3>
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        조직 스코프에 저장된 provider만 표시합니다. API key 원문은 응답에 포함되지 않습니다.
+                      </p>
+                    </div>
+                    <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-semibold text-foreground">
+                      {modelProviders.length}개
+                    </span>
+                  </div>
+
+                  {modelProviders.length > 0 ? (
+                    <div className="mt-5 grid gap-3">
+                      {modelProviders.map((provider) => (
+                        <article key={provider.id} className="rounded-xl border border-border bg-background p-4">
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="font-bold text-base">{provider.name}</h4>
+                                <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${provider.is_active ? 'bg-emerald-100 text-emerald-800' : 'bg-secondary text-muted-foreground'}`}>
+                                  {provider.is_active ? '활성 모델' : '대기 모델'}
+                                </span>
+                                <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${provider.configured ? 'bg-blue-100 text-blue-800' : 'bg-amber-100 text-amber-900'}`}>
+                                  {provider.configured ? '연결됨' : '설정 필요'}
+                                </span>
+                              </div>
+                              <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+                                <div>
+                                  <dt className="text-xs font-bold text-muted-foreground">Provider</dt>
+                                  <dd className="mt-1 break-all font-semibold">{getProviderTypeLabel(provider.provider_type)}</dd>
+                                </div>
+                                <div>
+                                  <dt className="text-xs font-bold text-muted-foreground">Endpoint</dt>
+                                  <dd className="mt-1 break-all font-semibold">{getProviderEndpointLabel(provider)}</dd>
+                                </div>
+                                <div>
+                                  <dt className="text-xs font-bold text-muted-foreground">모델</dt>
+                                  <dd className="mt-1 break-all font-semibold">{provider.model_identifier ?? '모델 지정 필요'}</dd>
+                                </div>
+                                <div>
+                                  <dt className="text-xs font-bold text-muted-foreground">임베딩</dt>
+                                  <dd className="mt-1 break-all font-semibold">{provider.embedding_model ?? '임베딩 지정 필요'}</dd>
+                                </div>
+                              </dl>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-2 rounded-full border border-border px-3 py-1 text-xs font-bold text-muted-foreground">
+                              <CheckCircle2 className="size-3.5 text-primary" />
+                              {provider.fingerprint ? `Key ${provider.fingerprint}` : '로컬 credential 없음'}
+                            </div>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-5 rounded-xl border border-dashed border-border p-4 text-sm font-semibold text-muted-foreground">
+                      등록된 AI 모델이 없습니다. Gemma4 로컬 모델 또는 상용 API 모델을 등록하세요.
+                    </p>
+                  )}
+                </section>
+
                 <div className="grid gap-6 md:grid-cols-2">
-                  <div className="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4">
+                  <form
+                    onSubmit={(event) => createModelProvider(event, commercialModelForm, {
+                      setSaving: setCommercialModelSaving,
+                      resetApiKey: () => setCommercialModelForm((current) => ({ ...current, apiKey: '' })),
+                      successMessage: '상용 API 모델을 등록했습니다.',
+                    })}
+                    className="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4"
+                  >
                     <div className="flex items-center gap-3 border-b border-border pb-4">
                       <div className="rounded-xl bg-blue-100 p-2.5"><Bot className="size-5 text-blue-700" /></div>
                       <div>
@@ -691,24 +960,54 @@ export function SettingsLayout() {
                     </div>
                     <div className="space-y-4">
                       <div className="space-y-2">
-                        <label className="text-sm font-bold text-muted-foreground">제공자 (Provider)</label>
-                        <select className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary">
-                          <option>OpenAI</option>
-                          <option>Anthropic</option>
-                          <option>Google Gemini</option>
+                        <label htmlFor="commercial-provider-name" className="text-sm font-bold text-muted-foreground">등록 이름</label>
+                        <input id="commercial-provider-name" value={commercialModelForm.name} onChange={(event) => updateCommercialModelField('name', event.target.value)} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="commercial-provider-type" className="text-sm font-bold text-muted-foreground">제공자</label>
+                        <select id="commercial-provider-type" value={commercialModelForm.providerType} onChange={(event) => updateCommercialModelField('providerType', event.target.value)} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary">
+                          <option value="openai">OpenAI 호환</option>
+                          <option value="anthropic">Anthropic</option>
+                          <option value="gemini">Google Gemini</option>
                         </select>
                       </div>
                       <div className="space-y-2">
-                        <label className="text-sm font-bold text-muted-foreground">API Key</label>
-                        <input type="password" placeholder="sk-..." className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <label htmlFor="commercial-base-url" className="text-sm font-bold text-muted-foreground">API endpoint</label>
+                        <input id="commercial-base-url" type="url" value={commercialModelForm.baseUrl} onChange={(event) => updateCommercialModelField('baseUrl', event.target.value)} placeholder="https://api.openai.com/v1" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
-                      <button type="button" className="w-full rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background hover:bg-foreground/90 transition-colors">
-                        모델 추가
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <label htmlFor="commercial-model-id" className="text-sm font-bold text-muted-foreground">모델 식별자</label>
+                          <input id="commercial-model-id" value={commercialModelForm.modelIdentifier} onChange={(event) => updateCommercialModelField('modelIdentifier', event.target.value)} placeholder="gpt-5.4" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        </div>
+                        <div className="space-y-2">
+                          <label htmlFor="commercial-embedding-model" className="text-sm font-bold text-muted-foreground">임베딩 모델</label>
+                          <select id="commercial-embedding-model" value={commercialModelForm.embeddingModel} onChange={(event) => updateCommercialModelField('embeddingModel', event.target.value)} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary">
+                            {embeddingModelOptions.map((option) => (
+                              <option key={option.value} value={option.value}>{option.label}</option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="commercial-api-key" className="text-sm font-bold text-muted-foreground">API Key</label>
+                        <input id="commercial-api-key" type="password" value={commercialModelForm.apiKey} onChange={(event) => updateCommercialModelField('apiKey', event.target.value)} placeholder="저장 시에만 전송" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <button type="submit" disabled={commercialModelSaving || modelProvidersLoading} className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60">
+                        <Plus className="size-4" />
+                        {commercialModelSaving ? '등록 중' : '상용 모델 추가'}
                       </button>
                     </div>
-                  </div>
+                  </form>
 
-                  <div className="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4">
+                  <form
+                    onSubmit={(event) => createModelProvider(event, localModelForm, {
+                      setSaving: setLocalModelSaving,
+                      resetApiKey: () => setLocalModelForm((current) => ({ ...current, apiKey: '' })),
+                      successMessage: 'Gemma4 로컬 모델을 등록했습니다.',
+                    })}
+                    className="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4"
+                  >
                     <div className="flex items-center gap-3 border-b border-border pb-4">
                       <div className="rounded-xl bg-emerald-100 p-2.5"><Cpu className="size-5 text-emerald-700" /></div>
                       <div>
@@ -718,18 +1017,37 @@ export function SettingsLayout() {
                     </div>
                     <div className="space-y-4">
                       <div className="space-y-2">
-                        <label className="text-sm font-bold text-muted-foreground">서버 엔드포인트 URL</label>
-                        <input type="url" placeholder="http://localhost:11434/v1" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <label htmlFor="local-provider-name" className="text-sm font-bold text-muted-foreground">등록 이름</label>
+                        <input id="local-provider-name" value={localModelForm.name} onChange={(event) => updateLocalModelField('name', event.target.value)} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                       <div className="space-y-2">
-                        <label className="text-sm font-bold text-muted-foreground">모델 식별자</label>
-                        <input type="text" placeholder="gemma4 또는 llama3:8b" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <label htmlFor="local-base-url" className="text-sm font-bold text-muted-foreground">서버 엔드포인트 URL</label>
+                        <input id="local-base-url" type="url" value={localModelForm.baseUrl} onChange={(event) => updateLocalModelField('baseUrl', event.target.value)} placeholder="http://ollama:11434/v1" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
-                      <button type="button" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm font-bold text-foreground hover:bg-secondary transition-colors">
-                        로컬 모델 등록
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <label htmlFor="local-model-id" className="text-sm font-bold text-muted-foreground">모델 식별자</label>
+                          <input id="local-model-id" value={localModelForm.modelIdentifier} onChange={(event) => updateLocalModelField('modelIdentifier', event.target.value)} placeholder="gemma4" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        </div>
+                        <div className="space-y-2">
+                          <label htmlFor="local-embedding-model" className="text-sm font-bold text-muted-foreground">임베딩 모델</label>
+                          <select id="local-embedding-model" value={localModelForm.embeddingModel} onChange={(event) => updateLocalModelField('embeddingModel', event.target.value)} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary">
+                            {embeddingModelOptions.map((option) => (
+                              <option key={option.value} value={option.value}>{option.label}</option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <label htmlFor="local-api-key" className="text-sm font-bold text-muted-foreground">Local API key override</label>
+                        <input id="local-api-key" type="password" value={localModelForm.apiKey} onChange={(event) => updateLocalModelField('apiKey', event.target.value)} placeholder="필요한 경우에만 입력" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                      </div>
+                      <button type="submit" disabled={localModelSaving || modelProvidersLoading} className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-60">
+                        <Cpu className="size-4" />
+                        {localModelSaving ? '등록 중' : 'Gemma4 로컬 모델 등록'}
                       </button>
                     </div>
-                  </div>
+                  </form>
                 </div>
 
                 <div className="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4">
@@ -740,35 +1058,61 @@ export function SettingsLayout() {
                       <p className="text-sm text-muted-foreground mt-1">벡터 스토어 및 RAG 구축을 위한 기본 임베딩 모델을 선택합니다.</p>
                     </div>
                   </div>
-                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                    <label className="flex cursor-pointer items-center justify-between rounded-xl border border-border p-4 hover:border-primary/50 transition-colors [&:has(:checked)]:border-primary [&:has(:checked)]:bg-primary/5">
-                      <div>
-                        <p className="font-bold">text-embedding-3-small</p>
-                        <p className="text-xs text-muted-foreground mt-1">OpenAI (1536차원)</p>
-                      </div>
-                      <input type="radio" name="embedding_model" className="size-4" defaultChecked />
-                    </label>
-                    <label className="flex cursor-pointer items-center justify-between rounded-xl border border-border p-4 hover:border-primary/50 transition-colors [&:has(:checked)]:border-primary [&:has(:checked)]:bg-primary/5">
-                      <div>
-                        <p className="font-bold">text-embedding-3-large</p>
-                        <p className="text-xs text-muted-foreground mt-1">OpenAI (3072차원)</p>
-                      </div>
-                      <input type="radio" name="embedding_model" className="size-4" />
-                    </label>
-                    <label className="flex cursor-pointer items-center justify-between rounded-xl border border-border p-4 hover:border-primary/50 transition-colors [&:has(:checked)]:border-primary [&:has(:checked)]:bg-primary/5">
-                      <div>
-                        <p className="font-bold">nomic-embed-text</p>
-                        <p className="text-xs text-muted-foreground mt-1">로컬 Ollama</p>
-                      </div>
-                      <input type="radio" name="embedding_model" className="size-4" />
-                    </label>
-                    <label className="flex cursor-pointer items-center justify-between rounded-xl border border-border p-4 hover:border-primary/50 transition-colors [&:has(:checked)]:border-primary [&:has(:checked)]:bg-primary/5">
-                      <div>
-                        <p className="font-bold">embeddinggemma</p>
-                        <p className="text-xs text-muted-foreground mt-1">Gemma 임베딩 · 로컬 Ollama</p>
-                      </div>
-                      <input type="radio" name="embedding_model" className="size-4" />
-                    </label>
+                  <div className="grid gap-4">
+                    <div className="space-y-2">
+                      <label htmlFor="embedding-provider" className="text-sm font-bold text-muted-foreground">대상 모델</label>
+                      <select
+                        id="embedding-provider"
+                        value={selectedEmbeddingProvider?.id ?? ''}
+                        onChange={(event) => {
+                          const providerId = Number.parseInt(event.target.value, 10);
+                          const provider = modelProviders.find((candidate) => candidate.id === providerId) ?? null;
+                          setSelectedEmbeddingProviderId(Number.isFinite(providerId) ? providerId : null);
+                          setSelectedEmbeddingModel(provider?.embedding_model ?? 'embeddinggemma');
+                          setModelProviderStatus(null);
+                        }}
+                        disabled={modelProviders.length === 0}
+                        className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {modelProviders.length === 0 ? (
+                          <option value="">등록된 모델 없음</option>
+                        ) : (
+                          modelProviders.map((provider) => (
+                            <option key={provider.id} value={provider.id}>{provider.name}</option>
+                          ))
+                        )}
+                      </select>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                      {embeddingModelOptions.map((option) => (
+                        <label key={option.value} className="flex min-h-24 cursor-pointer items-center justify-between rounded-xl border border-border p-4 transition-colors hover:border-primary/50 [&:has(:checked)]:border-primary [&:has(:checked)]:bg-primary/5">
+                          <div className="min-w-0">
+                            <p className="break-all font-bold">{option.label}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">{option.detail}</p>
+                          </div>
+                          <input
+                            type="radio"
+                            name="embedding_model"
+                            value={option.value}
+                            checked={selectedEmbeddingModel === option.value}
+                            onChange={() => {
+                              setSelectedEmbeddingModel(option.value);
+                              setModelProviderStatus(null);
+                            }}
+                            className="size-4 shrink-0"
+                          />
+                        </label>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleEmbeddingModelSave}
+                      disabled={!selectedEmbeddingProvider || embeddingSaving}
+                      className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+                    >
+                      <Network className="size-4" />
+                      {embeddingSaving ? '저장 중' : '임베딩 모델 저장'}
+                    </button>
                   </div>
                 </div>
               </div>

--- a/frontend/tests/SettingsLayout.test.tsx
+++ b/frontend/tests/SettingsLayout.test.tsx
@@ -1,23 +1,20 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import { SettingsTab } from '../src/components/SettingsLayout';
+import { describe, expect, it } from "vitest";
+import type { SettingsTab } from "../src/components/SettingsLayout";
 
-// Mocking the imported components that SettingsTab uses internally
-vi.mock('../src/components/SettingsLayout', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/components/SettingsLayout')>();
-  return {
-    ...actual,
-    SettingsLayout: () => <div data-testid="settings-layout-mock">Settings Layout</div>
-  };
-});
+describe("SettingsTab", () => {
+  it("uses the Korean-first settings destinations", () => {
+    const tabs: SettingsTab[] = [
+      "워크스페이스",
+      "멤버",
+      "AI 모델",
+      "연결 계정",
+      "알림",
+      "자동화",
+      "결제",
+      "개발자",
+    ];
 
-describe('SettingsTab Types', () => {
-  it('should be definable and assignable', () => {
-    // This is a simple type and unit test to fulfill the test coverage requirement for SettingsTab
-    const tab: SettingsTab = 'account';
-    expect(tab).toBe('account');
-    
-    const aiTab: SettingsTab = 'ai';
-    expect(aiTab).toBe('ai');
+    expect(tabs).toContain("AI 모델");
+    expect(tabs).toContain("연결 계정");
   });
 });

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -678,6 +678,33 @@ const accountConfig = {
   has_oauth_client_secret: true,
 };
 
+const llmProviders = [
+  {
+    id: 1,
+    name: 'Primary OpenAI',
+    provider_type: 'openai',
+    base_url: 'https://api.openai.com/v1',
+    model_identifier: 'gpt-5.4',
+    embedding_model: 'text-embedding-3-small',
+    is_active: true,
+    configured: true,
+    fingerprint: '***1234',
+    updated_at: '2026-06-11T04:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'Local Gemma4',
+    provider_type: 'ollama',
+    base_url: 'http://ollama:11434/v1',
+    model_identifier: 'gemma4',
+    embedding_model: 'embeddinggemma',
+    is_active: true,
+    configured: true,
+    fingerprint: null,
+    updated_at: '2026-06-11T05:00:00Z',
+  },
+];
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
@@ -781,6 +808,40 @@ export async function mockDashboardApi(page: Page, onApiRequest?: (path: string,
         pop3_username: body.pop3_username,
         oauth_client_id: body.oauth_client_id,
         oauth_redirect_uri: body.oauth_redirect_uri,
+      });
+      return;
+    }
+
+    if (path === '/api/llm-providers' && request.method() === 'GET') {
+      await fulfillJson(route, llmProviders);
+      return;
+    }
+
+    if (path === '/api/llm-providers' && request.method() === 'POST') {
+      const body = JSON.parse(request.postData() || '{}') as Record<string, unknown>;
+      await fulfillJson(route, {
+        id: 3,
+        name: body.name,
+        provider_type: body.provider_type,
+        base_url: body.base_url ?? null,
+        model_identifier: body.model_identifier ?? null,
+        embedding_model: body.embedding_model ?? null,
+        is_active: body.is_active ?? true,
+        configured: true,
+        fingerprint: body.api_key ? '***1234' : null,
+        updated_at: '2026-06-11T06:00:00Z',
+      });
+      return;
+    }
+
+    if (path.startsWith('/api/llm-providers/') && request.method() === 'PUT') {
+      const body = JSON.parse(request.postData() || '{}') as Record<string, unknown>;
+      const providerId = Number(path.split('/').at(-1));
+      const provider = llmProviders.find((candidate) => candidate.id === providerId) ?? llmProviders[0];
+      await fulfillJson(route, {
+        ...provider,
+        ...body,
+        updated_at: '2026-06-11T06:30:00Z',
       });
       return;
     }

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -1,17 +1,46 @@
 import { expect, test } from '@playwright/test';
 
+import { mockDashboardApi } from './helpers';
+
+const publicIdentityHeaders = [
+  'x-user-id',
+  'x-organization-id',
+  'x-group-id',
+  'x-group-ids',
+  'x-user-role',
+  'x-dev-auth-token',
+];
+
 test('nano test: verify user requested features', async ({ page }) => {
+  const sessionToken = 'signed-nano-session';
+  const providerRequestHeaders: Record<string, string>[] = [];
+  await mockDashboardApi(page, (path, request) => {
+    if (path === '/api/llm-providers' && request.method() === 'GET') {
+      providerRequestHeaders.push(request.headers());
+    }
+  });
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, sessionToken);
+
   // 1. Check AI Model Settings
   await page.goto('/settings');
   await expect(page.getByText('Naruon', { exact: false }).first()).toBeVisible();
-  
+
   // Click AI Models tab (use visible=true to avoid strict mode violation and hidden elements on responsive layouts)
   await page.getByRole('button', { name: 'AI 모델' }).first().click();
-  
+
+  await expect.poll(() => providerRequestHeaders.length).toBeGreaterThan(0);
+  const headers = providerRequestHeaders.at(-1) ?? {};
+  expect(headers.authorization).toBe(`Bearer ${sessionToken}`);
+  for (const headerName of publicIdentityHeaders) {
+    expect(headers[headerName]).toBeUndefined();
+  }
+
   // Verify Model registration UI
   await expect(page.getByText('로컬 모델 등록', { exact: true }).first()).toBeVisible();
   await expect(page.getByText('임베딩 모델 지정', { exact: true }).first()).toBeVisible();
-  
+
   // 2. Check Data page for email import
   await page.goto('/data');
   await expect(page.getByText('이메일 반입', { exact: false }).first()).toBeVisible();


### PR DESCRIPTION
## Summary
- add LLM provider model metadata for model identifiers and embedding models, including local Gemma/Ollama readiness without fake secrets
- replace static Settings AI model controls with signed /api/llm-providers registry forms and embedding selection
- harden Docker packaging to use pnpm, require runtime secrets from Compose, and start through the backend preflight path
- update nano Playwright smoke to use signed source-shaped API fixtures for settings/data coverage

## Validation
- PYTHONWARNINGS=ignore python -m pytest backend/tests/test_llm_providers_api.py backend/tests/test_bootstrap_db.py backend/tests/test_release_governance.py backend/tests/test_repo_hygiene.py -q
- pnpm test -- src/components/SettingsLayout.test.tsx tests/SettingsLayout.test.tsx
- pnpm exec tsc --noEmit
- pnpm exec eslint src/components/SettingsLayout.tsx src/components/SettingsLayout.test.tsx tests/SettingsLayout.test.tsx src/app/search/page.test.tsx tests/e2e/helpers.ts tests/e2e/nano.spec.ts
- env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_PORT=18183 pnpm exec playwright test tests/e2e/nano.spec.ts
- POSTGRES_PASSWORD=local-compose-only AUTH_SESSION_HMAC_SECRET=<generated> ENCRYPTION_KEY=<generated> docker compose config >/tmp/naruon-compose-config.txt 2>/tmp/naruon-compose-config.stderr
- docker build --progress=plain -t naruon-root-dockerfile-smoke .
- docker build --progress=plain -f frontend/Dockerfile -t naruon-frontend-dockerfile-smoke .
- docker run --rm --entrypoint node naruon-root-dockerfile-smoke --version
- docker run --rm --entrypoint /bin/sh naruon-root-dockerfile-smoke -c 'cd /app/frontend && ./node_modules/.bin/next --version'
- docker run --rm --entrypoint node naruon-frontend-dockerfile-smoke --version