### PR TITLE
🧪 _sanitize_display_text 함수 테스트 추가

### DIFF
--- a/backend/tests/test_email_parser.py
+++ b/backend/tests/test_email_parser.py
@@ -266,3 +266,30 @@ def test_sanitize_nul():
     assert _sanitize_nul(123) == "123"
     assert _sanitize_nul(12.3) == "12.3"
     assert _sanitize_nul(True) == "True"
+
+def test_sanitize_display_text():
+    from services.email_parser import _sanitize_display_text
+
+    # Normal string
+    assert _sanitize_display_text("hello world") == "hello world"
+
+    # Strings with NUL characters
+    assert _sanitize_display_text("hello\x00world") == "helloworld"
+
+    # Strings with HTML tags
+    assert _sanitize_display_text("<b>hello</b> world") == "hello world"
+    assert _sanitize_display_text("<script>alert('xss')</script>") == ""
+    assert _sanitize_display_text("hello <img src=x onerror=alert(1)>world") == "hello world"
+
+    # Strings combining NUL and HTML
+    assert _sanitize_display_text("<b>hello\x00</b>") == "hello"
+    assert _sanitize_display_text("<script\x00>alert('xss')</script>") == ""
+    # Let's see what happens exactly - _sanitize_nul strips NUL first, then strip_html_markup acts on the rest.
+    # So "<script\x00>..." becomes "<script>..." and then strip_html_markup strips it.
+    assert _sanitize_display_text("<script\x00>alert('xss\x00')</script>") == ""
+
+    # Empty string
+    assert _sanitize_display_text("") == ""
+
+    # None value (falls back to _sanitize_nul which converts None to "")
+    assert _sanitize_display_text(None) == ""


### PR DESCRIPTION
🎯 **What:** `backend/services/email_parser.py` 파일의 `_sanitize_display_text` 함수에 대한 테스트를 추가했습니다.

📊 **Coverage:** 다음의 시나리오들을 테스트합니다.
* 일반적인 문자열
* NUL 문자가 포함된 문자열 (`\x00`)
* HTML 태그가 포함된 문자열 (`<b>`, `<script>` 등)
* NUL 문자와 HTML 태그가 함께 포함된 문자열
* 빈 문자열 및 `None` 입력

✨ **Result:** `_sanitize_display_text` 함수에 대한 테스트 커버리지가 확보되었으며, NUL 문자와 HTML 태그가 함께 있는 경우의 동작 방식을 명확하게 문서화하고 보장합니다.

---
*PR created automatically by Jules for task [4704319802640812743](https://jules.google.com/task/4704319802640812743) started by @seonghobae*