### PR TITLE
Fix master Strix scan findings

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -147,6 +147,7 @@ ADMIN_ROLES = SYSTEM_ADMIN_ROLES | TENANT_ADMIN_ROLES
 SESSION_ISSUER = "naruon-control-plane"
 SESSION_AUDIENCE = "naruon-api"
 SESSION_SIGNING_ALGORITHM = "HS256"
+OIDC_SIGNING_ALGORITHM = "RS256"
 MIN_SESSION_SECRET_BYTES = 32
 
 
@@ -227,6 +228,8 @@ def _cached_oidc_signing_key_from_jwt(token: str) -> Any:
     except Exception:
         raise _authentication_error() from None
     _reject_unsupported_critical_headers(header)
+    if header.get("alg") != OIDC_SIGNING_ALGORITHM:
+        raise _authentication_error()
     key_id = header.get("kid")
     if not isinstance(key_id, str) or not key_id.strip():
         raise _authentication_error()
@@ -278,9 +281,9 @@ def _verify_signed_session_payload(
             payload = jwt.decode(
                 token,
                 signing_key.key,
-                algorithms=["RS256"],
+                algorithms=[OIDC_SIGNING_ALGORITHM],
                 audience=settings.OIDC_CLIENT_ID,
-                issuer=settings.OIDC_ISSUER_URL
+                issuer=settings.OIDC_ISSUER_URL,
             )
             _reject_signed_session_system_admin_payload(payload)
             return payload, "oidc"

--- a/backend/services/email_client.py
+++ b/backend/services/email_client.py
@@ -167,7 +167,7 @@ def _normalize_smtp_host(host: str) -> str:
     return _normalize_mail_host(host, SMTP_HOST_NOT_ALLOWED)
 
 
-def _validate_public_ip_address(address: str, host_error: str) -> None:
+def _validate_public_ip_address(address: str, host_error: str) -> str:
     try:
         ip_address = ipaddress.ip_address(address)
     except ValueError as exc:
@@ -182,6 +182,7 @@ def _validate_public_ip_address(address: str, host_error: str) -> None:
         or not ip_address.is_global
     ):
         raise ValueError(host_error)
+    return str(ip_address)
 
 
 def _is_ip_literal(candidate: str) -> bool:
