### PR TITLE
🧹 [Code Health] Reduce cyclomatic complexity of _normalize_llm_provider_base_url

### DIFF
--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -2,7 +2,7 @@ import asyncio
 import ipaddress
 from dataclasses import dataclass
 import socket
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import httpcore
 import httpx
@@ -151,13 +151,15 @@ async def _resolve_all_global_addresses_async(hostname: str, port: int) -> tuple
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
 
 
-def _parse_and_validate_candidate_url(value: str | None):
+def _parse_and_validate_candidate_url(
+    value: str | None,
+) -> tuple[SplitResult | None, int | None]:
     if value is None:
-        return None, None, None
+        return None, None
 
     candidate = value.strip()
     if not candidate:
-        return None, None, None
+        return None, None
 
     if "\\" in candidate or _has_url_control_character(candidate):
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
@@ -203,10 +205,9 @@ def _validate_remote_host_is_allowed(hostname: str) -> None:
 
 
 def _normalize_llm_provider_base_url(value: str | None):
-    result = _parse_and_validate_candidate_url(value)
-    if result == (None, None, None):
+    parsed, port = _parse_and_validate_candidate_url(value)
+    if parsed is None or port is None:
         return None, None, None
-    parsed, port = result
 
     hostname = (parsed.hostname or "").lower().rstrip(".")
     # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -151,7 +151,7 @@ async def _resolve_all_global_addresses_async(hostname: str, port: int) -> tuple
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
 
 
-def _normalize_llm_provider_base_url(value: str | None):
+def _parse_and_validate_candidate_url(value: str | None):
     if value is None:
         return None, None, None
 
@@ -166,13 +166,12 @@ def _normalize_llm_provider_base_url(value: str | None):
         parsed = urlsplit(candidate)
         default_port = 443 if parsed.scheme.lower() == "https" else 80
         port = parsed.port or default_port
+        return parsed, port
     except ValueError as exc:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc
 
-    hostname = (parsed.hostname or "").lower().rstrip(".")
-    # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
-    is_local_dev_host = _is_local_dev_host(hostname)
 
+def _validate_url_components(parsed, hostname: str, is_local_dev_host: bool) -> None:
     if parsed.scheme.lower() not in {"http", "https"}:
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
@@ -192,15 +191,32 @@ def _normalize_llm_provider_base_url(value: str | None):
     ):
         raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
 
+
+def _validate_remote_host_is_allowed(hostname: str) -> None:
     allowed_hosts = _parse_allowed_hosts()
+    if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
+        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+    if hostname not in allowed_hosts:
+        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+    if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
+        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+
+
+def _normalize_llm_provider_base_url(value: str | None):
+    result = _parse_and_validate_candidate_url(value)
+    if result == (None, None, None):
+        return None, None, None
+    parsed, port = result
+
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
+    is_local_dev_host = _is_local_dev_host(hostname)
+
+    _validate_url_components(parsed, hostname, is_local_dev_host)
+
     # If not localhost, must be in allowed hosts
     if not is_local_dev_host:
