### PR TITLE
Add signed email file import

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import or_, select
 from db.session import get_db
@@ -25,6 +25,13 @@ from services.email_dedupe_service import (
     candidate_message_lookup_values,
     candidate_strong_fingerprint,
     email_strong_fingerprint,
+)
+from services.email_import_service import (
+    MAX_IMPORT_UPLOAD_BYTES,
+    MAX_IMPORT_UPLOADS,
+    EmailImportItemStatus,
+    EmailImportUpload,
+    import_email_uploads,
 )
 from services.text_safety import strip_html_markup
 import logging
@@ -207,6 +214,25 @@ class UniqueThreadIntentResponse(BaseModel):
     provenance: Literal["server-authoritative"]
     provider_write_executed: bool
     audit_event: Literal["email.unique_thread_intent.created"]
+
+
+class EmailFileImportItem(BaseModel):
+    filename: str
+    status: EmailImportItemStatus
+    reason_code: str | None = None
+    attachment_count: int = 0
+
+
+class EmailFileImportResponse(BaseModel):
+    status: Literal["completed"]
+    imported_count: int
+    skipped_count: int
+    failed_count: int
+    attachment_count: int
+    items: list[EmailFileImportItem]
+    provenance: Literal["server-authoritative"]
+    provider_write_executed: bool
+    audit_event: Literal["email.file_import.completed"]
 
 
 @router.get("", response_model=dict[str, list[EmailListItem]])
@@ -449,6 +475,56 @@ async def create_unique_thread_intent(
         provenance="server-authoritative",
         provider_write_executed=False,
         audit_event="email.unique_thread_intent.created",
+    )
+
+
+@router.post("/import-files", response_model=EmailFileImportResponse)
+async def import_email_files(
+    files: list[UploadFile] = File(...),
+    db: AsyncSession = Depends(get_db),
+    auth_context: AuthContext = Depends(get_auth_context),
+):
+    if auth_context.organization_id is None:
+        raise HTTPException(status_code=403, detail="organization_required")
+    if len(files) > MAX_IMPORT_UPLOADS:
+        raise HTTPException(status_code=422, detail="too_many_files")
+
+    uploads: list[EmailImportUpload] = []
+    for upload in files:
+        content = await upload.read(MAX_IMPORT_UPLOAD_BYTES + 1)
+        if len(content) > MAX_IMPORT_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="file_too_large")
+        uploads.append(
+            EmailImportUpload(
+                filename=upload.filename or "upload",
+                content=content,
+            )
+        )
+
+    import_result = await import_email_uploads(
+        db,
+        uploads=uploads,
+        user_id=auth_context.user_id,
+        organization_id=auth_context.organization_id,
+    )
+    return EmailFileImportResponse(
+        status="completed",
+        imported_count=import_result.imported_count,
+        skipped_count=import_result.skipped_count,
+        failed_count=import_result.failed_count,
+        attachment_count=import_result.attachment_count,
+        items=[
+            EmailFileImportItem(
+                filename=item.filename,
+                status=item.status,
+                reason_code=item.reason_code,
+                attachment_count=item.attachment_count,
+            )
+            for item in import_result.items
+        ],
+        provenance="server-authoritative",
+        provider_write_executed=False,
+        audit_event="email.file_import.completed",
     )
 
 

