### PR TITLE
fix: revoke signed sessions on logout

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,5 @@
 import http.client
+import hashlib
 import json
 import logging
 import math
@@ -11,7 +12,8 @@ from urllib.parse import urlsplit
 
 import jwt
 from jwt import PyJWKClient
-from fastapi import Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel
 
 from core.config import settings, validate_auth_session_hmac_secret_value
 from core.url_validation import (
@@ -149,6 +151,9 @@ SESSION_AUDIENCE = "naruon-api"
 SESSION_SIGNING_ALGORITHM = "HS256"
 OIDC_SIGNING_ALGORITHM = "RS256"
 MIN_SESSION_SECRET_BYTES = 32
+_revoked_session_tokens: dict[str, float] = {}
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
 @dataclass(frozen=True)
@@ -159,6 +164,10 @@ class AuthContext:
     group_ids: tuple[str, ...]
     workspace_id: str
     session_verifier: SessionVerifier = field(default="override", compare=False)
+
+
+class LogoutResponse(BaseModel):
+    revoked: bool
 
 
 def ensure_organization_access(auth_context: AuthContext, organization_id: str) -> None:
@@ -267,6 +276,35 @@ def _extract_bearer_token(authorization: str | None) -> str:
     return token.strip()
 
 
+def _session_token_fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _prune_revoked_session_tokens(now: float | None = None) -> None:
+    current_time = time.time() if now is None else now
+    expired_fingerprints = [
+        fingerprint
+        for fingerprint, expires_at in _revoked_session_tokens.items()
+        if expires_at <= current_time
+    ]
+    for fingerprint in expired_fingerprints:
+        _revoked_session_tokens.pop(fingerprint, None)
+
+
+def revoke_session_token(token: str, expires_at: float) -> None:
+    _prune_revoked_session_tokens()
+    if expires_at <= time.time():
+        return
+    _revoked_session_tokens[_session_token_fingerprint(token)] = expires_at
+
+
+def _reject_revoked_session_token(token: str) -> None:
+    _prune_revoked_session_tokens()
+    expires_at = _revoked_session_tokens.get(_session_token_fingerprint(token))
+    if expires_at is not None and expires_at > time.time():
+        raise _authentication_error()
+
+
 def _verify_signed_session_payload(
     authorization: str | None,
 ) -> tuple[dict[str, Any], SessionVerifier]:
@@ -285,6 +323,7 @@ def _verify_signed_session_payload(
                 audience=settings.OIDC_CLIENT_ID,
                 issuer=settings.OIDC_ISSUER_URL,
             )
+            _reject_revoked_session_token(token)
             _reject_signed_session_system_admin_payload(payload)
             return payload, "oidc"
         except Exception:
@@ -310,6 +349,7 @@ def _verify_signed_session_payload(
         raise _authentication_error()
     if not isinstance(payload, dict):
         raise _authentication_error()
+    _reject_revoked_session_token(token)
     _reject_signed_session_system_admin_payload(payload)
     return payload, "hmac"
 
@@ -354,6 +394,15 @@ def _tuple_string_claim(payload: dict[str, Any], name: str) -> tuple[str, ...]:
     return tuple(normalized)
 
 
+def _session_expires_at(payload: dict[str, Any]) -> float:
+    expires_at = payload.get("exp")
+    if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+        raise _authentication_error()
+    if not math.isfinite(expires_at):
+        raise _authentication_error()
+    return float(expires_at)
+
+
 def _validate_session_metadata(payload: dict[str, Any]) -> None:
     # If OIDC is configured, the issuer/audience might be verified by jwt.decode
     if not settings.OIDC_ISSUER_URL:
@@ -363,12 +412,7 @@ def _validate_session_metadata(payload: dict[str, Any]) -> None:
             raise _authentication_error()
         if payload.get("aud") != SESSION_AUDIENCE:
             raise _authentication_error()
-    expires_at = payload.get("exp")
-    if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
-        raise _authentication_error()
-    if not math.isfinite(expires_at):
-        raise _authentication_error()
-    if expires_at <= time.time():
+    if _session_expires_at(payload) <= time.time():
         raise _authentication_error()
 
 
@@ -409,3 +453,14 @@ async def get_current_user_role(
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> str:
     return auth_context.role
+
+
+@router.post("/logout", response_model=LogoutResponse)
+async def logout_current_session(
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> LogoutResponse:
+    token = _extract_bearer_token(authorization)
+    payload, _session_verifier = _verify_signed_session_payload(authorization)
+    _validate_session_metadata(payload)
+    revoke_session_token(token, _session_expires_at(payload))
+    return LogoutResponse(revoked=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
-from api.auth import get_auth_context, preload_oidc_jwks
+from api.auth import get_auth_context, preload_oidc_jwks, router as auth_router
 from api.search import router as search_router
 from api.llm import router as llm_router
 from api.calendar import router as calendar_router
@@ -95,6 +95,7 @@ app.add_middleware(
 )
 
 app.include_router(search_router, dependencies=PRIVATE_API_DEPENDENCIES)
+app.include_router(auth_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(llm_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(calendar_router, dependencies=PRIVATE_API_DEPENDENCIES)
 app.include_router(network_router, dependencies=PRIVATE_API_DEPENDENCIES)

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -119,14 +119,19 @@ def restore_auth_flags():
     previous_debug = settings.DEBUG
     previous_runtime_environment = getattr(settings, "RUNTIME_ENVIRONMENT", None)
     previous_session_hmac_secret = getattr(settings, "AUTH_SESSION_HMAC_SECRET", None)
-    previous_oidc_signing_keys = sys.modules["api.auth"]._cached_oidc_signing_keys
+    auth_module = sys.modules["api.auth"]
+    previous_oidc_signing_keys = auth_module._cached_oidc_signing_keys
+    previous_revoked_session_tokens = dict(auth_module._revoked_session_tokens)
+    auth_module._revoked_session_tokens.clear()
     yield
     settings.DEBUG = previous_debug
     if previous_runtime_environment is not None:
         setattr(settings, "RUNTIME_ENVIRONMENT", previous_runtime_environment)
     if hasattr(settings, "AUTH_SESSION_HMAC_SECRET"):
         settings.AUTH_SESSION_HMAC_SECRET = previous_session_hmac_secret
-    sys.modules["api.auth"]._cached_oidc_signing_keys = previous_oidc_signing_keys
+    auth_module._cached_oidc_signing_keys = previous_oidc_signing_keys
+    auth_module._revoked_session_tokens.clear()
+    auth_module._revoked_session_tokens.update(previous_revoked_session_tokens)
 
 
 def _set_runtime_environment(value: str) -> None:
@@ -244,6 +249,49 @@ async def test_get_auth_context_accepts_signed_bearer_session():
         workspace_id="workspace-org-acme",
     )
     assert context.session_verifier == "hmac"
+
+
+@pytest.mark.asyncio
+async def test_get_auth_context_rejects_revoked_signed_bearer_session():
+    from api import auth as auth_module
+
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    payload = _valid_session_payload()
+    token = _signed_session_token(payload)
+
+    auth_module.revoke_session_token(token, float(payload["exp"]))
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
+
+
+def test_logout_endpoint_revokes_signed_bearer_session():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(_valid_session_payload())
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides.pop(get_auth_context, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            logout_response = client.post(
+                "/api/auth/logout",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            revoked_response = client.get(
+                "/api/runner-config",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert logout_response.status_code == 200
+    assert logout_response.json() == {"revoked": True}
+    assert revoked_response.status_code == 401
+    assert revoked_response.json() == {"detail": "Authentication required"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a signed-session logout endpoint at /api/auth/logout under the private API dependency policy
- track revoked bearer-token fingerprints until token expiration and reject revoked sessions in the HMAC and OIDC verification paths
- add auth tests for direct revoked-token rejection and HTTP logout revocation

## Evidence
- addresses master Strix run 27444565854 job 81129089466 finding: missing logout and token revocation

## Validation
- python3 -m py_compile backend/api/auth.py backend/main.py backend/tests/test_auth_real.py
- git diff --check -- backend/api/auth.py backend/main.py backend/tests/test_auth_real.py
- PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q backend/tests/test_auth_real.py