### PR TITLE
🧹 [코드 품질 향상] create_reply_sla_escalations 함수 리팩토링

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -127,6 +127,123 @@ def _task_response(task: TicketTask, source_email_id: str | None) -> TicketTaskR
     )
 
 
+async def _fetch_existing_tasks_by_email(
+    db: AsyncSession,
+    user_id: int,
+    organization_id: int,
+    email_ids: list[int],
+) -> dict[int, TicketTask]:
+    result = await db.execute(
+        select(TicketTask)
+        .where(
+            TicketTask.user_id == user_id,
+            TicketTask.organization_id == organization_id,
+            TicketTask.related_email_id.in_(email_ids),
+            TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
+        )
+        .order_by(TicketTask.updated_at.desc())
+    )
+    tasks_by_email = {}
+    for task in result.scalars().all():
+        if task.related_email_id not in tasks_by_email:
+            tasks_by_email[task.related_email_id] = task
+    return tasks_by_email
+
+
+async def _handle_reply_sla_escalations_fallback(
+    db: AsyncSession,
+    auth_context: AuthContext,
+    overdue_replies: list[Email],
+    email_ids: list[int],
+    now: datetime.datetime,
+) -> tuple[int, list[tuple[TicketTask, str]]]:
+    created_count = 0
+    escalated_tasks = []
+
+    # Re-fetch the existing tasks to find the newly inserted ones
+    existing_tasks_by_email_fallback = await _fetch_existing_tasks_by_email(
+        db, auth_context.user_id, auth_context.organization_id, email_ids
+    )
+
+    fallback_entries: list[tuple[Email, TicketTask | None]] = []
+    conflicted_email_ids: list[int] = []
+    for email in overdue_replies:
+        if email.id in existing_tasks_by_email_fallback:
+            task = existing_tasks_by_email_fallback[email.id]
+            if task.status != "done":
+                task.title = _reply_sla_task_title(email)
+                task.status = "blocked"
+                task.priority = "urgent"
+                task.related_thread_id = canonical_thread_key(email)
+                task.updated_at = now
+        else:
+            task = TicketTask(
+                user_id=auth_context.user_id,
+                organization_id=auth_context.organization_id,
+                title=_reply_sla_task_title(email),
+                status="blocked",
+                priority="urgent",
+                source_type=REPLY_SLA_SOURCE_TYPE,
+                related_email_id=email.id,
+                related_thread_id=canonical_thread_key(email),
+            )
+            try:
+                async with db.begin_nested():
+                    db.add(task)
+                    await db.flush()
+                created_count += 1
+            except IntegrityError:
+                conflicted_email_ids.append(email.id)
+                task = None
+        fallback_entries.append((email, task))
+
+    if conflicted_email_ids:
+        conflicted_tasks_by_email = await _fetch_existing_tasks_by_email(
+            db, auth_context.user_id, auth_context.organization_id, conflicted_email_ids
+        )
+
+        for index, (email, task) in enumerate(fallback_entries):
+            if task is not None or email.id not in conflicted_email_ids:
+                continue
+            task = conflicted_tasks_by_email.get(email.id)
+            if task is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error_code": "reply_sla_task_conflict",
+                        "message": "Reply SLA task conflict",
+                    },
+                ) from None
+
+            if task.status != "done":
+                task.title = _reply_sla_task_title(email)
+                task.status = "blocked"
+                task.priority = "urgent"
+                task.related_thread_id = canonical_thread_key(email)
+                task.updated_at = now
+            fallback_entries[index] = (email, task)
+
+    escalated_tasks.extend(
+        (task, email.message_id) for email, task in fallback_entries if task is not None
+    )
+
+    if created_count > 0 or any(t.status != "done" for t, _ in escalated_tasks):
+        await db.commit()
+
+        # Refetch updated values efficiently
+        refreshed_tasks_by_email = await _fetch_existing_tasks_by_email(
+            db, auth_context.user_id, auth_context.organization_id, email_ids
+        )
+
+        # Replace un-refreshed tasks to avoid validation errors.
+        for i, (task, message_id) in enumerate(escalated_tasks):
+            refreshed_task = refreshed_tasks_by_email.get(task.related_email_id)
+            if refreshed_task is not None:
+                escalated_tasks[i] = (refreshed_task, message_id)
+
+    return created_count, escalated_tasks
+
+
 @router.post("/reply-sla-escalations", response_model=ReplySlaEscalationResponse)
 async def create_reply_sla_escalations(
     request: ReplySlaEscalationRequest,
@@ -157,21 +274,9 @@ async def create_reply_sla_escalations(
 
     email_ids = [email.id for email in overdue_replies]
 
-    existing_result = await db.execute(
-        select(TicketTask)
-        .where(
-            TicketTask.user_id == auth_context.user_id,
-            TicketTask.organization_id == auth_context.organization_id,
-            TicketTask.related_email_id.in_(email_ids),
-            TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-        )
-        .order_by(TicketTask.updated_at.desc())
+    existing_tasks_by_email = await _fetch_existing_tasks_by_email(
+        db, auth_context.user_id, auth_context.organization_id, email_ids
     )
-
-    existing_tasks_by_email = {}
-    for task in existing_result.scalars().all():
-        if task.related_email_id not in existing_tasks_by_email:
-            existing_tasks_by_email[task.related_email_id] = task
 
     created_count = 0
     escalated_tasks: list[tuple[TicketTask, str | None]] = []
@@ -209,19 +314,9 @@ async def create_reply_sla_escalations(
 
             # Fetch updated values efficiently instead of looping db.refresh.
             if created_count > 0:
-                refreshed_result = await db.execute(
-                    select(TicketTask)
-                    .where(
-                        TicketTask.user_id == auth_context.user_id,
-                        TicketTask.organization_id == auth_context.organization_id,
-                        TicketTask.related_email_id.in_(email_ids),
-                        TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                    )
-                    .order_by(TicketTask.updated_at.desc())
+                refreshed_tasks_by_email = await _fetch_existing_tasks_by_email(
+                    db, auth_context.user_id, auth_context.organization_id, email_ids
                 )
-                refreshed_tasks_by_email = {
-                    t.related_email_id: t for t in refreshed_result.scalars().all()
-                }
 
                 # Replace un-refreshed tasks to avoid validation errors.
                 for i, (task, message_id) in enumerate(escalated_tasks):
@@ -230,123 +325,9 @@ async def create_reply_sla_escalations(
                         escalated_tasks[i] = (refreshed_task, message_id)
     except IntegrityError:
         await db.rollback()
-        created_count = 0
-        escalated_tasks.clear()
-
-        # Re-fetch the existing tasks to find the newly inserted ones
-        existing_result = await db.execute(
-            select(TicketTask)
-            .where(
-                TicketTask.user_id == auth_context.user_id,
-                TicketTask.organization_id == auth_context.organization_id,
-                TicketTask.related_email_id.in_(email_ids),
-                TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-            )
-            .order_by(TicketTask.updated_at.desc())
+        created_count, escalated_tasks = await _handle_reply_sla_escalations_fallback(
+            db, auth_context, overdue_replies, email_ids, now
         )
-        existing_tasks_by_email_fallback = {}
-        for t in existing_result.scalars().all():
-            if t.related_email_id not in existing_tasks_by_email_fallback:
-                existing_tasks_by_email_fallback[t.related_email_id] = t
-
-        fallback_entries: list[tuple[Email, TicketTask | None]] = []
-        conflicted_email_ids: list[int] = []
-        for email in overdue_replies:
-            if email.id in existing_tasks_by_email_fallback:
-                task = existing_tasks_by_email_fallback[email.id]
-                if task.status != "done":
-                    task.title = _reply_sla_task_title(email)
-                    task.status = "blocked"
-                    task.priority = "urgent"
-                    task.related_thread_id = canonical_thread_key(email)
-                    task.updated_at = now
-            else:
-                task = TicketTask(
-                    user_id=auth_context.user_id,
-                    organization_id=auth_context.organization_id,
-                    title=_reply_sla_task_title(email),
-                    status="blocked",
-                    priority="urgent",
-                    source_type=REPLY_SLA_SOURCE_TYPE,
-                    related_email_id=email.id,
-                    related_thread_id=canonical_thread_key(email),
-                )
-                try:
-                    async with db.begin_nested():
-                        db.add(task)
-                        await db.flush()
-                    created_count += 1
-                except IntegrityError:
-                    conflicted_email_ids.append(email.id)
-                    task = None
-            fallback_entries.append((email, task))
-
-        if conflicted_email_ids:
-            conflicted_result = await db.execute(
-                select(TicketTask)
-                .where(
-                    TicketTask.user_id == auth_context.user_id,
-                    TicketTask.organization_id == auth_context.organization_id,
-                    TicketTask.related_email_id.in_(conflicted_email_ids),
-                    TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                )
-                .order_by(TicketTask.updated_at.desc())
-            )
-            conflicted_tasks_by_email = {}
-            for task in conflicted_result.scalars().all():
-                if task.related_email_id not in conflicted_tasks_by_email:
-                    conflicted_tasks_by_email[task.related_email_id] = task
-
-            for index, (email, task) in enumerate(fallback_entries):
-                if task is not None or email.id not in conflicted_email_ids:
-                    continue
-                task = conflicted_tasks_by_email.get(email.id)
-                if task is None:
-                    raise HTTPException(
-                        status_code=409,
-                        detail={
-                            "error_code": "reply_sla_task_conflict",
-                            "message": "Reply SLA task conflict",
-                        },
-                    ) from None
-
-                if task.status != "done":
-                    task.title = _reply_sla_task_title(email)
-                    task.status = "blocked"
-                    task.priority = "urgent"
-                    task.related_thread_id = canonical_thread_key(email)
-                    task.updated_at = now
-                fallback_entries[index] = (email, task)
-
-        escalated_tasks.extend(
-            (task, email.message_id)
-            for email, task in fallback_entries
-            if task is not None
-        )
-
-        if created_count > 0 or any(t.status != "done" for t, _ in escalated_tasks):
-            await db.commit()
-
-            # Refetch updated values efficiently
-            refreshed_result = await db.execute(
-                select(TicketTask)
-                .where(
-                    TicketTask.user_id == auth_context.user_id,
-                    TicketTask.organization_id == auth_context.organization_id,
-                    TicketTask.related_email_id.in_(email_ids),
-                    TicketTask.source_type == REPLY_SLA_SOURCE_TYPE,
-                )
-                .order_by(TicketTask.updated_at.desc())
-            )
-            refreshed_tasks_by_email = {
-                t.related_email_id: t for t in refreshed_result.scalars().all()
-            }
-
-            # Replace un-refreshed tasks to avoid validation errors.
-            for i, (task, message_id) in enumerate(escalated_tasks):
-                refreshed_task = refreshed_tasks_by_email.get(task.related_email_id)
-                if refreshed_task is not None:
-                    escalated_tasks[i] = (refreshed_task, message_id)
 
     return ReplySlaEscalationResponse(
         evaluated=len(pending_replies),


### PR DESCRIPTION
🎯 **What:** `backend/api/tasks.py`의 `create_reply_sla_escalations` 함수에서 반복되는 로직을 분리하여 리팩토링했습니다.
- 기존 작업 조회 로직을 `_fetch_existing_tasks_by_email` 헬퍼 함수로 추출.
- 복잡한 `IntegrityError` 예외 처리 및 폴백 로직을 `_handle_reply_sla_escalations_fallback` 함수로 분리.

💡 **Why:** `create_reply_sla_escalations` 함수가 너무 길고 복잡하여 유지보수성 및 가독성을 떨어뜨리고 있었습니다. 헬퍼 함수로 분리함으로써 메인 비즈니스 로직의 흐름을 파악하기 쉽게 개선했습니다. 

✅ **Verification:**
- `pytest backend/tests/` 를 통해 전체 테스트 스위트를 실행하여 회귀 문제나 기존 기능 손상이 없음을 확인했습니다. (모든 테스트 통과)
- `ruff` 를 이용해 린팅 및 포매팅 체크를 통과했습니다.

✨ **Result:**
- `create_reply_sla_escalations` 함수의 길이가 크게 줄고, 각 기능별로 함수가 모듈화되어 향후 코드 수정이나 에러 추적이 더욱 수월해졌습니다.

### 변경 전후 비교

**변경 전:**
`create_reply_sla_escalations` 내에서 중복되는 `select(TicketTask)...` 데이터베이스 조회가 3번 존재했고 거대한 `try-except IntegrityError` 블록으로 인해 코드 흐름 파악이 어려웠습니다.

**변경 후:**
복잡한 조회 및 예외 로직을 헬퍼 함수로 추출하여 메인 함수의 가독성을 개선하였습니다. 
```python
    existing_tasks_by_email = await _fetch_existing_tasks_by_email(
        db, auth_context.user_id, auth_context.organization_id, email_ids
    )
...
    try:
...
    except IntegrityError:
        await db.rollback()
        created_count, escalated_tasks = await _handle_reply_sla_escalations_fallback(
            db, auth_context, overdue_replies, email_ids, now
        )
```

---
*PR created automatically by Jules for task [4451164886551283372](https://jules.google.com/task/4451164886551283372) started by @seonghobae*