--- a/backend/services/email_import_service.py
+++ b/backend/services/email_import_service.py
@@ -1,0 +1,293 @@
+import datetime
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Literal
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Attachment, Email
+from services.archive import extract_backup_async
+from services.email_dedupe_service import strong_email_fingerprint
+from services.email_parser import EmailData, parse_eml
+from services.exceptions import ArchiveError, EmailParseError
+from services.threading_service import (
+    assign_thread_id,
+    email_owner_filters,
+    generate_email_fingerprint,
+    normalize_message_id,
+)
+
+EMBEDDING_DIMENSION = 1536
+MAX_IMPORT_UPLOADS = 10
+MAX_IMPORT_UPLOAD_BYTES = 20 * 1024 * 1024
+MAX_IMPORT_EML_FILES = 100
+
+EmailImportItemStatus = Literal["imported", "skipped_duplicate", "failed"]
+
+
+@dataclass(frozen=True)
+class EmailImportUpload:
+    filename: str
+    content: bytes
+
+
+@dataclass
+class EmailImportItemResult:
+    filename: str
+    status: EmailImportItemStatus
+    reason_code: str | None = None
+    attachment_count: int = 0
+
+
+@dataclass
+class EmailImportResult:
+    imported_count: int = 0
+    skipped_count: int = 0
+    failed_count: int = 0
+    attachment_count: int = 0
+    items: list[EmailImportItemResult] = field(default_factory=list)
+
+    def add_item(self, item: EmailImportItemResult) -> None:
+        self.items.append(item)
+        if item.status == "imported":
+            self.imported_count += 1
+            self.attachment_count += item.attachment_count
+        elif item.status == "skipped_duplicate":
+            self.skipped_count += 1
+        else:
+            self.failed_count += 1
+
+
+def _safe_upload_filename(filename: str) -> str:
+    name = Path(filename or "upload").name.strip()
+    return name or "upload"
+
+
+def _safe_item_filename(upload_name: str, eml_path: Path | None = None) -> str:
+    safe_upload_name = _safe_upload_filename(upload_name)
+    if eml_path is None or eml_path.name == safe_upload_name:
+        return safe_upload_name
+    return f"{safe_upload_name}:{eml_path.name}"
+
+
+def _utc_datetime(value: object) -> datetime.datetime:
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _fallback_message_id(content: bytes) -> str:
+    digest = hashlib.sha256(content).hexdigest()
+    return f"import-{digest}@local.naruon"
+
+
+def _message_id_for(parsed: EmailData, content: bytes) -> str:
+    return normalize_message_id(parsed.get("message_id")) or _fallback_message_id(content)
+
+
+def _email_fingerprint(parsed: EmailData, persisted_date: datetime.datetime) -> str:
+    strong_fingerprint = strong_email_fingerprint(
+        sender=parsed.get("sender"),
+        subject=parsed.get("subject"),
+        date=persisted_date,
+        body=parsed.get("body"),
+    )
+    if strong_fingerprint:
+        return strong_fingerprint
+    return generate_email_fingerprint(
+        parsed.get("subject"),
+        persisted_date.isoformat(),
+        parsed.get("sender"),
+        parsed.get("recipients"),
+    )
+
+
+async def _find_existing_email(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    organization_id: str,
+    message_id: str,
+    fingerprint: str,
+) -> Email | None:
+    message_lookup_values = {message_id, f"<{message_id}>"}
+    result = await session.execute(
+        select(Email).where(
+            *email_owner_filters(user_id, organization_id),
+            or_(
+                Email.message_id.in_(message_lookup_values),
+                Email.fingerprint == fingerprint,
+            ),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _import_single_eml(
+    session: AsyncSession,
+    *,
+    eml_path: Path,
+    display_filename: str,
+    user_id: str,
+    organization_id: str,
+) -> EmailImportItemResult:
+    content = eml_path.read_bytes()
+    try:
+        parsed = parse_eml(eml_path)
+    except EmailParseError:
+        return EmailImportItemResult(
+            filename=display_filename,
+            status="failed",
+            reason_code="parse_failed",
+        )
+
+    message_id = _message_id_for(parsed, content)
+    parsed["message_id"] = message_id
+    persisted_date = _utc_datetime(parsed.get("date"))
+    fingerprint = _email_fingerprint(parsed, persisted_date)
+
+    existing_email = await _find_existing_email(
+        session,
+        user_id=user_id,
+        organization_id=organization_id,
+        message_id=message_id,
+        fingerprint=fingerprint,
+    )
+    if existing_email is not None:
+        return EmailImportItemResult(
+            filename=display_filename,
+            status="skipped_duplicate",
+            reason_code="duplicate_email",
+        )
+
+    thread_id = await assign_thread_id(
+        session,
+        parsed,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    email_obj = Email(
+        user_id=user_id,
+        organization_id=organization_id,
+        message_id=message_id,
+        thread_id=thread_id,
+        fingerprint=fingerprint,
+        sender=parsed.get("sender", ""),
+        reply_to=parsed.get("reply_to"),
+        recipients=parsed.get("recipients"),
+        subject=parsed.get("subject"),
+        in_reply_to=parsed.get("in_reply_to"),
+        references=parsed.get("references"),
+        date=persisted_date,
+        body=parsed.get("body", ""),
+        embedding=[0.0] * EMBEDDING_DIMENSION,
+    )
+
+    attachment_count = 0
+    for attachment in parsed.get("attachments", []):
+        email_obj.attachments.append(
+            Attachment(
+                filename=str(attachment.get("filename") or "attachment.txt"),
+                content=str(attachment.get("content") or ""),
+                embedding=[0.0] * EMBEDDING_DIMENSION,
+            )
+        )
+        attachment_count += 1
+
+    session.add(email_obj)
+    try:
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        return EmailImportItemResult(
+            filename=display_filename,
+            status="failed",
+            reason_code="database_commit_failed",
+        )
+
+    return EmailImportItemResult(
+        filename=display_filename,
+        status="imported",
+        attachment_count=attachment_count,
+    )
+
+
+async def _eml_paths_for_upload(
+    *,
+    upload: EmailImportUpload,
+    upload_dir: Path,
+) -> tuple[list[Path], str | None]:
+    upload_name = _safe_upload_filename(upload.filename)
+    upload_path = upload_dir / upload_name
+    upload_path.write_bytes(upload.content)
+
+    suffix = upload_path.suffix.lower()
+    if suffix == ".eml":
+        return [upload_path], None
+    if suffix != ".zip":
+        return [], "unsupported_file_type"
+
+    extract_dir = upload_dir / "extracted"
+    try:
+        extracted_paths = await extract_backup_async(upload_path, extract_dir)
+    except ArchiveError:
+        return [], "archive_extract_failed"
+
+    eml_paths = [
+        path
+        for path in extracted_paths
+        if path.is_file() and path.suffix.lower() == ".eml"
+    ]
+    if not eml_paths:
+        return [], "archive_contains_no_eml"
+    if len(eml_paths) > MAX_IMPORT_EML_FILES:
+        return [], "archive_too_many_eml_files"
+    return eml_paths, None
+
+
+async def import_email_uploads(
+    session: AsyncSession,
+    *,
+    uploads: list[EmailImportUpload],
+    user_id: str,
+    organization_id: str,
+) -> EmailImportResult:
+    result = EmailImportResult()
+
+    with TemporaryDirectory(prefix="naruon-email-import-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        for index, upload in enumerate(uploads):
+            upload_name = _safe_upload_filename(upload.filename)
+            upload_dir = temp_dir / f"upload_{index}"
+            upload_dir.mkdir(parents=True, exist_ok=True)
+            eml_paths, failure_reason = await _eml_paths_for_upload(
+                upload=upload,
+                upload_dir=upload_dir,
+            )
+            if failure_reason is not None:
+                result.add_item(
+                    EmailImportItemResult(
+                        filename=upload_name,
+                        status="failed",
+                        reason_code=failure_reason,
+                    )
+                )
+                continue
+
+            for eml_path in eml_paths:
+                result.add_item(
+                    await _import_single_eml(
+                        session,
+                        eml_path=eml_path,
+                        display_filename=_safe_item_filename(upload_name, eml_path),
+                        user_id=user_id,
+                        organization_id=organization_id,
+                    )
+                )
+
+    return result

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1,9 +1,11 @@
 import base64
 import hashlib
 import hmac
+import io
 import json
 import os
 import time
+import zipfile
 
 import pytest
 import pytest_asyncio
@@ -165,6 +167,29 @@ class ScalarQueryCapturingSession(MockSession):
         return await super().scalar(query)
 
 
+class ImportRecordingSession(MockSession):
+    def __init__(self, items, tenant_config=_DEFAULT_TENANT_CONFIG):
+        super().__init__(items, tenant_config=tenant_config)
+        self.added = []
+        self.queries = []
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, query):
+        self.queries.append(query)
+        return await super().execute(query)
+
+    def add(self, item):
+        self.added.append(item)
+        self.items.append(item)
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
 def compiled_query_text(query) -> str:
     return str(query).lower()
 
@@ -181,6 +206,30 @@ def assert_query_is_owner_scoped(query) -> None:
     assert "emails.organization_id = :organization_id_1" in query_text
     assert query_params["user_id_1"] == "testuser"
     assert query_params["organization_id_1"] == "org-acme"
+
+
+def _sample_eml_bytes(
+    *,
+    message_id: str = "<imported@example.com>",
+    subject: str = "Quarter plan",
+    body: str = "Body text",
+) -> bytes:
+    return (
+        "Message-ID: {message_id}\r\n"
+        "Date: Thu, 11 Jun 2026 10:00:00 +0000\r\n"
+        "From: Partner <partner@example.com>\r\n"
+        "To: User <user@example.com>\r\n"
+        "Subject: {subject}\r\n"
+        "\r\n"
+        "{body}\r\n"
+    ).format(message_id=message_id, subject=subject, body=body).encode("utf-8")
+
+
+def _zip_with_eml_bytes(filename: str, eml_bytes: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(filename, eml_bytes)
+    return buffer.getvalue()
 
 
 @pytest.fixture
@@ -615,6 +664,241 @@ def test_unique_email_thread_intent_accepts_signed_bearer_session(db_session):
     assert response.status_code == 200
     data = response.json()
     assert data["thread_updates"][0]["canonical_thread_id"] == "signed-thread"
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_persists_signed_scoped_eml_upload(
+    client: AsyncClient,
+):
+    from db.session import get_db
+
+    session = ImportRecordingSession([])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "customer-source.eml",
+                        _sample_eml_bytes(
+                            message_id="<imported@example.com>",
+                            subject="<script>bad()</script>Quarter plan",
+                            body="<p>Body text</p>",
+                        ),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "completed"
+    assert data["imported_count"] == 1
+    assert data["skipped_count"] == 0
+    assert data["failed_count"] == 0
+    assert data["provider_write_executed"] is False
+    assert data["provenance"] == "server-authoritative"
+    assert data["items"] == [
+        {
+            "filename": "customer-source.eml",
+            "status": "imported",
+            "reason_code": None,
+            "attachment_count": 0,
+        }
+    ]
+    assert "imported@example.com" not in json.dumps(data)
+
+    assert session.commit_count == 1
+    assert session.rollback_count == 0
+    assert len(session.added) == 1
+    added_email = session.added[0]
+    assert added_email.user_id == "testuser"
+    assert added_email.organization_id == "org-acme"
+    assert added_email.message_id == "imported@example.com"
+    assert added_email.subject == "Quarter plan"
+    assert added_email.body == "Body text"
+    assert added_email.fingerprint
+    assert len(added_email.embedding) == 1536
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_skips_duplicate_message_id(client: AsyncClient):
+    from db.session import get_db
+
+    existing_email = Email(
+        id=80,
+        user_id="testuser",
+        organization_id="org-acme",
+        message_id="<duplicate@example.com>",
+        thread_id="duplicate-thread",
+        sender="partner@example.com",
+        recipients="user@example.com",
+        subject="Duplicate",
+        date=datetime.datetime(2026, 6, 11, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Existing body",
+        embedding=[0.0] * 1536,
+    )
+    session = ImportRecordingSession([existing_email])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "duplicate.eml",
+                        _sample_eml_bytes(
+                            message_id="<duplicate@example.com>",
+                            subject="Duplicate",
+                            body="Existing body",
+                        ),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 0
+    assert data["skipped_count"] == 1
+    assert data["failed_count"] == 0
+    assert data["items"][0]["status"] == "skipped_duplicate"
+    assert data["items"][0]["reason_code"] == "duplicate_email"
+    assert session.added == []
+    assert session.commit_count == 0
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_extracts_eml_from_zip(client: AsyncClient):
+    from db.session import get_db
+
+    session = ImportRecordingSession([])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "email-archive.zip",
+                        _zip_with_eml_bytes(
+                            "nested/source.eml",
+                            _sample_eml_bytes(message_id="<zip-source@example.com>"),
+                        ),
+                        "application/zip",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 1
+    assert data["items"][0]["filename"] == "email-archive.zip:source.eml"
+    assert session.added[0].message_id == "zip-source@example.com"
+
+
+def test_import_email_files_accepts_signed_bearer_session(db_session):
+    from db.session import get_db
+
+    session = ImportRecordingSession([])
+    token = _signed_session_token(_valid_session_payload())
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    previous_auth_override = app.dependency_overrides.pop(auth_get_auth_context, None)
+    previous_db_override = app.dependency_overrides.get(get_db)
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = TestClient(app).post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "signed-source.eml",
+                        _sample_eml_bytes(message_id="<signed-import@example.com>"),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    finally:
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+        if previous_auth_override is not None:
+            app.dependency_overrides[auth_get_auth_context] = previous_auth_override
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 1
+    assert session.added[0].user_id == "testuser"
+    assert session.added[0].organization_id == "org-acme"
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_duplicate_query_is_owner_scoped(
+    client: AsyncClient,
+):
+    from db.session import get_db
+
+    session = ImportRecordingSession([])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "scoped-source.eml",
+                        _sample_eml_bytes(message_id="<scoped-import@example.com>"),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    assert session.queries
+    assert_query_is_owner_scoped(session.queries[0])
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/data/page.test.tsx
+++ b/frontend/src/app/data/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock("lucide-react", () => ({
   FileText: () => <svg aria-hidden="true" />,
   CheckCircle2: () => <svg aria-hidden="true" />,
   Server: () => <svg aria-hidden="true" />,
+  Upload: () => <svg aria-hidden="true" />,
 }));
 
 import DataPage from "./page";
@@ -256,6 +257,27 @@ function mockWebdavFetch() {
             dedupe_key: "sha256:duplicate",
             match_reason: "fingerprint",
             existing_message_id: "q2-root@example.com",
+          },
+        ],
+      });
+    }
+    if (path === "/api/emails/import-files") {
+      void init;
+      return jsonResponse({
+        status: "completed",
+        imported_count: 1,
+        skipped_count: 0,
+        failed_count: 0,
+        attachment_count: 1,
+        provider_write_executed: false,
+        provenance: "server-authoritative",
+        audit_event: "email.file_import.completed",
+        items: [
+          {
+            filename: "customer-source.eml",
+            status: "imported",
+            reason_code: null,
+            attachment_count: 1,
           },
         ],
       });
@@ -706,5 +728,70 @@ describe("DataPage", () => {
     expect(container.textContent).not.toContain("email.unique_thread_intent.created");
     expect(container.textContent).not.toContain("thread-q2-root");
     expect(container.textContent).not.toContain("provider_write_executed=false");
+  });
+
+  it("imports email source files through signed multipart upload without public identity headers", async () => {
+    localStorage.setItem("naruon_session_token", "signed-email-import-session");
+    const fetchMock = mockWebdavFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<DataPage />);
+    });
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(input).toBeDefined();
+    const emailFile = new File(["raw email"], "customer-source.eml", { type: "message/rfc822" });
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [emailFile],
+    });
+    await act(async () => {
+      input?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const importButton = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("선택 파일 반입"),
+    );
+    expect(importButton).toBeDefined();
+    await act(async () => {
+      importButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const importCall = fetchMock.mock.calls.find(([inputUrl]) => String(inputUrl) === "/api/emails/import-files");
+    expect(importCall).toBeDefined();
+    const [, init] = importCall ?? [];
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBeInstanceOf(FormData);
+    const headerEntries =
+      init?.headers instanceof Headers
+        ? Array.from(init.headers.entries())
+        : Object.entries((init?.headers as Record<string, string>) ?? {});
+    const requestHeaders = Object.fromEntries(
+      headerEntries.map(([key, value]) => [key.toLowerCase(), String(value)]),
+    );
+    expect(requestHeaders).toEqual(expect.objectContaining({
+      authorization: "Bearer signed-email-import-session",
+    }));
+    expect(requestHeaders["content-type"]).toBeUndefined();
+    for (const publicHeader of [
+      "x-user-id",
+      "x-organization-id",
+      "x-group-id",
+      "x-group-ids",
+      "x-user-role",
+      "x-dev-auth-token",
+    ]) {
+      expect(requestHeaders[publicHeader]).toBeUndefined();
+    }
+    expect(container.textContent).toContain("1개 반입");
+    expect(container.textContent).toContain("중복 0개");
+    expect(container.textContent).toContain("첨부 1개");
+    expect(container.textContent).toContain("의도만 기록");
+    expect(container.textContent).not.toContain("email.file_import.completed");
+    expect(container.textContent).not.toContain("imported@example.com");
   });
 });

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useState, useEffect } from 'react';
-import { Database, FileText, HardDrive, RefreshCw, FolderOpen, CheckCircle2, Server } from 'lucide-react';
+import { useCallback, useState, useEffect, type ChangeEvent } from 'react';
+import { Database, FileText, HardDrive, RefreshCw, FolderOpen, CheckCircle2, Server, Upload } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 
 type WebdavWritebackIntentResponse = {
@@ -42,6 +42,7 @@ type UniqueThreadIntentResponse = {
 };
 
 type UniqueThreadStatus = 'idle' | 'loading' | 'success' | 'auth' | 'error';
+type EmailImportStatus = 'idle' | 'loading' | 'success' | 'auth' | 'error';
 
 type DataSurfaceStatus = 'loading' | 'ready' | 'error';
 
@@ -112,6 +113,23 @@ type DataQualitySurfaceResponse = {
     state_code: string;
     detail_text: string | null;
     observed_at: string;
+  }>;
+};
+
+type EmailFileImportResponse = {
+  status: 'completed';
+  imported_count: number;
+  skipped_count: number;
+  failed_count: number;
+  attachment_count: number;
+  provider_write_executed: boolean;
+  provenance: 'server-authoritative';
+  audit_event: 'email.file_import.completed';
+  items: Array<{
+    filename: string;
+    status: 'imported' | 'skipped_duplicate' | 'failed';
+    reason_code?: string | null;
+    attachment_count: number;
   }>;
 };
 
