### PR TITLE
Fix local Compose model packaging and live smoke

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,31 @@
-# Stage 1: Build Frontend
+# Stage 1: Backend runtime for local Compose and backend-only deployments
+FROM python:3.11-slim AS backend-runtime
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+
+# Install system dependencies.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gcc \
+      libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Backend dependencies
+COPY backend/requirements.txt /app/requirements.txt
+RUN PIP_ROOT_USER_ACTION=ignore PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy Backend
+COPY backend /app/
+
+EXPOSE 8000
+
+CMD ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]
+
+# Stage 2: Build Frontend
 FROM node:22-slim AS frontend-builder
 WORKDIR /app
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
@@ -14,31 +41,12 @@ ENV POSTCSS_WORKERS=1
 ENV DISABLE_POSTCSS_WORKERS=true
 RUN pnpm run build
 
-# Stage 2: Final Image (Python + Node.js)
-FROM python:3.11-slim
-WORKDIR /app
+# Stage 3: Combined image (Python + Node.js)
+FROM backend-runtime
 
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/app
-
-# Install system dependencies. Runtime Node is copied from the frontend builder
-# so apt does not install a distro Node package with noisy alternatives output.
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      gcc \
-      libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
+# Runtime Node is copied from the frontend builder so apt does not install a
+# distro Node package with noisy alternatives output.
 COPY --from=frontend-builder /usr/local/bin/node /usr/local/bin/node
-
-# Install Backend dependencies
-COPY backend/requirements.txt /app/requirements.txt
-RUN PIP_ROOT_USER_ACTION=ignore PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    pip install --no-cache-dir -r requirements.txt
-
-# Copy Backend
-COPY backend /app/
 
 # Copy Frontend runtime artifacts
 COPY --from=frontend-builder /app/.next /app/frontend/.next

--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,14 +1,47 @@
 FROM ollama/ollama:latest
 
+ENV OLLAMA_MODELS=/usr/share/ollama/.ollama/models
+
+RUN useradd --system --create-home --home-dir /home/ollama --shell /usr/sbin/nologin ollama
+
 # Pull model weights at build time so the container is ready without network
-# access at runtime.  We start the server in the background, wait for it to be
-# ready with a readiness poll, pull the models, then stop the server.  A
-# fixed sleep is fragile on slow/constrained runners, so we use a loop instead.
-RUN nohup bash -c "ollama serve &" && \
-    until curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; do sleep 1; done && \
-    ollama pull gemma4 && \
-    ollama pull embeddinggemma
+# access at runtime.  Keep the large chat and smaller embedding model pulls in
+# separate layers so constrained Podman builders do not need to commit one
+# oversized model cache blob.
+RUN set -eux; \
+    mkdir -p "${OLLAMA_MODELS}"; \
+    chown -R ollama:ollama /usr/share/ollama/.ollama; \
+    ollama serve > /tmp/ollama-build.log 2>&1 & \
+    server_pid="$!"; \
+    trap 'kill "$server_pid" 2>/dev/null || true' EXIT; \
+    server_ready=false; \
+    for attempt in $(seq 1 60); do \
+      if ollama list > /dev/null 2>&1; then server_ready=true; break; fi; \
+      sleep 1; \
+    done; \
+    if [ "${server_ready}" != "true" ]; then cat /tmp/ollama-build.log; exit 1; fi; \
+    ollama pull gemma4; \
+    ollama list | grep -E '^gemma4(:|[[:space:]])'; \
+    kill "$server_pid"; \
+    wait "$server_pid" 2>/dev/null || true; \
+    chown -R ollama:ollama /usr/share/ollama/.ollama
+
+RUN set -eux; \
+    chown -R ollama:ollama /usr/share/ollama/.ollama; \
+    ollama serve > /tmp/ollama-build.log 2>&1 & \
+    server_pid="$!"; \
+    trap 'kill "$server_pid" 2>/dev/null || true' EXIT; \
+    server_ready=false; \
+    for attempt in $(seq 1 60); do \
+      if ollama list > /dev/null 2>&1; then server_ready=true; break; fi; \
+      sleep 1; \
+    done; \
+    if [ "${server_ready}" != "true" ]; then cat /tmp/ollama-build.log; exit 1; fi; \
+    ollama pull embeddinggemma; \
+    ollama list | grep -E '^embeddinggemma(:|[[:space:]])'; \
+    kill "$server_pid"; \
+    wait "$server_pid" 2>/dev/null || true; \
+    chown -R ollama:ollama /usr/share/ollama/.ollama
 
 # Run as non-root for security (DS-0002).
