### PR TITLE
🎨 Palette: Add contextual ARIA labels to utility buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Add context-rich ARIA labels to utility buttons
+**Learning:** Basic tooltips or titles are sometimes missing on icon-only or ambiguous utility buttons (e.g., '위치 보기', '의사결정 추가'). Including contextual information in the `aria-label` (e.g., '출시 회의 일정 삭제', '회의실 A (4층) 위치 보기') provides a significantly better experience for screen reader users by disambiguating the action target.
+**Action:** Proactively ensure that all utility actions have `aria-label`s that combine the action with its explicit context/target, rather than relying solely on surrounding text or icons.

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -496,7 +496,7 @@ export function CalendarLayout() {
           <div className="flex gap-3 items-center">
             <Video className="size-5 text-muted-foreground shrink-0" />
             <p className="text-sm font-semibold">회의실 A (4층)</p>
-            <button type="button" className="text-xs text-primary font-semibold ml-auto hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">위치 보기</button>
+            <button type="button" aria-label="회의실 A (4층) 위치 보기" className="text-xs text-primary font-semibold ml-auto hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">위치 보기</button>
           </div>
           <div className="flex gap-3 items-start">
             <Users className="size-5 text-muted-foreground shrink-0" />
@@ -536,9 +536,9 @@ export function CalendarLayout() {
         </div>
 
         <div className="mt-8 flex gap-3">
-          <button type="button" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">삭제</button>
-          <button type="button" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">복사</button>
-          <button type="button" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">수정</button>
+          <button type="button" aria-label="출시 회의 일정 삭제" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">삭제</button>
+          <button type="button" aria-label="출시 회의 일정 복사" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">복사</button>
+          <button type="button" aria-label="출시 회의 일정 수정" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">수정</button>
         </div>
       </aside>
     </div>

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -373,7 +373,7 @@ export function ProjectsLayout() {
               <section aria-label="프로젝트 의사결정 로그" className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
                 <div className="flex items-center justify-between border-b border-border bg-primary/5 p-5">
                   <h2 className="font-bold text-lg text-primary">의사결정 로그</h2>
-                  <button type="button" onClick={() => setViewMode('의사결정 로그')} className="rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90">의사결정 추가</button>
+                  <button type="button" aria-label="프로젝트 의사결정 추가" onClick={() => setViewMode('의사결정 로그')} className="rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground hover:bg-primary/90">의사결정 추가</button>
                 </div>
                 <div className="divide-y divide-border">
                   <article className="p-5">
@@ -445,9 +445,9 @@ export function ProjectsLayout() {
               <h2 className="mb-4 font-bold text-base">프로젝트 액션</h2>
               <div className="grid gap-2 text-sm">
                 <a href="/data" className="flex min-h-10 items-center gap-2 rounded-md bg-primary px-3 font-bold text-primary-foreground hover:bg-primary/90"><FolderOpen className="size-4" /> 새 프로젝트</a>
-                <button type="button" onClick={() => setViewMode('프로젝트 상세')} className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><CheckCircle2 className="size-4 text-primary" /> 프로젝트 열기</button>
+                <button type="button" aria-label="프로젝트 상세 열기" onClick={() => setViewMode('프로젝트 상세')} className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><CheckCircle2 className="size-4 text-primary" /> 프로젝트 열기</button>
                 <a href="/tasks" className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><ListChecks className="size-4 text-primary" /> 마일스톤 추가</a>
-                <button type="button" onClick={() => setViewMode('의사결정 로그')} className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><CheckCircle2 className="size-4 text-primary" /> 의사결정 추가</button>
+                <button type="button" aria-label="프로젝트 의사결정 추가" onClick={() => setViewMode('의사결정 로그')} className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><CheckCircle2 className="size-4 text-primary" /> 의사결정 추가</button>
                 <a href="/search" className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-background px-3 font-bold hover:bg-secondary"><Search className="size-4 text-primary" /> 관련 문서/메일 연결</a>
               </div>
             </section>

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -304,6 +304,7 @@ export function TasksLayout() {
             <input
               id="task-search-input"
               type="text"
+              aria-label="작업 검색"
               value={taskSearch}
               onChange={(event) => setTaskSearch(event.target.value)}
               placeholder="작업 검색..."


### PR DESCRIPTION
💡 What: Added context-rich `aria-label`s to generic utility buttons across several layouts (`CalendarLayout`, `ProjectsLayout`, `TasksLayout`).
🎯 Why: Screen reader users need sufficient context for what an action targets. Buttons that only say "수정" or "삭제" are ambiguous without visual layout cues. By injecting contextual string values into the `aria-label`s, we directly improve navigation clarity and accessibility.
📸 Before/After: No visual UI changes. Added labels in the DOM.
♿ Accessibility: Improved screen reader support for generic utility actions.

---
*PR created automatically by Jules for task [5735759581215326006](https://jules.google.com/task/5735759581215326006) started by @seonghobae*