@@ -251,6 +269,9 @@ export function DataLayout() {
   const [writebackResult, setWritebackResult] = useState<WebdavWritebackIntentResponse | null>(null);
   const [uniqueThreadStatus, setUniqueThreadStatus] = useState<UniqueThreadStatus>('idle');
   const [uniqueThreadResult, setUniqueThreadResult] = useState<UniqueThreadIntentResponse | null>(null);
+  const [emailImportStatus, setEmailImportStatus] = useState<EmailImportStatus>('idle');
+  const [emailImportResult, setEmailImportResult] = useState<EmailFileImportResponse | null>(null);
+  const [emailImportFiles, setEmailImportFiles] = useState<File[]>([]);
   const [dataSurfaceStatus, setDataSurfaceStatus] = useState<DataSurfaceStatus>('loading');
   const [dataQualitySurface, setDataQualitySurface] = useState<DataQualitySurfaceResponse | null>(null);
   const [selectedRepositoryAssetKey, setSelectedRepositoryAssetKey] = useState<string | null>(null);
@@ -340,10 +361,37 @@ export function DataLayout() {
     }
   }, []);
 
+  const handleEmailImportFileChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setEmailImportFiles(Array.from(event.target.files ?? []));
+    setEmailImportResult(null);
+    setEmailImportStatus('idle');
+  }, []);
+
+  const requestEmailFileImport = useCallback(async () => {
+    if (emailImportFiles.length === 0) {
+      setEmailImportStatus('error');
+      return;
+    }
+
+    setEmailImportStatus('loading');
+    setEmailImportResult(null);
+    try {
+      const formData = new FormData();
+      emailImportFiles.forEach((file) => formData.append('files', file));
+      const result = await apiClient.postForm<EmailFileImportResponse>('/api/emails/import-files', formData);
+      setEmailImportResult(result);
+      setEmailImportStatus('success');
+    } catch (error: unknown) {
+      const status = getApiErrorStatus(error);
+      setEmailImportStatus(status === 401 || status === 403 ? 'auth' : 'error');
+    }
+  }, [emailImportFiles]);
+
   const isWritebackLoading = writebackStatus === 'loading';
   const isWebdavSourceLoading = webdavAccountStatus === 'loading';
   const canRequestWebdavWriteback = webdavAccountStatus === 'ready';
   const isUniqueThreadLoading = uniqueThreadStatus === 'loading';