-# The ollama base image ships with an 'ollama' user.
 USER ollama

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -12,6 +12,7 @@ from services.tenant_config_scope import get_scoped_tenant_config
 
 router = APIRouter(prefix="/api")
 logger = logging.getLogger(__name__)
+SEARCH_VECTOR_DIMENSIONS = 1536
 
 
 class SearchRequest(BaseModel):
@@ -67,13 +68,24 @@ def build_reply_counts_subquery(
     return statement.group_by(group_key).subquery("thread_counts")
 
 
-def build_email_search_stmt(query: str, query_embedding, owner_filters, reply_counts):
+def _search_score(text_column, embedding_column, query: str, query_embedding):
     fts_score = func.ts_rank_cd(
-        func.to_tsvector("english", Email.body),
+        func.to_tsvector("english", text_column),
         func.plainto_tsquery("english", query),
     )
-    vector_distance = Email.embedding.cosine_distance(query_embedding)
-    hybrid_score = fts_score - vector_distance
+    if query_embedding is None:
+        return fts_score
+    vector_distance = embedding_column.cosine_distance(query_embedding)
+    return fts_score - vector_distance
+
+
+def build_email_search_stmt(query: str, query_embedding, owner_filters, reply_counts):
+    search_score = _search_score(
+        Email.body,
+        Email.embedding,
+        query,
+        query_embedding,
+    )
 
     return (
         select(
@@ -85,7 +97,7 @@ def build_email_search_stmt(query: str, query_embedding, owner_filters, reply_co
             thread_group_key().label("thread_id"),
             reply_counts.c.reply_count,
             Email.body.label("content"),
-            hybrid_score.label("score"),
+            search_score.label("score"),
         )
         .select_from(Email)
         .join(reply_counts, reply_counts.c.thread_key == thread_group_key())
@@ -96,12 +108,12 @@ def build_email_search_stmt(query: str, query_embedding, owner_filters, reply_co
 def build_attachment_search_stmt(
     query: str, query_embedding, owner_filters, reply_counts
 ):
-    fts_score = func.ts_rank_cd(
-        func.to_tsvector("english", Attachment.content),
-        func.plainto_tsquery("english", query),
+    search_score = _search_score(
+        Attachment.content,
+        Attachment.embedding,
+        query,
+        query_embedding,
     )
-    vector_distance = Attachment.embedding.cosine_distance(query_embedding)
-    hybrid_score = fts_score - vector_distance
 
     return (
         select(
@@ -113,7 +125,7 @@ def build_attachment_search_stmt(
             thread_group_key().label("thread_id"),
             reply_counts.c.reply_count,
             Attachment.content.label("content"),
-            hybrid_score.label("score"),
+            search_score.label("score"),
         )
         .select_from(Attachment)
         .join(Email, Attachment.email_id == Email.id)
@@ -184,7 +196,12 @@ async def hybrid_search(
         openai_api_key = tenant_config.openai_api_key
 
         embeddings = await generate_embeddings([request.query], openai_api_key)
-        query_embedding = embeddings[0]
+        query_embedding = embeddings[0] if embeddings else None
+        if (
+            query_embedding is not None
+            and len(query_embedding) != SEARCH_VECTOR_DIMENSIONS
+        ):
+            query_embedding = None
 
         owner_filters = email_owner_filters(
             target_user_id, auth_context.organization_id

--- a/backend/tests/live/seed_live_data.py
+++ b/backend/tests/live/seed_live_data.py
@@ -6,8 +6,9 @@ import asyncio
 import datetime as dt
 
 from sqlalchemy import delete
+from sqlalchemy import select
 
-from db.models import Email
+from db.models import Email, TenantConfig
 from db.session import AsyncSessionLocal
 
 
@@ -18,11 +19,26 @@ MESSAGE_IDS = [
     "<live-e2e-root@example.test>",
     "<live-e2e-reply@example.test>",
 ]
+LIVE_E2E_OPENAI_API_KEY = "ollama"
 
 
 async def seed_live_data() -> None:
     async with AsyncSessionLocal() as session:
         await session.execute(delete(Email).where(Email.message_id.in_(MESSAGE_IDS)))
+        result = await session.execute(
+            select(TenantConfig).where(
+                TenantConfig.user_id == LIVE_E2E_USER_ID,
+                TenantConfig.organization_id == LIVE_E2E_ORGANIZATION_ID,
+            )
+        )
+        tenant_config = result.scalar_one_or_none()
+        if tenant_config is None:
+            tenant_config = TenantConfig(
+                user_id=LIVE_E2E_USER_ID,
+                organization_id=LIVE_E2E_ORGANIZATION_ID,
+            )
+            session.add(tenant_config)
+        tenant_config.openai_api_key = LIVE_E2E_OPENAI_API_KEY
         session.add_all(
             [
                 Email(

--- a/backend/tests/live/test_live_api_sequence.py
+++ b/backend/tests/live/test_live_api_sequence.py
@@ -2,16 +2,70 @@
 
 from __future__ import annotations
 
-import json
+import base64
+import hashlib
+import hmac
 import http.client
+import json
+import os
 import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 
-def read_json(url: str, *, attempts: int = 12) -> dict[str, Any]:
+def _encode_json(value: dict[str, Any]) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _signed_live_session_token() -> str:
+    secret = os.environ.get("LIVE_E2E_SESSION_SECRET")
+    if not secret:
+        raise AssertionError("LIVE_E2E_SESSION_SECRET is required for live API smoke")
+
+    header = _encode_json({"alg": "HS256", "typ": "JWT"})
+    payload = _encode_json(
+        {
+            "ver": 1,
+            "iss": "naruon-control-plane",
+            "aud": "naruon-api",
+            "sub": "testuser",
+            "role": "member",
+            "org": "org-acme",
+            "groups": ["group-1", "group-2"],
+            "workspace": "workspace-org-acme",
+            "exp": int(time.time()) + 300,
+        }
+    )
+    signing_input = f"{header}.{payload}".encode("ascii")
+    signature = (
+        base64.urlsafe_b64encode(
+            hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return f"{header}.{payload}.{signature}"
+
+
+def _live_base_url() -> str:
+    live_base_url = os.environ.get("LIVE_BASE_URL")
+    if not live_base_url:
+        raise AssertionError("LIVE_BASE_URL is required for live API smoke")
+    return live_base_url.rstrip("/")
+
+
+def read_json(
+    url: str,
+    token: str,
+    *,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    attempts: int = 12,
+) -> dict[str, Any]:
     last_error: Exception | None = None
+    request_body = json.dumps(body).encode("utf-8") if body is not None else None
     for _ in range(attempts):
         try:
             parsed_url = urlsplit(url)
@@ -31,7 +85,15 @@ def read_json(url: str, *, attempts: int = 12) -> dict[str, Any]:
                 timeout=5,
             )
             try:
-                connection.request("GET", request_path)
+                headers = {"Authorization": f"Bearer {token}"}
+                if request_body is not None:
+                    headers["Content-Type"] = "application/json"
+                connection.request(
+                    method,
+                    request_path,
+                    body=request_body,
+                    headers=headers,
+                )
                 response = connection.getresponse()
                 if response.status != 200:
                     raise http.client.HTTPException(
@@ -46,14 +108,31 @@ def read_json(url: str, *, attempts: int = 12) -> dict[str, Any]:
     raise AssertionError(f"live endpoint unavailable: {url}") from last_error
 
 
-def test_live_api_sequence_uses_real_http(live_base_url: str) -> None:
+def test_live_api_sequence_uses_real_http() -> None:
+    live_base_url = _live_base_url()
+    token = _signed_live_session_token()
     for _ in range(12):
-        inbox = read_json(f"{live_base_url}/api/emails")
+        inbox = read_json(f"{live_base_url}/api/emails", token)
         subjects = {item.get("subject") for item in inbox["emails"]}
         if "Live E2E Release" in subjects:
             return
         time.sleep(1)
     raise AssertionError("seeded live email was not observed in time")
+
+
+def test_live_search_handles_local_embedding_dimension() -> None:
+    live_base_url = _live_base_url()
+    token = _signed_live_session_token()
+    search_results = read_json(
+        f"{live_base_url}/api/search",
+        token,
+        method="POST",
+        body={"query": "Live E2E Release", "limit": 3},
+        attempts=3,
+    )
+
+    subjects = {item.get("subject") for item in search_results["results"]}
+    assert "Live E2E Release" in subjects
 
 
 def test_live_harness_forbids_in_process_clients_and_mocks() -> None:

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -156,17 +156,25 @@ def test_frontend_dockerfile_builds_and_starts_production_artifact() -> None:
         "RUN pnpm run build"
     )
     assert "pnpm run build" in dockerfile
-    assert 'CMD ["pnpm", "run", "start"' in dockerfile or "pnpm run start" in dockerfile
+    assert "ENV POSTCSS_WORKERS=1" in dockerfile
+    assert "ENV DISABLE_POSTCSS_WORKERS=true" in dockerfile
+    assert (
+        'CMD ["./node_modules/.bin/next", "start", "--hostname", "0.0.0.0", "--port", "3000"]'
+        in dockerfile
+    )
+    assert "pnpm run start" not in dockerfile
     assert "pnpm run dev" not in dockerfile
 
 
 def test_backend_dockerfile_uses_modern_env_syntax() -> None:
     dockerfile = read_repo_text("Dockerfile")
 
+    assert "FROM python:3.11-slim AS backend-runtime" in dockerfile
     assert "ENV PYTHONDONTWRITEBYTECODE=1" in dockerfile
     assert "ENV PYTHONUNBUFFERED=1" in dockerfile
     assert "pnpm install --frozen-lockfile" in dockerfile
     assert "pnpm run build" in dockerfile
+    assert "FROM backend-runtime" in dockerfile
     assert "COPY --from=frontend-builder /usr/local/bin/node" in dockerfile
     assert "nodejs" not in dockerfile
     assert "ENV PYTHONDONTWRITEBYTECODE 1" not in dockerfile
@@ -181,6 +189,10 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     compose = read_repo_text("docker-compose.yml")
     live_e2e_compose = read_repo_text("docker-compose.live-e2e.yml")
 
+    backend_block = compose.split("  backend:", 1)[1].split("  frontend:", 1)[0]
+    assert "target: backend-runtime" in backend_block
+    assert 'DEBUG: "false"' in backend_block
+    assert 'DEBUG: "true"' not in backend_block
     assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
     assert '"scripts/start_backend.py"' in live_e2e_compose
 
@@ -191,6 +203,8 @@ def test_compose_log_scanner_exists_for_warning_policy() -> None:
     assert "warning|warn|deprecated|notice|fatal|denied|unable" in scanner
     assert "allowed_count" in scanner
     assert "unexpected_count" in scanner
+    assert "Use --ui/--no-ui" in scanner
+    assert "or deprecated --webui/--no-webui" in scanner
 
 
 def test_strix_workflow_uses_github_models_default_and_narrow_warning_filter() -> (

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -27,6 +27,31 @@ def test_frontend_dockerfile_runs_as_non_root_user():
     assert dockerfile.rfind("USER node") > dockerfile.rfind("RUN pnpm run build")
 
 
+def test_ollama_dockerfile_keeps_pulled_models_available_to_runtime_user():
+    dockerfile = (REPO_ROOT / "Dockerfile.ollama").read_text()
+
+    assert "ENV OLLAMA_MODELS=/usr/share/ollama/.ollama/models" in dockerfile
+    assert "useradd --system --create-home --home-dir /home/ollama" in dockerfile
+    assert "curl " not in dockerfile
+    assert "for attempt in $(seq 1 60)" in dockerfile
+    assert "if ollama list > /dev/null 2>&1" in dockerfile
+    assert "cat /tmp/ollama-build.log; exit 1" in dockerfile
+    assert "ollama pull gemma4" in dockerfile
+    assert "ollama pull embeddinggemma" in dockerfile
+    assert dockerfile.count("RUN set -eux;") >= 2
+    assert dockerfile.find("ollama pull gemma4") < dockerfile.find(
+        "ollama pull embeddinggemma"
+    )
+    assert "ollama list | grep -E '^gemma4(:|[[:space:]])'" in dockerfile
+    assert (
+        "ollama list | grep -E '^embeddinggemma(:|[[:space:]])'" in dockerfile
+    )
+    assert "chown -R ollama:ollama /usr/share/ollama/.ollama" in dockerfile
+    assert dockerfile.rfind("USER ollama") > dockerfile.rfind(
+        "chown -R ollama:ollama /usr/share/ollama/.ollama"
+    )
+
+
 def test_backend_requirements_do_not_pin_yanked_email_validator():
     requirements = (REPO_ROOT / "backend" / "requirements.txt").read_text()
 

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -139,3 +139,29 @@ def test_search_endpoint_query_is_scoped_to_current_user(mock_generate_embedding
     }
     assert user_scope_params == {"testuser"}
     assert organization_scope_params == {"org-acme"}
+
+
+@patch("api.search.generate_embeddings", new_callable=AsyncMock)
+def test_search_falls_back_to_text_rank_when_embedding_dimension_mismatches(
+    mock_generate_embeddings,
+):
+    mock_generate_embeddings.return_value = [[0.1] * 768]
+    session = CapturingMockSession()
+
+    async def override_scoped_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_scoped_db
+    try:
+        with TestClient(
+            app,
+            headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"},
+        ) as client:
+            response = client.post("/api/search", json={"query": "test query"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    query_text = str(session.statements[-1]).lower()
+    assert "ts_rank_cd" in query_text
+    assert "<=>" not in query_text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: backend-runtime
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}@db:5432/${POSTGRES_DB:-ai_email}
-      DEBUG: "true"
+      DEBUG: "false"
       ALLOW_LOCAL_LLM_PROVIDERS: "true"
       ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,9 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
+ENV POSTCSS_WORKERS=1
+ENV DISABLE_POSTCSS_WORKERS=true
+
 RUN pnpm run build
 
 RUN chown -R node:node /app
@@ -32,4 +35,4 @@ USER node
 
 EXPOSE 3000
 
-CMD ["pnpm", "run", "start", "--", "--hostname", "0.0.0.0"]
+CMD ["./node_modules/.bin/next", "start", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,12 +15,14 @@ export default defineConfig({
     actionTimeout: 15_000,
     navigationTimeout: 60_000,
   },
-  webServer: {
-    command: `npm run dev -- -p ${devServerPort}`,
-    port: devServerPort,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: process.env.LIVE_BASE_URL
+    ? undefined
+    : {
+        command: `npm run dev -- -p ${devServerPort}`,
+        port: devServerPort,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
   projects: [
     {
       name: 'desktop',

--- a/frontend/tests/e2e/live-smoke.spec.ts
+++ b/frontend/tests/e2e/live-smoke.spec.ts
@@ -1,4 +1,39 @@
 import { expect, test } from '@playwright/test';
+import crypto from 'node:crypto';
+
+const liveSessionPayload = {
+  ver: 1,
+  iss: 'naruon-control-plane',
+  aud: 'naruon-api',
+  sub: 'testuser',
+  role: 'member',
+  org: 'org-acme',
+  groups: ['group-1', 'group-2'],
+  workspace: 'workspace-org-acme',
+};
+
+function encodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function signLiveSession(): string {
+  const secret = process.env.LIVE_E2E_SESSION_SECRET;
+  if (!secret) {
+    throw new Error('LIVE_E2E_SESSION_SECRET is required for live smoke tests.');
+  }
+
+  const header = encodeJson({ alg: 'HS256', typ: 'JWT' });
+  const payload = encodeJson({
+    ...liveSessionPayload,
+    exp: Math.floor(Date.now() / 1000) + 300,
+  });
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`, 'ascii')
+    .digest('base64url');
+
+  return `${header}.${payload}.${signature}`;
+}
 
 test.skip(
   !process.env.LIVE_BASE_URL && process.env.RUN_LIVE_E2E !== '1',
@@ -17,9 +52,16 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('live dashboard renders seeded inbox through real HTTP', async ({ page }) => {
+  const sessionToken = signLiveSession();
+
+  await page.addInitScript((token) => {
+    window.localStorage.setItem('naruon_session_token', token);
+  }, sessionToken);
   await page.goto('/');
 
   await expect(page.getByRole('img', { name: 'Naruon' })).toBeVisible();
-  await expect(page.getByText('Live E2E Release')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText('Live E2E Release').first()).toBeVisible({
+    timeout: 15_000,
+  });
   await expect(page.getByText('Failed to load emails.')).toHaveCount(0);
 });

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -43,5 +43,6 @@ test('nano test: verify user requested features', async ({ page }) => {
 
   // 2. Check Data page for email import
   await page.goto('/data');
-  await expect(page.getByText('이메일 반입', { exact: false }).first()).toBeVisible();
+  await expect(page.getByRole('button', { name: '이메일 파일 선택' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '선택 파일 반입' })).toBeVisible();
 });

--- a/scripts/check_compose_logs.py
+++ b/scripts/check_compose_logs.py
@@ -95,6 +95,16 @@ ALLOWLIST: tuple[AllowedLogPattern, ...] = (
             re.IGNORECASE,
         ),
     ),
+    AllowedLogPattern(
+        component="ollama",
+        version="ollama/ollama local runner",
+        rationale="Ollama's bundled llama.cpp runner emits an informational UI flag migration hint.",
+        pattern=re.compile(
+            r"srv\s+init:\s+Use --ui/--no-ui "
+            r"\(or deprecated --webui/--no-webui\) to enable/disable",
+            re.IGNORECASE,
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- split the root Dockerfile so Compose can build a backend-runtime target without building the frontend
- package Gemma4 and Embeddinggemma into the Ollama image with runtime-readable model storage
- make live smoke tests use signed bearer sessions and seed scoped local model config
- fall back to text ranking when a local embedding model returns a non-1536 vector

## Validation
- python -m pytest --noconftest tests/test_repo_hygiene.py::test_ollama_dockerfile_keeps_pulled_models_available_to_runtime_user tests/test_release_governance.py::test_frontend_dockerfile_builds_and_starts_production_artifact tests/test_release_governance.py::test_backend_dockerfile_uses_modern_env_syntax tests/test_release_governance.py::test_backend_compose_commands_use_startup_preflight tests/test_release_governance.py::test_compose_log_scanner_exists_for_warning_policy -q
- LIVE_BASE_URL=http://127.0.0.1:8000 LIVE_E2E_SESSION_SECRET=*** python -m pytest --noconftest tests/live/test_live_api_sequence.py -q
- LIVE_BASE_URL=http://127.0.0.1:3000 RUN_LIVE_E2E=1 LIVE_E2E_SESSION_SECRET=*** pnpm exec playwright test tests/e2e/live-smoke.spec.ts --project=desktop --reporter=line
- pnpm exec playwright test tests/e2e/nano.spec.ts --project=desktop --reporter=line
- pnpm exec tsc --noEmit --pretty false
- podman exec naruon-goal_backend_1 python -m pytest tests/test_search.py::test_search_falls_back_to_text_rank_when_embedding_dimension_mismatches -q
- scripts/check_compose_logs.py over backend/frontend/ollama/db logs
- ./scripts/naruon_compose.sh -p naruon-goal build backend
- ./scripts/naruon_compose.sh -p naruon-goal build frontend
- ./scripts/naruon_compose.sh -p naruon-goal build ollama
- ./scripts/naruon_compose.sh -p naruon-goal up -d
