### PR TITLE
🧪 [테스트 개선] backend-url 파싱 예외 처리 테스트 추가

### DIFF
--- a/frontend/src/lib/backend-url.test.ts
+++ b/frontend/src/lib/backend-url.test.ts
@@ -52,6 +52,48 @@ describe("backend URL guard", () => {
     );
   });
 
+  it("rejects invalid URL strings", () => {
+    expect(() => parseBackendInternalUrl("not-a-valid-url")).toThrow(
+      "BACKEND_INTERNAL_URL is not a valid URL",
+    );
+  });
+
+  it("rejects non-HTTPS URLs in normal mode", () => {
+    expect(() => parseBackendInternalUrl("http://api.naruon.net")).toThrow(
+      "must use https:// in split deployments",
+    );
+  });
+
+  it("rejects URLs without a hostname", () => {
+    // A mock URL object with protocol "https:" but empty hostname
+    // since Node.js newer URL parser rejects `https:///` and similar.
+    const originalURL = global.URL;
+    try {
+      global.URL = class extends URL {
+        constructor(input: string | URL, base?: string | URL) {
+          super(input, base);
+          if (input === "https:///empty") {
+            Object.defineProperty(this, "hostname", { get: () => "" });
+          }
+        }
+      } as any;
+      expect(() => parseBackendInternalUrl("https:///empty")).toThrow(
+        "BACKEND_INTERNAL_URL must include a hostname",
+      );
+    } finally {
+      global.URL = originalURL;
+    }
+  });
+
+  it("uses the environment variable when provided", () => {
+    vi.stubEnv("BACKEND_INTERNAL_URL", "https://backend.example.com");
+    expect(backendApiBaseUrl().origin).toBe("https://backend.example.com");
+  });
+
+  it("falls back to local backend in development", () => {
+    expect(backendApiBaseUrl().origin).toBe("http://127.0.0.1:8000");
+  });
+
   it("requires a runtime backend origin in production", () => {
     vi.stubEnv("NODE_ENV", "production");
     expect(() => backendApiBaseUrl()).toThrow("production runtime");


### PR DESCRIPTION
🎯 **What:** `frontend/src/lib/backend-url.ts` 내의 `parseBackendInternalUrl` 함수에 대한 예외 처리 테스트가 누락된 문제를 해결했습니다.
📊 **Coverage:** 다음과 같은 시나리오를 추가로 테스트합니다:
- 유효하지 않은 URL 형식
- HTTPS가 아닌 프로토콜 처리
- 호스트 이름 누락 (URL 객체의 Mocking 활용)
- 환경 변수(`process.env.BACKEND_INTERNAL_URL`)를 올바르게 사용하는지에 대한 확인
✨ **Result:** 예외 처리 로직에 대한 테스트 커버리지가 대폭 향상되었으며 잠재적인 버그를 사전에 방지할 수 있습니다.

---
**변경 전:**
`backend-url.test.ts` 파일에서 유효하지 않은 URL이나 호스트명이 누락된 경우 등 예외 처리 분기에 대한 테스트가 부족했습니다. 환경 변수와 함께 사용될 때의 테스트도 명시적이지 않았습니다.

**변경 후:**
유효하지 않은 URL 형식, HTTPS 프로토콜 검사, `vi.stubGlobal`을 이용한 빈 호스트이름 시나리오 테스트, 환경 변수를 활용할 때의 `backendApiBaseUrl` 테스트 케이스가 추가되었습니다.

---
*PR created automatically by Jules for task [2598532925309148922](https://jules.google.com/task/2598532925309148922) started by @seonghobae*