### PR TITLE
fix: persist signed session revocations

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,5 @@
 import http.client
+import datetime
 import hashlib
 import json
 import logging
@@ -11,6 +12,7 @@ from typing import Annotated, Any, Literal, cast
 from urllib.parse import urlsplit
 
 import jwt
+from asyncpg import Connection, connect as asyncpg_connect
 from jwt import PyJWKClient
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
@@ -151,7 +153,6 @@ SESSION_AUDIENCE = "naruon-api"
 SESSION_SIGNING_ALGORITHM = "HS256"
 OIDC_SIGNING_ALGORITHM = "RS256"
 MIN_SESSION_SECRET_BYTES = 32
-_revoked_session_tokens: dict[str, float] = {}
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -194,7 +195,7 @@ def is_admin_role(role: str) -> bool:
 async def get_auth_context(
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> AuthContext:
-    return build_auth_context(authorization=authorization)
+    return await build_persistent_auth_context(authorization)
 
 
 def build_auth_context(authorization: str | None = None) -> AuthContext:
@@ -208,6 +209,15 @@ def build_auth_context(authorization: str | None = None) -> AuthContext:
     use explicit FastAPI dependency overrides.
     """
     payload, session_verifier = _verify_signed_session_payload(authorization)
+    return _auth_context_from_session_payload(payload, session_verifier)
+
+
+async def build_persistent_auth_context(
+    authorization: str | None,
+) -> AuthContext:
+    token = _extract_bearer_token(authorization)
+    payload, session_verifier = _verify_signed_session_token(token)
+    await _reject_persistently_revoked_session_token(token)
     return _auth_context_from_session_payload(payload, session_verifier)
 
 
@@ -280,28 +290,108 @@ def _session_token_fingerprint(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
-def _prune_revoked_session_tokens(now: float | None = None) -> None:
-    current_time = time.time() if now is None else now
-    expired_fingerprints = [
-        fingerprint
-        for fingerprint, expires_at in _revoked_session_tokens.items()
-        if expires_at <= current_time
-    ]
-    for fingerprint in expired_fingerprints:
-        _revoked_session_tokens.pop(fingerprint, None)
+def _utc_now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
-def revoke_session_token(token: str, expires_at: float) -> None:
-    _prune_revoked_session_tokens()
-    if expires_at <= time.time():
+def _as_aware_utc(value: datetime.datetime) -> datetime.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def _session_expiration_datetime(payload: dict[str, Any]) -> datetime.datetime:
+    return datetime.datetime.fromtimestamp(
+        _session_expires_at(payload), datetime.timezone.utc
+    )
+
+
+def _revocation_database_url() -> str:
+    database_url = str(settings.DATABASE_URL)
+    if database_url.startswith("postgresql+asyncpg://"):
+        return "postgresql://" + database_url[len("postgresql+asyncpg://") :]
+    if database_url.startswith("postgres+asyncpg://"):
+        return "postgres://" + database_url[len("postgres+asyncpg://") :]
+    return database_url
+
+
+async def revoke_session_token(
+    token: str,
+    expires_at: datetime.datetime,
+    *,
+    user_id: str,
+    organization_id: str | None,
+    workspace_id: str,
+) -> None:
+    now = _utc_now()
+    normalized_expires_at = _as_aware_utc(expires_at)
+    if normalized_expires_at <= now:
         return
-    _revoked_session_tokens[_session_token_fingerprint(token)] = expires_at
+    fingerprint = _session_token_fingerprint(token)
+
+    connection: Connection | None = None
+    try:
+        connection = await asyncpg_connect(_revocation_database_url(), timeout=5)
+        await connection.execute(
+            "DELETE FROM revoked_session_tokens WHERE expires_at <= $1",
+            now,
+        )
+        await connection.execute(
+            """
+            INSERT INTO revoked_session_tokens (
+                token_fingerprint,
+                user_id,
+                organization_id,
+                workspace_id,
+                expires_at,
+                revoked_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (token_fingerprint) DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                organization_id = EXCLUDED.organization_id,
+                workspace_id = EXCLUDED.workspace_id,
+                expires_at = EXCLUDED.expires_at,
+                revoked_at = EXCLUDED.revoked_at
+            """,
+            fingerprint,
+            user_id,
+            organization_id,
+            workspace_id,
+            normalized_expires_at,
+            now,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise _authentication_error() from None
+    finally:
+        if connection is not None:
+            await connection.close()
 
 
-def _reject_revoked_session_token(token: str) -> None:
-    _prune_revoked_session_tokens()
-    expires_at = _revoked_session_tokens.get(_session_token_fingerprint(token))
-    if expires_at is not None and expires_at > time.time():
+async def _reject_persistently_revoked_session_token(token: str) -> None:
+    connection: Connection | None = None
+    try:
+        connection = await asyncpg_connect(_revocation_database_url(), timeout=5)
+        is_revoked = await connection.fetchval(
+            """
+            SELECT TRUE
+            FROM revoked_session_tokens
+            WHERE token_fingerprint = $1 AND expires_at > $2
+            LIMIT 1
+            """,
+            _session_token_fingerprint(token),
+            _utc_now(),
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise _authentication_error() from None
+    finally:
+        if connection is not None:
+            await connection.close()
+    if is_revoked:
         raise _authentication_error()
 
 
@@ -309,7 +399,10 @@ def _verify_signed_session_payload(
     authorization: str | None,
 ) -> tuple[dict[str, Any], SessionVerifier]:
     token = _extract_bearer_token(authorization)
+    return _verify_signed_session_token(token)
 
+
+def _verify_signed_session_token(token: str) -> tuple[dict[str, Any], SessionVerifier]:
     # OIDC RS256 verification is authoritative when configured.
     if settings.OIDC_ISSUER_URL:
         if jwks_client is None:
@@ -323,7 +416,6 @@ def _verify_signed_session_payload(
                 audience=settings.OIDC_CLIENT_ID,
                 issuer=settings.OIDC_ISSUER_URL,
             )
-            _reject_revoked_session_token(token)
             _reject_signed_session_system_admin_payload(payload)
             return payload, "oidc"
         except Exception:
@@ -349,7 +441,6 @@ def _verify_signed_session_payload(
         raise _authentication_error()
     if not isinstance(payload, dict):
         raise _authentication_error()
-    _reject_revoked_session_token(token)
     _reject_signed_session_system_admin_payload(payload)
     return payload, "hmac"
 
@@ -403,15 +494,18 @@ def _session_expires_at(payload: dict[str, Any]) -> float:
     return float(expires_at)
 
 
-def _validate_session_metadata(payload: dict[str, Any]) -> None:
-    # If OIDC is configured, the issuer/audience might be verified by jwt.decode
-    if not settings.OIDC_ISSUER_URL:
+def _validate_session_metadata(
+    payload: dict[str, Any], session_verifier: SessionVerifier
+) -> None:
+    if session_verifier == "hmac":
         if payload.get("ver") != 1:
             raise _authentication_error()
         if payload.get("iss") != SESSION_ISSUER:
             raise _authentication_error()
         if payload.get("aud") != SESSION_AUDIENCE:
             raise _authentication_error()
+    elif session_verifier != "oidc":
+        raise _authentication_error()
     if _session_expires_at(payload) <= time.time():
         raise _authentication_error()
 
@@ -419,7 +513,7 @@ def _validate_session_metadata(payload: dict[str, Any]) -> None:
 def _auth_context_from_session_payload(
     payload: dict[str, Any], session_verifier: SessionVerifier
 ) -> AuthContext:
-    _validate_session_metadata(payload)
+    _validate_session_metadata(payload, session_verifier)
     role_value = _required_string_claim(payload, "role")
     if role_value not in ALLOWED_ROLES:
         raise _authentication_error()
@@ -460,7 +554,13 @@ async def logout_current_session(
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> LogoutResponse:
     token = _extract_bearer_token(authorization)
-    payload, _session_verifier = _verify_signed_session_payload(authorization)
-    _validate_session_metadata(payload)
-    revoke_session_token(token, _session_expires_at(payload))
+    payload, session_verifier = _verify_signed_session_token(token)
+    auth_context = _auth_context_from_session_payload(payload, session_verifier)
+    await revoke_session_token(
+        token,
+        _session_expiration_datetime(payload),
+        user_id=auth_context.user_id,
+        organization_id=auth_context.organization_id,
+        workspace_id=auth_context.workspace_id,
+    )
     return LogoutResponse(revoked=True)

--- a/backend/api/runner_ws.py
+++ b/backend/api/runner_ws.py
@@ -15,7 +15,7 @@ from fastapi import (
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
-from api.auth import AuthContext, build_auth_context
+from api.auth import AuthContext, build_persistent_auth_context
 from db.models import ConnectorSignalEvent, WorkspaceRunnerConfig
 from db.session import AsyncSessionLocal
 
@@ -155,9 +155,11 @@ def _policy_violation() -> WebSocketException:
     return WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
 
 
-def _auth_context_from_websocket(websocket: WebSocket) -> AuthContext:
+async def _auth_context_from_websocket(websocket: WebSocket) -> AuthContext:
     try:
-        return build_auth_context(websocket.headers.get("authorization"))
+        return await build_persistent_auth_context(
+            websocket.headers.get("authorization")
+        )
     except HTTPException as exc:
         raise _policy_violation() from exc
 
@@ -227,7 +229,7 @@ async def _runner_connection_key(token: str, auth_context: AuthContext) -> str:
 
 @router.websocket("/ws/runner/{token}")
 async def runner_endpoint(websocket: WebSocket, token: str):
-    auth_context = _auth_context_from_websocket(websocket)
+    auth_context = await _auth_context_from_websocket(websocket)
     connection_key = await _runner_connection_key(token, auth_context)
     await manager.connect(websocket, connection_key, auth_context)
     try:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -118,6 +118,31 @@ class SecurityAuditEvent(Base):
     )
 
 
+class RevokedSessionToken(Base):
+    __tablename__ = "revoked_session_tokens"
+
+    token_fingerprint: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    expires_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), index=True, nullable=False
+    )
+    revoked_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        nullable=False,
+    )
+    __table_args__ = (
+        Index(
+            "ix_revoked_session_tokens_scope_expiry",
+            "organization_id",
+            "workspace_id",
+            "expires_at",
+        ),
+    )
+
+
 class LLMProvider(Base):
     __tablename__ = "llm_providers"
     __table_args__ = (

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,6 +15,7 @@ from fastapi import Header, HTTPException
 from typing import cast
 
 from api.auth import AuthContext, RoleName, get_auth_context, get_current_user
+from api import auth as auth_module
 from main import app
 
 TEST_SCOPED_ROLES = {
@@ -25,6 +26,26 @@ TEST_SCOPED_ROLES = {
     "group_admin",
     "member",
 }
+
+
+class _NoRevocationConnection:
+    async def fetchval(self, query, *args):
+        return None
+
+    async def close(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def no_revoked_signed_sessions(monkeypatch):
+    async def connect_without_revoked_tokens(*args, **kwargs):
+        return _NoRevocationConnection()
+
+    monkeypatch.setattr(
+        auth_module,
+        "asyncpg_connect",
+        connect_without_revoked_tokens,
+    )
 
 
 def _normalize_header_value(value: str | None) -> str | None:

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import hashlib
 import hmac
 import inspect
@@ -119,24 +120,56 @@ def restore_auth_flags():
     previous_debug = settings.DEBUG
     previous_runtime_environment = getattr(settings, "RUNTIME_ENVIRONMENT", None)
     previous_session_hmac_secret = getattr(settings, "AUTH_SESSION_HMAC_SECRET", None)
+    previous_oidc_issuer_url = settings.OIDC_ISSUER_URL
+    previous_oidc_client_id = settings.OIDC_CLIENT_ID
     auth_module = sys.modules["api.auth"]
     previous_oidc_signing_keys = auth_module._cached_oidc_signing_keys
-    previous_revoked_session_tokens = dict(auth_module._revoked_session_tokens)
-    auth_module._revoked_session_tokens.clear()
     yield
     settings.DEBUG = previous_debug
     if previous_runtime_environment is not None:
         setattr(settings, "RUNTIME_ENVIRONMENT", previous_runtime_environment)
     if hasattr(settings, "AUTH_SESSION_HMAC_SECRET"):
         settings.AUTH_SESSION_HMAC_SECRET = previous_session_hmac_secret
+    settings.OIDC_ISSUER_URL = previous_oidc_issuer_url
+    settings.OIDC_CLIENT_ID = previous_oidc_client_id
     auth_module._cached_oidc_signing_keys = previous_oidc_signing_keys
-    auth_module._revoked_session_tokens.clear()
-    auth_module._revoked_session_tokens.update(previous_revoked_session_tokens)
 
 
 def _set_runtime_environment(value: str) -> None:
     if hasattr(settings, "RUNTIME_ENVIRONMENT"):
         setattr(settings, "RUNTIME_ENVIRONMENT", value)
+
+
+def _install_fake_revocation_store(monkeypatch):
+    from api import auth as auth_module
+
+    revoked_fingerprints: set[str] = set()
+
+    class _FakeRevocationConnection:
+        async def execute(self, query, *args):
+            if "INSERT INTO revoked_session_tokens" not in query:
+                return None
+            fingerprint, user_id, organization_id, workspace_id, expires_at, _now = args
+            assert user_id == "alice"
+            assert organization_id == "org-acme"
+            assert workspace_id == "workspace-org-acme"
+            assert expires_at > datetime.datetime.now(datetime.timezone.utc)
+            revoked_fingerprints.add(fingerprint)
+            return None
+
+        async def fetchval(self, query, fingerprint, _now):
+            if fingerprint in revoked_fingerprints:
+                return True
+            return None
+
+        async def close(self):
+            return None
+
+    async def connect_with_revocation_store(*args, **kwargs):
+        return _FakeRevocationConnection()
+
+    monkeypatch.setattr(auth_module, "asyncpg_connect", connect_with_revocation_store)
+    return revoked_fingerprints
 
 
 def _enable_local_dev_headers() -> None:
@@ -252,14 +285,22 @@ async def test_get_auth_context_accepts_signed_bearer_session():
 
 
 @pytest.mark.asyncio
-async def test_get_auth_context_rejects_revoked_signed_bearer_session():
+async def test_get_auth_context_rejects_revoked_signed_bearer_session(monkeypatch):
     from api import auth as auth_module
 
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     payload = _valid_session_payload()
     token = _signed_session_token(payload)
+    revoked_fingerprints = _install_fake_revocation_store(monkeypatch)
 
-    auth_module.revoke_session_token(token, float(payload["exp"]))
+    await auth_module.revoke_session_token(
+        token,
+        datetime.datetime.fromtimestamp(float(payload["exp"]), datetime.timezone.utc),
+        user_id="alice",
+        organization_id="org-acme",
+        workspace_id="workspace-org-acme",
+    )
+    assert auth_module._session_token_fingerprint(token) in revoked_fingerprints
 
     with pytest.raises(HTTPException) as exc:
         await get_auth_context(authorization=f"Bearer {token}")
@@ -267,13 +308,18 @@ async def test_get_auth_context_rejects_revoked_signed_bearer_session():
     assert exc.value.status_code == 401
 
 
-def test_logout_endpoint_revokes_signed_bearer_session():
+def test_logout_endpoint_revokes_signed_bearer_session(monkeypatch):
     settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
     token = _signed_session_token(_valid_session_payload())
+    revoked_fingerprints = _install_fake_revocation_store(monkeypatch)
+
+    async def override_get_db():
+        yield _EmptyRunnerConfigSession()
 
     original_overrides = dict(app.dependency_overrides)
     app.dependency_overrides.pop(get_auth_context, None)
     app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides[get_db] = override_get_db
     try:
         with TestClient(app, raise_server_exceptions=False) as client:
             logout_response = client.post(
@@ -290,8 +336,26 @@ def test_logout_endpoint_revokes_signed_bearer_session():
 
     assert logout_response.status_code == 200
     assert logout_response.json() == {"revoked": True}
+    from api import auth as auth_module
+
+    assert auth_module._session_token_fingerprint(token) in revoked_fingerprints
     assert revoked_response.status_code == 401
     assert revoked_response.json() == {"detail": "Authentication required"}
+
+
+def test_hmac_session_metadata_requires_control_plane_claims_when_oidc_configured():
+    from api import auth as auth_module
+
+    settings.OIDC_ISSUER_URL = "https://login.example.test/realms/naruon"
+    settings.OIDC_CLIENT_ID = "naruon-api"
+
+    with pytest.raises(HTTPException) as exc:
+        auth_module._auth_context_from_session_payload(
+            _valid_session_payload(iss="arbitrary-issuer", aud="arbitrary-audience"),
+            "hmac",
+        )
+
+    assert exc.value.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_bootstrap_db.py
+++ b/backend/tests/test_bootstrap_db.py
@@ -11,6 +11,7 @@ from db.models import (
     CalendarWritebackSource,
     ConnectorSignalEvent,
     ProjectFolder,
+    RevokedSessionToken,
     SecurityAuditEvent,
     SenderRelationship,
     TenantConfig,
@@ -489,6 +490,23 @@ def test_security_audit_event_model_uses_two_word_names():
     assert all("_" in column_name for column_name in column_names)
     assert "ix_security_audit_events_scope_time" in index_names
     assert "ix_security_audit_events_actor_scope" in index_names
+
+
+def test_revoked_session_token_model_uses_persistent_scope_names():
+    assert RevokedSessionToken.__tablename__ == "revoked_session_tokens"
+    column_names = {column.name for column in RevokedSessionToken.__table__.columns}
+    index_names = {index.name for index in RevokedSessionToken.__table__.indexes}
+
+    assert column_names == {
+        "token_fingerprint",
+        "user_id",
+        "organization_id",
+        "workspace_id",
+        "expires_at",
+        "revoked_at",
+    }
+    assert all("_" in column_name for column_name in column_names)
+    assert "ix_revoked_session_tokens_scope_expiry" in index_names
 
 
 def test_schema_backfill_creates_connector_signal_events():


### PR DESCRIPTION
## Summary
- persist signed-session logout revocations in the `revoked_session_tokens` PostgreSQL table instead of process memory
- make default auth and runner websocket auth reject persisted revoked token fingerprints
- keep HMAC session metadata validation tied to the verified HMAC path so issuer/audience/version checks remain enforced independently of OIDC configuration

## Evidence
- master Strix run `27446447475` on `19d49f7` reported token revocation persistence and session metadata validation findings
- `python3 -m py_compile backend/api/auth.py backend/api/runner_ws.py backend/db/models.py backend/main.py backend/tests/conftest.py backend/tests/test_auth_real.py backend/tests/test_runner_ws_api.py backend/tests/test_bootstrap_db.py`
- `git diff --check -- backend/api/auth.py backend/api/runner_ws.py backend/db/models.py backend/tests/conftest.py backend/tests/test_auth_real.py backend/tests/test_runner_ws_api.py backend/tests/test_bootstrap_db.py`
- `PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q backend/tests/test_auth_real.py backend/tests/test_runner_ws_api.py backend/tests/test_bootstrap_db.py::test_revoked_session_token_model_uses_persistent_scope_names`
- `PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q -m 'not postgres' backend/tests`