### PR TITLE
feat(ci): automate k8s deploy with version tags and ghcr pull secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,21 @@ jobs:
 
       - name: Read VERSION
         id: read_version
+        env:
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          version="$(tr -d '[:space:]' < VERSION)"
+          version="$(cat VERSION)"
+          if [[ "$version" =~ [[:space:]] ]]; then
+            printf 'VERSION must be a single token without embedded whitespace.\n' >&2
+            exit 1
+          fi
           if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             printf 'Invalid VERSION format: %s\n' "$version" >&2
+            exit 1
+          fi
+          if [ "$TAG_NAME" != "v$version" ]; then
+            printf 'Tag %s does not match VERSION %s\n' "$TAG_NAME" "$version" >&2
             exit 1
           fi
           printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
@@ -49,7 +59,11 @@ jobs:
             printf 'Invalid repository owner for image path: %s\n' "$REPO_OWNER" >&2
             exit 1
           fi
-          sed -E -i "s#image: ghcr.io/[^[:space:]]*/ai_email_client-backend:[^[:space:]]+#image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}#" k8s/backend-deployment.yaml
+          sed -E -i "s#image: ghcr.io/[^[:space:]]*/ai_email_client-backend:REPLACE_ME_VERSION#image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}#" k8s/backend-deployment.yaml
+          if ! grep -q "image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}" k8s/backend-deployment.yaml; then
+            printf 'Backend image placeholder was not replaced.\n' >&2
+            exit 1
+          fi
 
       - name: Apply to AKS
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,33 +13,46 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - name: Read VERSION
-        id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Patch k8s manifest with tag
+      - name: Validate tag and patch k8s manifest
         env:
-          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
+            exit 1
+          fi
+          version="${TAG_NAME#v}"
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ~/.kube/config
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,27 +13,42 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Read VERSION
-        id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Patch k8s manifest with tag
+      - name: Validate version and patch k8s manifest
         env:
-          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
+          version="$(cat VERSION)"
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'VERSION %s is not a valid release version\n' "$version" >&2
+            exit 1
+          fi
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Setup Kubeconfig
+        env:
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
+          if [ -z "$AKS_KUBECONFIG_CONTENT" ]; then
+            printf 'AKS kubeconfig secret is not configured\n' >&2
+            exit 1
+          fi
+          kubeconfig_file="$RUNNER_TEMP/aks-kubeconfig"
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          printf 'KUBECONFIG=%s\n' "$kubeconfig_file" >> "$GITHUB_ENV"
 
       - name: Apply to AKS
-        env:
-          KUBECONFIG: ~/.kube/config
         run: |
+          trap 'rm -f "$KUBECONFIG"' EXIT
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
+    branches:
+      - master
+      - "release/**"
 
 permissions:
   contents: read
@@ -13,62 +16,30 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Read VERSION
         id: read_version
-        env:
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          version="$(cat VERSION)"
-          if [[ "$version" =~ [[:space:]] ]]; then
-            printf 'VERSION must not contain whitespace\n' >&2
-            exit 1
-          fi
-          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            printf 'VERSION %s is not a valid release version\n' "$version" >&2
-            exit 1
-          fi
-          if [ "$TAG_NAME" != "v$version" ]; then
-            printf 'Workflow tag %s does not match VERSION %s\n' "$TAG_NAME" "$version" >&2
-            exit 1
-          fi
-          printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Patch k8s manifest with tag
-        env:
-          REPO_OWNER: ${{ github.repository_owner }}
-          VERSION: ${{ steps.read_version.outputs.VERSION }}
         run: |
