### PR TITLE
feat: 이메일 상세뷰 InsightCard LLM Confidence 연동

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2026-06-10 - Optimize redundant dictionary lookups in tight loops
  **Learning:** Using `dict.setdefault` and multiple `dict.get` or `key in dict` checks inside tight loops significantly impacts performance due to repeated dictionary lookups and unnecessary list allocations. Caching dictionary lookups (e.g., using a single `dict.get(key)`) and conditionally handling the logic based on the result is much more performant.
  **Action:** When aggregating or grouping items in a loop, avoid `setdefault`. Instead, check if the key exists using a single `.get()`, and perform initialization/updates conditionally. Additionally, hoist loop-invariant checks (e.g., `folder == "sent"`) outside the loop to avoid redundant evaluations.
+
+## 2025-02-12 - Handle UI Rendering with Optional Number Values
+**Learning:** When displaying numerical data in React where `0` is a valid number, using truthiness checks like `{value && (<div>{value}%</div>)}` will skip rendering when `value === 0` because `0` is falsy in JavaScript.
+**Action:** When handling optional numerical data (e.g., confidence scores, indices, percentages), always explicitly check for `!== undefined` or `!== null` (e.g., `{confidence !== undefined && (...)}`) instead of relying on generic truthiness to ensure valid `0` values render properly and safely.

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -26,6 +26,7 @@ type EmailData = ThreadEmailData & {
 interface LlmData {
   summary: string;
   todos: string[];
+  confidence?: number;
 }
 
 interface CreateTasksFromEmailResponse {
@@ -356,7 +357,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             loading={!llmData && !llmError}
             error={llmError}
             provenance="AI 생성"
-            // TODO: API 연동 시 실제 llmData.confidence 값으로 대체
+            confidence={llmData?.confidence !== undefined ? Math.round(llmData.confidence * 100) : undefined}
           >
             {llmData ? (
               <div className="flex flex-col gap-2">
@@ -378,7 +379,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             empty={Boolean(llmData && llmData.todos.length === 0)}
             emptyMessage="실행 항목이 없습니다."
             provenance={`${llmData?.todos.length || 0}개 실행 항목`}
-            // TODO: API 연동 시 실제 llmData.confidence 값으로 대체
+            confidence={llmData?.confidence !== undefined ? Math.round(llmData.confidence * 100) : undefined}
             footerActions={llmData && (llmData.todos.length > 0 || syncStatus || taskStatus) ? (
               <>
                 {llmData.todos.length > 0 && (


### PR DESCRIPTION
이메일 상세 뷰에서 AI 기반 요약과 실행 항목 InsightCard 컴포넌트에 사용되는 신뢰도 값을 API에서 제공되는 실제 `llmData.confidence` 데이터를 백분율로 환산하여 반영하도록 업데이트했습니다.

**변경사항:**
- `LlmData` 인터페이스에 `confidence?: number;` 속성을 추가
- 맥락 종합 `InsightCard`에 `confidence` prop 값으로 `Math.round(llmData.confidence * 100)`을 계산하여 전달하도록 연동
- 실행 항목 `InsightCard`에 `confidence` prop 값으로 `Math.round(llmData.confidence * 100)`을 계산하여 전달하도록 연동
- 하드코딩되었던 TODO 주석 제거

---
*PR created automatically by Jules for task [17512005730989805150](https://jules.google.com/task/17512005730989805150) started by @seonghobae*