### PR TITLE
Verify local Gemma4 live E2E path

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -213,12 +213,19 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
     assert '"scripts/start_backend.py"' in live_e2e_compose
     assert "Dockerfile.ollama" in live_e2e_compose
+    assert "DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for live E2E}" in live_e2e_compose
+    assert "postgresql+asyncpg://" not in live_e2e_compose
+    assert '"127.0.0.1:18080:8080"' in live_e2e_compose
     assert 'OLLAMA_NO_CLOUD: "true"' in compose
     assert 'OLLAMA_NO_CLOUD: "true"' in live_e2e_compose
     assert "OPENAI_BASE_URL: http://ollama:11434/v1" in live_e2e_compose
     assert "OPENAI_MODEL: gemma4" in live_e2e_compose
     assert "OPENAI_EMBEDDING_MODEL: embeddinggemma" in live_e2e_compose
-    assert "proxy_read_timeout 600s" in read_repo_text("tests/live/nginx.conf")
+    live_nginx = read_repo_text("tests/live/nginx.conf")
+    assert "proxy_read_timeout 600s" in live_nginx
+    assert 'add_header Referrer-Policy "strict-origin-when-cross-origin" always;' in live_nginx
+    assert 'add_header X-Content-Type-Options "nosniff" always;' in live_nginx
+    assert 'add_header X-Frame-Options "DENY" always;' in live_nginx
 
 
 def test_compose_log_scanner_exists_for_warning_policy() -> None:

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -26,7 +26,7 @@ services:
   migrate:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for live E2E}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
@@ -40,7 +40,7 @@ services:
   live-seed:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for live E2E}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
@@ -54,7 +54,7 @@ services:
   backend:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for live E2E}@db:5432/${POSTGRES_DB:-ai_email_live}
+      DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for live E2E}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY for live E2E}
       AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET for live E2E}
       TRUST_DEV_HEADERS: ${TRUST_DEV_HEADERS:-false}
@@ -90,7 +90,7 @@ services:
       - backend
       - frontend
     ports:
-      - "18080:8080"
+      - "127.0.0.1:18080:8080"
     volumes:
       - ./tests/live/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 

--- a/tests/live/nginx.conf
+++ b/tests/live/nginx.conf
@@ -17,6 +17,9 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_read_timeout 600s;
     proxy_send_timeout 600s;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 
     location /api/ {
         proxy_pass http://live_backend;


### PR DESCRIPTION
## Summary
- wire backend chat and embedding clients to a configured OpenAI-compatible base URL for the local Ollama provider
- run live E2E Compose against baked Ollama Gemma4 + embeddinggemma models with signed-session Playwright nano coverage
- keep combined-image startup governance aligned with the current docker_entrypoint.sh, disable Ollama cloud metadata calls, require DATABASE_URL from the live E2E env file, and bind the live nginx gateway to localhost with security headers

## Validation
- python -m pytest tests/test_embedding.py tests/test_llm_service.py tests/test_config.py tests/test_release_governance.py tests/test_repo_hygiene.py -q
- npm test -- src/app/search/page.test.tsx src/components/SettingsLayout.test.tsx src/lib/api-client.test.ts
- git diff --check
- bash -n backend/scripts/docker_entrypoint.sh
- docker compose -f docker-compose.live-e2e.yml config with explicit DATABASE_URL
- RUN_LIVE_MODEL_E2E=1 Playwright nano live model test: passed after cold Gemma4 start; backend/nginx 200 for /api/llm/draft and /api/search; Ollama 200 for /v1/chat/completions and /v1/embeddings; runtime event log scan clean for warning/error/fatal/denied signals