-        if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
-            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
-        if hostname not in allowed_hosts:
-            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
-        if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
-            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
+        _validate_remote_host_is_allowed(hostname)
 
     netloc = _format_normalized_netloc(
         hostname, port, explicit_port=parsed.port is not None


### PR DESCRIPTION
🎯 **What:**
`backend/services/llm_provider_urls.py`에 있는 `_normalize_llm_provider_base_url` 함수의 사이클로매틱 복잡도(cyclomatic complexity)가 너무 높아 이를 개선했습니다.

💡 **Why:**
함수 하나에 URL 파싱, 스킴/호스트 등 여러 컴포넌트 검증 로직, 호스트명 허용 여부 확인 등 다양한 검증 로직이 한데 섞여 있어 유지보수가 어렵고 가독성이 떨어졌습니다. 기능별로 헬퍼 함수를 분리함으로써 각 로직의 목적이 뚜렷해지고 테스트 및 유지보수가 쉬워졌습니다.

✅ **Verification:**
모든 `backend/tests/test_llm_provider_urls.py` 테스트가 정상적으로 통과됨을 확인했습니다.
`pytest`를 통한 백엔드 전체 테스트도 Regression 없이 모두 성공했습니다.

✨ **Result:**
기존 동작을 완벽히 유지하면서 `_normalize_llm_provider_base_url`의 복잡도가 크게 줄어들고 코드 가독성이 대폭 향상되었습니다.

**변경 전:**
```python
def _normalize_llm_provider_base_url(value: str | None):
    if value is None:
        return None, None, None

    candidate = value.strip()
    if not candidate:
        return None, None, None

    if "\\" in candidate or _has_url_control_character(candidate):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    try:
        parsed = urlsplit(candidate)
        default_port = 443 if parsed.scheme.lower() == "https" else 80
        port = parsed.port or default_port
    except ValueError as exc:
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc

    hostname = (parsed.hostname or "").lower().rstrip(".")
    # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
    is_local_dev_host = _is_local_dev_host(hostname)

    if parsed.scheme.lower() not in {"http", "https"}:
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    if (
        parsed.scheme.lower() == "http"
        and not is_local_dev_host
        and not _is_allowlisted_local_provider_host(hostname)
    ):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    if (
        not hostname
        or parsed.username is not None
        or parsed.password is not None
        or parsed.query
        or parsed.fragment
    ):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    allowed_hosts = _parse_allowed_hosts()
    # If not localhost, must be in allowed hosts
    if not is_local_dev_host:
        if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
        if hostname not in allowed_hosts:
            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
        if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
            raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    netloc = _format_normalized_netloc(
        hostname, port, explicit_port=parsed.port is not None
    )
    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path or "", "", "")), hostname, port
```

**변경 후:**
```python
def _parse_and_validate_candidate_url(value: str | None):
    if value is None:
        return None, None, None

    candidate = value.strip()
    if not candidate:
        return None, None, None

    if "\\" in candidate or _has_url_control_character(candidate):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    try:
        parsed = urlsplit(candidate)
        default_port = 443 if parsed.scheme.lower() == "https" else 80
        port = parsed.port or default_port
        return parsed, port
    except ValueError as exc:
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED) from exc


def _validate_url_components(parsed, hostname: str, is_local_dev_host: bool) -> None:
    if parsed.scheme.lower() not in {"http", "https"}:
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    if (
        parsed.scheme.lower() == "http"
        and not is_local_dev_host
        and not _is_allowlisted_local_provider_host(hostname)
    ):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)

    if (
        not hostname
        or parsed.username is not None
        or parsed.password is not None
        or parsed.query
        or parsed.fragment
    ):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)


def _validate_remote_host_is_allowed(hostname: str) -> None:
    allowed_hosts = _parse_allowed_hosts()
    if not allowed_hosts or any("*" in allowed_host for allowed_host in allowed_hosts):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
    if hostname not in allowed_hosts:
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)
    if _is_ip_literal(hostname) or _looks_like_ip_literal(hostname):
        raise ValueError(LLM_BASE_URL_NOT_ALLOWED)


def _normalize_llm_provider_base_url(value: str | None):
    result = _parse_and_validate_candidate_url(value)
    if result == (None, None, None):
        return None, None, None
    parsed, port = result

    hostname = (parsed.hostname or "").lower().rstrip(".")
    # Note: Container names like 'ollama' are NOT treated as localhost unless explicitly intended.
    is_local_dev_host = _is_local_dev_host(hostname)

    _validate_url_components(parsed, hostname, is_local_dev_host)

    # If not localhost, must be in allowed hosts
    if not is_local_dev_host:
        _validate_remote_host_is_allowed(hostname)

    netloc = _format_normalized_netloc(
        hostname, port, explicit_port=parsed.port is not None
    )
    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path or "", "", "")), hostname, port
```

---
*PR created automatically by Jules for task [15904410025064928478](https://jules.google.com/task/15904410025064928478) started by @seonghobae*