### PR TITLE
🧹 [Code Health] detect_reply_tracking 함수 위치 및 서명 리팩터링

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -19,12 +19,6 @@ def generate_email_fingerprint(email_data: Dict[str, Any]) -> str:
     raw_str = f"{sender}|{subject}|{date}|{body_snippet}"
     return hashlib.sha256(raw_str.encode("utf-8")).hexdigest()
 
-def detect_reply_tracking(email_data: Dict[str, Any]) -> bool:
-    """
-    Detects if the user sent an email that expects a reply.
-    """
-    body = str(email_data.get("body") or "").lower()
-    return "please reply" in body or "?" in body
 
 def process_self_to_self(email_data: Dict[str, Any], user_email: str) -> bool:
     """

--- a/backend/services/reply_tracking_service.py
+++ b/backend/services/reply_tracking_service.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from db.models import Email, TenantConfig
 from services.tenant_config_scope import get_scoped_tenant_config
-from services.email_service import detect_reply_tracking
+
 from services.threading_service import normalize_message_id
 import datetime
 import email.utils as email_utils
@@ -68,6 +68,14 @@ def reply_tracking_thread_key(email_message: Email) -> str:
     return normalized_key or email_message.message_id
 
 
+
+def detect_reply_tracking(body: str | None) -> bool:
+    """
+    Detects if the user sent an email that expects a reply.
+    """
+    body_str = str(body or "").lower()
+    return "please reply" in body_str or "?" in body_str
+
 def thread_reply_candidate(
     thread_messages: list[Email], user_addresses: set[str]
 ) -> Email | None:
@@ -91,7 +99,7 @@ def thread_reply_candidate(
                 and latest_external_date > message.date
             )
             if not has_later_external_reply:
-                if detect_reply_tracking({"body": message.body}):
+                if detect_reply_tracking(message.body):
                     return message
 
     return None

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,7 +1,6 @@
 import hashlib
 
 from services.email_service import (
-    detect_reply_tracking,
     generate_email_fingerprint,
     process_self_to_self,
 )
@@ -67,25 +66,6 @@ class TestEmailService:
         assert generate_email_fingerprint(email_data) == generate_email_fingerprint(
             email_data.copy()
         )
-
-    def test_detect_reply_tracking_please_reply(self):
-        assert detect_reply_tracking(
-            {"body": "This is an important message, please reply soon."}
-        ) is True
-
-    def test_detect_reply_tracking_question_mark(self):
-        assert detect_reply_tracking({"body": "How are you doing today?"}) is True
-
-    def test_detect_reply_tracking_case_insensitive(self):
-        assert detect_reply_tracking({"body": "Please Reply to this email."}) is True
-
-    def test_detect_reply_tracking_no_match(self):
-        assert detect_reply_tracking(
-            {"body": "This is a standard statement without any tracking triggers."}
-        ) is False
-
-    def test_detect_reply_tracking_empty_body(self):
-        assert detect_reply_tracking({}) is False
 
     def test_process_self_to_self_basic(self):
         email_data = {

--- a/backend/tests/test_reply_tracking_service.py
+++ b/backend/tests/test_reply_tracking_service.py
@@ -1,7 +1,7 @@
 import datetime
 
 from db.models import Email
-from services.reply_tracking_service import thread_reply_candidate
+from services.reply_tracking_service import thread_reply_candidate, detect_reply_tracking
 
 
 USER_ADDRESSES = {"me@example.com"}
@@ -155,3 +155,21 @@ def test_thread_requires_reply_returns_false_when_no_candidate():
         body="I will handle it.",
     )
     assert thread_requires_reply([sent_message, later_external_reply], USER_ADDRESSES) is False
+
+def test_detect_reply_tracking_please_reply():
+    assert detect_reply_tracking("This is an important message, please reply soon.") is True
+
+def test_detect_reply_tracking_question_mark():
+    assert detect_reply_tracking("How are you doing today?") is True
+
+def test_detect_reply_tracking_case_insensitive():
+    assert detect_reply_tracking("Please Reply to this email.") is True
+
+def test_detect_reply_tracking_no_match():
+    assert detect_reply_tracking(
+        "This is a standard statement without any tracking triggers."
+    ) is False
+
+def test_detect_reply_tracking_empty_body():
+    assert detect_reply_tracking(None) is False
+    assert detect_reply_tracking("") is False


### PR DESCRIPTION
🎯 **What:** `detect_reply_tracking` 함수가 `email_service.py` 에서 `reply_tracking_service.py` 로 이동되었으며, 더 직관적인 서명을 갖도록 리팩터링되었습니다 (`Dict` 대신 `body: str | None` 을 직접 받음). 이 함수의 관련 테스트들도 이동되었습니다.

💡 **Why:** `detect_reply_tracking` 함수는 `email_service.py`에서는 사용되지 않았고 오직 `reply_tracking_service.py`에서만 쓰이고 있었습니다. 함수를 그것이 사용되는 곳에 더 가깝게 배치하여 코드 지역성(locality)을 개선하였고, 파라미터로 불필요한 dictionary 구조를 넘기는 대신 깔끔하게 string 형식으로 넘기도록 변경하여 코드의 가독성과 유지보수성을 향상시켰습니다. 기능상의 변경은 없습니다.

✅ **Verification:**
- 백엔드 유닛 테스트들 (`test_email_service.py`, `test_reply_tracking_service.py`, `test_reply_tracking.py`) 이 모두 문제 없이 통과하는 것을 확인했습니다.
- 이동된 테스트 및 사용처 모두 새 시그니처에 맞게 호출하도록 업데이트되었으며 정상 동작함을 확인했습니다.

✨ **Result:**
- `detect_reply_tracking`의 사용 위치와 선언 위치가 통일되어 유지보수가 용이해졌습니다.
- 파라미터 타입이 단순해져 함수의 의도가 명확해졌고 호출부의 코드도 간결해졌습니다.

---
*PR created automatically by Jules for task [17916730904915005271](https://jules.google.com/task/17916730904915005271) started by @seonghobae*