@@ -224,10 +225,12 @@ def _resolve_all_public_mail_addresses(
         raise ValueError(host_error) from exc
 
     validated_address_infos = []
-    for address_info in address_infos:
-        sockaddr = address_info[4]
-        _validate_public_ip_address(str(sockaddr[0]), host_error)
-        validated_address_infos.append(address_info)
+    for family, socktype, proto, canonname, sockaddr in address_infos:
+        validated_address = _validate_public_ip_address(str(sockaddr[0]), host_error)
+        validated_sockaddr = (validated_address, *tuple(sockaddr[1:]))
+        validated_address_infos.append(
+            (family, socktype, proto, canonname, validated_sockaddr)
+        )
     if not validated_address_infos:
         raise ValueError(host_error)
     return validated_address_infos
@@ -373,18 +376,21 @@ def _resolve_smtp_connect_address(
     raise ValueError(SMTP_HOST_NOT_ALLOWED)
 
 
-def _validate_pinned_smtp_sockaddr(sockaddr: tuple[Any, ...]) -> None:
+def _validate_pinned_smtp_sockaddr(sockaddr: tuple[Any, ...]) -> tuple[Any, ...]:
     """Ensure the connection target is a pre-resolved public IP, not a hostname."""
     if not sockaddr:
         raise ValueError(SMTP_HOST_NOT_ALLOWED)
-    _validate_public_ip_address(str(sockaddr[0]), SMTP_HOST_NOT_ALLOWED)
+    validated_address = _validate_public_ip_address(
+        str(sockaddr[0]), SMTP_HOST_NOT_ALLOWED
+    )
+    return (validated_address, *tuple(sockaddr[1:]))
 
 
 async def _connect_validated_smtp_socket(
     smtp_destination: ValidatedSmtpDestination,
 ) -> socket.socket:
     """Connect a non-blocking socket to the pre-resolved SMTP address."""
-    _validate_pinned_smtp_sockaddr(smtp_destination.sockaddr)
+    connect_sockaddr = _validate_pinned_smtp_sockaddr(smtp_destination.sockaddr)
     smtp_socket = socket.socket(
         smtp_destination.family, smtp_destination.socktype, smtp_destination.proto
     )
@@ -392,7 +398,7 @@ async def _connect_validated_smtp_socket(
     try:
         await asyncio.wait_for(
             asyncio.get_running_loop().sock_connect(
-                smtp_socket, smtp_destination.sockaddr
+                smtp_socket, connect_sockaddr
             ),
             timeout=SMTP_TIMEOUT_SECONDS,
         )

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -894,6 +894,49 @@ async def test_oidc_rejects_unknown_critical_header_before_decode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_oidc_rejects_non_rs256_algorithm_before_decode(monkeypatch):
+    import jwt
+
+    previous_issuer_url = settings.OIDC_ISSUER_URL
+    previous_client_id = settings.OIDC_CLIENT_ID
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.OIDC_ISSUER_URL = "https://login.example.test/realms/naruon"
+    settings.OIDC_CLIENT_ID = "naruon-api"
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+
+    class MockKey:
+        key_id = "test-key"
+        key = "public_key"
+
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (MockKey(),))
+
+    decode_called = False
+
+    def mock_jwt_decode(*args, **kwargs):
+        nonlocal decode_called
+        decode_called = True
+        return {}
+
+    monkeypatch.setattr(jwt, "decode", mock_jwt_decode)
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={"alg": "HS256", "typ": "JWT", "kid": "test-key"},
+    )
+
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        settings.OIDC_ISSUER_URL = previous_issuer_url
+        settings.OIDC_CLIENT_ID = previous_client_id
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+
+    assert exc.value.status_code == 401
+    assert decode_called is False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("role_claim", ("system_admin", "platform_admin"))
 async def test_oidc_session_rejects_platform_system_admin_role_claim(
     monkeypatch, role_claim: str

--- a/backend/tests/test_tenant_config_model.py
+++ b/backend/tests/test_tenant_config_model.py
@@ -128,20 +128,24 @@ def test_tenant_config_model_encryption(db_session):
 
     # Verify that the value in the database is actually encrypted
     result = db_session.execute(
-        text("SELECT openai_api_key FROM tenant_configs WHERE user_id='test_user2'")
+        text("SELECT openai_api_key FROM tenant_configs WHERE user_id = :user_id"),
+        {"user_id": "test_user2"},
     ).scalar()
     assert result != "test_key2"
     assert result is not None
     assert isinstance(result, str)
 
     imap_pw = db_session.execute(
-        text("SELECT imap_password FROM tenant_configs WHERE user_id='test_user2'")
+        text("SELECT imap_password FROM tenant_configs WHERE user_id = :user_id"),
+        {"user_id": "test_user2"},
     ).scalar()
     smtp_pw = db_session.execute(
-        text("SELECT smtp_password FROM tenant_configs WHERE user_id='test_user2'")
+        text("SELECT smtp_password FROM tenant_configs WHERE user_id = :user_id"),
+        {"user_id": "test_user2"},
     ).scalar()
     pop3_pw = db_session.execute(
-        text("SELECT pop3_password FROM tenant_configs WHERE user_id='test_user2'")
+        text("SELECT pop3_password FROM tenant_configs WHERE user_id = :user_id"),
+        {"user_id": "test_user2"},
     ).scalar()
     assert imap_pw != TEST_IMAP_PASSWORD
     assert smtp_pw != TEST_SMTP_PASSWORD


### PR DESCRIPTION
## Summary
- reject non-RS256 OIDC JWT headers before JWKS key lookup and decode
- keep SMTP DNS-pinning dataflow explicit by connecting only to the normalized validated global IP sockaddr
- parameterize tenant config encryption test SQL queries flagged by Strix

## Evidence
- Failed master Strix source: run 27437203184 on 4d52fbd
- PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q tests/test_email_client_smtp.py tests/test_auth_real.py tests/test_tenant_config_model.py -> 99 passed
- PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m py_compile backend/services/email_client.py backend/api/auth.py backend/tests/test_tenant_config_model.py backend/tests/test_auth_real.py
- git diff --check -- backend/services/email_client.py backend/api/auth.py backend/tests/test_tenant_config_model.py backend/tests/test_auth_real.py