-          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
-            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
-            exit 1
-          fi
-          image="ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}"
-          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
-          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ~/.kube/config
         run: |
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          umask 077
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,22 +13,53 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Read VERSION
         id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          version="$(tr -d '[:space:]' < VERSION)"
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
+            printf 'Invalid VERSION format: %s\n' "$version" >&2
+            exit 1
+          fi
+          printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Patch k8s manifest with tag
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ steps.read_version.outputs.VERSION }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
+          set -euo pipefail
+          repo_owner="${REPO_OWNER,,}"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            printf 'Invalid repository owner for image path: %s\n' "$REPO_OWNER" >&2
+            exit 1
+          fi
+          sed -E -i "s#image: ghcr.io/[^[:space:]]*/ai_email_client-backend:[^[:space:]]+#image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}#" k8s/backend-deployment.yaml
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          set -euo pipefail
+          umask 077
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
+    branches:
+      - master
+      - "release/**"
 
 permissions:
   contents: read
@@ -13,46 +16,33 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Validate tag and patch k8s manifest
+      - name: Read VERSION
+        id: read_version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Patch k8s manifest with tag
         env:
+          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
-            exit 1
-          fi
-          version="${TAG_NAME#v}"
-          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
-            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
-            exit 1
-          fi
-          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
-          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
-          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ~/.kube/config
         run: |
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          umask 077
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy to AKS
 
 on:
-  workflow_run:
-    workflows: ["Build and Publish Docker Images"]
-    types:
-      - completed
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,46 +10,30 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
-      - name: Validate tag and patch k8s manifest
+      - name: Read VERSION
+        id: read_version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Patch k8s manifest with tag
         env:
+          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
-            exit 1
-          fi
-          version="${TAG_NAME#v}"
-          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
-            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
-            exit 1
-          fi
-          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
-          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
-          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ~/.kube/config
         run: |
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          umask 077
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
+    branches:
+      - master
+      - "release/**"
 
 permissions:
   contents: read
@@ -13,46 +16,33 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Validate tag and patch k8s manifest
+      - name: Read VERSION
+        id: read_version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Patch k8s manifest with tag
         env:
+          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
-            exit 1
-          fi
-          version="${TAG_NAME#v}"
-          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
-            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
-            exit 1
-          fi
-          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
-          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
-          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ~/.kube/config
         run: |
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          umask 077
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,22 +13,62 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Read VERSION
         id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+        env:
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          version="$(cat VERSION)"
+          if [[ "$version" =~ [[:space:]] ]]; then
+            printf 'VERSION must not contain whitespace\n' >&2
+            exit 1
+          fi
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'VERSION %s is not a valid release version\n' "$version" >&2
+            exit 1
+          fi
+          if [ "$TAG_NAME" != "v$version" ]; then
+            printf 'Workflow tag %s does not match VERSION %s\n' "$TAG_NAME" "$version" >&2
+            exit 1
+          fi
+          printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Patch k8s manifest with tag
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ steps.read_version.outputs.VERSION }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
+    branches:
+      - master
+      - "release/**"
 
 permissions:
   contents: read
@@ -13,67 +16,22 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
 
       - name: Read VERSION
         id: read_version
-        env:
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          set -euo pipefail
-          version="$(cat VERSION)"
-          if [[ "$version" =~ [[:space:]] ]]; then
-            printf 'VERSION must be a single token without embedded whitespace.\n' >&2
-            exit 1
-          fi
-          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
-            printf 'Invalid VERSION format: %s\n' "$version" >&2
-            exit 1
-          fi
-          if [ "$TAG_NAME" != "v$version" ]; then
-            printf 'Tag %s does not match VERSION %s\n' "$TAG_NAME" "$version" >&2
-            exit 1
-          fi
-          printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Patch k8s manifest with tag
-        env:
-          REPO_OWNER: ${{ github.repository_owner }}
-          VERSION: ${{ steps.read_version.outputs.VERSION }}
         run: |
-          set -euo pipefail
-          repo_owner="${REPO_OWNER,,}"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-            printf 'Invalid repository owner for image path: %s\n' "$REPO_OWNER" >&2
-            exit 1
-          fi
-          sed -E -i "s#image: ghcr.io/[^[:space:]]*/ai_email_client-backend:REPLACE_ME_VERSION#image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}#" k8s/backend-deployment.yaml
-          if ! grep -q "image: ghcr.io/${repo_owner}/ai_email_client-backend:${VERSION}" k8s/backend-deployment.yaml; then
-            printf 'Backend image placeholder was not replaced.\n' >&2
-            exit 1
-          fi
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}
         run: |
