### PR TITLE
🔒 Fix: Remove hardcoded default runner token in agent.py

### DIFF
--- a/backend/runner/agent.py
+++ b/backend/runner/agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import websockets
 import sys
+import os
 import logging
 
 logger = logging.getLogger(__name__)
@@ -26,5 +27,12 @@ async def run_agent(token: str, url: str = "ws://127.0.0.1:8000/ws/runner"):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    token = sys.argv[1] if len(sys.argv) > 1 else "demo-token"
+    token = os.environ.get("RUNNER_TOKEN")
+    if not token and len(sys.argv) > 1:
+        token = sys.argv[1]
+
+    if not token:
+        logger.error("No token provided. Please set the RUNNER_TOKEN environment variable or provide it as a CLI argument.")
+        sys.exit(1)
+
     asyncio.run(run_agent(token))


### PR DESCRIPTION
🔒 **보안 취약점 수정: 하드코딩된 기본 러너 토큰 제거**

🎯 **수정 내용 (What):**
`backend/runner/agent.py` 파일 내에 존재하던 하드코딩된 기본 러너 토큰(`demo-token`)을 제거했습니다. 이제 스크립트 실행 시 토큰을 환경 변수(`RUNNER_TOKEN`) 혹은 CLI 인자(`sys.argv[1]`)로 명시적으로 제공해야 하며, 제공되지 않을 경우 에러를 발생시키고 실행을 중단합니다.

⚠️ **위험성 (Risk):**
하드코딩된 토큰이 기본값으로 사용될 경우, 프로덕션이나 운영 환경에서 예기치 않은 접근 권한이 부여되거나 인증 우회를 통한 악의적 제어가 발생할 위험이 있었습니다.

🛡️ **해결 방법 (Solution):**
* `os.environ.get("RUNNER_TOKEN")`을 통해 환경 변수에서 토큰을 우선적으로 확인합니다.
* 환경 변수가 없을 경우 `sys.argv[1]`을 통해 CLI 인자를 확인합니다.
* 두 방법 모두 토큰을 찾지 못한 경우, `logger.error`로 오류를 알리고 `sys.exit(1)`을 호출하여 안전하게 프로세스를 종료합니다.

**변경 전/후:**

*변경 전:*
```python
if __name__ == "__main__":
    logging.basicConfig(level=logging.INFO)
    token = sys.argv[1] if len(sys.argv) > 1 else "demo-token"
    asyncio.run(run_agent(token))
```

*변경 후:*
```python
if __name__ == "__main__":
    logging.basicConfig(level=logging.INFO)
    token = os.environ.get("RUNNER_TOKEN")
    if not token and len(sys.argv) > 1:
        token = sys.argv[1]
    
    if not token:
        logger.error("No token provided. Please set the RUNNER_TOKEN environment variable or provide it as a CLI argument.")
        sys.exit(1)

    asyncio.run(run_agent(token))
```

---
*PR created automatically by Jules for task [18073825264805400181](https://jules.google.com/task/18073825264805400181) started by @seonghobae*