### PR TITLE
🧹 [코드 건강 개선] _PinnedLLMProviderNetworkBackend의 connect_tcp 복잡도 감소

### DIFF
--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -272,6 +272,49 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
             socket_options=socket_options,
         )
 
+    async def _cancel_tasks(self, tasks: set[asyncio.Task]) -> None:
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _handle_done_tasks(
+        self,
+        done: set[asyncio.Task],
+        successful_stream: httpcore.AsyncNetworkStream | None,
+        last_error: Exception | None,
+    ) -> tuple[httpcore.AsyncNetworkStream | None, Exception | None]:
+        for task in done:
+            try:
+                stream = task.result()
+            except Exception as exc:  # pragma: no cover - backend-specific
+                last_error = exc
+                continue
+
+            if successful_stream is None:
+                successful_stream = stream
+            else:
+                await stream.aclose()
+        return successful_stream, last_error
+
+    async def _wait_for_first_stream(
+        self, tasks: set[asyncio.Task]
+    ) -> tuple[
+        httpcore.AsyncNetworkStream | None, set[asyncio.Task], Exception | None
+    ]:
+        last_error: Exception | None = None
+        successful_stream = None
+        while tasks:
+            done, tasks = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            successful_stream, last_error = await self._handle_done_tasks(
+                done, successful_stream, last_error
+            )
+            if successful_stream is not None:
+                return successful_stream, tasks, None
+        return None, tasks, last_error
+
     async def connect_tcp(
         self,
         host: str,
@@ -297,38 +340,16 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
             )
             for address in self._addresses
         }
-        last_error: Exception | None = None
-        successful_stream = None
+
         try:
-            while tasks:
-                done, tasks = await asyncio.wait(
-                    tasks, return_when=asyncio.FIRST_COMPLETED
-                )
-                for task in done:
-                    try:
-                        stream = task.result()
-                    except Exception as exc:  # pragma: no cover - backend-specific
-                        last_error = exc
-                        continue
-
-                    if successful_stream is None:
-                        successful_stream = stream
-                    else:
-                        await stream.aclose()
-
-                if successful_stream is not None:
-                    pending_tasks = tasks
-                    tasks = set()
-                    for pending_task in pending_tasks:
-                        pending_task.cancel()
-                    if pending_tasks:
-                        await asyncio.gather(*pending_tasks, return_exceptions=True)
-                    return successful_stream
+            successful_stream, tasks, last_error = await self._wait_for_first_stream(tasks)
+            if successful_stream is not None:
+                pending_tasks = tasks
+                tasks = set()
+                await self._cancel_tasks(pending_tasks)
+                return successful_stream
         finally:
-            for task in tasks:
-                task.cancel()
-            if tasks:
-                await asyncio.gather(*tasks, return_exceptions=True)
+            await self._cancel_tasks(tasks)
 
         if last_error is not None:
             raise last_error


### PR DESCRIPTION
🎯 **What:** `backend/services/llm_provider_urls.py`의 `connect_tcp` 메서드의 높은 순환 복잡도(cyclomatic complexity) 문제 해결
💡 **Why:** 복잡한 에러 처리 및 태스크 관리 로직을 세분화된 헬퍼 메서드로 분리하여 코드의 유지보수성과 가독성을 높이기 위함
✅ **Verification:** 모든 헬퍼 메서드 분리 후 flake8로 복잡도를 검사하고, 관련 테스트(`pytest backend/tests/test_llm_provider_urls.py`)가 성공적으로 통과함을 확인하여 기존 로직과 동일하게 동작함을 검증
✨ **Result:** `connect_tcp`의 McCabe 복잡도 점수가 낮아졌으며 코드 건강(Code Health)이 전반적으로 개선됨

**변경 전:**
`connect_tcp` 메서드는 비동기 태스크 생성, 대기, 결과 처리 및 리소스 정리(Cancellation)를 하나의 거대한 `try...finally` 블록 안에 모두 포함하여 높은 복잡도 점수를 보였습니다.

**변경 후:**
이를 `_cancel_tasks`, `_handle_done_tasks`, `_wait_for_first_stream` 등의 의미 있는 헬퍼 메서드로 리팩토링하여 각 기능 단위별로 분리시켰습니다.

---
*PR created automatically by Jules for task [6410264180126628078](https://jules.google.com/task/6410264180126628078) started by @seonghobae*