### PR TITLE
🧪 [테스트 개선] _validate_global_address 로직 커버리지 확보

### DIFF
--- a/backend/tests/test_llm_provider_urls.py
+++ b/backend/tests/test_llm_provider_urls.py
@@ -1,0 +1,79 @@
+import pytest
+
+from core.config import settings
+from services.llm_provider_urls import _validate_global_address, LLM_BASE_URL_NOT_ALLOWED
+
+
+def test_validate_global_address_valid_ipv4():
+    """Test that a valid global IPv4 address is accepted."""
+    assert _validate_global_address("93.184.216.34") == "93.184.216.34"
+
+
+def test_validate_global_address_valid_ipv6():
+    """Test that a valid global IPv6 address is accepted."""
+    assert (
+        _validate_global_address("2606:2800:220:1:248:1893:25c8:1946")
+        == "2606:2800:220:1:248:1893:25c8:1946"
+    )
+
+
+def test_validate_global_address_invalid_ip():
+    """Test that an invalid IP address string raises a ValueError."""
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("not-an-ip-address")
+
+
+def test_validate_global_address_private_ip():
+    """Test that a private IP address is rejected."""
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("192.168.1.1")
+
+
+def test_validate_global_address_loopback_ip_rejected():
+    """Test that a loopback IP address is rejected by default."""
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("127.0.0.1")
+
+
+def test_validate_global_address_link_local_ip_rejected():
+    """Test that a link-local IP address is rejected."""
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("169.254.1.1")
+
+
+def test_validate_global_address_multicast_ip_rejected():
+    """Test that a multicast IP address is rejected."""
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("224.0.0.1")
+
+
+def test_validate_global_address_loopback_allowed_when_settings_enabled(monkeypatch):
+    """Test that a loopback IP is allowed when ALLOW_LOCAL_LLM_PROVIDERS is True."""
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+    assert _validate_global_address("127.0.0.1") == "127.0.0.1"
+
+
+def test_validate_global_address_private_allowed_when_host_allowed(monkeypatch):
+    """Test that a private IP is allowed when the hostname is in ALLOWED_LLM_BASE_URL_HOSTS."""
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "ollama,other-host")
+
+    assert _validate_global_address("192.168.1.5", hostname="ollama") == "192.168.1.5"
+
+
+def test_validate_global_address_private_rejected_when_host_not_allowed(monkeypatch):
+    """Test that a private IP is rejected even with ALLOW_LOCAL_LLM_PROVIDERS if the hostname is not allowed."""
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "ollama,other-host")
+
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("192.168.1.5", hostname="unallowed-host")
+
+
+def test_validate_global_address_private_rejected_without_hostname(monkeypatch):
+    """Test that a private IP is rejected if ALLOW_LOCAL_LLM_PROVIDERS is True but no hostname is provided."""
+    monkeypatch.setattr(settings, "ALLOW_LOCAL_LLM_PROVIDERS", True)
+    monkeypatch.setattr(settings, "ALLOWED_LLM_BASE_URL_HOSTS", "ollama,other-host")
+
+    with pytest.raises(ValueError, match=LLM_BASE_URL_NOT_ALLOWED):
+        _validate_global_address("192.168.1.5")


### PR DESCRIPTION
🎯 **What:** `_validate_global_address` 함수에 대한 누락된 단위 테스트 추가.
📊 **Coverage:** 유효한 IPv4 및 IPv6, 잘못된 IP 형식, 루프백, 프라이빗, 링크 로컬, 멀티캐스트 IP와 `ALLOW_LOCAL_LLM_PROVIDERS` 설정 조합을 통한 모든 시나리오 및 예외 사항을 검증합니다.
✨ **Result:** `llm_provider_urls.py`의 핵심 검증 로직에 대해 포괄적인 테스트 커버리지를 제공하여 안전성과 신뢰성을 확보합니다.

---
*PR created automatically by Jules for task [17787943566610476078](https://jules.google.com/task/17787943566610476078) started by @seonghobae*