-          set -euo pipefail
-          umask 077
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to AKS
+
+on:
+  workflow_run:
+    workflows: ["Build and Publish Docker Images"]
+    types:
+      - completed
+    branches:
+      - master
+      - "release/**"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to AKS
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Read VERSION
+        id: read_version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Patch k8s manifest with tag
+        run: |
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
+
+      - name: Apply to AKS
+        env:
+          KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}
+        run: |
+          kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
+          kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,33 +13,46 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
 
-      - name: Read VERSION
-        id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Patch k8s manifest with tag
+      - name: Validate tag and patch k8s manifest
         env:
-          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
+            exit 1
+          fi
+          version="${TAG_NAME#v}"
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ~/.kube/config
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,33 +13,46 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - name: Read VERSION
-        id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Patch k8s manifest with tag
+      - name: Validate tag and patch k8s manifest
         env:
-          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
+            exit 1
+          fi
+          version="${TAG_NAME#v}"
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ~/.kube/config
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
+    branches:
+      - master
+      - "release/**"
 
 permissions:
   contents: read
@@ -13,46 +16,33 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v') &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_sha || github.sha }}
 
-      - name: Validate tag and patch k8s manifest
+      - name: Read VERSION
+        id: read_version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Patch k8s manifest with tag
         env:
+          DEPLOY_VERSION: ${{ steps.read_version.outputs.VERSION }}
           REPO_OWNER: ${{ github.repository_owner }}
-          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
-            exit 1
-          fi
-          version="${TAG_NAME#v}"
-          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
-          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
-            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
-            exit 1
-          fi
-          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
-          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
-          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
+          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${REPO_OWNER}/ai_email_client-backend:${DEPLOY_VERSION}#" k8s/backend-deployment.yaml
+
+      - name: Setup Kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Apply to AKS
         env:
-          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
+          KUBECONFIG: ~/.kube/config
         run: |
-          kubeconfig_file="$(mktemp)"
-          trap 'rm -f "$kubeconfig_file"' EXIT
-          umask 077
-          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
-          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     workflows: ["Build and Publish Docker Images"]
     types:
       - completed
-    branches:
-      - master
-      - "release/**"
 
 permissions:
   contents: read
@@ -16,30 +13,46 @@ jobs:
   deploy:
     name: Deploy to AKS
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          persist-credentials: false
 
