### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XXE Vulnerability in tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Log Injection / Terminal Escape Sequence Injection (CWE-117)
 **Learning:** Custom logic like `path.replace("\n", "").replace("\r", "")` is insufficient to prevent log injection and terminal escape sequence injection, as it leaves characters like ANSI color codes intact.
 **Prevention:** Use standard mechanisms like `repr()` or proper unicode escaping instead of custom string replacements.
+## 2026-06-09 - Insecure XML Parsing in Tests
+**Vulnerability:** Found `xml.etree.ElementTree.fromstring` being used to parse HTTP responses in `backend/tests/test_dav_api.py`.
+**Learning:** Using the standard library `xml.etree` module for parsing untrusted or external XML data exposes the application to XML External Entity (XXE) and XML bomb attacks (CWE-20). This was flagged by static analysis tools (Bandit B314).
+**Prevention:** Always use `defusedxml.ElementTree` instead of `xml.etree.ElementTree` when parsing XML to ensure protection against XML vulnerabilities. Ensure `defusedxml` is listed in `requirements.txt`.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,4 @@ opentelemetry-exporter-otlp==1.25.0
 setuptools==78.1.1
 websockets==14.1
 PyJWT==2.13.0
+defusedxml==0.7.1

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `xml.etree.ElementTree.fromstring` was used to parse HTTP responses in `backend/tests/test_dav_api.py`, which is susceptible to XML External Entity (XXE) and XML bomb attacks (CWE-20). This was flagged by Bandit (B314).
🎯 Impact: While this specific issue was found in test code, it represents a poor security pattern that could be copied into production code. It could potentially allow local file reading or denial-of-service if executed against malicious XML.
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` and added `defusedxml` to `requirements.txt`.
✅ Verification: Ran `bandit` scanner to confirm the B314 vulnerability is resolved, and executed the `pytest` test suite to verify tests continue to pass correctly.

---
*PR created automatically by Jules for task [9183334885646538507](https://jules.google.com/task/9183334885646538507) started by @seonghobae*