### PR TITLE
🔒 보안 수정: 과도하게 허용된 CORS 정책 제한 (Secure CORS Origin Policy)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 from fastapi import Depends, FastAPI
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -76,9 +77,9 @@ async def add_security_headers(request: Request, call_next):
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        origin.strip()
+        f"{parsed.scheme}://{parsed.netloc}"
         for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
-        if origin.strip()
+        if origin.strip() and (parsed := urlparse(origin.strip())).scheme and parsed.netloc and origin.strip() != "*"
     ],
     allow_credentials=True,
     allow_methods=[


### PR DESCRIPTION
🎯 **What:**
The previous CORS policy implementation allowed any origin string from the `ALLOWED_CORS_ORIGINS` setting directly into `allow_origins`. If a trailing slash, path, or wildcard was included, it could bypass strict origin checking or cause misconfigurations.

⚠️ **Risk:**
An overly permissive CORS configuration with `allow_credentials=True` allows malicious origins (like `*` or `null`) or origins with trailing slashes/paths to potentially access sensitive authenticated data. 

🛡️ **Solution:**
I updated `backend/main.py` to parse the origins using `urlparse`. The code now securely reconstructs the origins dynamically to strictly match `scheme://netloc` (and explicitly rejects `*`), enforcing exact matching as required by modern browsers.

## 변경 전
```python
        origin.strip()
        for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
        if origin.strip()
```

## 변경 후
```python
        f"{parsed.scheme}://{parsed.netloc}"
        for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
        if origin.strip() and (parsed := urlparse(origin.strip())).scheme and parsed.netloc and origin.strip() != "*"
```

---
*PR created automatically by Jules for task [9690895364784110462](https://jules.google.com/task/9690895364784110462) started by @seonghobae*