### PR TITLE
🎨 Palette: Add ARIA labels to interactive buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-06-08 - Focus-visible styles on interactive elements
 **Learning:** Keyboard accessibility relies on visual indicators when elements receive focus. Standard focus-visible rings (e.g. `focus-visible:ring-2 focus-visible:ring-ring/40`) must be applied globally to all interactive elements like buttons and tabs, instead of randomly missing them in different pages.
 **Action:** Audit all interactive elements (buttons, links, custom inputs) across components and standardise on `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40` to provide predictable tab navigation feedback.
+## 2024-03-20 - Add ARIA Labels to Missing Buttons
+**Learning:** Found multiple instances where buttons lacked `aria-label`s, which is critical for screen reader users and assistive technologies, especially for icon-only buttons or interactive elements like 'Add Item' and 'Change Status'.
+**Action:** When inspecting components with multiple interactive actions (like TasksLayout, CalendarLayout, and AIHubLayout), always ensure `aria-label`s are consistently applied alongside existing visual and keyboard styling.

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -122,8 +122,8 @@ export function CalendarLayout() {
     <div className="flex h-full min-h-0 bg-background text-foreground">
       {/* Left Sidebar - Calendar List */}
       <aside className="w-64 shrink-0 flex-col overflow-y-auto border-r border-border bg-card p-4 hidden lg:flex">
-        <button type="button" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
-          <Plus className="size-4" />새 일정
+        <button type="button" aria-label="새 일정 만들기" className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+          <Plus className="size-4" aria-hidden="true" />새 일정
         </button>
 
         <div className="mt-8">
@@ -145,8 +145,8 @@ export function CalendarLayout() {
               </li>
             ))}
           </ul>
-          <button type="button" className="mt-4 flex items-center gap-2 text-sm font-semibold text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
-            <Plus className="size-4" /> 캘린더 추가
+          <button type="button" aria-label="새 캘린더 계정 추가" className="mt-4 flex items-center gap-2 text-sm font-semibold text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+            <Plus className="size-4" aria-hidden="true" /> 캘린더 추가
           </button>
         </div>
       </aside>

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -270,11 +270,11 @@ export function TasksLayout() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
             <input type="text" placeholder="작업 검색..." className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-4 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64" />
           </div>
-          <button type="button" className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
-            <Filter className="size-4" /> 필터
+          <button type="button" aria-label="작업 필터링" className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-semibold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+            <Filter className="size-4" aria-hidden="true" /> 필터
           </button>
-          <button type="button" className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
-            <Plus className="size-4" /> 새 작업
+          <button type="button" aria-label="새 작업 추가" className="flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-bold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+            <Plus className="size-4" aria-hidden="true" /> 새 작업
           </button>
         </div>
       </header>
@@ -533,8 +533,8 @@ export function TasksLayout() {
                   ))}
                 </div>
                 <div className="p-3 border-t border-border">
-                  <button type="button" className="flex w-full items-center justify-center gap-2 rounded-md py-1.5 text-sm font-semibold text-muted-foreground hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
-                    <Plus className="size-4" /> 항목 추가
+                  <button type="button" aria-label="이 열에 새 작업 항목 추가" className="flex w-full items-center justify-center gap-2 rounded-md py-1.5 text-sm font-semibold text-muted-foreground hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+                    <Plus className="size-4" aria-hidden="true" /> 항목 추가
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to interactive buttons

💡 What: Added contextually descriptive `aria-label`s and `aria-hidden="true"` to icon elements inside key action buttons in `TasksLayout.tsx` and `CalendarLayout.tsx`.
🎯 Why: Certain interactive buttons lacked explicit accessible names or unnecessarily announced decorative icons. Adding these labels ensures assistive technologies (like screen readers) correctly interpret the function of these buttons.
♿ Accessibility: Improved keyboard and screen reader accessibility by ensuring clear, specific action intent is provided for icon-heavy buttons while maintaining existing keyboard focus states.

---
*PR created automatically by Jules for task [6584498802342613012](https://jules.google.com/task/6584498802342613012) started by @seonghobae*