### PR TITLE
🧪 [테스트 개선] 런타임 설정 데이터 페칭 테스트 추가

### DIFF
--- a/frontend/src/lib/runtime-config.test.ts
+++ b/frontend/src/lib/runtime-config.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeConfig } from "./runtime-config";
+
+describe("fetchRuntimeConfig", () => {
+  let fetchRuntimeConfig: typeof import("./runtime-config").fetchRuntimeConfig;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const module = await import("./runtime-config");
+    fetchRuntimeConfig = module.fetchRuntimeConfig;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const mockConfig: RuntimeConfig = {
+    product_name: "TestProduct",
+    version: "1.0.0",
+    features: { test_feature: true },
+  };
+
+  const fallbackConfig: RuntimeConfig = {
+    product_name: "Naruon",
+    version: "fallback",
+    features: {},
+  };
+
+  it("fetches runtime config without baseUrl and caches the result", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockConfig,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/api/runtime-config");
+    expect(config).toEqual(mockConfig);
+  });
+
+  it("fetches runtime config with baseUrl", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockConfig,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config = await fetchRuntimeConfig("https://example.com");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/api/runtime-config");
+    expect(config).toEqual(mockConfig);
+  });
+
+  it("returns cached config on subsequent calls without fetching again", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockConfig,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config1 = await fetchRuntimeConfig();
+    const config2 = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(config1).toEqual(mockConfig);
+    expect(config2).toEqual(mockConfig);
+  });
+
+  it("returns the in-flight promise if a fetch is already in progress", async () => {
+    let resolveJson: (value: any) => void;
+    const jsonPromise = new Promise((resolve) => {
+      resolveJson = resolve;
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => jsonPromise,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise1 = fetchRuntimeConfig();
+    const promise2 = fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveJson!(mockConfig);
+
+    const [config1, config2] = await Promise.all([promise1, promise2]);
+
+    expect(config1).toEqual(mockConfig);
+    expect(config2).toEqual(mockConfig);
+  });
+
+  it("returns fallback config when fetch response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", expect.any(Error));
+    expect(config).toEqual(fallbackConfig);
+  });
+
+  it("returns fallback config when fetch throws a network error", async () => {
+    const networkError = new Error("Network Error");
+    const fetchMock = vi.fn().mockRejectedValue(networkError);
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", networkError);
+    expect(config).toEqual(fallbackConfig);
+  });
+});


### PR DESCRIPTION
🎯 **What:** `frontend/src/lib/runtime-config.ts`의 `fetchRuntimeConfig` 함수에 대한 단위 테스트가 없어서, 전역 `fetch` API 모킹과 모듈 수준의 캐시 상태 관리를 검증하는 테스트 코드를 추가했습니다.

📊 **Coverage:** 다음의 시나리오들이 새롭게 테스트 되었습니다.
1. `baseUrl` 유무에 따른 올바른 `fetch` URL 요청 및 응답 캐싱
2. 후속 호출 시 `fetch` 요청 없이 캐시된 결과값 반환
3. `fetch` 요청 진행 중 중복 호출 시 동일한 진행 중인 Promise 반환
4. HTTP 에러(200 OK 아님) 시 폴백(fallback) 설정값 반환
5. 네트워크 장애(throw) 발생 시 폴백(fallback) 설정값 반환

✨ **Result:** 코드 커버리지가 향상되었으며, 캐싱과 예외 처리 로직에 대한 신뢰성을 확보하여 추후 리팩토링 시 사이드 이펙트를 쉽게 감지할 수 있게 되었습니다.

```typescript
// 변경 전: 테스트 코드 부재 (frontend/src/lib/runtime-config.test.ts 없음)

// 변경 후: `frontend/src/lib/runtime-config.test.ts`에 Vitest 테스트 구현 완료
// vi.resetModules() 및 동적 import를 활용해 모듈 레벨 상태 초기화
```

---
*PR created automatically by Jules for task [1223626509591387686](https://jules.google.com/task/1223626509591387686) started by @seonghobae*