### PR TITLE
feat(mail): add clear button and loading state to email search

### DIFF
--- a/frontend/src/components/EmailList.test.tsx
+++ b/frontend/src/components/EmailList.test.tsx
@@ -21,6 +21,15 @@ async function flushAsyncWork() {
   }
 }
 
+function setInputValue(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  valueSetter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
 describe("EmailList", () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
@@ -110,6 +119,69 @@ describe("EmailList", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("(제목 없음)");
+  });
+
+  it("shows search loading feedback and clears the query back to inbox results", async () => {
+    let resolveSearch: ((value: ReturnType<typeof jsonResponse>) => void) | null = null;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/search")) {
+        return new Promise((resolve) => {
+          resolveSearch = resolve;
+        });
+      }
+      return Promise.resolve(jsonResponse({ emails: [] }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<EmailList onSelectEmail={vi.fn()} selectedEmailId={null} />);
+    });
+    await flushAsyncWork();
+
+    const input = container.querySelector<HTMLInputElement>("#email-search");
+    const form = input?.closest("form");
+    const submitButton = form?.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(input).not.toBeNull();
+    expect(form).not.toBeNull();
+    expect(submitButton).not.toBeNull();
+
+    await act(async () => {
+      setInputValue(input as HTMLInputElement, "계약");
+    });
+    const clearButton = container.querySelector<HTMLButtonElement>('button[aria-label="검색어 지우기"]');
+    expect(clearButton).not.toBeNull();
+
+    await act(async () => {
+      form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    expect(submitButton?.disabled).toBe(true);
+    expect(submitButton?.textContent).toContain("검색 중");
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ query: "계약" }),
+      }),
+    );
+
+    await act(async () => {
+      resolveSearch?.(jsonResponse({ results: [] }));
+    });
+    await flushAsyncWork();
+
+    await act(async () => {
+      clearButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(input?.value).toBe("");
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/emails", expect.any(Object));
   });
 
   it("renders sent mail reply tracking mode from the sent folder API", async () => {

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { CheckCircle2, Mail, MessagesSquare, Network, Search, Sparkles } from "lucide-react";
+import { CheckCircle2, Loader2, Mail, MessagesSquare, Network, Search, Sparkles, X } from "lucide-react";
 import { formatEmailDate } from "@/lib/email-threading";
 import { toMailDisplayText } from "@/lib/mail-text";
 
@@ -217,10 +217,24 @@ export function EmailList({
               placeholder="메일, 사람, 키워드 검색..."
               value={searchQuery}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
-              className="h-10 rounded-xl border-input bg-background/80 pl-9 shadow-inner shadow-slate-950/[0.02]"
+              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02]"
             />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchQuery("");
+                  void fetchEmails("");
+                }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+                aria-label="검색어 지우기"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            )}
           </div>
           <Button type="submit" disabled={isSearching || loading} className="h-10 rounded-xl px-4">
+            {isSearching && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
             {isSearching ? "검색 중" : "검색"}
           </Button>
         </form>


### PR DESCRIPTION
## What
- Accessible clear (X) button in the 받은편지함 search input — appears when a query is present, resets the query and re-runs 맥락 검색 (`aria-label=검색어 지우기`).
- Loading spinner on the search button while a search is in flight.
- New unit tests in `EmailList.test.tsx`.

## Why re-cut
This is the clean, focused version of #468, which had accumulated develop-sync noise and now conflicts with the strix workflow migration landed in #476. Re-cut off current develop so strix/CI run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)