### PR TITLE
🧹 refactor(tenant_config): Extract helper functions to reduce complexity

### DIFF
--- a/backend/api/tenant_config.py
+++ b/backend/api/tenant_config.py
@@ -151,16 +151,7 @@ def _field_value(
     return None
 
 
-def validate_mail_config_update(
-    config_data: dict, db_config: TenantConfig | None
-) -> None:
-    smtp_server = _field_value(config_data, db_config, "smtp_server")
-    smtp_port = _field_value(config_data, db_config, "smtp_port")
-    imap_server = _field_value(config_data, db_config, "imap_server")
-    imap_port = _field_value(config_data, db_config, "imap_port")
-    pop3_server = _field_value(config_data, db_config, "pop3_server")
-    pop3_port = _field_value(config_data, db_config, "pop3_port")
-
+def _validate_smtp_config(smtp_server: str | None, smtp_port: int | None) -> None:
     try:
         if smtp_server is not None:
             validate_smtp_host(smtp_server, resolve_host=True)
@@ -171,6 +162,8 @@ def validate_mail_config_update(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+
+def _validate_imap_config(imap_server: str | None, imap_port: int | None) -> None:
     try:
         if imap_server is not None and imap_port is not None:
             validate_imap_destination(imap_server, imap_port)
@@ -184,6 +177,8 @@ def validate_mail_config_update(
             detail=f"imap_server/imap_port validation failed: {exc}",
         ) from exc
 
+
+def _validate_pop3_config(pop3_server: str | None, pop3_port: int | None) -> None:
     try:
         if pop3_server is not None and pop3_port is not None:
             validate_pop3_destination(pop3_server, pop3_port)
@@ -196,6 +191,21 @@ def validate_mail_config_update(
             status_code=400,
             detail=f"pop3_server/pop3_port validation failed: {exc}",
         ) from exc
+
+
+def validate_mail_config_update(
+    config_data: dict, db_config: TenantConfig | None
+) -> None:
+    smtp_server = _field_value(config_data, db_config, "smtp_server")
+    smtp_port = _field_value(config_data, db_config, "smtp_port")
+    imap_server = _field_value(config_data, db_config, "imap_server")
+    imap_port = _field_value(config_data, db_config, "imap_port")
+    pop3_server = _field_value(config_data, db_config, "pop3_server")
+    pop3_port = _field_value(config_data, db_config, "pop3_port")
+
+    _validate_smtp_config(smtp_server, smtp_port)
+    _validate_imap_config(imap_server, imap_port)
+    _validate_pop3_config(pop3_server, pop3_port)
 
 
 @router.post("")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `validate_mail_config_update` function in `backend/api/tenant_config.py` had high cyclomatic complexity due to having try/except blocks for SMTP, IMAP, and POP3 validation all in one place.
I extracted these blocks into three helper functions:
- `_validate_smtp_config`
- `_validate_imap_config`
- `_validate_pop3_config`

💡 **Why:** How this improves maintainability
This refactoring improves the readability and maintainability of the code by separating the validation logic for each protocol into its own function. It also makes testing easier since the individual functions can be tested independently.

✅ **Verification:** How you confirmed the change is safe
I ran the tests for the `backend/api/tenant_config.py` and they all passed.

✨ **Result:** The improvement achieved
The `validate_mail_config_update` function is now much simpler and delegates the validation logic to the respective helper functions.

변경 전:
```python
def validate_mail_config_update(
    config_data: dict, db_config: TenantConfig | None
) -> None:
    smtp_server = _field_value(config_data, db_config, "smtp_server")
    smtp_port = _field_value(config_data, db_config, "smtp_port")
    imap_server = _field_value(config_data, db_config, "imap_server")
    imap_port = _field_value(config_data, db_config, "imap_port")
    pop3_server = _field_value(config_data, db_config, "pop3_server")
    pop3_port = _field_value(config_data, db_config, "pop3_port")

    try:
        if smtp_server is not None:
            validate_smtp_host(smtp_server, resolve_host=True)
        if smtp_port is not None:
            validate_smtp_port(smtp_port)
        if smtp_server is not None and smtp_port is not None:
            validate_smtp_destination(smtp_server, smtp_port)
    except ValueError as exc:
        raise HTTPException(status_code=400, detail=str(exc)) from exc
    # ... more code
```

변경 후:
```python
def _validate_smtp_config(smtp_server: str | None, smtp_port: int | None) -> None:
    try:
        if smtp_server is not None:
            validate_smtp_host(smtp_server, resolve_host=True)
        if smtp_port is not None:
            validate_smtp_port(smtp_port)
        if smtp_server is not None and smtp_port is not None:
            validate_smtp_destination(smtp_server, smtp_port)
    except ValueError as exc:
        raise HTTPException(status_code=400, detail=str(exc)) from exc

# ... more helpers

def validate_mail_config_update(
    config_data: dict, db_config: TenantConfig | None
) -> None:
    smtp_server = _field_value(config_data, db_config, "smtp_server")
    smtp_port = _field_value(config_data, db_config, "smtp_port")
    imap_server = _field_value(config_data, db_config, "imap_server")
    imap_port = _field_value(config_data, db_config, "imap_port")
    pop3_server = _field_value(config_data, db_config, "pop3_server")
    pop3_port = _field_value(config_data, db_config, "pop3_port")

    _validate_smtp_config(smtp_server, smtp_port)
    _validate_imap_config(imap_server, imap_port)
    _validate_pop3_config(pop3_server, pop3_port)
```

---
*PR created automatically by Jules for task [2607040557061025038](https://jules.google.com/task/2607040557061025038) started by @seonghobae*