### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix hardcoded CORS origins

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-11 - Fastapi CORS Configuration Hardening
+**Vulnerability:** Fastapi `allow_origins` for CORS was hardcoded to allow `localhost` in `backend/main.py`.
+**Learning:** Hardcoding local domains permits requests from unauthorized local development servers in production, violating secure defaults. Production origins should be strictly injected via environment variables.
+**Prevention:** Load CORS allowed origins from an environment variable (like `ALLOWED_CORS_ORIGINS`) via `pydantic-settings` in `core.config.py`, providing local fallback defaults only when the environment variable is not explicitly provided.

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     ALLOWED_POP3_HOSTS: str = ""
     ALLOWED_POP3_PORTS: str = "995"
     ALLOWED_LLM_BASE_URL_HOSTS: str = ""
+    ALLOWED_CORS_ORIGINS: str = ""
     ENABLE_PROMETHEUS_METRICS: bool = False
     SECURITY_CONTENT_SECURITY_POLICY: str = (
         "default-src 'self'; "

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,14 +73,22 @@ async def add_security_headers(request: Request, call_next):
         )
     return response
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+cors_origins = [
+    origin.strip()
+    for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
+    if origin.strip()
+]
+if not cors_origins:
+    cors_origins = [
         "http://localhost:3000",
         "http://127.0.0.1:3000",
         "http://localhost:8000",
         "http://127.0.0.1:8000",
-    ],
+    ]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** FastAPI's `allow_origins` configuration in `CORSMiddleware` was hardcoded to `localhost` and `127.0.0.1`.
🎯 **Impact:** In production, this overly permissive configuration allows requests from local development servers or potentially malicious local scripts running on a user's machine if the API is exposed or reachable.
🔧 **Fix:** Moved the allowed origins to an environment variable (`ALLOWED_CORS_ORIGINS`) via `core/config.py`. The application parses this configuration, and if empty, falls back to the local defaults. This ensures that production environments can be locked down strictly to trusted domains.
✅ **Verification:** Ran `cd backend && python3 -m pytest tests -q`. All 554 tests pass. Verified the changes in `backend/core/config.py` and `backend/main.py`.

---
*PR created automatically by Jules for task [13678306230225010309](https://jules.google.com/task/13678306230225010309) started by @seonghobae*