### PR TITLE
🧪 [Testing] 런타임 시크릿 유효성 검사 단위 테스트 추가

### DIFF
--- a/backend/tests/test_runtime_secrets.py
+++ b/backend/tests/test_runtime_secrets.py
@@ -1,0 +1,37 @@
+import pytest
+from core.runtime_secrets import (
+    validate_auth_session_hmac_secret_value,
+    _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS,
+    _LOW_ENTROPY_PLACEHOLDER_TERMS
+)
+
+def test_validate_auth_session_hmac_secret_value_valid():
+    validate_auth_session_hmac_secret_value("thisisaverylongandsecurestring123!")
+
+def test_validate_auth_session_hmac_secret_value_empty():
+    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+        validate_auth_session_hmac_secret_value("")
+    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+        validate_auth_session_hmac_secret_value(None)
+
+def test_validate_auth_session_hmac_secret_value_short():
+    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+        validate_auth_session_hmac_secret_value("short")
+    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+        validate_auth_session_hmac_secret_value("a" * 31)
+
+def test_validate_auth_session_hmac_secret_value_repeated():
+    with pytest.raises(ValueError, match="must not be a repeated character"):
+        validate_auth_session_hmac_secret_value("a" * 32)
+    with pytest.raises(ValueError, match="must not be a repeated character"):
+        validate_auth_session_hmac_secret_value("1" * 64)
+
+def test_validate_auth_session_hmac_secret_value_public_fixture():
+    for public_fixture in _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS:
+        with pytest.raises(ValueError, match="must not use a public fixture value"):
+            validate_auth_session_hmac_secret_value(public_fixture)
+
+def test_validate_auth_session_hmac_secret_value_placeholder():
+    for term in _LOW_ENTROPY_PLACEHOLDER_TERMS:
+        with pytest.raises(ValueError, match="must not contain placeholder terms"):
+            validate_auth_session_hmac_secret_value(f"this_is_a_sufficiently_long_prefix_for_testing_purposes_{term}")


### PR DESCRIPTION
🎯 **무엇을:**
`backend/core/runtime_secrets.py` 내의 런타임 시크릿 유효성 검사 함수인 `validate_auth_session_hmac_secret_value`에 대한 단위 테스트가 누락되어 있었습니다. 이 PR에서는 해당 함수에 대한 포괄적인 단위 테스트를 추가합니다.

📊 **테스트 커버리지:**
추가된 테스트는 다음 시나리오들을 다룹니다:
- 유효한 시크릿 (Happy path)
- 빈 문자열 및 None 입력
- 최소 길이(32바이트) 미만의 짧은 문자열
- 단일 문자가 반복되는 패턴의 시크릿
- 알려진 공용 픽스처(fixture) 값을 포함하는 시크릿 (`_KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS` 변수 활용)
- 취약한 자리 표시자(placeholder) 단어를 포함하는 시크릿 (`_LOW_ENTROPY_PLACEHOLDER_TERMS` 변수 활용)

✨ **결과:**
- 런타임 시크릿 검사 로직의 모든 조건 분기(branch)에 대한 테스트 커버리지를 달성했습니다.
- 하드코딩된 값 대신 실제 상수를 `import`하여 테스트가 코드 변경에 대해 더욱 견고해졌습니다.

**변경 전:**
`backend/tests/` 내에 `core/runtime_secrets.py` 관련 테스트가 존재하지 않음.

**변경 후:**
`backend/tests/test_runtime_secrets.py`가 생성되었으며, 모든 테스트 케이스가 성공적으로 통과함.

---
*PR created automatically by Jules for task [16218454011147394496](https://jules.google.com/task/16218454011147394496) started by @seonghobae*