### PR TITLE
ci(strix): bump GitHub Models default to openai/openai/gpt-5 (correct double prefix)

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -24,7 +24,7 @@ on:
       strix_llm:
         description: Optional Strix model override for manual evidence runs
         required: false
-        default: openai/openai/gpt-4.1
+        default: openai/openai/gpt-5
         type: string
 
 concurrency:
@@ -115,7 +115,7 @@ jobs:
       - name: Gate Strix secrets
         id: gate
         env:
-          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/openai/gpt-4.1' }}
+          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/openai/gpt-5' }}
           STRIX_OPENAI_API_KEY: ${{ secrets.STRIX_OPENAI_API_KEY }}
           STRIX_VERTEX_CREDENTIALS: ${{ secrets.GCP_SA_KEY }}
           GITHUB_MODELS_TOKEN: ${{ github.token }}
@@ -242,7 +242,7 @@ jobs:
       - name: Prepare Strix model input file
         if: steps.gate.outputs.enabled == 'true'
         env:
-          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/openai/gpt-4.1' }}
+          STRIX_MODEL: ${{ github.event.inputs.strix_llm || 'openai/openai/gpt-5' }}
         run: |
           umask 077
           strix_llm_file="$RUNNER_TEMP/strix_llm.txt"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -119,7 +119,7 @@ assert_strix_workflow_pr_trigger_hardened() {
 	assert_file_not_contains "$workflow_file" "STRIX_TOTAL_TIMEOUT_SECONDS:" "strix workflow must not expose total timeout env names in GitHub logs"
 	assert_file_not_contains "$workflow_file" "STRIX_PR_SCOPE_MAX_FILES_PER_BATCH" "strix workflow must not split Strix PR evidence into separate scanner runs"
 	assert_file_not_contains "$workflow_file" "secrets.STRIX_LLM == 'vertex_ai/gemini-3.1-pro-preview-customtools' && 'vertex_ai/gemini-2.5-flash'" "strix workflow must not quarantine the approved Vertex preview model after organization secret visibility is fixed"
-	assert_file_contains "$workflow_file" "github.event.inputs.strix_llm || 'openai/openai/gpt-4.1'" "strix workflow defaults PR Strix scans to GitHub Models"
+	assert_file_contains "$workflow_file" "github.event.inputs.strix_llm || 'openai/openai/gpt-5'" "strix workflow defaults PR Strix scans to GitHub Models"
 	assert_file_not_contains "$workflow_file" "secrets.STRIX_LLM ||" "strix workflow must not let the legacy STRIX_LLM secret override PR defaults"
 	assert_file_contains "$workflow_file" "STRIX_LLM must select GitHub Models openai/openai/*, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" "strix workflow rejects unsupported model inputs"
 	assert_file_contains "$workflow_file" "vertex_ai/gemini-3.1-pro-preview-customtools | vertex_ai/gemini-2.5-flash)" "strix workflow accepts only exact approved organization Vertex AI models"


### PR DESCRIPTION
master already addresses GitHub Models via LiteLLM with the **double provider prefix** `openai/openai/<catalog-id>`, so the inference endpoint (`models.github.ai`) receives the publisher-qualified model id. This keeps that correct form and only bumps the version:

`openai/openai/gpt-4.1` → `openai/openai/gpt-5` (strix.yml ×3 + the test's expected-default assertion).

The gate already accepts `openai/openai/gpt-5` (the test guard explicitly asserts it), so no gate change is needed. The `strix-selftest` check validates this on the PR head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)