### PR TITLE
Verify local Gemma4 live E2E path

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     )
 
     # OpenAI Settings
+    OPENAI_BASE_URL: str | None = None
     OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-small"
     OPENAI_MODEL: str = "gpt-4o"
 

--- a/backend/services/embedding.py
+++ b/backend/services/embedding.py
@@ -2,6 +2,7 @@ import openai
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from openai import AsyncOpenAI
 from core.config import settings
+from services.llm_provider_urls import build_llm_provider_http_client
 from services.exceptions import EmbeddingGenerationError
 
 
@@ -22,7 +23,14 @@ async def generate_embeddings(texts: list[str], openai_api_key: str) -> list[lis
         raise ValueError("OPENAI_API_KEY is not set")
     
     # Instantiate client locally to avoid global state race conditions across tenants
-    client = AsyncOpenAI(api_key=openai_api_key)
+    validated_base_url, http_client = await build_llm_provider_http_client(
+        settings.OPENAI_BASE_URL
+    )
+    client = AsyncOpenAI(
+        api_key=openai_api_key,
+        base_url=validated_base_url,
+        http_client=http_client,
+    )
 
     try:
         response = await client.embeddings.create(
@@ -31,3 +39,5 @@ async def generate_embeddings(texts: list[str], openai_api_key: str) -> list[lis
         return [data.embedding for data in response.data]
     except openai.OpenAIError as e:
         raise EmbeddingGenerationError(f"Failed to generate embeddings: {str(e)}")
+    finally:
+        await client.close()

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -30,7 +30,10 @@ async def extract_todos_and_summary(
     if not openai_api_key:
         raise ValueError("API Key is not set")
 
-    validated_base_url, http_client = await build_llm_provider_http_client(base_url)
+    configured_base_url = base_url if base_url is not None else settings.OPENAI_BASE_URL
+    validated_base_url, http_client = await build_llm_provider_http_client(
+        configured_base_url
+    )
     client = AsyncOpenAI(
         api_key=openai_api_key,
         base_url=validated_base_url,
@@ -72,7 +75,10 @@ async def draft_reply(
     if not openai_api_key:
         raise ValueError("API Key is not set")
 
-    validated_base_url, http_client = await build_llm_provider_http_client(base_url)
+    configured_base_url = base_url if base_url is not None else settings.OPENAI_BASE_URL
+    validated_base_url, http_client = await build_llm_provider_http_client(
+        configured_base_url
+    )
     client = AsyncOpenAI(
         api_key=openai_api_key,
         base_url=validated_base_url,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -204,6 +204,7 @@ def test_settings_repr_redacts_auth_session_hmac_secret(monkeypatch):
 def test_openai_config():
     from core.config import settings
 
+    assert hasattr(settings, "OPENAI_BASE_URL")
     assert hasattr(settings, "OPENAI_EMBEDDING_MODEL")
     assert hasattr(settings, "OPENAI_MODEL")
 

--- a/backend/tests/test_embedding.py
+++ b/backend/tests/test_embedding.py
@@ -18,6 +18,7 @@ async def test_generate_embeddings_success():
         "services.embedding.AsyncOpenAI"
     ) as mock_async_openai:
         mock_client = mock_async_openai.return_value
+        mock_client.close = AsyncMock()
         mock_client.embeddings.create = AsyncMock()
         mock_response = AsyncMock()
         mock_data_1 = AsyncMock()
@@ -29,11 +30,13 @@ async def test_generate_embeddings_success():
 
         with patch("services.embedding.settings") as mock_settings:
             mock_settings.OPENAI_EMBEDDING_MODEL = "test-model"
+            mock_settings.OPENAI_BASE_URL = None
             
             embeddings = await generate_embeddings(["test1", "test2"], "test-key")
             assert len(embeddings) == 2
             assert embeddings[0] == [0.1, 0.2, 0.3]
             assert embeddings[1] == [0.4, 0.5, 0.6]
+            mock_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -42,14 +45,17 @@ async def test_generate_embeddings_api_error():
         "services.embedding.AsyncOpenAI"
     ) as mock_async_openai:
         mock_client = mock_async_openai.return_value
+        mock_client.close = AsyncMock()
         mock_client.embeddings.create = AsyncMock(side_effect=openai.OpenAIError("API error"))
 
         with patch("services.embedding.settings") as mock_settings:
             mock_settings.OPENAI_EMBEDDING_MODEL = "test-model"
+            mock_settings.OPENAI_BASE_URL = None
             
             with pytest.raises(EmbeddingGenerationError, match="Failed to generate embeddings: API error"):
 
                 await generate_embeddings(["test"], "test-key")
+            mock_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -181,8 +181,25 @@ def test_backend_dockerfile_uses_modern_env_syntax() -> None:
     assert "ENV PYTHONUNBUFFERED 1" not in dockerfile
     assert "secrets.token_hex" not in dockerfile
     assert "ENV DATABASE_URL=" not in dockerfile
-    assert '"/app/start.sh"' in dockerfile
+    assert '"/app/scripts/docker_entrypoint.sh"' in dockerfile
+    assert "RUN chmod +x /app/scripts/docker_entrypoint.sh" in dockerfile
+    assert "COPY scripts/start_combined.sh" not in dockerfile
+    assert "RUN echo '#!/bin/bash" not in dockerfile
     assert "uvicorn" not in dockerfile.split("CMD", 1)[1]
+
+
+def test_combined_image_start_script_preflights_env_and_logs_service_exit() -> None:
+    start_script = read_repo_text("backend/scripts/docker_entrypoint.sh")
+
+    assert "for var in DATABASE_URL AUTH_SESSION_HMAC_SECRET ENCRYPTION_KEY" in start_script
+    assert "Fernet.generate_key()" in start_script
+    assert "database bootstrap failed" in start_script
+    assert "Backend and frontend will not start." in start_script
+    assert "Starting backend (uvicorn :8000)" in start_script
+    assert "Starting frontend (next start :3000)" in start_script
+    assert 'wait -n "$backend_pid" "$frontend_pid"' in start_script
+    assert "Backend (:8000) exited with code" in start_script
+    assert "Frontend (:3000) exited with code" in start_script
 
 
 def test_backend_compose_commands_use_startup_preflight() -> None:
@@ -195,6 +212,13 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     assert 'DEBUG: "true"' not in backend_block
     assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
     assert '"scripts/start_backend.py"' in live_e2e_compose
+    assert "Dockerfile.ollama" in live_e2e_compose
+    assert 'OLLAMA_NO_CLOUD: "true"' in compose
+    assert 'OLLAMA_NO_CLOUD: "true"' in live_e2e_compose
+    assert "OPENAI_BASE_URL: http://ollama:11434/v1" in live_e2e_compose
+    assert "OPENAI_MODEL: gemma4" in live_e2e_compose
+    assert "OPENAI_EMBEDDING_MODEL: embeddinggemma" in live_e2e_compose
+    assert "proxy_read_timeout 600s" in read_repo_text("tests/live/nginx.conf")
 
 
 def test_compose_log_scanner_exists_for_warning_policy() -> None:

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -14,11 +14,20 @@ services:
     volumes:
       - live-postgres-data:/var/lib/postgresql/data
 
+  ollama:
+    build:
+      context: .
+      dockerfile: Dockerfile.ollama
+    environment:
+      OLLAMA_NO_CLOUD: "true"
+    expose:
+      - "11434"
+
   migrate:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
@@ -32,7 +41,7 @@ services:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
@@ -46,16 +55,21 @@ services:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
       DEBUG: "false"
-      OPENAI_API_KEY: ""
-      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
-      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o}
+      ALLOW_LOCAL_LLM_PROVIDERS: "true"
+      ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
+      OPENAI_API_KEY: ollama
+      OPENAI_BASE_URL: http://ollama:11434/v1
+      OPENAI_EMBEDDING_MODEL: embeddinggemma
+      OPENAI_MODEL: gemma4
     depends_on:
       live-seed:
         condition: service_completed_successfully
+      ollama:
+        condition: service_started
     expose:
       - "8000"
     command: ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ollama
+    environment:
+      OLLAMA_NO_CLOUD: "true"
     ports:
       - "11434:11434"
 

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import crypto from 'node:crypto';
 
 import { mockDashboardApi } from './helpers';
 
@@ -10,6 +11,40 @@ const publicIdentityHeaders = [
   'x-user-role',
   'x-dev-auth-token',
 ];
+
+const liveSessionPayload = {
+  ver: 1,
+  iss: 'naruon-control-plane',
+  aud: 'naruon-api',
+  sub: 'testuser',
+  role: 'member',
+  org: 'org-acme',
+  groups: ['group-1', 'group-2'],
+  workspace: 'workspace-org-acme',
+};
+
+function encodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function signLiveSession(): string {
+  const secret = process.env.LIVE_E2E_SESSION_SECRET;
+  if (!secret) {
+    throw new Error('LIVE_E2E_SESSION_SECRET is required for live model nano E2E.');
+  }
+
+  const header = encodeJson({ alg: 'HS256', typ: 'JWT' });
+  const payload = encodeJson({
+    ...liveSessionPayload,
+    exp: Math.floor(Date.now() / 1000) + 300,
+  });
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`, 'ascii')
+    .digest('base64url');
+
+  return `${header}.${payload}.${signature}`;
+}
 
 test('nano test: verify user requested features', async ({ page }) => {
   const sessionToken = 'signed-nano-session';
@@ -45,4 +80,38 @@ test('nano test: verify user requested features', async ({ page }) => {
   await page.goto('/data');
   await expect(page.getByRole('button', { name: '이메일 파일 선택' })).toBeVisible();
   await expect(page.getByRole('button', { name: '선택 파일 반입' })).toBeVisible();
+});
+
+test('nano live model: ollama gemma4 chat and embedding search complete', async ({ request }) => {
+  test.skip(
+    process.env.RUN_LIVE_MODEL_E2E !== '1' || !process.env.LIVE_BASE_URL,
+    'Requires live Docker Compose stack with Ollama Gemma4 models.',
+  );
+
+  const token = signLiveSession();
+  const authorization = `Bearer ${token}`;
+
+  const draftResponse = await request.post('/api/llm/draft', {
+    headers: { Authorization: authorization },
+    data: {
+      email_body: 'Live Gemma4 verification request from Naruon E2E.',
+      instruction: 'Reply with one concise Korean sentence confirming receipt.',
+    },
+    timeout: 600_000,
+  });
+  expect(draftResponse.ok()).toBeTruthy();
+  const draftBody = await draftResponse.json();
+  expect(String(draftBody.draft ?? '').trim().length).toBeGreaterThan(0);
+
+  const searchResponse = await request.post('/api/search', {
+    headers: { Authorization: authorization },
+    data: { query: 'Live E2E Release', limit: 3 },
+    timeout: 600_000,
+  });
+  expect(searchResponse.ok()).toBeTruthy();
+  const searchBody = await searchResponse.json();
+  const subjects = new Set(
+    (searchBody.results ?? []).map((item: { subject?: string | null }) => item.subject),
+  );
+  expect(subjects.has('Live E2E Release')).toBe(true);
 });

--- a/tests/live/nginx.conf
+++ b/tests/live/nginx.conf
@@ -15,6 +15,8 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
 
     location /api/ {
         proxy_pass http://live_backend;


### PR DESCRIPTION
## Summary
- wire backend chat and embedding clients to a configured OpenAI-compatible base URL for the local Ollama provider
- run live E2E Compose against baked Ollama Gemma4 + embeddinggemma models with signed-session Playwright nano coverage
- keep combined-image startup governance aligned with the current docker_entrypoint.sh and disable Ollama cloud metadata calls in local model Compose

## Validation
- python -m pytest tests/test_embedding.py tests/test_llm_service.py tests/test_config.py tests/test_release_governance.py tests/test_repo_hygiene.py -q
- npm test -- src/app/search/page.test.tsx src/components/SettingsLayout.test.tsx src/lib/api-client.test.ts
- git diff --check
- bash -n backend/scripts/docker_entrypoint.sh
- RUN_LIVE_MODEL_E2E=1 Playwright nano live model test: passed after cold Gemma4 start; backend/nginx 200 for /api/llm/draft and /api/search; Ollama 200 for /v1/chat/completions and /v1/embeddings; runtime event log scan clean for warning/error/fatal/denied signals