### PR TITLE
feat(ui): display LLM confidence in EmailDetail InsightCards

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -3,7 +3,7 @@ import logging
 from openai import AsyncOpenAI
 from core.config import settings
 from core.exceptions import LLMServiceError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.llm_provider_urls import build_llm_provider_http_client
 
 logger = logging.getLogger(__name__)
@@ -13,6 +13,7 @@ class ExtractionResult(BaseModel):
     summary: str
     todos: list[str]
     provenance: str | None = None
+    confidence: int = Field(description="Confidence score from 0 to 100")
 
 
 async def extract_todos_and_summary(

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -13,7 +13,12 @@ class ExtractionResult(BaseModel):
     summary: str
     todos: list[str]
     provenance: str | None = None
-    confidence: int = Field(description="Confidence score from 0 to 100")
+    confidence: int | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Optional confidence score from 0 to 100",
+    )
 
 
 async def extract_todos_and_summary(
@@ -37,7 +42,11 @@ async def extract_todos_and_summary(
             messages=[
                 {
                     "role": "system",
-                    "content": "You are a helpful assistant. Summarize the email and extract action items.",
+                    "content": (
+                        "You are a helpful assistant. Summarize the email, "
+                        "extract action items, and include a confidence score "
+                        "from 0 to 100 when enough evidence is available."
+                    ),
                 },
                 {"role": "user", "content": email_body},
             ],

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -48,7 +48,7 @@ def test_llm_endpoints_exist(mock_draft, mock_extract, client):
     from services.llm_service import ExtractionResult
 
     mock_extract.return_value = ExtractionResult(
-        summary="Test summary", todos=["Task 1"]
+        summary="Test summary", todos=["Task 1"], provenance="OpenAI", confidence=90
     )
     mock_draft.return_value = "This is a draft reply."
 
@@ -66,7 +66,7 @@ def test_summarize_endpoint(mock_extract, client):
     from services.llm_service import ExtractionResult
 
     mock_extract.return_value = ExtractionResult(
-        summary="Test summary", todos=["Task 1"]
+        summary="Test summary", todos=["Task 1"], provenance="OpenAI", confidence=90
     )
 
     resp = client.post("/api/llm/summarize", json={"email_body": "test email"})
@@ -74,7 +74,8 @@ def test_summarize_endpoint(mock_extract, client):
     assert resp.json() == {
         "summary": "Test summary",
         "todos": ["Task 1"],
-        "provenance": None,
+        "provenance": "OpenAI",
+        "confidence": 90,
     }
 
 

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -176,7 +176,7 @@ async def test_extract_todos_and_summary_success(mock_openai):
     # Setup mock response
     mock_response = MagicMock()
     mock_message = MagicMock()
-    mock_message.parsed = ExtractionResult(summary="Test summary", todos=["Task 1"])
+    mock_message.parsed = ExtractionResult(summary="Test summary", todos=["Task 1"], confidence=90)
     mock_choice = MagicMock()
     mock_choice.message = mock_message
     mock_response.choices = [mock_choice]
@@ -225,7 +225,7 @@ async def test_extract_todos_and_summary_disables_redirect_following_for_custom_
         mock_client.close = AsyncMock()
         mock_response = MagicMock()
         mock_message = MagicMock()
-        mock_message.parsed = ExtractionResult(summary="Test summary", todos=["Task 1"])
+        mock_message.parsed = ExtractionResult(summary="Test summary", todos=["Task 1"], confidence=90)
         mock_choice = MagicMock()
         mock_choice.message = mock_message
         mock_response.choices = [mock_choice]

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -26,6 +26,25 @@ def mock_openai():
 # Removed reset_client fixture
 
 
+def test_extraction_result_confidence_is_optional_and_bounded():
+    omitted = ExtractionResult(summary="Test summary", todos=[])
+    assert omitted.confidence is None
+
+    assert ExtractionResult(
+        summary="Test summary",
+        todos=[],
+        confidence=0,
+    ).confidence == 0
+    assert ExtractionResult(
+        summary="Test summary",
+        todos=[],
+        confidence=100,
+    ).confidence == 100
+
+    with pytest.raises(ValueError):
+        ExtractionResult(summary="Test summary", todos=[], confidence=101)
+
+
 @pytest.mark.asyncio
 async def test_llm_provider_pinned_backend_uses_validated_ip_address():
     calls = []

--- a/frontend/src/components/EmailDetail.test.tsx
+++ b/frontend/src/components/EmailDetail.test.tsx
@@ -280,6 +280,7 @@ describe("EmailDetail", () => {
         return Promise.resolve(jsonResponse({
           summary: "출시 메시지의 핵심 맥락입니다.",
           todos: ["캘린더에 출시 리뷰 일정을 반영", "답장 초안 준비"],
+          confidence: 0.82,
         }));
       }
       throw new Error(`Unexpected fetch: ${url}`);
@@ -300,7 +301,9 @@ describe("EmailDetail", () => {
     );
     expect(cards.find((card) => card.getAttribute("aria-label") === "답장 초안")?.querySelector('[role="heading"][aria-level="3"]')?.textContent).toContain("답장 초안");
     expect(cards.find((card) => card.getAttribute("aria-label") === "맥락 종합")?.textContent).toContain("출시 메시지의 핵심 맥락입니다.");
+    expect(cards.find((card) => card.getAttribute("aria-label") === "맥락 종합")?.textContent).toContain("82%");
     expect(cards.find((card) => card.getAttribute("aria-label") === "실행 항목")?.textContent).toContain("캘린더에 출시 리뷰 일정을 반영");
+    expect(cards.find((card) => card.getAttribute("aria-label") === "실행 항목")?.textContent).toContain("82%");
     expect(cards.find((card) => card.getAttribute("aria-label") === "답장 초안")?.querySelector('textarea[aria-label="답장 초안"]')).not.toBeNull();
   });
 

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -30,6 +30,15 @@ interface LlmData {
   confidence?: number;
 }
 
+function toConfidencePercent(confidence: number | undefined): number | undefined {
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) {
+    return undefined;
+  }
+
+  const percent = confidence >= 0 && confidence <= 1 ? confidence * 100 : confidence;
+  return Math.round(Math.min(100, Math.max(0, percent)));
+}
+
 interface CreateTasksFromEmailResponse {
   created: number;
 }
@@ -318,6 +327,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
   const safeEmailSender = toMailDisplayText(email.sender, '보낸 사람');
   const safeEmailSubject = toMailDisplayText(email.subject, '(제목 없음)');
   const safeReplyTo = toMailDisplayText(email.reply_to || email.sender, '답장 주소 없음');
+  const confidencePercent = toConfidencePercent(llmData?.confidence);
 
   return (
     <div className="flex h-full flex-col bg-card">
@@ -358,7 +368,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             loading={!llmData && !llmError}
             error={llmError}
             provenance={llmData?.provenance || "AI 생성"}
-            confidence={llmData?.confidence}
+            confidence={confidencePercent}
           >
             {llmData ? (
               <div className="flex flex-col gap-2">
@@ -380,7 +390,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             empty={Boolean(llmData && llmData.todos.length === 0)}
             emptyMessage="실행 항목이 없습니다."
             provenance={`${llmData?.todos.length || 0}개 실행 항목`}
-            confidence={llmData?.confidence}
+            confidence={confidencePercent}
             footerActions={llmData && (llmData.todos.length > 0 || syncStatus || taskStatus) ? (
               <>
                 {llmData.todos.length > 0 && (

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -26,6 +26,8 @@ type EmailData = ThreadEmailData & {
 interface LlmData {
   summary: string;
   todos: string[];
+  provenance?: string;
+  confidence?: number;
 }
 
 interface CreateTasksFromEmailResponse {
@@ -355,8 +357,8 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             icon={<span aria-hidden="true">✦</span>}
             loading={!llmData && !llmError}
             error={llmError}
-            provenance="AI 생성"
-            // TODO: API 연동 시 실제 llmData.confidence 값으로 대체
+            provenance={llmData?.provenance || "AI 생성"}
+            confidence={llmData?.confidence}
           >
             {llmData ? (
               <div className="flex flex-col gap-2">
@@ -378,7 +380,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
             empty={Boolean(llmData && llmData.todos.length === 0)}
             emptyMessage="실행 항목이 없습니다."
             provenance={`${llmData?.todos.length || 0}개 실행 항목`}
-            // TODO: API 연동 시 실제 llmData.confidence 값으로 대체
+            confidence={llmData?.confidence}
             footerActions={llmData && (llmData.todos.length > 0 || syncStatus || taskStatus) ? (
               <>
                 {llmData.todos.length > 0 && (


### PR DESCRIPTION
This PR addresses the task: "Use actual confidence value from API in InsightCard provenance".

**Changes:**
1.  **Backend (`llm_service.py`, tests):**
    *   Added a `confidence: int` field with a Pydantic `Field(description=...)` to `ExtractionResult`. This utilizes OpenAI's structured output parser to natively deduce a confidence score during summarization and extraction.
    *   Updated the tests in `test_llm_api.py` and `test_llm_service.py` to mock the newly required `confidence` attribute.
2.  **Frontend (`EmailDetail.tsx`):**
    *   Extended `LlmData` interface to accommodate `confidence` and `provenance`.
    *   Replaced the hardcoded static `provenance` value strings with actual logic and `llmData?.confidence` in both `<InsightCard>` calls (맥락 종합 and 실행 항목), fulfilling the `// TODO` requirement.

---
*PR created automatically by Jules for task [17844120233744292361](https://jules.google.com/task/17844120233744292361) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated summaries and extracted tasks now display confidence scores (0–100) indicating extraction reliability.
  * Source attribution for AI-generated content is now properly displayed throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->