### PR TITLE
🧪 [테스트 추가] workspace-preferences.ts 로컬 스토리지 상호작용 테스트 보강

### DIFF
--- a/frontend/src/lib/workspace-preferences.test.ts
+++ b/frontend/src/lib/workspace-preferences.test.ts
@@ -1,12 +1,30 @@
 /* @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getWorkspaceStartupView, setWorkspaceStartupView } from "./workspace-preferences";
+import {
+  getWorkspaceStartupView,
+  setWorkspaceStartupView,
+  subscribeWorkspaceStartupView,
+} from "./workspace-preferences";
 
 describe("workspace startup preferences", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     localStorage.clear();
+  });
+
+  it("returns dashboard when localStorage is empty", () => {
+    expect(getWorkspaceStartupView()).toBe("dashboard");
+  });
+
+  it("returns the stored valid view when available", () => {
+    localStorage.setItem("naruon_startup_view", "email");
+    expect(getWorkspaceStartupView()).toBe("email");
+  });
+
+  it("returns dashboard when localStorage contains an invalid value", () => {
+    localStorage.setItem("naruon_startup_view", "invalid_view");
+    expect(getWorkspaceStartupView()).toBe("dashboard");
   });
 
   it("falls back to dashboard when localStorage reads throw", () => {
@@ -15,6 +33,19 @@ describe("workspace startup preferences", () => {
     });
 
     expect(getWorkspaceStartupView()).toBe("dashboard");
+  });
+
+  it("stores the value in localStorage and dispatches a CustomEvent", () => {
+    const listener = vi.fn();
+    window.addEventListener("naruon:startup-view-change", listener);
+
+    setWorkspaceStartupView("calendar");
+
+    expect(localStorage.getItem("naruon_startup_view")).toBe("calendar");
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].detail).toEqual({ view: "calendar" });
+
+    window.removeEventListener("naruon:startup-view-change", listener);
   });
 
   it("does not throw or skip notification when localStorage writes throw", () => {
@@ -28,5 +59,28 @@ describe("workspace startup preferences", () => {
     expect(listener).toHaveBeenCalledTimes(1);
 
     window.removeEventListener("naruon:startup-view-change", listener);
+  });
+
+  it("subscribes to and cleans up custom and storage events correctly", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeWorkspaceStartupView(listener);
+
+    // Test custom event
+    window.dispatchEvent(new CustomEvent("naruon:startup-view-change", { detail: { view: "email" } }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Test unrelated storage event
+    window.dispatchEvent(new StorageEvent("storage", { key: "some_other_key" }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Test related storage event
+    window.dispatchEvent(new StorageEvent("storage", { key: "naruon_startup_view" }));
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    // Test unsubscribe
+    unsubscribe();
+    window.dispatchEvent(new CustomEvent("naruon:startup-view-change", { detail: { view: "calendar" } }));
+    window.dispatchEvent(new StorageEvent("storage", { key: "naruon_startup_view" }));
+    expect(listener).toHaveBeenCalledTimes(2); // Should not increase
   });
 });

--- a/frontend/src/lib/workspace-preferences.test.ts
+++ b/frontend/src/lib/workspace-preferences.test.ts
@@ -70,17 +70,23 @@ describe("workspace startup preferences", () => {
     expect(listener).toHaveBeenCalledTimes(1);
 
     // Test unrelated storage event
-    window.dispatchEvent(new StorageEvent("storage", { key: "some_other_key" }));
+    const unrelatedStorageEvent = new Event("storage") as StorageEvent;
+    Object.defineProperty(unrelatedStorageEvent, "key", { value: "some_other_key", configurable: true });
+    window.dispatchEvent(unrelatedStorageEvent);
     expect(listener).toHaveBeenCalledTimes(1);
 
     // Test related storage event
-    window.dispatchEvent(new StorageEvent("storage", { key: "naruon_startup_view" }));
+    const relatedStorageEvent = new Event("storage") as StorageEvent;
+    Object.defineProperty(relatedStorageEvent, "key", { value: "naruon_startup_view", configurable: true });
+    window.dispatchEvent(relatedStorageEvent);
     expect(listener).toHaveBeenCalledTimes(2);
 
     // Test unsubscribe
     unsubscribe();
     window.dispatchEvent(new CustomEvent("naruon:startup-view-change", { detail: { view: "calendar" } }));
-    window.dispatchEvent(new StorageEvent("storage", { key: "naruon_startup_view" }));
+    const unsubscribedStorageEvent = new Event("storage") as StorageEvent;
+    Object.defineProperty(unsubscribedStorageEvent, "key", { value: "naruon_startup_view", configurable: true });
+    window.dispatchEvent(unsubscribedStorageEvent);
     expect(listener).toHaveBeenCalledTimes(2); // Should not increase
   });
 });


### PR DESCRIPTION
🎯 **What:** `frontend/src/lib/workspace-preferences.ts` 의 local storage와 커스텀 이벤트 상호작용에 대한 테스트 부재 해결
📊 **Coverage:** 
  - `getWorkspaceStartupView`: 정상 케이스 (유효한 값), 비어있는 값, 잘못된 값 
  - `setWorkspaceStartupView`: 값 쓰기 및 `naruon:startup-view-change` 이벤트 발송 
  - `subscribeWorkspaceStartupView`: 이벤트 리스닝, 저장소 이벤트 리스닝 및 구독 해지(clean up) 로직
✨ **Result:** 작업 환경 설정과 관련된 핵심 데이터 저장/조회 및 상태 구독 기능의 테스트 커버리지가 완전하게 개선됨

---
*PR created automatically by Jules for task [1621457009068881146](https://jules.google.com/task/1621457009068881146) started by @seonghobae*