### PR TITLE
ci: authenticate Strix PR head fetch

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Fetch pull request head for trusted scan
         if: github.event_name == 'pull_request_target' || github.event.inputs.pr_number != ''
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.event.inputs.pr_number }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.event.inputs.pr_base_sha }}
           PR_HEAD_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.event.inputs.pr_head_sha }}
@@ -81,6 +82,7 @@ jobs:
             echo "::error::PR number and head SHA are required for trusted PR-scope Strix evidence."
             exit 1
           fi
+          gh auth setup-git
           if ! [[ "$PR_HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "::error::PR head SHA must be a 40-character git SHA."
             exit 1

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -115,6 +115,20 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" '[[ "$PR_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]' "strix workflow validates PR base SHA before trusted fetch"
 	assert_file_contains "$workflow_file" 'fetch --no-tags --depth=1 origin "$PR_BASE_SHA"' "strix workflow fetches manual PR-scope base commit for diffing"
 	assert_file_contains "$workflow_file" "refs/remotes/pull" "strix workflow verifies fetched PR head ref"
+	local pr_head_fetch_block
+	pr_head_fetch_block="$(
+		awk '
+			/- name: Fetch pull request head for trusted scan/ { in_block = 1 }
+			in_block && /- name: Self-test Strix gate script/ { exit }
+			in_block { print }
+		' "$workflow_file"
+	)"
+	if [[ "$pr_head_fetch_block" != *'GH_TOKEN: ${{ github.token }}'* ]]; then
+		record_failure "strix workflow passes GH_TOKEN to PR head fetch step"
+	fi
+	if [[ "$pr_head_fetch_block" != *"gh auth setup-git"* ]]; then
+		record_failure "strix workflow configures git credentials in PR head fetch step"
+	fi
 	assert_file_contains "$workflow_file" "for pr_head_fetch_attempt in 1 2 3 4 5 6" "strix workflow retries stale PR head ref propagation"
 	assert_file_contains "$workflow_file" "PR head ref did not resolve to expected commit" "strix workflow fails closed when PR head ref remains stale"
 	assert_file_contains "$workflow_file" "sleep 10" "strix workflow waits between stale PR head ref retries"


### PR DESCRIPTION
Fix the canonical Strix workflow so the pull_request_target PR-head fetch step has GH_TOKEN available and refreshes git credentials in that step. This keeps the trusted-workspace flow intact while preventing unauthenticated HTTPS fetch failures on follow-up PRs.\n\nValidation:\n- bash -n scripts/ci/strix_quick_gate.sh scripts/ci/strix_model_utils.sh scripts/ci/test_strix_quick_gate.sh\n- bash scripts/ci/test_strix_quick_gate.sh