### PR TITLE
fix(docker): robust combined-image entrypoint that surfaces startup failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,19 +55,12 @@ COPY --from=frontend-builder /app/node_modules /app/frontend/node_modules
 COPY --from=frontend-builder /app/package.json /app/frontend/package.json
 COPY --from=frontend-builder /app/next.config.ts /app/frontend/next.config.ts
 
-# Create a startup script. DATABASE_URL and AUTH_SESSION_HMAC_SECRET must be
-# supplied by the operator or orchestrator; do not generate runtime secrets here.
-RUN echo '#!/bin/bash\n\
-set -euo pipefail\n\
-echo "Starting Naruon Backend and Frontend..."\n\
-python scripts/bootstrap_db.py\n\
-python scripts/start_backend.py --host 0.0.0.0 --port 8000 &\n\
-BACKEND_PID=$!\n\
-cd frontend && ./node_modules/.bin/next start --hostname 0.0.0.0 --port 3000 &\n\
-FRONTEND_PID=$!\n\
-trap "kill $BACKEND_PID $FRONTEND_PID 2>/dev/null || true" EXIT\n\
-wait -n "$BACKEND_PID" "$FRONTEND_PID"\n\
-' > /app/start.sh && chmod +x /app/start.sh
+# Startup is handled by scripts/docker_entrypoint.sh (copied with the backend in
+# stage 1). It validates required configuration (DATABASE_URL,
+# AUTH_SESSION_HMAC_SECRET, and a valid Fernet ENCRYPTION_KEY — never generated
+# at runtime), then starts backend and frontend together and reports which
+# service exits. Secrets must be supplied by the operator or orchestrator.
+RUN chmod +x /app/scripts/docker_entrypoint.sh
 
 # Create non-root user
 RUN useradd -m -s /bin/bash appuser && chown -R appuser:appuser /app
@@ -80,4 +73,4 @@ ENV ALLOW_DOCKER_BACKEND_INTERNAL_URL=1
 
 EXPOSE 3000 8000
 
-CMD ["/app/start.sh"]
+CMD ["/app/scripts/docker_entrypoint.sh"]

--- a/backend/scripts/docker_entrypoint.sh
+++ b/backend/scripts/docker_entrypoint.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Combined-image entrypoint: starts the Naruon backend (:8000) and frontend
+# (:3000) together in a single container. Validates required configuration up
+# front and reports which service exits, so a failed start is diagnosable
+# instead of silently taking both services down behind a raw stack trace.
+set -uo pipefail
+
+log() { printf '[naruon] %s\n' "$*"; }
+fail() { printf '[naruon] ERROR: %s\n' "$*" >&2; exit 1; }
+
+log "Starting Naruon combined image (backend :8000, frontend :3000)"
+
+# 1. Validate required runtime configuration before doing any work. These are
+#    supplied by the operator/orchestrator and are never generated at runtime.
+missing=()
+for var in DATABASE_URL AUTH_SESSION_HMAC_SECRET ENCRYPTION_KEY; do
+  if [ -z "${!var:-}" ]; then
+    missing+=("$var")
+  fi
+done
+if [ "${#missing[@]}" -ne 0 ]; then
+  fail "missing required environment: ${missing[*]}. ENCRYPTION_KEY must be a valid Fernet key (generate with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')."
+fi
+
+# 1b. Validate the Fernet key format up front. ENCRYPTION_KEY is otherwise only
+#     validated lazily on the first encrypted write, which surfaces as a
+#     confusing mid-runtime failure long after the container "came up".
+if ! python -c "import os; from cryptography.fernet import Fernet; Fernet(os.environ['ENCRYPTION_KEY'].encode())" 2>/dev/null; then
+  fail "ENCRYPTION_KEY is not a valid Fernet key. Generate one with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'."
+fi
+
+# 2. Bootstrap the database schema. A failure here must be reported with an
+#    actionable message rather than just an asyncpg/SQLAlchemy traceback.
+log "Bootstrapping database schema..."
+if ! python scripts/bootstrap_db.py; then
+  fail "database bootstrap failed. Common causes: DATABASE_URL unreachable; ENCRYPTION_KEY is not a valid Fernet key; or existing emails require NARUON_IMPORT_USER_ID and NARUON_IMPORT_ORGANIZATION_ID. Backend and frontend will not start."
+fi
+
+# 3. Start backend and frontend, tracking each PID.
+log "Starting backend (uvicorn :8000)..."
+python scripts/start_backend.py --host 0.0.0.0 --port 8000 &
+backend_pid=$!
+
+log "Starting frontend (next start :3000)..."
+( cd frontend && exec ./node_modules/.bin/next start --hostname 0.0.0.0 --port 3000 ) &
+frontend_pid=$!
+
+terminate() {
+  trap - EXIT INT TERM
+  log "Shutting down (stopping backend ${backend_pid} and frontend ${frontend_pid})..."
+  kill "$backend_pid" "$frontend_pid" 2>/dev/null || true
+  wait "$backend_pid" "$frontend_pid" 2>/dev/null || true
+}
+trap terminate EXIT INT TERM
+
+# 4. Wait for either service to exit and report which one. The container is meant
+#    to stop if either critical service dies so an orchestrator can restart it.
+wait -n "$backend_pid" "$frontend_pid"
+exit_code=$?
+if ! kill -0 "$backend_pid" 2>/dev/null; then
+  log "Backend (:8000) exited with code ${exit_code}; stopping container."
+elif ! kill -0 "$frontend_pid" 2>/dev/null; then
+  log "Frontend (:3000) exited with code ${exit_code}; stopping container."
+else
+  log "A service exited with code ${exit_code}; stopping container."
+fi
+exit "$exit_code"


### PR DESCRIPTION
## Problem
The combined image generated `start.sh` inline (`echo '...\n...' > /app/start.sh`) and ran it under `set -euo pipefail`. Any bootstrap failure — most commonly an **invalid Fernet ENCRYPTION_KEY**, a missing secret, or an unreachable `DATABASE_URL` — aborted the container before either service started, emitting only a raw asyncpg/SQLAlchemy traceback. Result: "frontend and backend don't come up together" with no actionable signal.

## Fix
Replace the inline script with a real entrypoint file `backend/scripts/docker_entrypoint.sh` that:
- validates `DATABASE_URL`, `AUTH_SESSION_HMAC_SECRET`, `ENCRYPTION_KEY` up front;
- **pre-flight-validates the Fernet key format** (otherwise only checked lazily on first encrypt — a confusing mid-runtime failure);
- prints an actionable message if `bootstrap_db.py` fails;
- starts backend (:8000) + frontend (:3000) and logs **which** service exits.

## Verification (built `naruon-combined` and ran it)
- valid env + clean db → both serve: backend `/docs` 200, frontend `/` 200, clear startup banner.
- missing `ENCRYPTION_KEY` → `[naruon] ERROR: missing required environment: ENCRYPTION_KEY...`, exit 1.
- invalid Fernet key → `[naruon] ERROR: ENCRYPTION_KEY is not a valid Fernet key...`, caught pre-flight, exit 1.
- db bootstrap failure → clear `[naruon] ERROR: database bootstrap failed...` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)