### PR TITLE
feat: route runtime LLM calls through active providers

### DIFF
--- a/backend/api/llm.py
+++ b/backend/api/llm.py
@@ -10,7 +10,7 @@ from services.llm_service import (
     ExtractionResult,
 )
 from core.exceptions import LLMServiceError
-from services.tenant_config_scope import get_scoped_tenant_config
+from services.llm_provider_selection import resolve_runtime_llm_provider
 
 router = APIRouter(prefix="/api/llm")
 
@@ -36,16 +36,21 @@ async def summarize_endpoint(
     target_user_id = user_id or auth_context.user_id
 
     try:
-        tenant_config = await get_scoped_tenant_config(
+        runtime_provider = await resolve_runtime_llm_provider(
             db,
-            target_user_id,
-            auth_context.organization_id,
+            user_id=target_user_id,
+            organization_id=auth_context.organization_id,
         )
-        if not tenant_config or not tenant_config.openai_api_key:
+        if runtime_provider is None:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")
 
-        openai_api_key = tenant_config.openai_api_key
-        return await extract_todos_and_summary(request.email_body, openai_api_key)
+        return await extract_todos_and_summary(
+            request.email_body,
+            runtime_provider.api_key,
+            base_url=runtime_provider.base_url,
+            provider_name=runtime_provider.provider_name,
+            model=runtime_provider.chat_model,
+        )
     except LLMServiceError:
         raise HTTPException(
             status_code=500,
@@ -72,16 +77,21 @@ async def draft_endpoint(
     target_user_id = user_id or auth_context.user_id
 
     try:
-        tenant_config = await get_scoped_tenant_config(
+        runtime_provider = await resolve_runtime_llm_provider(
             db,
-            target_user_id,
-            auth_context.organization_id,
+            user_id=target_user_id,
+            organization_id=auth_context.organization_id,
         )
-        if not tenant_config or not tenant_config.openai_api_key:
+        if runtime_provider is None:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")
 
-        openai_api_key = tenant_config.openai_api_key
-        reply = await draft_reply(request.email_body, request.instruction, openai_api_key)
+        reply = await draft_reply(
+            request.email_body,
+            request.instruction,
+            runtime_provider.api_key,
+            base_url=runtime_provider.base_url,
+            model=runtime_provider.chat_model,
+        )
         return {"draft": reply}
     except LLMServiceError:
         raise HTTPException(

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -8,7 +8,7 @@ from db.session import get_db
 from db.models import Email, Attachment
 from services.embedding import generate_embeddings
 from api.auth import AuthContext, get_auth_context
-from services.tenant_config_scope import get_scoped_tenant_config
+from services.llm_provider_selection import resolve_runtime_llm_provider
 
 router = APIRouter(prefix="/api")
 logger = logging.getLogger(__name__)
@@ -185,17 +185,20 @@ async def hybrid_search(
         return SearchResponse(results=[])
 
     try:
-        tenant_config = await get_scoped_tenant_config(
+        runtime_provider = await resolve_runtime_llm_provider(
             db,
-            target_user_id,
-            auth_context.organization_id,
+            user_id=target_user_id,
+            organization_id=auth_context.organization_id,
         )
-        if not tenant_config or not tenant_config.openai_api_key:
+        if runtime_provider is None:
             raise HTTPException(status_code=400, detail="OpenAI API key not configured")
 
-        openai_api_key = tenant_config.openai_api_key
-
-        embeddings = await generate_embeddings([request.query], openai_api_key)
+        embeddings = await generate_embeddings(
+            [request.query],
+            runtime_provider.api_key,
+            base_url=runtime_provider.base_url,
+            model=runtime_provider.embedding_model,
+        )
         query_embedding = embeddings[0] if embeddings else None
         if (
             query_embedding is not None

--- a/backend/services/embedding.py
+++ b/backend/services/embedding.py
@@ -18,13 +18,19 @@ def chunk_text(
     return splitter.split_text(text)
 
 
-async def generate_embeddings(texts: list[str], openai_api_key: str) -> list[list[float]]:
+async def generate_embeddings(
+    texts: list[str],
+    openai_api_key: str,
+    base_url: str | None = None,
+    model: str | None = None,
+) -> list[list[float]]:
     if not openai_api_key:
         raise ValueError("OPENAI_API_KEY is not set")
-    
+
     # Instantiate client locally to avoid global state race conditions across tenants
+    configured_base_url = base_url if base_url is not None else settings.OPENAI_BASE_URL
     validated_base_url, http_client = await build_llm_provider_http_client(
-        settings.OPENAI_BASE_URL
+        configured_base_url
     )
     client = AsyncOpenAI(
         api_key=openai_api_key,
@@ -34,7 +40,7 @@ async def generate_embeddings(texts: list[str], openai_api_key: str) -> list[lis
 
     try:
         response = await client.embeddings.create(
-            model=settings.OPENAI_EMBEDDING_MODEL, input=texts
+            model=model or settings.OPENAI_EMBEDDING_MODEL, input=texts
         )
         return [data.embedding for data in response.data]
     except openai.OpenAIError as e:

--- a/backend/services/llm_provider_selection.py
+++ b/backend/services/llm_provider_selection.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from db.models import LLMProvider
+from services.llm_provider_readiness import (
+    LOCAL_PROVIDER_TYPES,
+    is_llm_provider_configured,
+    llm_provider_model_label,
+)
+from services.tenant_config_scope import get_scoped_tenant_config
+
+
+ProviderSource = Literal["llm_provider", "tenant_config"]
+LOCAL_PROVIDER_API_KEY = "local-provider"
+
+
+@dataclass(frozen=True)
+class RuntimeLLMProvider:
+    api_key: str
+    base_url: str | None
+    chat_model: str
+    embedding_model: str
+    provider_name: str
+    provider_source: ProviderSource
+    provider_id: int | None = None
+
+
+def _provider_type(provider: LLMProvider) -> str:
+    return (provider.provider_type or "").strip().lower()
+
+
+def _is_local_provider(provider: LLMProvider) -> bool:
+    return _provider_type(provider) in LOCAL_PROVIDER_TYPES
+
+
+def _provider_api_key(provider: LLMProvider) -> str | None:
+    if provider.api_key and provider.api_key.strip():
+        return provider.api_key
+    if _is_local_provider(provider):
+        return LOCAL_PROVIDER_API_KEY
+    return None
+
+
+async def get_active_llm_provider(
+    session: AsyncSession,
+    organization_id: str | None,
+) -> LLMProvider | None:
+    if not organization_id:
+        return None
+
+    result = await session.execute(
+        select(LLMProvider)
+        .where(
+            LLMProvider.organization_id == organization_id,
+            LLMProvider.is_active.is_(True),
+        )
+        .order_by(desc(LLMProvider.updated_at), desc(LLMProvider.id))
+        .limit(1)
+    )
+    return result.scalars().first()
+
+
+def _runtime_from_provider(provider: LLMProvider) -> RuntimeLLMProvider | None:
+    if not is_llm_provider_configured(provider):
+        return None
+
+    api_key = _provider_api_key(provider)
+    if not api_key:
+        return None
+
+    return RuntimeLLMProvider(
+        api_key=api_key,
+        base_url=provider.base_url,
+        chat_model=(provider.model_identifier or "").strip() or settings.OPENAI_MODEL,
+        embedding_model=(provider.embedding_model or "").strip()
+        or settings.OPENAI_EMBEDDING_MODEL,
+        provider_name=llm_provider_model_label(provider),
+        provider_source="llm_provider",
+        provider_id=provider.id,
+    )
+
+
+async def resolve_runtime_llm_provider(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    organization_id: str | None,
+) -> RuntimeLLMProvider | None:
+    active_provider = await get_active_llm_provider(session, organization_id)
+    if active_provider is not None:
+        runtime_provider = _runtime_from_provider(active_provider)
+        if runtime_provider is not None:
+            return runtime_provider
+
+    tenant_config = await get_scoped_tenant_config(session, user_id, organization_id)
+    if tenant_config is None or not tenant_config.openai_api_key:
+        return None
+
+    return RuntimeLLMProvider(
+        api_key=tenant_config.openai_api_key,
+        base_url=settings.OPENAI_BASE_URL,
+        chat_model=settings.OPENAI_MODEL,
+        embedding_model=settings.OPENAI_EMBEDDING_MODEL,
+        provider_name="OpenAI",
+        provider_source="tenant_config",
+        provider_id=None,
+    )

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -26,6 +26,7 @@ async def extract_todos_and_summary(
     openai_api_key: str,
     base_url: str | None = None,
     provider_name: str = "OpenAI",
+    model: str | None = None,
 ) -> ExtractionResult:
     if not openai_api_key:
         raise ValueError("API Key is not set")
@@ -39,9 +40,10 @@ async def extract_todos_and_summary(
         base_url=validated_base_url,
         http_client=http_client,
     )
+    selected_model = model or settings.OPENAI_MODEL
     try:
         response = await client.beta.chat.completions.parse(
-            model=settings.OPENAI_MODEL,
+            model=selected_model,
             messages=[
                 {
                     "role": "system",
@@ -65,12 +67,16 @@ async def extract_todos_and_summary(
     if not parsed:
         raise RuntimeError("Failed to parse LLM response")
 
-    parsed.provenance = f"{provider_name} ({settings.OPENAI_MODEL})"
+    parsed.provenance = f"{provider_name} ({selected_model})"
     return parsed
 
 
 async def draft_reply(
-    email_body: str, instruction: str, openai_api_key: str, base_url: str | None = None
+    email_body: str,
+    instruction: str,
+    openai_api_key: str,
+    base_url: str | None = None,
+    model: str | None = None,
 ) -> str:
     if not openai_api_key:
         raise ValueError("API Key is not set")
@@ -84,9 +90,10 @@ async def draft_reply(
         base_url=validated_base_url,
         http_client=http_client,
     )
+    selected_model = model or settings.OPENAI_MODEL
     try:
         response = await client.chat.completions.create(
-            model=settings.OPENAI_MODEL,
+            model=selected_model,
             messages=[
                 {
                     "role": "system",

--- a/backend/tests/test_embedding.py
+++ b/backend/tests/test_embedding.py
@@ -36,7 +36,42 @@ async def test_generate_embeddings_success():
             assert len(embeddings) == 2
             assert embeddings[0] == [0.1, 0.2, 0.3]
             assert embeddings[1] == [0.4, 0.5, 0.6]
+            mock_client.embeddings.create.assert_awaited_once_with(
+                model="test-model", input=["test1", "test2"]
+            )
             mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_uses_selected_provider_model_and_base_url():
+    with patch("services.embedding.AsyncOpenAI") as mock_async_openai, patch(
+        "services.embedding.build_llm_provider_http_client",
+        new_callable=AsyncMock,
+    ) as mock_build_client:
+        mock_http_client = AsyncMock()
+        mock_build_client.return_value = ("http://ollama:11434/v1", mock_http_client)
+        mock_client = mock_async_openai.return_value
+        mock_client.close = AsyncMock()
+        mock_client.embeddings.create = AsyncMock()
+        mock_response = AsyncMock()
+        mock_data = AsyncMock()
+        mock_data.embedding = [0.1, 0.2, 0.3]
+        mock_response.data = [mock_data]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embeddings = await generate_embeddings(
+            ["test"],
+            "local-provider",
+            base_url="http://ollama:11434/v1",
+            model="embeddinggemma",
+        )
+
+    assert embeddings == [[0.1, 0.2, 0.3]]
+    mock_build_client.assert_awaited_once_with("http://ollama:11434/v1")
+    mock_client.embeddings.create.assert_awaited_once_with(
+        model="embeddinggemma", input=["test"]
+    )
+    mock_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_api.py
+++ b/backend/tests/test_llm_api.py
@@ -1,8 +1,10 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
+from db.models import LLMProvider
 from main import app
 from db.session import get_db
+from services.llm_provider_selection import LOCAL_PROVIDER_API_KEY
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
@@ -20,11 +22,30 @@ class MockTenantConfigResult:
         return self.tenant_config
 
 
+class MockScalars:
+    def __init__(self, items):
+        self.items = items
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class MockProviderResult:
+    def __init__(self, providers):
+        self.providers = providers
+
+    def scalars(self):
+        return MockScalars(self.providers)
+
+
 class MockSession:
-    def __init__(self, tenant_config=None):
+    def __init__(self, tenant_config=None, providers=None):
         self.tenant_config = tenant_config or MockTenantConfig()
+        self.providers = providers or []
 
     async def execute(self, stmt):
+        if "llm_providers" in str(stmt).lower():
+            return MockProviderResult(self.providers)
         return MockTenantConfigResult(self.tenant_config)
 
     async def scalar(self, stmt):
@@ -89,6 +110,55 @@ def test_draft_endpoint(mock_draft, client):
     )
     assert resp.status_code == 200
     assert resp.json() == {"draft": "This is a draft reply."}
+
+
+@patch("api.llm.draft_reply", new_callable=AsyncMock)
+def test_draft_endpoint_uses_active_local_model_provider(mock_draft):
+    provider = LLMProvider(
+        id=7,
+        user_id="admin",
+        organization_id="org-acme",
+        name="Local Gemma4",
+        provider_type="ollama",
+        base_url="http://ollama:11434/v1",
+        model_identifier="gemma4",
+        embedding_model="embeddinggemma",
+        api_key=None,
+        is_active=True,
+    )
+    mock_draft.return_value = "Gemma4 draft"
+
+    async def override_get_db():
+        yield MockSession(
+            tenant_config=MockTenantConfig(openai_api_key=None),
+            providers=[provider],
+        )
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(
+            app,
+            headers={
+                "X-User-Id": "testuser",
+                "X-Organization-Id": "org-acme",
+            },
+        ) as test_client:
+            resp = test_client.post(
+                "/api/llm/draft",
+                json={"email_body": "test email", "instruction": "reply nicely"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json() == {"draft": "Gemma4 draft"}
+    mock_draft.assert_awaited_once_with(
+        "test email",
+        "reply nicely",
+        LOCAL_PROVIDER_API_KEY,
+        base_url="http://ollama:11434/v1",
+        model="gemma4",
+    )
 
 
 def test_llm_endpoints_preserve_missing_key_400():

--- a/backend/tests/test_llm_provider_selection.py
+++ b/backend/tests/test_llm_provider_selection.py
@@ -1,0 +1,99 @@
+import datetime
+
+import pytest
+
+from db.models import LLMProvider
+from services.llm_provider_selection import (
+    LOCAL_PROVIDER_API_KEY,
+    resolve_runtime_llm_provider,
+)
+
+
+class MockScalars:
+    def __init__(self, items):
+        self.items = items
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class MockProviderResult:
+    def __init__(self, providers):
+        self.providers = providers
+
+    def scalars(self):
+        return MockScalars(self.providers)
+
+
+class MockTenantResult:
+    def __init__(self, tenant_config):
+        self.tenant_config = tenant_config
+
+    def scalar_one_or_none(self):
+        return self.tenant_config
+
+
+class MockTenantConfig:
+    def __init__(self, openai_api_key="sk-tenant"):
+        self.openai_api_key = openai_api_key
+
+
+class MockSession:
+    def __init__(self, *, providers=None, tenant_config=None):
+        self.providers = providers or []
+        self.tenant_config = tenant_config
+
+    async def execute(self, stmt):
+        statement_text = str(stmt).lower()
+        if "llm_providers" in statement_text:
+            return MockProviderResult(self.providers)
+        if "tenant_configs" in statement_text:
+            return MockTenantResult(self.tenant_config)
+        raise AssertionError(f"unexpected statement: {stmt}")
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_llm_provider_prefers_active_local_provider():
+    provider = LLMProvider(
+        id=10,
+        user_id="admin",
+        organization_id="org-acme",
+        name="Local Gemma4",
+        provider_type="ollama",
+        base_url="http://ollama:11434/v1",
+        model_identifier="gemma4",
+        embedding_model="embeddinggemma",
+        api_key=None,
+        is_active=True,
+        updated_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    runtime_provider = await resolve_runtime_llm_provider(
+        MockSession(
+            providers=[provider],
+            tenant_config=MockTenantConfig(openai_api_key=None),
+        ),
+        user_id="testuser",
+        organization_id="org-acme",
+    )
+
+    assert runtime_provider is not None
+    assert runtime_provider.provider_source == "llm_provider"
+    assert runtime_provider.provider_id == 10
+    assert runtime_provider.api_key == LOCAL_PROVIDER_API_KEY
+    assert runtime_provider.base_url == "http://ollama:11434/v1"
+    assert runtime_provider.chat_model == "gemma4"
+    assert runtime_provider.embedding_model == "embeddinggemma"
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_llm_provider_falls_back_to_tenant_config():
+    runtime_provider = await resolve_runtime_llm_provider(
+        MockSession(providers=[], tenant_config=MockTenantConfig("sk-tenant")),
+        user_id="testuser",
+        organization_id="org-acme",
+    )
+
+    assert runtime_provider is not None
+    assert runtime_provider.provider_source == "tenant_config"
+    assert runtime_provider.api_key == "sk-tenant"

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -209,6 +209,33 @@ async def test_extract_todos_and_summary_success(mock_openai):
     assert result.summary == "Test summary"
     assert result.todos == ["Task 1"]
     mock_openai.beta.chat.completions.parse.assert_called_once()
+    assert (
+        mock_openai.beta.chat.completions.parse.call_args.kwargs["model"]
+        == settings.OPENAI_MODEL
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_todos_and_summary_uses_selected_provider_model(mock_openai):
+    mock_response = MagicMock()
+    mock_message = MagicMock()
+    mock_message.parsed = ExtractionResult(
+        summary="Test summary", todos=["Task 1"], confidence=90
+    )
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+    mock_openai.beta.chat.completions.parse = AsyncMock(return_value=mock_response)
+
+    result = await extract_todos_and_summary(
+        "Test email",
+        "test-key",
+        provider_name="Local Gemma4",
+        model="gemma4",
+    )
+
+    assert result.provenance == "Local Gemma4 (gemma4)"
+    assert mock_openai.beta.chat.completions.parse.call_args.kwargs["model"] == "gemma4"
 
 
 @pytest.mark.asyncio
@@ -425,6 +452,32 @@ async def test_draft_reply_success(mock_openai):
     # Verify results
     assert result == "Drafted reply text"
     mock_openai.chat.completions.create.assert_called_once()
+    assert (
+        mock_openai.chat.completions.create.call_args.kwargs["model"]
+        == settings.OPENAI_MODEL
+    )
+
+
+@pytest.mark.asyncio
+async def test_draft_reply_uses_selected_provider_model(mock_openai):
+    mock_response = MagicMock()
+    mock_message = MagicMock()
+    mock_message.content = "Drafted reply text"
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    mock_openai.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    result = await draft_reply(
+        "Test email",
+        "Draft a positive reply",
+        "test-key",
+        model="gemma4",
+    )
+
+    assert result == "Drafted reply text"
+    assert mock_openai.chat.completions.create.call_args.kwargs["model"] == "gemma4"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -2,8 +2,10 @@ import datetime
 import pytest
 from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
+from db.models import LLMProvider
 from main import app
 from db.session import get_db
+from services.llm_provider_selection import LOCAL_PROVIDER_API_KEY
 
 pytestmark = pytest.mark.usefixtures("dev_auth_dependency_overrides")
 
@@ -34,14 +36,36 @@ class MockTenantConfigResult:
         return self.config
 
 
+class MockScalars:
+    def __init__(self, items):
+        self.items = items
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class MockProviderResult:
+    def __init__(self, providers):
+        self.providers = providers
+
+    def scalars(self):
+        return MockScalars(self.providers)
+
+
 class MockTenantConfig:
     def __init__(self):
         self.openai_api_key = "test-key"
 
 
 class MockSession:
+    def __init__(self, providers=None):
+        self.providers = providers or []
+
     async def execute(self, stmt):
-        if "tenant_configs" in str(stmt).lower():
+        statement_text = str(stmt).lower()
+        if "llm_providers" in statement_text:
+            return MockProviderResult(self.providers)
+        if "tenant_configs" in statement_text:
             return MockTenantConfigResult(MockTenantConfig())
         return MockResult()
 
@@ -55,6 +79,7 @@ async def override_get_db():
 
 class CapturingMockSession(MockSession):
     def __init__(self):
+        super().__init__()
         self.statements = []
 
     async def execute(self, stmt):
@@ -91,6 +116,45 @@ def test_search_endpoint_success(mock_generate_embeddings, client):
     assert data["results"][0]["source_message_id"] == "<test@example.com>"
     assert data["results"][0]["thread_id"] == "thread-123"
     assert data["results"][0]["reply_count"] == 2
+
+
+@patch("api.search.generate_embeddings", new_callable=AsyncMock)
+def test_search_endpoint_uses_active_provider_embedding_model(mock_generate_embeddings):
+    provider = LLMProvider(
+        id=4,
+        user_id="admin",
+        organization_id="org-acme",
+        name="Local Gemma4",
+        provider_type="ollama",
+        base_url="http://ollama:11434/v1",
+        model_identifier="gemma4",
+        embedding_model="embeddinggemma",
+        api_key=None,
+        is_active=True,
+    )
+    mock_generate_embeddings.return_value = [[0.1] * 1536]
+    session = MockSession(providers=[provider])
+
+    async def override_scoped_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_scoped_db
+    try:
+        with TestClient(
+            app,
+            headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"},
+        ) as client:
+            response = client.post("/api/search", json={"query": "test query"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    mock_generate_embeddings.assert_awaited_once_with(
+        ["test query"],
+        LOCAL_PROVIDER_API_KEY,
+        base_url="http://ollama:11434/v1",
+        model="embeddinggemma",
+    )
 
 
 def test_search_reply_counts_group_by_coalesced_thread_key():


### PR DESCRIPTION
## Summary
- add a runtime LLM provider resolver that prefers the active organization provider and preserves the existing TenantConfig fallback
- route `/api/llm/summarize`, `/api/llm/draft`, and `/api/search` through the selected provider model/base URL/API key
- make local Ollama providers usable without storing a fake secret, so Gemma4 chat and EmbeddingGemma search paths use registered provider settings

## Validation
- python3 -m py_compile backend/services/llm_provider_selection.py backend/services/llm_service.py backend/services/embedding.py backend/api/llm.py backend/api/search.py
- python3 -m pytest tests/test_llm_api.py tests/test_search.py tests/test_embedding.py tests/test_llm_service.py tests/test_llm_provider_selection.py -q
- git diff --check refs/remotes/origin/develop..refs/remotes/origin/feat/runtime-llm-provider-wiring -- backend/api/llm.py backend/api/search.py backend/services backend/tests
