### PR TITLE
ci: require failed-check evidence in OpenCode reviews

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -69,12 +69,102 @@ jobs:
 
       - name: Prepare bounded OpenCode review evidence
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           OPENCODE_EVIDENCE_FILE: ${{ runner.temp }}/opencode-review-evidence.md
+          OPENCODE_FAILED_CHECK_EVIDENCE_FILE: ${{ runner.temp }}/opencode-failed-check-evidence.md
+          FAILED_CHECK_EVIDENCE_ATTEMPTS: "31"
+          FAILED_CHECK_EVIDENCE_SLEEP_SECONDS: "10"
         run: |
           set -euo pipefail
+
+          current_peer_checks_still_running() {
+            local owner="${GH_REPOSITORY%%/*}"
+            local name="${GH_REPOSITORY#*/}"
+
+            # Exclude this OpenCode check run; otherwise the evidence step would
+            # wait on itself until the bounded retry budget is exhausted.
+            # shellcheck disable=SC2016
+            gh api graphql \
+              -f owner="$owner" \
+              -f name="$name" \
+              -F number="$PR_NUMBER" \
+              -f query='
+                query($owner:String!,$name:String!,$number:Int!) {
+                  repository(owner:$owner,name:$name) {
+                    pullRequest(number:$number) {
+                      statusCheckRollup {
+                        contexts(first: 100) {
+                          nodes {
+                            __typename
+                            ... on CheckRun {
+                              name
+                              status
+                              checkSuite {
+                                workflowRun {
+                                  workflow {
+                                    name
+                                  }
+                                }
+                              }
+                            }
+                            ... on StatusContext {
+                              context
+                              state
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ' \
+              --jq '
+                [
+                  (.data.repository.pullRequest.statusCheckRollup.contexts.nodes // [])
+                  | .[]
+                  | if .__typename == "CheckRun" then
+                      select((.name // "") != "opencode-review")
+                      | select((.checkSuite.workflowRun.workflow.name // "") != "OpenCode PR Review")
+                      | select((.status // "") != "COMPLETED")
+                    elif .__typename == "StatusContext" then
+                      select((.context // "") != "opencode-review")
+                      | select((.state // "" | ascii_upcase) as $s | ["PENDING","EXPECTED"] | index($s))
+                    else
+                      empty
+                    end
+                ]
+                | length > 0
+              '
+          }
+
+          collect_failed_check_evidence_with_wait() {
+            local evidence_file="$1"
+            local attempts="${FAILED_CHECK_EVIDENCE_ATTEMPTS:-19}"
+            local sleep_seconds="${FAILED_CHECK_EVIDENCE_SLEEP_SECONDS:-10}"
+            local attempt=1
+
+            while [ "$attempt" -le "$attempts" ]; do
+              if scripts/ci/collect_failed_check_evidence.sh "$evidence_file"; then
+                if ! grep -Fq "No completed failed GitHub Checks were present" "$evidence_file"; then
+                  return 0
+                fi
+                if [ "$(current_peer_checks_still_running 2>/dev/null || printf 'false')" != "true" ]; then
+                  return 0
+                fi
+              fi
+
+              if [ "$attempt" -lt "$attempts" ]; then
+                sleep "$sleep_seconds"
+              fi
+              attempt=$((attempt + 1))
+            done
+
+            scripts/ci/collect_failed_check_evidence.sh "$evidence_file"
+          }
 
           {
             printf '# OpenCode bounded PR review evidence\n\n'
@@ -87,6 +177,14 @@ jobs:
             printf '## CodeGraph evidence\n\n'
             printf 'The workflow initialized CodeGraph before this evidence file was built.\n'
             printf 'OpenCode must use the configured CodeGraph MCP tools for structural frontend review questions.\n\n'
+
+            printf '## Failed GitHub Check evidence\n\n'
+            if collect_failed_check_evidence_with_wait "$OPENCODE_FAILED_CHECK_EVIDENCE_FILE"; then
+              sed -n '1,900p' "$OPENCODE_FAILED_CHECK_EVIDENCE_FILE"
+            else
+              printf 'Failed GitHub Check evidence could not be collected. OpenCode must treat check lookup failure as a review blocker unless later gate evidence proves checks passed.\n'
+            fi
+            printf '\n'
 
             printf '## Changed files\n\n'
             git diff --name-status "$PR_MERGE_BASE" "$PR_HEAD_SHA"
@@ -116,7 +214,11 @@ jobs:
           for repository documentation, Context7 for current library/API behavior, and web_search only for
           bounded external lookups. Also inspect changed files and focused hunks directly when MCP evidence
           is insufficient. Cover security boundaries, data isolation, workflow contracts, tests, user-facing
-          behavior, and regression risk. Do not edit files or execute project code.
+          behavior, and regression risk. If GitHub Checks failed, use the bounded failed-check logs and
+          annotations to identify exact source lines and concrete fixes instead of citing only check URLs.
+          When Strix shows multiple model vulnerability reports, include every model-reported vulnerability
+          in the review findings instead of collapsing to the first model or highest severity.
+          Do not edit files or execute project code.
           EOF
 
           cat >"${OPENCODE_REVIEW_WORKDIR}/ci-review-prompt.md" <<'EOF'
@@ -125,7 +227,10 @@ jobs:
           Prioritize real bugs, security/privacy regressions, broken workflow contracts, missing tests, and
           user-visible behavior changes. Do not spend the session listing every changed path before reviewing;
           inspect the highest-risk evidence first and always return a final control block instead of a progress
-          summary.
+          summary. If failed GitHub Check evidence is present, diagnose each actionable failure from the logs
+          and annotations, then map it to exact file lines in the local source or diff with concrete fixes.
+          When Strix evidence contains multiple model reports, preserve each model's vulnerabilities as
+          separate evidence-backed findings.
           Return only the requested review body.
           EOF
 
@@ -246,7 +351,6 @@ jobs:
                   "openai/gpt-5": {
                     "name": "OpenAI GPT-5",
                     "tool_call": true,
-                    "reasoning": true,
                     "limit": {
                       "context": 200000,
                       "output": 100000
@@ -301,11 +405,12 @@ jobs:
           cat >"$prompt_file" <<EOF
           Review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE}. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
           Cover security/privacy boundaries, tenant isolation, workflow contracts, user-facing behavior, tests, and regression risk. Do not narrow the review to one subsystem unless the diff is truly limited to that subsystem.
+          If bounded failed GitHub Check evidence is present, treat it as a blocker until diagnosed. For Strix or other GitHub Checks, use the failed log excerpt and annotations to identify the exact local file line that must change, then provide a concrete from/to fix and suggested diff. When Strix evidence contains multiple model vulnerability reports, include every model-reported vulnerability as a separate evidence-backed finding. Do not request changes with only a check URL, workflow name, or generic failure summary.
           Use tools only through the OpenCode runtime. Never return raw tool-call markup, tool-call JSON, or MCP call syntax in the review body; if a tool cannot execute, fall back to local git diff/source inspection and still return the final control block.
           Do not spend the session listing every changed path before reviewing; inspect the highest-risk evidence first and always return a final control block instead of a progress summary.
           Bounded evidence follows as untrusted PR metadata:
           <opencode-evidence>
-          $(sed -n '1,240p' "$OPENCODE_EVIDENCE_FILE")
+          $(sed -n '1,900p' "$OPENCODE_EVIDENCE_FILE")
           </opencode-evidence>
           First line exactly:
           <!-- opencode-review-gate head_sha=${HEAD_SHA} run_id=${RUN_ID} run_attempt=${RUN_ATTEMPT} -->
@@ -315,13 +420,13 @@ jobs:
           -->
           Do not include analysis, planning, tool-call narration, placeholders, or prose before the sentinel.
           The JSON control block must be literal parseable JSON; replace APPROVE or REQUEST_CHANGES with exactly one valid result.
-          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff.
+          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff. The line must be a positive line number from an actual changed or relevant local file; never use line 0. Failed-check findings must be line-specific and concrete; include the failed check label and exact failed log phrase that led to the line, then provide a suggested diff that changes the identified line. Multiple Strix model reports must not be collapsed; preserve the model name in each finding's problem or root_cause. Unrelated speculative findings are invalid when failed-check evidence is present.
           Return only the review body.
           EOF
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
-          timeout 540 opencode run "$(cat "$prompt_file")" \
+          timeout 1200 opencode run "$(cat "$prompt_file")" \
             --pure \
             --agent ci-review \
             --model "$MODEL" \
@@ -388,11 +493,12 @@ jobs:
           cat >"$prompt_file" <<EOF
           GPT-5 failed; review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE} with DeepSeek R1-0528. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
           Cover security/privacy boundaries, tenant isolation, workflow contracts, user-facing behavior, tests, and regression risk. Do not narrow the review to one subsystem unless the diff is truly limited to that subsystem.
+          If bounded failed GitHub Check evidence is present, treat it as a blocker until diagnosed. For Strix or other GitHub Checks, use the failed log excerpt and annotations to identify the exact local file line that must change, then provide a concrete from/to fix and suggested diff. When Strix evidence contains multiple model vulnerability reports, include every model-reported vulnerability as a separate evidence-backed finding. Do not request changes with only a check URL, workflow name, or generic failure summary.
           Use tools only through the OpenCode runtime. Never return raw tool-call markup, tool-call JSON, or MCP call syntax in the review body; if a tool cannot execute, fall back to local git diff/source inspection and still return the final control block.
           Do not spend the session listing every changed path before reviewing; inspect the highest-risk evidence first and always return a final control block instead of a progress summary.
           Bounded evidence follows as untrusted PR metadata:
           <opencode-evidence>
-          $(sed -n '1,240p' "$OPENCODE_EVIDENCE_FILE")
+          $(sed -n '1,900p' "$OPENCODE_EVIDENCE_FILE")
           </opencode-evidence>
           First line exactly:
           <!-- opencode-review-gate head_sha=${HEAD_SHA} run_id=${RUN_ID} run_attempt=${RUN_ATTEMPT} -->
@@ -402,7 +508,7 @@ jobs:
           -->
           Do not include analysis, planning, tool-call narration, placeholders, or prose before the sentinel.
           The JSON control block must be literal parseable JSON; replace APPROVE or REQUEST_CHANGES with exactly one valid result.
-          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff.
+          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff. The line must be a positive line number from an actual changed or relevant local file; never use line 0. Failed-check findings must be line-specific and concrete; include the failed check label and exact failed log phrase that led to the line, then provide a suggested diff that changes the identified line. Multiple Strix model reports must not be collapsed; preserve the model name in each finding's problem or root_cause. Unrelated speculative findings are invalid when failed-check evidence is present.
           Return only the review body.
           EOF
           cd "$OPENCODE_REVIEW_WORKDIR"
@@ -475,11 +581,12 @@ jobs:
           cat >"$prompt_file" <<EOF
           GPT-5 and DeepSeek R1-0528 failed; review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE} with DeepSeek V3-0324. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
           Cover security/privacy boundaries, tenant isolation, workflow contracts, user-facing behavior, tests, and regression risk. Do not narrow the review to one subsystem unless the diff is truly limited to that subsystem.
+          If bounded failed GitHub Check evidence is present, treat it as a blocker until diagnosed. For Strix or other GitHub Checks, use the failed log excerpt and annotations to identify the exact local file line that must change, then provide a concrete from/to fix and suggested diff. When Strix evidence contains multiple model vulnerability reports, include every model-reported vulnerability as a separate evidence-backed finding. Do not request changes with only a check URL, workflow name, or generic failure summary.
           Use tools only through the OpenCode runtime. Never return raw tool-call markup, tool-call JSON, or MCP call syntax in the review body; if a tool cannot execute, fall back to local git diff/source inspection and still return the final control block.
           Do not spend the session listing every changed path before reviewing; inspect the highest-risk evidence first and always return a final control block instead of a progress summary.
           Bounded evidence follows as untrusted PR metadata:
           <opencode-evidence>
-          $(sed -n '1,240p' "$OPENCODE_EVIDENCE_FILE")
+          $(sed -n '1,900p' "$OPENCODE_EVIDENCE_FILE")
           </opencode-evidence>
           First line exactly:
           <!-- opencode-review-gate head_sha=${HEAD_SHA} run_id=${RUN_ID} run_attempt=${RUN_ATTEMPT} -->
@@ -489,7 +596,7 @@ jobs:
           -->
           Do not include analysis, planning, tool-call narration, placeholders, or prose before the sentinel.
           The JSON control block must be literal parseable JSON; replace APPROVE or REQUEST_CHANGES with exactly one valid result.
-          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff.
+          APPROVE only for no blockers. REQUEST_CHANGES findings require path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff. The line must be a positive line number from an actual changed or relevant local file; never use line 0. Failed-check findings must be line-specific and concrete; include the failed check label and exact failed log phrase that led to the line, then provide a suggested diff that changes the identified line. Multiple Strix model reports must not be collapsed; preserve the model name in each finding's problem or root_cause. Unrelated speculative findings are invalid when failed-check evidence is present.
           Return only the review body.
           EOF
           cd "$OPENCODE_REVIEW_WORKDIR"
@@ -687,7 +794,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPOSITORY: ${{ github.repository }}
+          STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
           OPENCODE_APP_TOKEN: ${{ steps.opencode_app_token.outputs.token }}
+          OPENCODE_EVIDENCE_FILE: ${{ runner.temp }}/opencode-review-evidence.md
+          OPENCODE_FAILED_CHECK_EVIDENCE_FILE: ${{ runner.temp }}/opencode-failed-check-evidence.md
+          OPENCODE_FAILED_CHECK_DIAGNOSIS_FILE: ${{ runner.temp }}/opencode-failed-check-diagnosis.md
+          OPENCODE_REVIEW_WORKDIR: ${{ runner.temp }}/opencode-review-project
+          MODEL: github-models/openai/gpt-5
+          USE_GITHUB_TOKEN: "true"
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          NO_COLOR: "1"
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ID: ${{ github.run_id }}
@@ -727,6 +843,231 @@ jobs:
               "- Workflow run: ${RUN_ID}" \
               "- Workflow attempt: ${RUN_ATTEMPT}")"
             create_pull_review "REQUEST_CHANGES" "$body"
+          }
+
+          format_request_changes_body() {
+            local control_json="$1"
+            local body_file="$2"
+            local summary
+            local reason
+            local findings
+
+            summary="$(jq -r '.summary // ""' "$control_json")"
+            reason="$(jq -r '.reason // ""' "$control_json")"
+            findings="$(
+              # shellcheck disable=SC2016
+              jq -r '
+                (.findings // [])
+                | to_entries
+                | map(
+                    "### " + ((.key + 1) | tostring) + ". " + ((.value.severity // "severity") | ascii_upcase) + " " + (.value.path // "unknown") + ":" + ((.value.line // 0) | tostring) + " - " + (.value.title // "Finding") + "\n"
+                    + "- Problem: " + (.value.problem // "") + "\n"
+                    + "- Root cause: " + (.value.root_cause // "") + "\n"
+                    + "- Fix: " + (.value.fix_direction // "") + "\n"
+                    + "- Regression test: " + (.value.regression_test_direction // "") + "\n"
+                    + "- Suggested diff:\n```diff\n" + (.value.suggested_diff // "") + "\n```"
+                  )
+                | join("\n\n")
+              ' "$control_json"
+            )"
+            if [ -z "$findings" ]; then
+              findings="OpenCode returned REQUEST_CHANGES without structured line-specific findings. Re-run the review after fixing the control payload."
+            fi
+
+            {
+              printf 'OpenCode Agent requested changes.\n\n'
+              printf '%s\n\n' "$summary"
+              printf -- '- Result: REQUEST_CHANGES\n'
+              printf -- '- Reason: %s\n\n' "$reason"
+              printf '%s\n\n' "$findings"
+              printf -- "- Head SHA: \`%s\`\n" "$HEAD_SHA"
+              printf -- '- Workflow run: %s\n' "$RUN_ID"
+              printf -- '- Workflow attempt: %s\n' "$RUN_ATTEMPT"
+            } >"$body_file"
+          }
+
+          emit_line_specific_fallback_findings() {
+            local evidence_file="$1"
+            local finding_index=0
+            local repo_root="${GITHUB_WORKSPACE:-$PWD}"
+
+            emit_known_missing_string_finding() {
+              local needle="$1"
+              local title="$2"
+              local preferred_path
+              local match=""
+              local path=""
+              local line=""
+
+              if ! grep -Fq -- "$needle" "$evidence_file"; then
+                return 0
+              fi
+
+              shift 2
+              for preferred_path in "$@"; do
+                if [ -f "${repo_root%/}/$preferred_path" ]; then
+                  match="$(grep -nF -- "$needle" "${repo_root%/}/$preferred_path" | head -n 1 || true)"
+                  if [ -n "$match" ]; then
+                    path="$preferred_path"
+                    line="${match%%:*}"
+                    break
+                  fi
+                fi
+              done
+
+              finding_index=$((finding_index + 1))
+              if [ -n "$path" ] && [ -n "$line" ]; then
+                printf '### %s. HIGH %s:%s - %s\n' "$finding_index" "$path" "$line" "$title"
+                printf -- '- Problem: Strix failed because the trusted self-test log reported missing "%s".\n' "$needle"
+                printf -- '- Root cause: The failed check is executing trusted-base workflow material, so this exact line must exist in the trusted workflow/test contract before the check can pass.\n'
+                printf -- '- Fix: Keep or add the current-head line at "%s:%s" so trusted-base Strix/OpenCode evidence contains "%s".\n' "$path" "$line" "$needle"
+                printf -- '- Regression test: Keep scripts/ci/test_strix_quick_gate.sh assertions covering this exact string.\n\n'
+              else
+                printf '### %s. HIGH unknown:1 - %s\n' "$finding_index" "$title"
+                printf -- '- Problem: Strix failed because the trusted self-test log reported missing "%s".\n' "$needle"
+                printf -- '- Root cause: No current-head line containing this exact string was found in the expected workflow/test files.\n'
+                printf -- '- Fix: Add the exact string "%s" to the relevant workflow or test contract line.\n' "$needle"
+                printf -- '- Regression test: Add a static assertion for this exact string.\n\n'
+              fi
+            }
+
+            emit_known_missing_string_finding \
+              "github.event.inputs.strix_llm || 'openai/gpt-5'" \
+              "Strix PR scans must default to GitHub Models GPT-5" \
+              ".github/workflows/strix.yml" \
+              "scripts/ci/test_strix_quick_gate.sh"
+            emit_known_missing_string_finding \
+              "STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" \
+              "Strix unsupported-model errors must name the allowed providers" \
+              ".github/workflows/strix.yml" \
+              "scripts/ci/test_strix_quick_gate.sh"
+            emit_known_missing_string_finding \
+              "MODEL: github-models/openai/gpt-5" \
+              "OpenCode review must try GitHub Models GPT-5 first" \
+              ".github/workflows/opencode-review.yml" \
+              "scripts/ci/test_strix_quick_gate.sh"
+
+            if [ "$finding_index" -eq 0 ]; then
+              printf 'No deterministic missing-string markers were recognized. Use the failed-check evidence below to map each failed check to exact local source lines before approving.\n\n'
+            fi
+          }
+
+          build_failed_check_fallback_body() {
+            local failed_checks_file="$1"
+            local evidence_file="$2"
+            local body_file="$3"
+
+            {
+              printf 'OpenCode Agent requested changes because GitHub Checks failed on the current head.\n\n'
+              printf -- '- Result: REQUEST_CHANGES\n'
+              printf -- "- Reason: one or more GitHub Checks failed on current head \`%s\`.\n" "$HEAD_SHA"
+              printf -- "- Head SHA: \`%s\`\n" "$HEAD_SHA"
+              printf -- '- Workflow run: %s\n' "$RUN_ID"
+              printf -- '- Workflow attempt: %s\n\n' "$RUN_ATTEMPT"
+              printf 'Failed checks:\n'
+              cat "$failed_checks_file"
+              printf '\n\nLine-specific fallback findings:\n\n'
+              emit_line_specific_fallback_findings "$evidence_file"
+              printf 'Failed check evidence for line-specific fixes:\n\n'
+              if [ -s "$evidence_file" ]; then
+                sed -n '1,900p' "$evidence_file"
+              else
+                printf 'Detailed failed-check evidence could not be collected. The review must not approve until the failed check log is available and mapped to exact source lines.\n'
+              fi
+            } >"$body_file"
+          }
+
+          normalize_opencode_output() {
+            local output_file="$1"
+
+            if bash "$GITHUB_WORKSPACE/scripts/ci/opencode_review_approve_gate.sh" "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT" "$output_file" >/dev/null; then
+              return 0
+            fi
+
+            if python3 "$GITHUB_WORKSPACE/scripts/ci/opencode_review_normalize_output.py" \
+              "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT" "$output_file"; then
+              bash "$GITHUB_WORKSPACE/scripts/ci/opencode_review_approve_gate.sh" "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT" "$output_file" >/dev/null
+              return $?
+            fi
+
+            return 1
+          }
+
+          run_failed_check_diagnosis() {
+            local failed_checks_file="$1"
+            local evidence_file="$2"
+            local body_file="$3"
+            local prompt_file
+            local opencode_json_file
+            local opencode_export_file
+            local opencode_output_file
+            local control_json
+            local session_id
+            local gate_result
+
+            if [ ! -s "$evidence_file" ] || [ ! -d "$OPENCODE_REVIEW_WORKDIR" ]; then
+              return 1
+            fi
+            if [ -z "${STRIX_GITHUB_MODELS_TOKEN:-}" ]; then
+              return 1
+            fi
+
+            prompt_file="$(mktemp)"
+            opencode_json_file="$(mktemp)"
+            opencode_export_file="$(mktemp)"
+            opencode_output_file="$(mktemp)"
+            control_json="$(mktemp)"
+
+            {
+              printf 'GitHub Checks failed after the initial OpenCode review. Diagnose the failed checks and return a line-specific REQUEST_CHANGES review for PR #%s in %s.\n' "$PR_NUMBER" "$GITHUB_WORKSPACE"
+              printf 'Use the failed log excerpt and annotations below as evidence, then inspect local source files and focused hunks to identify the exact line to edit. For each actionable Strix or GitHub Check failure, provide one finding with path,line,severity,title,problem,root_cause,fix_direction,regression_test_direction,suggested_diff. The line must be a positive line number from an actual changed or relevant local file; never use line 0. Include the failed check label and exact failed log phrase in problem or root_cause; unrelated speculative findings are invalid. The fix_direction must state the concrete from/to change, not only the workflow URL. If Strix evidence contains multiple model vulnerability reports, include every model-reported vulnerability as a separate evidence-backed finding and preserve the model name in problem or root_cause. If a failure is external infrastructure with no source fix, the finding must identify the exact external blocker, supporting log line, and why no repository line can fix it.\n\n'
+              printf 'Failed checks:\n'
+              cat "$failed_checks_file"
+              printf '\n\nDetailed failed-check evidence:\n<failed-check-evidence>\n'
+              sed -n '1,900p' "$evidence_file"
+              printf '\n</failed-check-evidence>\n\n'
+              printf 'Bounded PR evidence:\n<opencode-evidence>\n'
+              sed -n '1,500p' "$OPENCODE_EVIDENCE_FILE"
+              printf '\n</opencode-evidence>\n\n'
+              printf 'First line exactly:\n'
+              printf '<!-- opencode-review-gate head_sha=%s run_id=%s run_attempt=%s -->\n' "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT"
+              printf 'Then exactly one control block:\n'
+              printf '<!-- opencode-review-control-v1\n'
+              printf '{"head_sha":"%s","run_id":"%s","run_attempt":"%s","result":"REQUEST_CHANGES","reason":"short reason","summary":"short review summary with concrete failed-check evidence","findings":[]}\n' "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT"
+              printf -- '-->\n'
+              printf 'Do not include analysis, planning, tool-call narration, placeholders, or prose before the sentinel.\n'
+              printf 'The JSON control block must be literal parseable JSON. The result must be REQUEST_CHANGES.\n'
+              printf 'Return only the review body.\n'
+            } >"$prompt_file"
+
+            cd "$OPENCODE_REVIEW_WORKDIR"
+            if ! timeout 600 opencode run "$(cat "$prompt_file")" \
+              --pure \
+              --agent ci-review-fallback \
+              --model "$MODEL" \
+              --format json \
+              --title "PR #${PR_NUMBER} failed-check diagnosis ${MODEL}" >"$opencode_json_file"; then
+              return 1
+            fi
+            session_id="$(jq -r 'select(.type == "step_start") | .sessionID' "$opencode_json_file" | tail -n 1)"
+            if [ -z "$session_id" ] || [ "$session_id" = "null" ]; then
+              return 1
+            fi
+            if ! opencode export "$session_id" --pure >"$opencode_export_file"; then
+              return 1
+            fi
+            jq -r '.messages[] | select(.info.role == "assistant") | .parts[]? | select(.type == "text") | .text' "$opencode_export_file" >"$opencode_output_file"
+            if [ ! -s "$opencode_output_file" ]; then
+              return 1
+            fi
+            if ! normalize_opencode_output "$opencode_output_file"; then
+              return 1
+            fi
+            gate_result="$(bash "$GITHUB_WORKSPACE/scripts/ci/opencode_review_approve_gate.sh" "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT" "$opencode_output_file" "$control_json")" || return 1
+            if [ "$gate_result" != "REQUEST_CHANGES" ]; then
+              return 1
+            fi
+            format_request_changes_body "$control_json" "$body_file"
           }
 
           collect_failed_github_checks() {
@@ -805,7 +1146,27 @@ jobs:
           fi
 
           if [ "$opencode_review_outcome" != "success" ]; then
-            request_changes_for_gate_failure "OpenCode action outcomes were primary=${OPENCODE_PRIMARY_OUTCOME:-unknown}, fallback=${OPENCODE_FALLBACK_OUTCOME:-unknown}, second_fallback=${OPENCODE_SECOND_FALLBACK_OUTCOME:-unknown}."
+            failed_checks_file="$(mktemp)"
+            failed_check_evidence_file="$(mktemp)"
+            failed_check_review_body_file="$(mktemp)"
+            # shellcheck disable=SC2329
+            cleanup_failed_outcome_files() {
+              rm -f "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"
+            }
+            trap cleanup_failed_outcome_files EXIT
+            if collect_failed_github_checks "$failed_checks_file" && [ -s "$failed_checks_file" ]; then
+              if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+                printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
+              fi
+              if run_failed_check_diagnosis "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"; then
+                create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+              else
+                build_failed_check_fallback_body "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"
+                create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+              fi
+            else
+              request_changes_for_gate_failure "OpenCode action outcomes were primary=${OPENCODE_PRIMARY_OUTCOME:-unknown}, fallback=${OPENCODE_FALLBACK_OUTCOME:-unknown}, second_fallback=${OPENCODE_SECOND_FALLBACK_OUTCOME:-unknown}."
+            fi
             echo "::endgroup::"
             exit 0
           fi
@@ -826,7 +1187,13 @@ jobs:
           tmp_body="$(mktemp)"
           control_json="$(mktemp)"
           failed_checks_file=""
-          trap 'rm -f "$tmp_body" "$control_json" "$failed_checks_file"' EXIT
+          failed_check_evidence_file=""
+          failed_check_review_body_file=""
+          # shellcheck disable=SC2329
+          cleanup_approval_files() {
+            rm -f "$tmp_body" "$control_json" "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"
+          }
+          trap cleanup_approval_files EXIT
           printf '%s\n' "$comment_body" >"$tmp_body"
 
           gate_result="$(bash scripts/ci/opencode_review_approve_gate.sh "$HEAD_SHA" "$RUN_ID" "$RUN_ATTEMPT" "$tmp_body" "$control_json")" || true
@@ -849,18 +1216,17 @@ jobs:
                 exit 0
               fi
               if [ -s "$failed_checks_file" ]; then
-                body="$(printf '%s\n' \
-                  "OpenCode Agent requested changes because GitHub Checks failed on the current head." \
-                  "" \
-                  "- Result: REQUEST_CHANGES" \
-                  "- Reason: one or more GitHub Checks failed on current head \`${HEAD_SHA}\`." \
-                  "- Head SHA: \`${HEAD_SHA}\`" \
-                  "- Workflow run: ${RUN_ID}" \
-                  "- Workflow attempt: ${RUN_ATTEMPT}" \
-                  "" \
-                  "Failed checks:" \
-                  "$(cat "$failed_checks_file")")"
-                create_pull_review "REQUEST_CHANGES" "$body"
+                failed_check_evidence_file="$(mktemp)"
+                failed_check_review_body_file="$(mktemp)"
+                if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+                  printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
+                fi
+                if run_failed_check_diagnosis "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"; then
+                  create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+                else
+                  build_failed_check_fallback_body "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"
+                  create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+                fi
                 echo "::endgroup::"
                 exit 0
               fi
@@ -879,23 +1245,32 @@ jobs:
               create_pull_review "APPROVE" "$body"
               ;;
             REQUEST_CHANGES)
-              summary="$(jq -r '.summary' "$control_json")"
-              reason="$(jq -r '.reason' "$control_json")"
-              findings="$(jq -r '.findings | to_entries | map(((.key + 1) | tostring) + ". " + .value.severity + " " + .value.path + ":" + (.value.line | tostring) + " - " + .value.title + "\n" + .value.problem + "\nFix: " + .value.fix_direction) | join("\n\n")' "$control_json")"
-              body="$(printf '%s\n' \
-                "OpenCode Agent requested changes." \
-                "" \
-                "$summary" \
-                "" \
-                "- Result: REQUEST_CHANGES" \
-                "- Reason: ${reason}" \
-                "" \
-                "$findings" \
-                "" \
-                "- Head SHA: \`${HEAD_SHA}\`" \
-                "- Workflow run: ${RUN_ID}" \
-                "- Workflow attempt: ${RUN_ATTEMPT}")"
-              create_pull_review "REQUEST_CHANGES" "$body"
+              failed_check_review_body_file="$(mktemp)"
+              failed_checks_file="$(mktemp)"
+              if ! collect_failed_github_checks "$failed_checks_file"; then
+                request_changes_for_gate_failure "GitHub Checks statusCheckRollup could not be read before validating OpenCode REQUEST_CHANGES against current-head failed checks."
+                echo "::endgroup::"
+                exit 0
+              fi
+
+              if [ -s "$failed_checks_file" ]; then
+                failed_check_evidence_file="$(mktemp)"
+                if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+                  printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
+                fi
+                if scripts/ci/validate_opencode_failed_check_review.sh "$control_json" "$failed_checks_file" "$failed_check_evidence_file"; then
+                  format_request_changes_body "$control_json" "$failed_check_review_body_file"
+                  create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+                elif run_failed_check_diagnosis "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"; then
+                  create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+                else
+                  build_failed_check_fallback_body "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"
+                  create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+                fi
+              else
+                format_request_changes_body "$control_json" "$failed_check_review_body_file"
+                create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
+              fi
               ;;
             *)
               request_changes_for_gate_failure "Approval gate result was ${gate_result:-empty}."

--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -124,8 +124,14 @@ jobs:
         run: |
           strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
-            openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-            openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
+            openai/gpt-5-mini* | openai/gpt-5-nano* | \
+            openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | \
+            github_models/openai/gpt-5-mini* | github_models/openai/gpt-5-nano*)
+              echo '::error::STRIX_LLM must not select mini or nano GPT-5 variants for security evidence.'
+              exit 1
+              ;;
+            openai/gpt-5* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
+            openai/openai/gpt-5* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
             github_models/*)
               echo 'enabled=true' >> "$GITHUB_OUTPUT"
               echo 'provider_mode=github_models' >> "$GITHUB_OUTPUT"
@@ -252,9 +258,18 @@ jobs:
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"
           strix_model="$(printf '%s' "$STRIX_MODEL" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           case "$strix_model" in
-            openai/gpt-5* | openai/gpt-5-mini* | openai/gpt-5-nano* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
-            openai/openai/gpt-5* | openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
+            openai/gpt-5-mini* | openai/gpt-5-nano* | \
+            openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | \
+            github_models/openai/gpt-5-mini* | github_models/openai/gpt-5-nano*)
+              echo '::error::STRIX_LLM must not select mini or nano GPT-5 variants for security evidence.'
+              exit 1
+              ;;
+            openai/gpt-5* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
+            openai/openai/gpt-5* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
             github_models/*)
+              printf '%s' "${strix_model#github_models/}" > "$strix_llm_file"
+              ;;
+            openai/*)
               printf '%s' "$strix_model" > "$strix_llm_file"
               ;;
             openai-direct/gpt-*)
@@ -300,8 +315,8 @@ jobs:
           STRIX_SOURCE_DIRS: .
           STRIX_REASONING_EFFORT: low
           STRIX_LLM_MAX_RETRIES: 1
-          STRIX_TRANSIENT_RETRY_PER_MODEL: 2
-          STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
+          STRIX_TRANSIENT_RETRY_PER_MODEL: 5
+          STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 60
           STRIX_FALLBACK_MODELS: ${{ steps.gate.outputs.provider_mode == 'github_models' && 'deepseek/deepseek-r1-0528 deepseek/deepseek-v3-0324' || '' }}
           STRIX_FAIL_ON_PROVIDER_SIGNAL: "1"
           STRIX_VERTEX_FALLBACK_MODELS: ""

--- a/scripts/ci/collect_failed_check_evidence.sh
+++ b/scripts/ci/collect_failed_check_evidence.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: $0 <output-file>" >&2
+	exit 2
+fi
+
+: "${GH_REPOSITORY:?GH_REPOSITORY is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+
+OUTPUT_FILE="$1"
+FAILED_CHECK_LOG_LINES="${FAILED_CHECK_LOG_LINES:-180}"
+
+strip_ansi() {
+	perl -pe 's/\x1b\[[0-9;?]*[A-Za-z]//g'
+}
+
+emit_bounded_file() {
+	local file_path="$1"
+	local max_lines="$2"
+	local total_lines
+	local head_lines
+	local tail_lines
+
+	total_lines="$(wc -l <"$file_path" | tr -d '[:space:]')"
+	if [ -z "$total_lines" ] || [ "$total_lines" -le "$max_lines" ]; then
+		sed -n "1,${max_lines}p" "$file_path"
+		return 0
+	fi
+
+	head_lines=$((max_lines / 2))
+	tail_lines=$((max_lines - head_lines))
+	sed -n "1,${head_lines}p" "$file_path"
+	printf '\n... truncated %s middle log lines ...\n\n' "$((total_lines - max_lines))"
+	tail -n "$tail_lines" "$file_path"
+}
+
+emit_strix_vulnerability_evidence() {
+	local log_file="$1"
+	local summary_tmp
+	local ranges_tmp
+	local merged_ranges_tmp
+	local report_index=0
+	local start_line
+	local end_line
+
+	summary_tmp="$(mktemp)"
+	ranges_tmp="$(mktemp)"
+	merged_ranges_tmp="$(mktemp)"
+	tmp_files+=("$summary_tmp" "$ranges_tmp" "$merged_ranges_tmp")
+
+	awk '
+		/Strix run failed for model/ ||
+		/Primary model unavailable; retrying with fallback/ ||
+		/Strix fallback model/ ||
+		/Below-threshold findings detected/ ||
+		/Unable to map Strix findings/ ||
+		/Model [[:alnum:]_.\/-]+/ ||
+		/Vulnerabilities[[:space:]]+[0-9]/ ||
+		/Vulnerabilities[[:space:]]+.*Total/ ||
+		/(CRITICAL|HIGH|MEDIUM|LOW):[[:space:]]+[0-9]/ {
+			if (!seen[$0]++) {
+				print
+			}
+		}
+	' "$log_file" >"$summary_tmp"
+
+	awk '
+		/Vulnerability Report/ {
+			start = NR - 12
+			if (start < 1) {
+				start = 1
+			}
+			end = NR + 190
+			print start, end
+		}
+	' "$log_file" >"$ranges_tmp"
+
+	if [ ! -s "$summary_tmp" ] && [ ! -s "$ranges_tmp" ]; then
+		return 1
+	fi
+
+	printf '### Strix model attempt and finding summary\n\n'
+	if [ -s "$summary_tmp" ]; then
+		printf '```text\n'
+		emit_bounded_file "$summary_tmp" 180
+		printf '\n```\n\n'
+	else
+		printf 'No model summary lines were detected in the failed Strix log.\n\n'
+	fi
+
+	if [ ! -s "$ranges_tmp" ]; then
+		printf 'No Strix vulnerability report windows were detected in the failed log.\n\n'
+		return 0
+	fi
+
+	awk '
+		NR == 1 {
+			start = $1
+			end = $2
+			next
+		}
+		$1 <= end + 5 {
+			if ($2 > end) {
+				end = $2
+			}
+			next
+		}
+		{
+			print start, end
+			start = $1
+			end = $2
+		}
+		END {
+			if (start != "") {
+				print start, end
+			}
+		}
+	' "$ranges_tmp" >"$merged_ranges_tmp"
+
+	while read -r start_line end_line; do
+		report_index=$((report_index + 1))
+		printf '### Strix vulnerability report window %s (log lines %s-%s)\n\n' "$report_index" "$start_line" "$end_line"
+		printf '```text\n'
+		sed -n "${start_line},${end_line}p" "$log_file"
+		printf '\n```\n\n'
+	done <"$merged_ranges_tmp"
+}
+
+owner="${GH_REPOSITORY%%/*}"
+repo="${GH_REPOSITORY#*/}"
+failed_contexts="$(mktemp)"
+tmp_files=("$failed_contexts")
+cleanup() {
+	rm -f "${tmp_files[@]}"
+}
+trap cleanup EXIT
+
+# shellcheck disable=SC2016
+gh api graphql \
+	-f owner="$owner" \
+	-f name="$repo" \
+	-F number="$PR_NUMBER" \
+	-f query='
+		query($owner:String!,$name:String!,$number:Int!) {
+			repository(owner:$owner,name:$name) {
+				pullRequest(number:$number) {
+					statusCheckRollup {
+						contexts(first: 100) {
+							nodes {
+								__typename
+								... on CheckRun {
+									databaseId
+									name
+									status
+									conclusion
+									detailsUrl
+									checkSuite {
+										workflowRun {
+											databaseId
+											workflow {
+												name
+											}
+										}
+									}
+								}
+								... on StatusContext {
+									context
+									state
+									targetUrl
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	' \
+	--jq '
+		(.data.repository.pullRequest.statusCheckRollup.contexts.nodes // [])
+		| map(
+			if .__typename == "CheckRun" then
+				select((.status // "") == "COMPLETED")
+				| select((.conclusion // "" | ascii_upcase) as $c | ["FAILURE","TIMED_OUT","ACTION_REQUIRED","CANCELLED","STARTUP_FAILURE"] | index($c))
+				| [
+					"check_run",
+					(((.checkSuite.workflowRun.workflow.name // "") + "/" + (.name // "check")) | gsub("^/"; "")),
+					(.conclusion // "unknown"),
+					(.detailsUrl // ""),
+					((.checkSuite.workflowRun.databaseId // "") | tostring),
+					((.databaseId // "") | tostring)
+				]
+			elif .__typename == "StatusContext" then
+				select((.state // "" | ascii_upcase) as $s | ["FAILURE","ERROR"] | index($s))
+				| [
+					"status_context",
+					(.context // "status"),
+					(.state // "unknown"),
+					(.targetUrl // ""),
+					"",
+					""
+				]
+			else
+				empty
+			end
+		)
+		| .[]
+		| @tsv
+	' >"$failed_contexts"
+
+{
+	printf '# Failed GitHub Check Evidence\n\n'
+	printf -- '- PR: #%s\n' "$PR_NUMBER"
+	printf -- '- Head SHA: `%s`\n' "$HEAD_SHA"
+	printf -- '- Repository: `%s`\n\n' "$GH_REPOSITORY"
+	printf '## Line-specific repair contract\n\n'
+	printf -- '- Treat the check logs and annotations below as diagnostic evidence, not as a complete review.\n'
+	printf -- '- For each actionable failed check, inspect the local source or diff and identify the exact file line that must change.\n'
+	printf -- '- OpenCode `REQUEST_CHANGES` findings must include `path`, `line`, `root_cause`, `fix_direction`, `regression_test_direction`, and `suggested_diff`.\n'
+	printf -- '- Do not request changes with only a GitHub Actions URL or a generic check name.\n\n'
+	printf -- '- When Strix logs contain multiple `Vulnerability Report` or `Model ... Vulnerabilities ...` sections, include every model-reported vulnerability in the review evidence and findings.\n\n'
+
+	if [ ! -s "$failed_contexts" ]; then
+		printf 'No completed failed GitHub Checks were present when evidence was collected.\n'
+		exit 0
+	fi
+
+	while IFS=$'\t' read -r kind label conclusion details_url run_id check_run_id; do
+		printf '## Failed check: %s\n\n' "$label"
+		printf -- '- Type: `%s`\n' "$kind"
+		printf -- '- Conclusion: `%s`\n' "$conclusion"
+		if [ -n "$details_url" ]; then
+			printf -- '- Details URL: %s\n' "$details_url"
+		fi
+		if [ -n "$run_id" ]; then
+			printf -- '- Workflow run id: `%s`\n' "$run_id"
+		fi
+		if [ -n "$check_run_id" ]; then
+			printf -- '- Check run id: `%s`\n' "$check_run_id"
+		fi
+		printf '\n'
+
+		if [ "$kind" != "check_run" ] || [ -z "$check_run_id" ]; then
+			printf 'No GitHub Actions job log is available for this status context.\n\n'
+			continue
+		fi
+
+		job_json="$(mktemp)"
+		tmp_files+=("$job_json")
+		if gh api -X GET "repos/${GH_REPOSITORY}/actions/jobs/${check_run_id}" >"$job_json" 2>/dev/null; then
+			failed_steps="$(
+				jq -r '
+					(.steps // [])
+					| map(select((.conclusion // "" | ascii_downcase) as $c | ["failure","timed_out","cancelled","startup_failure"] | index($c)))
+					| .[]
+					| "- step " + ((.number // 0) | tostring) + ": " + (.name // "step") + " (" + (.conclusion // "unknown") + ")"
+				' "$job_json"
+			)"
+			if [ -n "$failed_steps" ]; then
+				printf '### Failed job steps\n\n'
+				printf '%s\n\n' "$failed_steps"
+			fi
+		fi
+
+		annotations_tmp="$(mktemp)"
+		tmp_files+=("$annotations_tmp")
+		if gh api -X GET "repos/${GH_REPOSITORY}/check-runs/${check_run_id}/annotations" --paginate \
+			--jq '
+				.[]?
+				| "- " + (.path // "unknown") + ":" + ((.start_line // 0) | tostring) + "-" + ((.end_line // .start_line // 0) | tostring) + " [" + (.annotation_level // "annotation") + "] " + ((.message // .title // "") | gsub("\r|\n"; " "))
+			' >"$annotations_tmp" 2>/dev/null; then
+			if [ -s "$annotations_tmp" ]; then
+				printf '### Check annotations\n\n'
+				emit_bounded_file "$annotations_tmp" 40
+				printf '\n'
+			fi
+		fi
+
+		log_raw="$(mktemp)"
+		log_clean="$(mktemp)"
+		tmp_files+=("$log_raw" "$log_clean")
+		if [ -n "$run_id" ] && gh run view "$run_id" \
+			--repo "$GH_REPOSITORY" \
+			--job "$check_run_id" \
+			--log-failed >"$log_raw" 2>&1; then
+			strip_ansi <"$log_raw" >"$log_clean"
+			if [ -s "$log_clean" ]; then
+				if emit_strix_vulnerability_evidence "$log_clean"; then
+					printf '\n'
+				fi
+				printf '### Failed log excerpt\n\n'
+				printf '```text\n'
+				emit_bounded_file "$log_clean" "$FAILED_CHECK_LOG_LINES"
+				printf '\n```\n\n'
+			fi
+		else
+			printf '### Failed log excerpt\n\n'
+			printf 'The failed job log could not be collected with `gh run view --log-failed`.\n\n'
+			if [ -s "$log_raw" ]; then
+				printf '```text\n'
+				strip_ansi <"$log_raw" | sed -n '1,40p'
+				printf '\n```\n\n'
+			fi
+		fi
+	done <"$failed_contexts"
+} >"$OUTPUT_FILE"

--- a/scripts/ci/opencode_review_approve_gate.sh
+++ b/scripts/ci/opencode_review_approve_gate.sh
@@ -109,7 +109,7 @@ if ! jq -e '
   )
   and all(.findings[];
     (.path | type == "string" and length > 0)
-    and (.line | type == "number")
+    and (.line | type == "number" and . > 0 and floor == .)
     and (.severity | type == "string" and length > 0)
     and (.title | type == "string" and length > 0)
     and (.problem | type == "string" and length > 0)

--- a/scripts/ci/opencode_review_normalize_output.py
+++ b/scripts/ci/opencode_review_normalize_output.py
@@ -56,7 +56,7 @@ def valid_control(
     for finding in findings:
         if not isinstance(finding, dict):
             return None
-        if not isinstance(finding.get("line"), int):
+        if not isinstance(finding.get("line"), int) or finding["line"] <= 0:
             return None
         for field in required_finding_fields:
             if not isinstance(finding.get(field), str) or not finding[field].strip():

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -187,8 +187,10 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_contains "$workflow_file" "LLM_API_BASE_FILE" "strix workflow passes the GitHub Models API base through a trusted input file"
 	assert_file_not_contains "$workflow_file" '${{ secrets.STRIX_OPENAI_API_KEY || github.token }}' "strix workflow must not use fallback-secret syntax for LLM API keys"
 	assert_file_contains "$workflow_file" "deepseek/deepseek-r1-0528 deepseek/deepseek-v3-0324" "strix workflow configures reachable stronger-than-GPT-4.1 GitHub Models fallback models"
+	assert_file_contains "$workflow_file" '${strix_model#github_models/}' "strix workflow strips manual github_models routing prefix before passing model names to LiteLLM"
 	assert_file_not_contains "$workflow_file" "openai/gpt-4.1" "strix workflow must not fall back to GPT-4.1 or weaker review evidence"
 	assert_file_not_contains "$workflow_file" "openai/gpt-5-*" "strix workflow must not accept older GPT-5 variants when GPT-5.4 is required"
+	assert_file_contains "$workflow_file" "openai/gpt-5-mini* | openai/gpt-5-nano*" "strix workflow rejects mini and nano GPT-5 variants for security evidence"
 	assert_file_contains "$workflow_file" "openai/gpt-5*" "strix workflow accepts GitHub Models OpenAI GPT-5 model prefixes"
 	assert_file_not_contains "$workflow_file" "github/gpt-4o" "strix workflow must not default to an unsupported GitHub Models alias"
 	assert_file_not_contains "$workflow_file" "gemini/gemini-pro-3.1-preview" "strix workflow must not default to Gemini API when GitHub Models is required"
@@ -202,6 +204,11 @@ assert_strix_workflow_pr_trigger_hardened() {
 assert_strix_gpt54_model_guard_semantics() {
 	local model="$1"
 	case "$model" in
+	openai/gpt-5-mini* | openai/gpt-5-nano* | \
+	openai/openai/gpt-5-mini* | openai/openai/gpt-5-nano* | \
+	github_models/openai/gpt-5-mini* | github_models/openai/gpt-5-nano*)
+		return 1
+		;;
 	openai/gpt-5* | openai/gpt-[6-9]* | openai/gpt-[1-9][0-9]* | \
 	openai/openai/gpt-5* | openai/openai/gpt-[6-9]* | openai/openai/gpt-[1-9][0-9]* | \
 	github_models/* | \
@@ -219,6 +226,12 @@ assert_strix_gpt54_model_guard_semantics() {
 assert_strix_gpt54_model_guard_cases() {
 	if ! assert_strix_gpt54_model_guard_semantics "openai/gpt-5"; then
 		record_failure "strix guard must accept GitHub Models openai/gpt-5"
+	fi
+	if assert_strix_gpt54_model_guard_semantics "openai/gpt-5-mini"; then
+		record_failure "strix guard must reject GitHub Models openai/gpt-5-mini"
+	fi
+	if assert_strix_gpt54_model_guard_semantics "github_models/openai/gpt-5-nano"; then
+		record_failure "strix guard must reject manual GitHub Models openai/gpt-5-nano"
 	fi
 	if assert_strix_gpt54_model_guard_semantics "gpt-5"; then
 		record_failure "strix GPT-5.4 guard must reject plain gpt-5"
@@ -305,7 +318,7 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "Never return raw tool-call markup, tool-call JSON, or MCP call syntax in the review body" "opencode review prompt forbids raw tool-call transcripts as final review output"
 	assert_file_contains "$workflow_file" "Do not spend the session listing every changed path before reviewing" "opencode review prompt prevents fallback sessions from exhausting steps on file listing"
 	assert_file_contains "$workflow_file" "always return a final control block instead of a progress summary" "opencode review prompt requires a gate conclusion instead of a progress summary"
-	assert_file_contains "$workflow_file" "timeout 540 opencode run" "opencode review primary model has a bounded extended timeout for larger workflow diffs"
+	assert_file_contains "$workflow_file" "timeout 1200 opencode run" "opencode review primary model has a bounded extended timeout for larger workflow diffs"
 	assert_file_contains "$workflow_file" '"ci-review-fallback"' "opencode review workflow declares a dedicated fallback agent"
 	assert_file_contains "$workflow_file" '"steps": 12' "opencode review fallback agent has enough bounded steps to conclude after MCP inspection"
 	assert_file_contains "$workflow_file" '"read": "allow"' "opencode review allows read-only file inspection"
@@ -342,6 +355,45 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "MODEL: github-models/deepseek/deepseek-v3-0324" "opencode review has a second reachable DeepSeek V3 fallback model"
 	assert_file_contains "$workflow_file" "Publish bounded OpenCode review comment" "opencode review workflow publishes the agent control comment for the approval gate"
 	assert_file_contains "$workflow_file" "statusCheckRollup" "opencode review workflow reads current-head GitHub Checks before approval"
+	assert_file_contains "$workflow_file" "OPENCODE_FAILED_CHECK_EVIDENCE_FILE" "opencode review workflow persists failed-check evidence across review and approval steps"
+	assert_file_contains "$workflow_file" "collect_failed_check_evidence.sh" "opencode review workflow collects failed check logs and annotations"
+	assert_file_contains "$workflow_file" "FAILED_CHECK_EVIDENCE_ATTEMPTS" "opencode review workflow bounds waiting for peer check failures before model review"
+	assert_file_contains "$workflow_file" 'FAILED_CHECK_EVIDENCE_ATTEMPTS: "31"' "opencode review workflow waits long enough for slow Strix self-test failures"
+	assert_file_contains "$workflow_file" "collect_failed_check_evidence_with_wait" "opencode review workflow waits briefly for failed checks before building model evidence"
+	assert_file_contains "$workflow_file" "current_peer_checks_still_running" "opencode review workflow distinguishes pending peer checks from completed check state"
+	assert_file_contains "$workflow_file" 'select((.name // "") != "opencode-review")' "opencode review evidence wait excludes its own check run"
+	assert_file_contains "$workflow_file" 'select((.checkSuite.workflowRun.workflow.name // "") != "OpenCode PR Review")' "opencode review evidence wait excludes its own workflow"
+	assert_file_contains "$workflow_file" "No completed failed GitHub Checks were present" "opencode review evidence wait retries while no failed checks are available yet"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" 'gh run view "$run_id"' "failed-check evidence collector reads failed GitHub Actions job logs"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" 'check-runs/${check_run_id}/annotations' "failed-check evidence collector reads GitHub Check annotations"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" "Line-specific repair contract" "failed-check evidence requires line-specific repairs"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" "Strix model attempt and finding summary" "failed-check evidence collector summarizes every Strix model attempt"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" "Strix vulnerability report window" "failed-check evidence collector preserves Strix vulnerability report windows"
+	assert_file_contains "$REPO_ROOT/scripts/ci/collect_failed_check_evidence.sh" "When Strix logs contain multiple" "failed-check evidence collector requires all model-reported vulnerabilities"
+	assert_file_contains "$workflow_file" "If bounded failed GitHub Check evidence is present, treat it as a blocker until diagnosed." "opencode review prompt forces failed-check diagnosis"
+	assert_file_contains "$workflow_file" "include every model-reported vulnerability as a separate evidence-backed finding" "opencode review prompt requires all Strix model findings"
+	assert_file_contains "$workflow_file" "Multiple Strix model reports must not be collapsed" "opencode review prompt prevents collapsing multiple Strix model reports"
+	assert_file_contains "$workflow_file" 'sed -n '"'"'1,900p'"'"' "$OPENCODE_FAILED_CHECK_EVIDENCE_FILE"' "opencode review includes enough failed-check evidence for multiple Strix model reports"
+	assert_file_contains "$workflow_file" "Do not request changes with only a check URL, workflow name, or generic failure summary." "opencode review prompt forbids generic failed-check reviews"
+	assert_file_contains "$workflow_file" "Failed-check findings must be line-specific and concrete" "opencode review prompt requires line-specific failed-check findings"
+	assert_file_contains "$workflow_file" "never use line 0" "opencode review prompt forbids non-specific line 0 findings"
+	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" '.line | type == "number" and . > 0 and floor == .' "opencode approval gate rejects line zero findings"
+	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" 'finding["line"] <= 0' "opencode normalizer rejects line zero findings"
+	assert_file_contains "$workflow_file" "validate_opencode_failed_check_review.sh" "opencode approval gate validates request-changes reviews against failed-check evidence"
+	assert_file_contains "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" "FAILED_CHECK_EVIDENCE_NOT_REFERENCED" "failed-check review validator rejects unrelated speculative findings"
+	assert_file_contains "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" "github(?:_|-)models" "failed-check review validator extracts both github_models and github-models model prefixes"
+	assert_file_contains "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" "Self-test Strix gate script" "failed-check review validator requires Strix failed step evidence"
+	assert_file_contains "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" "github.event.inputs.strix_llm" "failed-check review validator requires exact Strix missing assertion evidence"
+	assert_file_contains "$workflow_file" "Unrelated speculative findings are invalid when failed-check evidence is present." "opencode review prompt forbids unrelated failed-check findings"
+	assert_file_contains "$workflow_file" "run_failed_check_diagnosis" "opencode approval gate reruns OpenCode diagnosis when checks fail after the initial review"
+	assert_file_contains "$workflow_file" "OpenCode action outcomes were primary=" "opencode approval gate records invalid model outcome details"
+	assert_file_contains "$workflow_file" "Failed check evidence for line-specific fixes" "opencode approval gate includes failed-check evidence when diagnosis cannot complete"
+	assert_file_contains "$workflow_file" "emit_line_specific_fallback_findings" "opencode failed-check fallback maps known Strix failures to source lines"
+	assert_file_contains "$workflow_file" 'repo_root="${GITHUB_WORKSPACE:-$PWD}"' "opencode failed-check fallback maps source lines from the repository root"
+	assert_file_contains "$workflow_file" "Line-specific fallback findings" "opencode failed-check fallback publishes line-specific repair findings"
+	assert_file_contains "$workflow_file" "- Root cause:" "opencode review request-changes body includes root cause per finding"
+	assert_file_contains "$workflow_file" "- Regression test:" "opencode review request-changes body includes regression test direction per finding"
+	assert_file_contains "$workflow_file" "- Suggested diff:" "opencode review request-changes body includes suggested diff per finding"
 	assert_file_contains "$workflow_file" "OpenCode Agent requested changes because GitHub Checks failed on the current head." "opencode review workflow requests changes when current-head GitHub Checks failed"
 	assert_file_contains "$workflow_file" "OpenCode Agent could not verify GitHub Checks before approval." "opencode review workflow explains check lookup failures instead of approving"
 	assert_file_contains "$workflow_file" '["FAILURE","TIMED_OUT","ACTION_REQUIRED","CANCELLED","STARTUP_FAILURE"]' "opencode review workflow treats failed check-run conclusions as request-changes blockers"
@@ -408,6 +460,101 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+assert_opencode_review_gate_rejects_line_zero_findings() {
+	local tmp_dir
+	local output_file
+	local rc
+	local gate_result
+	tmp_dir="$(mktemp -d)"
+	output_file="$tmp_dir/opencode-output.md"
+
+	cat >"$output_file" <<'EOF'
+<!-- opencode-review-gate head_sha=abc123 run_id=42 run_attempt=1 -->
+
+<!-- opencode-review-control-v1
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"REQUEST_CHANGES","reason":"Generic blocker","summary":"Generic finding with no real source line.","findings":[{"path":"scripts/ci/example.sh","line":0,"severity":"HIGH","title":"Generic finding","problem":"Line zero is not actionable.","root_cause":"The review did not inspect a concrete line.","fix_direction":"Inspect the actual file and cite a positive line number.","regression_test_direction":"Add a gate test for line zero rejection.","suggested_diff":"diff --git a/scripts/ci/example.sh b/scripts/ci/example.sh\n--- a/scripts/ci/example.sh\n+++ b/scripts/ci/example.sh\n@@ -1 +1 @@\n-old\n+new"}]}
+-->
+EOF
+
+	set +e
+	gate_result="$(
+		bash "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" \
+			"abc123" "42" "1" "$output_file"
+	)"
+	rc=$?
+	set -e
+
+	assert_equals "4" "$rc" "opencode approval gate rejects line zero findings"
+	assert_equals "NO_CONCLUSION" "$gate_result" "line zero rejection gate result"
+
+	set +e
+	python3 "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" \
+		"abc123" "42" "1" "$output_file" >"$tmp_dir/normalize.out" 2>"$tmp_dir/normalize.err"
+	rc=$?
+	set -e
+
+	assert_equals "4" "$rc" "opencode normalizer rejects line zero findings"
+	assert_file_contains "$tmp_dir/normalize.err" "NO_CONCLUSION" "opencode normalizer reports no valid conclusion for line zero findings"
+
+	rm -rf "$tmp_dir"
+}
+
+assert_opencode_failed_check_review_validator_rejects_unrelated_findings() {
+	local tmp_dir
+	local control_json
+	local failed_checks_file
+	local evidence_file
+	local rc
+	tmp_dir="$(mktemp -d)"
+	control_json="$tmp_dir/control.json"
+	failed_checks_file="$tmp_dir/failed-checks.txt"
+	evidence_file="$tmp_dir/failed-check-evidence.md"
+
+	cat >"$failed_checks_file" <<'EOF'
+- Strix Security Scan/strix: FAILURE (https://github.com/example/repo/actions/runs/1/job/2)
+EOF
+	cat >"$evidence_file" <<'EOF'
+## Failed check: Strix Security Scan/strix
+
+### Failed job steps
+
+- step 6: Self-test Strix gate script (failure)
+
+### Strix vulnerability report window 1
+
+Model github-models/openai/gpt-5 Vulnerabilities 1
+
+### Failed log excerpt
+
+FAIL: strix workflow defaults PR Strix scans to GitHub Models GPT-5 (missing 'github.event.inputs.strix_llm || 'openai/gpt-5'')
+FAIL: strix workflow rejects unsupported model inputs (missing 'STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model')
+FAIL: opencode review tries GitHub Models GPT-5 first (missing 'MODEL: github-models/openai/gpt-5')
+EOF
+	cat >"$control_json" <<'EOF'
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"REQUEST_CHANGES","reason":"Generic security concern","summary":"Generic speculative CI issues.","findings":[{"path":"scripts/ci/collect_failed_check_evidence.sh","line":15,"severity":"HIGH","title":"Generic finding","problem":"Speculative input validation issue unrelated to failed checks.","root_cause":"The review did not use the failed Strix evidence.","fix_direction":"Add generic validation.","regression_test_direction":"Add a generic test.","suggested_diff":"diff --git a/scripts/ci/collect_failed_check_evidence.sh b/scripts/ci/collect_failed_check_evidence.sh\n--- a/scripts/ci/collect_failed_check_evidence.sh\n+++ b/scripts/ci/collect_failed_check_evidence.sh\n@@ -1 +1 @@\n-old\n+new"}]}
+EOF
+
+	set +e
+	bash "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" \
+		"$control_json" "$failed_checks_file" "$evidence_file" >"$tmp_dir/bad.out" 2>"$tmp_dir/bad.err"
+	rc=$?
+	set -e
+	assert_equals "4" "$rc" "failed-check review validator rejects unrelated findings"
+	assert_file_contains "$tmp_dir/bad.out" "FAILED_CHECK_EVIDENCE_NOT_REFERENCED" "failed-check validator explains unrelated finding rejection"
+
+	cat >"$control_json" <<'EOF'
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"REQUEST_CHANGES","reason":"Strix Security Scan/strix failed","summary":"Strix Security Scan/strix failed in Self-test Strix gate script because the trusted workflow is missing expected model evidence strings.","findings":[{"path":".github/workflows/strix.yml","line":120,"severity":"HIGH","title":"Strix workflow default is not visible to trusted self-test","problem":"Strix Security Scan/strix failed in Self-test Strix gate script: strix workflow defaults PR Strix scans to GitHub Models GPT-5 (missing 'github.event.inputs.strix_llm || 'openai/gpt-5''); strix workflow rejects unsupported model inputs (missing 'STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model'); opencode review tries GitHub Models GPT-5 first (missing 'MODEL: github-models/openai/gpt-5').","root_cause":"The failed check evidence shows Self-test Strix gate script could not find github.event.inputs.strix_llm, STRIX_LLM must select, and MODEL: github-models/openai/gpt-5 in trusted-base files.","fix_direction":"Update the workflow lines that provide the Strix model default and OpenCode model env so the trusted self-test can find those exact strings.","regression_test_direction":"Keep the static self-test assertions for all three missing strings.","suggested_diff":"diff --git a/.github/workflows/strix.yml b/.github/workflows/strix.yml\n--- a/.github/workflows/strix.yml\n+++ b/.github/workflows/strix.yml\n@@ -120 +120 @@\n-          STRIX_MODEL: old\n+          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/gpt-5' }}"}]}
+EOF
+	set +e
+	bash "$REPO_ROOT/scripts/ci/validate_opencode_failed_check_review.sh" \
+		"$control_json" "$failed_checks_file" "$evidence_file" >"$tmp_dir/good.out" 2>"$tmp_dir/good.err"
+	rc=$?
+	set -e
+	assert_equals "0" "$rc" "failed-check review validator accepts Strix log-backed findings"
+
+	rm -rf "$tmp_dir"
+}
+
 assert_internal_pr_scope_targets() {
 	local target_log_file="$1"
 	local repo_root_dir="$2"
@@ -458,7 +605,7 @@ run_gate_case() {
 	fi
 	local transient_retry_per_model="${12-0}"
 	local min_fail_severity="${13-CRITICAL}"
-	local transient_retry_backoff_seconds="${14-0}"
+	local transient_retry_backoff_seconds="${14:-0}"
 	local custom_target_path="${15-}"
 	local custom_source_dirs="${16-}"
 	local process_timeout_seconds="${17-1200}"
@@ -4790,6 +4937,10 @@ assert_strix_child_target_uses_constant_argument
 assert_opencode_review_uses_codegraph_and_gpt5_fallback
 
 assert_opencode_review_normalizer_accepts_transcript_json
+
+assert_opencode_review_gate_rejects_line_zero_findings
+
+assert_opencode_failed_check_review_validator_rejects_unrelated_findings
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1521,7 +1521,7 @@ EOS
 			echo "│  Penetration test in progress                                                │"
 			echo "│  Vulnerabilities 0                                                           │"
 			echo "╰──────────────────────────────────────────────────────────────────────────────╯"
-			sleep 2
+			sleep 4
 			exit 0
 			;;
 		*)
@@ -1537,11 +1537,11 @@ EOS
 			echo "│  Penetration test in progress                                                │"
 			echo "│  Vulnerabilities 0                                                           │"
 			echo "╰──────────────────────────────────────────────────────────────────────────────╯"
-			sleep 2
+			sleep 4
 			exit 0
 			;;
 		vertex_ai/fallback-one)
-			sleep 2
+			sleep 4
 			exit 0
 			;;
 		*)
@@ -1561,11 +1561,11 @@ EOS
 			echo "│  Penetration test in progress                                                │"
 			echo "│  Vulnerabilities 0                                                           │"
 			echo "╰──────────────────────────────────────────────────────────────────────────────╯"
-			sleep 2
+			sleep 4
 			exit 0
 			;;
 		vertex_ai/fallback-one)
-			sleep 2
+			sleep 4
 			exit 0
 			;;
 		*)
@@ -5597,7 +5597,7 @@ run_gate_case_allow_provider_signal "zero-findings-timeout-all-models" \
 	"0" \
 	"" \
 	"" \
-	"1" \
+	"2" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
@@ -5618,7 +5618,7 @@ run_gate_case_allow_provider_signal "zero-findings-timeout-all-models" \
 	"0" \
 	"" \
 	"" \
-	"1" \
+	"2" \
 	"0" \
 	"push"
 
@@ -5638,7 +5638,7 @@ run_gate_case_allow_provider_signal "zero-findings-sticky-across-fallback" \
 	"0" \
 	"" \
 	"" \
-	"1" \
+	"2" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
@@ -5659,7 +5659,7 @@ run_gate_case_allow_provider_signal "zero-findings-with-low-report-timeout" \
 	"0" \
 	"" \
 	"" \
-	"1" \
+	"2" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java"
@@ -5680,7 +5680,7 @@ run_gate_case "strict-zero-findings-timeout-fails-pr" \
 	"0" \
 	"" \
 	"" \
-	"1" \
+	"2" \
 	"0" \
 	"pull_request" \
 	"sync-module-system/smart-crawling-biz/src/main/java/org/empasy/sync/modules/system/controller/SysPositionController.java" \

--- a/scripts/ci/validate_opencode_failed_check_review.sh
+++ b/scripts/ci/validate_opencode_failed_check_review.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <control-json-file> <failed-checks-file> <failed-check-evidence-file>" >&2
+  exit 64
+fi
+
+CONTROL_JSON_FILE="$1"
+FAILED_CHECKS_FILE="$2"
+FAILED_CHECK_EVIDENCE_FILE="$3"
+
+if [ ! -r "$CONTROL_JSON_FILE" ] || [ ! -r "$FAILED_CHECKS_FILE" ] || [ ! -r "$FAILED_CHECK_EVIDENCE_FILE" ]; then
+  echo "FAILED_CHECK_EVIDENCE_NOT_REFERENCED"
+  exit 4
+fi
+
+if [ ! -s "$FAILED_CHECKS_FILE" ]; then
+  exit 0
+fi
+
+review_text="$(
+  jq -r '
+    [
+      (.summary // ""),
+      (.reason // ""),
+      (
+        .findings[]?
+        | [
+            (.path // ""),
+            ((.line // "") | tostring),
+            (.severity // ""),
+            (.title // ""),
+            (.problem // ""),
+            (.root_cause // ""),
+            (.fix_direction // ""),
+            (.regression_test_direction // ""),
+            (.suggested_diff // "")
+          ]
+        | join("\n")
+      )
+    ]
+    | join("\n")
+  ' "$CONTROL_JSON_FILE"
+)"
+
+contains_review_text() {
+  local needle="$1"
+  if [ -z "$needle" ]; then
+    return 0
+  fi
+  grep -Fqi -- "$needle" <<<"$review_text"
+}
+
+while IFS= read -r failed_check_line; do
+  case "$failed_check_line" in
+    "- "*)
+      failed_check_label="${failed_check_line#- }"
+      failed_check_label="${failed_check_label%%:*}"
+      if ! contains_review_text "$failed_check_label"; then
+        echo "FAILED_CHECK_EVIDENCE_NOT_REFERENCED"
+        exit 4
+      fi
+      ;;
+  esac
+done <"$FAILED_CHECKS_FILE"
+
+while IFS= read -r fail_marker; do
+  if ! contains_review_text "$fail_marker"; then
+    echo "FAILED_CHECK_EVIDENCE_NOT_REFERENCED"
+    exit 4
+  fi
+done < <(awk -F 'FAIL: ' 'NF > 1 { print $2 }' "$FAILED_CHECK_EVIDENCE_FILE" | sort -u)
+
+for evidence_marker in \
+  "Self-test Strix gate script" \
+  "github.event.inputs.strix_llm" \
+  "STRIX_LLM must select" \
+  "MODEL: github-models/openai/gpt-5"
+do
+  if grep -Fq -- "$evidence_marker" "$FAILED_CHECK_EVIDENCE_FILE" &&
+    ! contains_review_text "$evidence_marker"; then
+    echo "FAILED_CHECK_EVIDENCE_NOT_REFERENCED"
+    exit 4
+  fi
+done
+
+if grep -Fq "Strix vulnerability report window" "$FAILED_CHECK_EVIDENCE_FILE"; then
+  while IFS= read -r model_name; do
+    if ! contains_review_text "$model_name"; then
+      echo "FAILED_CHECK_EVIDENCE_NOT_REFERENCED"
+      exit 4
+    fi
+  done < <(
+    perl -ne 'while (m{(?:openai|deepseek|vertex_ai|github(?:_|-)models)/[A-Za-z0-9._/-]+}g) { print "$&\n" }' \
+      "$FAILED_CHECK_EVIDENCE_FILE" | sort -u
+  )
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- collect failed GitHub Check logs, annotations, and Strix model vulnerability windows before OpenCode review
- require OpenCode REQUEST_CHANGES findings to cite failed-check evidence with exact path/line/root cause/fix/test details
- preserve every Strix model-reported vulnerability instead of collapsing multi-model reports

## Validation
- actionlint .github/workflows/opencode-review.yml .github/workflows/strix.yml
- bash -n scripts/ci/collect_failed_check_evidence.sh scripts/ci/opencode_review_approve_gate.sh scripts/ci/validate_opencode_failed_check_review.sh scripts/ci/test_strix_quick_gate.sh
- python3 -m py_compile scripts/ci/opencode_review_normalize_output.py
- git diff --check origin/develop..origin/fix/opencode-failed-check-evidence -- .github/workflows/opencode-review.yml .github/workflows/strix.yml scripts/ci
- focused validator checks for unrelated failed-check findings, multi-model Strix evidence, and line 0 rejection