### PR TITLE
ci(strix): migrate trusted-base model contract to openai/gpt-5

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -131,7 +131,7 @@ jobs:
 
           jq -n --arg workspace "$GITHUB_WORKSPACE" '{
             "$schema": "https://opencode.ai/config.json",
-            "model": "github-models/openai/gpt-4o",
+            "model": "github-models/openai/gpt-5",
             "small_model": "github-models/deepseek/deepseek-v3-0324",
             "enabled_providers": ["github-models"],
             "mcp": {
@@ -243,12 +243,13 @@ jobs:
                   "apiKey": "{env:STRIX_GITHUB_MODELS_TOKEN}"
                 },
                 "models": {
-                  "openai/gpt-4o": {
-                    "name": "OpenAI GPT-4o",
+                  "openai/gpt-5": {
+                    "name": "OpenAI GPT-5",
                     "tool_call": true,
+                    "reasoning": true,
                     "limit": {
-                      "context": 128000,
-                      "output": 4096
+                      "context": 200000,
+                      "output": 100000
                     }
                   },
                   "deepseek/deepseek-r1-0528": {
@@ -282,7 +283,7 @@ jobs:
         env:
           STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODEL: github-models/openai/gpt-4o
+          MODEL: github-models/openai/gpt-5
           USE_GITHUB_TOKEN: "true"
           SHARE: "false"
           NPM_CONFIG_IGNORE_SCRIPTS: "true"

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -24,7 +24,7 @@ on:
       strix_llm:
         description: Optional Strix model override for manual evidence runs
         required: false
-        default: openai/gpt-4o
+        default: openai/gpt-5
         type: string
 
 concurrency:
@@ -117,15 +117,15 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/gpt-4o' }}
+          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/gpt-5' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
           STRIX_VERTEX_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
           STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
         run: |
           strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
-            openai/gpt-4* | openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-            openai/openai/gpt-4* | openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
+            openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
+            openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
             github_models/*)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               echo 'provider_mode=github_models' >> "$GITHUB_OUTPUT"
@@ -158,7 +158,7 @@ jobs:
               fi
               ;;
             *)
-              echo '::error::STRIX_LLM must select GitHub Models openai/gpt-4o or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
+              echo '::error::STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
               exit 1
               ;;
           esac
@@ -246,14 +246,14 @@ jobs:
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/gpt-4o' }}
+          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/gpt-5' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
           strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
-            openai/gpt-4* | openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-            openai/openai/gpt-4* | openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
+            openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
+            openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
             github_models/*)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
@@ -267,7 +267,7 @@ jobs:
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
             *)
-              echo '::error::STRIX_LLM must select GitHub Models openai/gpt-4o or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
+              echo '::error::STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model.'
               exit 1
               ;;
           esac


### PR DESCRIPTION
## Why
develop's strix self-test (`scripts/ci/test_strix_quick_gate.sh`) asserts the trusted-base workflow files default to GitHub Models `openai/gpt-5` (200000/100000 limits), but `strix.yml` and `opencode-review.yml` still pinned `openai/gpt-4o`. The mismatch fails the **Self-test Strix gate script** step on every develop-targeted PR (#468, #470, #471), cascading into the opencode-agent review gate auto-requesting changes.

## What
Minimal, surgical migration of the two trusted-base workflow files to the gpt-5 contract:
- `strix.yml`: default model override, accepted model-id case patterns, error messages → gpt-5
- `opencode-review.yml`: reviewer model + strix model config + advertised GPT-5 context/output limits (200000/100000)

Gate **scripts** are already correct on develop; only the workflow files lagged. This is the bootstrap fix — strix runs against the trusted base, so this PR's own strix check still runs against pre-merge develop and will fail (strix is non-required); once merged, develop-targeted PRs pass strix.

## Verification
The migrated files match the assertions in develop's `test_strix_quick_gate.sh` (gpt-5 default, rejection message, MODEL line, 200000/100000 limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)