+  const isEmailImportLoading = emailImportStatus === 'loading';
   const selectedWebdavAccount = webdavAccounts.find((account) => (
     account.source_id === selectedWebdavSourceId && account.writeback_enabled
   )) ?? webdavAccounts.find((account) => account.writeback_enabled) ?? null;
@@ -400,22 +448,56 @@ export function DataLayout() {
                       style={{ width: `${embeddingStage?.progress_percent ?? 0}%` }}
                     ></div>
                   </div>
-                  <div className="mt-4 flex flex-wrap gap-2 justify-end">
-                    <button type="button" className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground hover:bg-secondary/80">
-                      이메일 반입 (MBOX/EML)
+                  <div className="mt-4 grid gap-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <label className="inline-flex min-h-9 cursor-pointer items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs font-bold text-foreground hover:bg-secondary sm:w-fit">
+                        <Upload className="size-4" />
+                        이메일 파일 선택
+                        <input
+                          type="file"
+                          multiple
+                          accept=".eml,.zip,message/rfc822,application/zip"
+                          className="sr-only"
+                          onChange={handleEmailImportFileChange}
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => void requestEmailFileImport()}
+                        disabled={isEmailImportLoading || emailImportFiles.length === 0}
+                        aria-busy={isEmailImportLoading}
+                        className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+                      >
+                        <Upload className="size-4" />
+                        선택 파일 반입
+                      </button>
+                    </div>
+                    <div role="status" aria-live="polite" className="text-xs font-semibold text-muted-foreground">
+                      {emailImportStatus === 'idle' && emailImportFiles.length === 0 && 'EML 또는 ZIP 원본을 선택해 메일/첨부 근거로 수집합니다.'}
+                      {emailImportStatus === 'idle' && emailImportFiles.length > 0 && `${formatCount(emailImportFiles.length)}개 파일 선택됨`}
+                      {emailImportStatus === 'loading' && '이메일 원본 파일을 반입하는 중입니다.'}
+                      {emailImportStatus === 'auth' && <span className="font-bold text-red-700">signed session이 필요합니다. 공개 identity header로는 이메일 원본을 반입할 수 없습니다.</span>}
+                      {emailImportStatus === 'error' && <span className="font-bold text-red-700">이메일 원본 파일 반입에 실패했습니다.</span>}
+                      {emailImportStatus === 'success' && emailImportResult && (
+                        <span className="text-foreground">
+                          {formatCount(emailImportResult.imported_count)}개 반입 · 중복 {formatCount(emailImportResult.skipped_count)}개 · 실패 {formatCount(emailImportResult.failed_count)}개 · 첨부 {formatCount(emailImportResult.attachment_count)}개 · {getWriteBoundaryLabel(emailImportResult.provider_write_executed)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2 justify-end">
+                    <button type="button" disabled className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground opacity-50 cursor-not-allowed">
+                      문서 업로드 (준비 중)
                     </button>
-                    <button type="button" className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground hover:bg-secondary/80">
-                      문서 업로드
+                    <button type="button" disabled className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground opacity-50 cursor-not-allowed">
+                      재파싱 (준비 중)
                     </button>
-                    <button type="button" className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground hover:bg-secondary/80">
-                      재파싱
+                    <button type="button" disabled className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground opacity-50 cursor-not-allowed">
+                      임베딩 재생성 (준비 중)
                     </button>
-                    <button type="button" className="rounded bg-secondary px-3 py-1.5 text-xs font-bold text-secondary-foreground hover:bg-secondary/80">
-                      임베딩 재생성
+                    <button type="button" disabled className="rounded bg-primary/10 px-3 py-1.5 text-xs font-bold text-primary opacity-50 cursor-not-allowed">
+                      HWP 변환 (준비 중)
                     </button>
-                    <button type="button" className="rounded bg-primary/10 px-3 py-1.5 text-xs font-bold text-primary hover:bg-primary/20">
-                      HWP 변환
-                    </button>
+                    </div>
                   </div>
                 </div>
                 

--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -160,4 +160,32 @@ describe("ApiClient", () => {
     });
     expect((requestInit as RequestInit).headers).not.toHaveProperty("authorization");
   });
+
+  it("sends multipart form data with bearer auth and without caller identity headers", async () => {
+    localStorage.setItem("naruon_session_token", "signed.form.token");
+    const fetchMock = mockFetchResponse({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient();
+    const formData = new FormData();
+    formData.append("files", new File(["raw email"], "source.eml", { type: "message/rfc822" }));
+
+    await client.postForm("/api/emails/import-files", formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+        "X-User-Id": "forged-user",
+        "X-Trace-Id": "trace-456",
+      },
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBe(formData);
+    expect((requestInit as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer signed.form.token",
+      "X-Trace-Id": "trace-456",
+    });
+    expect((requestInit as RequestInit).headers).not.toHaveProperty("Content-Type");
+    expect((requestInit as RequestInit).headers).not.toHaveProperty("X-User-Id");
+  });
 });

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -44,6 +44,23 @@ export class ApiClient {
     return headers;
   }
 
+  private getFormHeaders(init?: RequestInit): HeadersInit {
+    const sessionToken = this.getSessionToken();
+    const headers: Record<string, string> = this.getSafeCallerHeaders(init?.headers);
+    Object.keys(headers).forEach((name) => {
+      if (name.toLowerCase() === 'content-type') {
+        delete headers[name];
+      }
+    });
+    if (sessionToken) {
+      return {
+        ...headers,
+        Authorization: `Bearer ${sessionToken}`,
+      };
+    }
+    return headers;
+  }
+
   private getSafeCallerHeaders(headers?: HeadersInit): Record<string, string> {
     const safeHeaders: Record<string, string> = {};
     const includeHeader = (name: string, value: string) => {
@@ -126,6 +143,21 @@ export class ApiClient {
       method: 'POST',
       headers: this.getHeaders(init),
       body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const error = new Error(`API POST ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+    return response.json();
+  }
+
+  async postForm<T>(endpoint: string, body: FormData, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...init,
+      method: 'POST',
+      headers: this.getFormHeaders(init),
+      body,
     });
     if (!response.ok) {
       const error = new Error(`API POST ${endpoint} failed: ${response.status} ${response.statusText}`) as Error & { status?: number };


### PR DESCRIPTION
## Summary
- add signed `/api/emails/import-files` multipart import for EML and ZIP uploads
- persist imported emails and text attachments with owner/org scope, thread assignment, fingerprints, duplicate skipping, and no raw message/thread identifiers in the response
- wire the Data workspace email file picker through bearer-session FormData requests while leaving future provider actions disabled

## Tests
- `PYTHONWARNINGS=ignore python -m pytest backend/tests/test_emails_api.py -q`
- `pnpm --dir frontend exec vitest run src/lib/api-client.test.ts src/app/data/page.test.tsx`
- `pnpm --dir frontend exec tsc --noEmit`
- `pnpm --dir frontend exec eslint src/lib/api-client.ts src/components/DataLayout.tsx src/lib/api-client.test.ts src/app/data/page.test.tsx`
- `ruff check backend/api/emails.py backend/services/email_import_service.py backend/tests/test_emails_api.py`