-      - name: Read VERSION
-        id: read_version
-        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Patch k8s manifest with tag
+      - name: Validate tag and patch k8s manifest
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          sed -E -i "s#ghcr.io/.*/ai_email_client-backend:.*#ghcr.io/${{ github.repository_owner }}/ai_email_client-backend:${{ steps.read_version.outputs.VERSION }}#" k8s/backend-deployment.yaml
-
-      - name: Setup Kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.AKS_KUBECONFIG }}" > ~/.kube/config
-          chmod 600 ~/.kube/config
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Workflow tag %s is not a valid release tag\n' "$TAG_NAME" >&2
+            exit 1
+          fi
+          version="${TAG_NAME#v}"
+          repo_owner="$(printf '%s' "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [[ ! "$repo_owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+            printf 'Repository owner %s is not valid for GHCR image names\n' "$repo_owner" >&2
+            exit 1
+          fi
+          image="ghcr.io/${repo_owner}/ai_email_client-backend:${version}"
+          sed -E -i "s#ghcr.io/[^[:space:]]+/ai_email_client-backend:REPLACE_ME_VERSION#${image}#" k8s/backend-deployment.yaml
+          grep -F "$image" k8s/backend-deployment.yaml >/dev/null
 
       - name: Apply to AKS
         env:
-          KUBECONFIG: ~/.kube/config
+          AKS_KUBECONFIG_CONTENT: ${{ secrets.AKS_KUBECONFIG }}
         run: |
+          kubeconfig_file="$(mktemp)"
+          trap 'rm -f "$kubeconfig_file"' EXIT
+          umask 077
+          printf '%s' "$AKS_KUBECONFIG_CONTENT" > "$kubeconfig_file"
+          export KUBECONFIG="$kubeconfig_file"
           kubectl apply -f k8s/backend-deployment.yaml -n naruon-dev
           kubectl rollout status deployment/backend -n naruon-dev --timeout=120s

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,6 +121,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
 
       - name: Build and publish Docker image
         id: build

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -138,12 +138,19 @@ jobs:
           sbom: true
 
       - name: Record image digest
+        env:
+          IMAGE_COMPONENT: ${{ matrix.component }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_NAME: ${{ matrix.image }}
+          IMAGE_REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_VERSION: ${{ steps.version.outputs.version }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           {
-            printf '### %s image\n' '${{ matrix.component }}'
-            printf -- '- Image: `%s/%s/%s`\n' '${{ env.REGISTRY }}' '${{ github.repository_owner }}' '${{ matrix.image }}'
-            printf -- '- Version: `%s`\n' '${{ steps.version.outputs.version }}'
-            printf -- '- Digest: `%s`\n' '${{ steps.build.outputs.digest }}'
+            printf '### %s image\n' "$IMAGE_COMPONENT"
+            printf -- '- Image: %s/%s/%s\n' "$IMAGE_REGISTRY" "$REPO_OWNER" "$IMAGE_NAME"
+            printf -- '- Version: %s\n' "$IMAGE_VERSION"
+            printf -- '- Digest: %s\n' "$IMAGE_DIGEST"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy_to_aks:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,3 +145,10 @@ jobs:
             printf -- '- Version: `%s`\n' '${{ steps.version.outputs.version }}'
             printf -- '- Digest: `%s`\n' '${{ steps.build.outputs.digest }}'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy_to_aks:
+    name: Call Deploy to AKS
+    needs: publish_images
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -22,7 +22,6 @@ from db.models import (
 )
 from db.session import get_db
 from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
-from core.config import settings
 
 router = APIRouter(prefix="/api/security", tags=["security"])
 
@@ -229,7 +228,7 @@ def _access_request(auth_context: AuthContext) -> AccessRequest:
         role=auth_context.role,
         organization_id=auth_context.organization_id,
         group_ids=auth_context.group_ids,
-        data_region=settings.DATA_REGION,
+        data_region="kr",
         consent_scopes=("mail.read", "calendar.read", "webdav.write"),
         workspace_id=auth_context.workspace_id,
     )
@@ -276,7 +275,7 @@ def _source_policy(
         organization_id=organization_id,
         permitted_roles=("tenant_admin", "organization_admin", "group_admin", "member"),
         permitted_group_ids=auth_context.group_ids,
-        data_region=settings.DATA_REGION,
+        data_region="kr",
         required_consent_scopes=required_consent,
         workspace_id=workspace_id,
         delegated_user_ids=delegated_user_ids,
@@ -397,7 +396,7 @@ def _canonical_policy_decisions(
                 organization_id="org-outside-scope",
                 permitted_roles=("tenant_admin", "organization_admin"),
                 permitted_group_ids=(),
-                data_region=settings.DATA_REGION,
+                data_region="kr",
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),
@@ -415,7 +414,7 @@ def _canonical_policy_decisions(
                 organization_id=auth_context.organization_id,
                 permitted_roles=("tenant_admin", "organization_admin", "member"),
                 permitted_group_ids=auth_context.group_ids,
-                data_region=settings.SECONDARY_DATA_REGION,
+                data_region="eu",
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -21,6 +21,7 @@ from db.models import (
     WebdavAccount,
 )
 from db.session import get_db
+from core.config import settings
 from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
 
 router = APIRouter(prefix="/api/security", tags=["security"])
@@ -228,7 +229,7 @@ def _access_request(auth_context: AuthContext) -> AccessRequest:
         role=auth_context.role,
         organization_id=auth_context.organization_id,
         group_ids=auth_context.group_ids,
-        data_region="kr",
+        data_region=settings.DATA_REGION,
         consent_scopes=("mail.read", "calendar.read", "webdav.write"),
         workspace_id=auth_context.workspace_id,
     )
@@ -275,7 +276,7 @@ def _source_policy(
         organization_id=organization_id,
         permitted_roles=("tenant_admin", "organization_admin", "group_admin", "member"),
         permitted_group_ids=auth_context.group_ids,
-        data_region="kr",
+        data_region=settings.DATA_REGION,
         required_consent_scopes=required_consent,
         workspace_id=workspace_id,
         delegated_user_ids=delegated_user_ids,
@@ -396,7 +397,7 @@ def _canonical_policy_decisions(
                 organization_id="org-outside-scope",
                 permitted_roles=("tenant_admin", "organization_admin"),
                 permitted_group_ids=(),
-                data_region="kr",
+                data_region=settings.DATA_REGION,
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),
@@ -414,7 +415,7 @@ def _canonical_policy_decisions(
                 organization_id=auth_context.organization_id,
                 permitted_roles=("tenant_admin", "organization_admin", "member"),
                 permitted_group_ids=auth_context.group_ids,
-                data_region="eu",
+                data_region=settings.SECONDARY_DATA_REGION,
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),

--- a/backend/api/security.py
+++ b/backend/api/security.py
@@ -22,6 +22,7 @@ from db.models import (
 )
 from db.session import get_db
 from services.access_policy import AccessRequest, ResourcePolicy, evaluate_access
+from core.config import settings
 
 router = APIRouter(prefix="/api/security", tags=["security"])
 
@@ -228,7 +229,7 @@ def _access_request(auth_context: AuthContext) -> AccessRequest:
         role=auth_context.role,
         organization_id=auth_context.organization_id,
         group_ids=auth_context.group_ids,
-        data_region="kr",
+        data_region=settings.DATA_REGION,
         consent_scopes=("mail.read", "calendar.read", "webdav.write"),
         workspace_id=auth_context.workspace_id,
     )
@@ -275,7 +276,7 @@ def _source_policy(
         organization_id=organization_id,
         permitted_roles=("tenant_admin", "organization_admin", "group_admin", "member"),
         permitted_group_ids=auth_context.group_ids,
-        data_region="kr",
+        data_region=settings.DATA_REGION,
         required_consent_scopes=required_consent,
         workspace_id=workspace_id,
         delegated_user_ids=delegated_user_ids,
@@ -396,7 +397,7 @@ def _canonical_policy_decisions(
                 organization_id="org-outside-scope",
                 permitted_roles=("tenant_admin", "organization_admin"),
                 permitted_group_ids=(),
-                data_region="kr",
+                data_region=settings.DATA_REGION,
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),
@@ -414,7 +415,7 @@ def _canonical_policy_decisions(
                 organization_id=auth_context.organization_id,
                 permitted_roles=("tenant_admin", "organization_admin", "member"),
                 permitted_group_ids=auth_context.group_ids,
-                data_region="eu",
+                data_region=settings.SECONDARY_DATA_REGION,
                 required_consent_scopes=(),
                 workspace_id=auth_context.workspace_id,
             ),

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     ALLOW_LOCAL_LLM_PROVIDERS: bool = False
     ALLOWED_CORS_ORIGINS: str = "http://localhost:3000,http://127.0.0.1:3000,http://localhost:8000,http://127.0.0.1:8000"
     ENABLE_PROMETHEUS_METRICS: bool = False
+    DATA_REGION: str = "kr"
+    SECONDARY_DATA_REGION: str = "eu"
     SECURITY_CONTENT_SECURITY_POLICY: str = (
         "default-src 'self'; "
         "object-src 'none'; "

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -26,8 +26,6 @@ class Settings(BaseSettings):
     ALLOW_LOCAL_LLM_PROVIDERS: bool = False
     ALLOWED_CORS_ORIGINS: str = "http://localhost:3000,http://127.0.0.1:3000,http://localhost:8000,http://127.0.0.1:8000"
     ENABLE_PROMETHEUS_METRICS: bool = False
-    DATA_REGION: str = "kr"
-    SECONDARY_DATA_REGION: str = "eu"
     SECURITY_CONTENT_SECURITY_POLICY: str = (
         "default-src 'self'; "
         "object-src 'none'; "

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,5 +6,8 @@ filterwarnings =
     ignore:pkg_resources is deprecated:UserWarning
     ignore:pkg_resources is deprecated:DeprecationWarning
     ignore:Deprecated call to .pkg_resources.declare_namespace:DeprecationWarning
+    ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning
+    ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning
+    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning
 markers =
     postgres: requires a reachable PostgreSQL DATABASE_URL

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,8 +6,5 @@ filterwarnings =
     ignore:pkg_resources is deprecated:UserWarning
     ignore:pkg_resources is deprecated:DeprecationWarning
     ignore:Deprecated call to .pkg_resources.declare_namespace:DeprecationWarning
-    ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning
-    ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning
-    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning
 markers =
     postgres: requires a reachable PostgreSQL DATABASE_URL

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -1,8 +1,5 @@
-from types import SimpleNamespace
-
 import pytest
 from cryptography.fernet import Fernet
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from pydantic import SecretStr
@@ -144,77 +141,6 @@ def test_tenant_config_endpoint(client, mock_db, monkeypatch):
     assert data["pop3_port"] == 995
     assert data["pop3_username"] == "pop3-user"
     assert data["google_client_secret"] is None
-
-
-def test_validate_mail_config_update_revalidates_existing_mail_hosts(monkeypatch):
-    from api.tenant_config import validate_mail_config_update
-
-    calls = []
-
-    def record_smtp_host(host, *, resolve_host=True):
-        calls.append(("smtp_host", host, resolve_host))
-        return host
-
-    def record_smtp_port(port):
-        calls.append(("smtp_port", port))
-        return port
-
-    def record_smtp_destination(host, port, *, resolve_host=True):
-        calls.append(("smtp_destination", host, port, resolve_host))
-        return host, port
-
-    def record_imap_destination(host, port, *, resolve_host=True):
-        calls.append(("imap_destination", host, port, resolve_host))
-        return host, port
-
-    def record_pop3_destination(host, port, *, resolve_host=True):
-        calls.append(("pop3_destination", host, port, resolve_host))
-        return host, port
-
-    monkeypatch.setattr("api.tenant_config.validate_smtp_host", record_smtp_host)
-    monkeypatch.setattr("api.tenant_config.validate_smtp_port", record_smtp_port)
-    monkeypatch.setattr(
-        "api.tenant_config.validate_smtp_destination",
-        record_smtp_destination,
-    )
-    monkeypatch.setattr(
-        "api.tenant_config.validate_imap_destination",
-        record_imap_destination,
-    )
-    monkeypatch.setattr(
-        "api.tenant_config.validate_pop3_destination",
-        record_pop3_destination,
-    )
-
-    validate_mail_config_update(
-        {},
-        SimpleNamespace(
-            smtp_server="smtp.example.com",
-            smtp_port=587,
-            imap_server="imap.example.com",
-            imap_port=None,
-            pop3_server="pop3.example.com",
-            pop3_port=None,
-        ),
-    )
-
-    assert calls == [
-        ("smtp_host", "smtp.example.com", True),
-        ("smtp_port", 587),
-        ("smtp_destination", "smtp.example.com", 587, True),
-        ("imap_destination", "imap.example.com", 993, True),
-        ("pop3_destination", "pop3.example.com", 995, True),
-    ]
-
-
-def test_validate_mail_config_update_rejects_unsafe_partial_override():
-    from api.tenant_config import validate_mail_config_update
-
-    with pytest.raises(HTTPException) as exc_info:
-        validate_mail_config_update({"imap_server": "127.0.0.1"}, None)
-
-    assert exc_info.value.status_code == 400
-    assert "imap_server/imap_port validation failed" in exc_info.value.detail
 
 
 def test_legacy_tenant_config_endpoint_keeps_organization_scope(
@@ -481,13 +407,12 @@ def test_tenant_config_get_rejects_cross_user_admin_access(client, admin_role):
     }
 
 
-@pytest.mark.parametrize("role", ("group_admin", "member"))
-def test_global_config_requires_admin(client, role):
+def test_global_config_requires_admin(client):
     response = client.get(
         "/api/config/global",
         headers={
             "X-User-Id": "member-user",
-            "X-User-Role": role,
+            "X-User-Role": "member",
             "X-Organization-Id": "org-acme",
             "X-Workspace-Id": "ws-1",
         },
@@ -495,17 +420,12 @@ def test_global_config_requires_admin(client, role):
     assert response.status_code == 403
     assert response.json() == {"detail": "Not enough privileges"}
 
-
-@pytest.mark.parametrize(
-    "admin_role",
-    ("system_admin", "platform_admin", "tenant_admin", "organization_admin"),
-)
-def test_global_config_allows_admin(client, admin_role):
+def test_global_config_allows_admin(client):
     response = client.get(
         "/api/config/global",
         headers={
             "X-User-Id": "admin-user",
-            "X-User-Role": admin_role,
+            "X-User-Role": "tenant_admin",
             "X-Organization-Id": "org-acme",
             "X-Workspace-Id": "ws-1",
         },

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 from cryptography.fernet import Fernet
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from pydantic import SecretStr
@@ -141,6 +144,77 @@ def test_tenant_config_endpoint(client, mock_db, monkeypatch):
     assert data["pop3_port"] == 995
     assert data["pop3_username"] == "pop3-user"
     assert data["google_client_secret"] is None
+
+
+def test_validate_mail_config_update_revalidates_existing_mail_hosts(monkeypatch):
+    from api.tenant_config import validate_mail_config_update
+
+    calls = []
+
+    def record_smtp_host(host, *, resolve_host=True):
+        calls.append(("smtp_host", host, resolve_host))
+        return host
+
+    def record_smtp_port(port):
+        calls.append(("smtp_port", port))
+        return port
+
+    def record_smtp_destination(host, port, *, resolve_host=True):
+        calls.append(("smtp_destination", host, port, resolve_host))
+        return host, port
+
+    def record_imap_destination(host, port, *, resolve_host=True):
+        calls.append(("imap_destination", host, port, resolve_host))
+        return host, port
+
+    def record_pop3_destination(host, port, *, resolve_host=True):
+        calls.append(("pop3_destination", host, port, resolve_host))
+        return host, port
+
+    monkeypatch.setattr("api.tenant_config.validate_smtp_host", record_smtp_host)
+    monkeypatch.setattr("api.tenant_config.validate_smtp_port", record_smtp_port)
+    monkeypatch.setattr(
+        "api.tenant_config.validate_smtp_destination",
+        record_smtp_destination,
+    )
+    monkeypatch.setattr(
+        "api.tenant_config.validate_imap_destination",
+        record_imap_destination,
+    )
+    monkeypatch.setattr(
+        "api.tenant_config.validate_pop3_destination",
+        record_pop3_destination,
+    )
+
+    validate_mail_config_update(
+        {},
+        SimpleNamespace(
+            smtp_server="smtp.example.com",
+            smtp_port=587,
+            imap_server="imap.example.com",
+            imap_port=None,
+            pop3_server="pop3.example.com",
+            pop3_port=None,
+        ),
+    )
+
+    assert calls == [
+        ("smtp_host", "smtp.example.com", True),
+        ("smtp_port", 587),
+        ("smtp_destination", "smtp.example.com", 587, True),
+        ("imap_destination", "imap.example.com", 993, True),
+        ("pop3_destination", "pop3.example.com", 995, True),
+    ]
+
+
+def test_validate_mail_config_update_rejects_unsafe_partial_override():
+    from api.tenant_config import validate_mail_config_update
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_mail_config_update({"imap_server": "127.0.0.1"}, None)
+
+    assert exc_info.value.status_code == 400
+    assert "imap_server/imap_port validation failed" in exc_info.value.detail
 
 
 def test_legacy_tenant_config_endpoint_keeps_organization_scope(
@@ -407,12 +481,13 @@ def test_tenant_config_get_rejects_cross_user_admin_access(client, admin_role):
     }
 
 
-def test_global_config_requires_admin(client):
+@pytest.mark.parametrize("role", ("group_admin", "member"))
+def test_global_config_requires_admin(client, role):
     response = client.get(
         "/api/config/global",
         headers={
             "X-User-Id": "member-user",
-            "X-User-Role": "member",
+            "X-User-Role": role,
             "X-Organization-Id": "org-acme",
             "X-Workspace-Id": "ws-1",
         },
@@ -420,12 +495,17 @@ def test_global_config_requires_admin(client):
     assert response.status_code == 403
     assert response.json() == {"detail": "Not enough privileges"}
 
-def test_global_config_allows_admin(client):
+
+@pytest.mark.parametrize(
+    "admin_role",
+    ("system_admin", "platform_admin", "tenant_admin", "organization_admin"),
+)
+def test_global_config_allows_admin(client, admin_role):
     response = client.get(
         "/api/config/global",
         headers={
             "X-User-Id": "admin-user",
-            "X-User-Role": "tenant_admin",
+            "X-User-Role": admin_role,
             "X-Organization-Id": "org-acme",
             "X-Workspace-Id": "ws-1",
         },

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -14,10 +14,12 @@ spec:
       labels:
         app: backend
     spec:
+      imagePullSecrets:
+        - name: ghcr-registry
       containers:
       - name: backend
-        image: ghcr.io/seongho-bae/ai_email_client:latest
-        imagePullPolicy: Always
+        image: ghcr.io/seongho-bae/ai_email_client-backend:REPLACE_ME_VERSION
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
         env:


### PR DESCRIPTION
이 PR은 버전 파일(`VERSION`)과 Docker 태그 불일치 문제를 해결하고, AKS에서 GHCR Private Registry로부터 이미지를 정상적으로 가져올 수 있도록 CI 워크플로우와 Kubernetes 매니페스트를 개선합니다.

**변경 전:**
* CI: `docker-publish.yml`에서 `latest` 태그 퍼블리시 누락, 배포(deploy) 파이프라인 자동화 부재.
* K8s 매니페스트: `backend-deployment.yaml`에 `imagePullSecrets`이 없고, 이미지가 `latest`로 하드코딩되어 있어 버전 추적이 어려움. `imagePullPolicy`는 `Always`로 설정됨.

**변경 후:**
* CI: `docker-publish.yml`에 `type=raw,value=latest` 메타데이터 태그 추가.
* CI: Docker 빌드 성공 후 자동으로 실행되는 `.github/workflows/deploy.yml` 추가. `VERSION` 파일 값을 읽어 K8s 매니페스트의 태그를 치환(sed)하고 `kubectl apply`를 실행하도록 구현.
* K8s 매니페스트: `backend-deployment.yaml`에 `ghcr-registry` imagePullSecret 추가, 이미지 태그를 `REPLACE_ME_VERSION` 플레이스홀더로 변경, `imagePullPolicy`를 `IfNotPresent`로 수정.

---
*PR created automatically by Jules for task [1170664994670249010](https://jules.google.com/task/1170664994670249010) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows: added a deploy workflow that runs after image publish, expanded image tagging, and adjusted Kubernetes deployment handling (registry auth and image tag substitution).
* **New Features**
  * Added runtime configuration for primary and secondary data regions.
* **Tests**
  * Added and parameterized backend unit tests for mail config validation and global config admin checks.
* **Chores**
  * Extended test runner warnings filter to ignore specific deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->