### PR TITLE
fix: harden auth verifier and account config ownership

### DIFF
--- a/backend/api/accounts.py
+++ b/backend/api/accounts.py
@@ -84,6 +84,14 @@ def _ensure_mailbox_account_owner_session(auth_ctx: AuthContext) -> None:
         raise HTTPException(status_code=403, detail=MAILBOX_ACCOUNT_SETTINGS_FORBIDDEN)
 
 
+def _ensure_tenant_config_owner(config, auth_ctx: AuthContext) -> None:
+    if (
+        config.user_id != auth_ctx.user_id
+        or config.organization_id != auth_ctx.organization_id
+    ):
+        raise HTTPException(status_code=403, detail=MAILBOX_ACCOUNT_SETTINGS_FORBIDDEN)
+
+
 @router.get("/config", response_model=TenantConfigResponse)
 async def get_tenant_config(
     db: AsyncSession = Depends(get_db),
@@ -98,6 +106,7 @@ async def get_tenant_config(
     if not config:
         return _empty_tenant_config_response(auth_ctx.user_id)
 
+    _ensure_tenant_config_owner(config, auth_ctx)
     return _tenant_config_response(config)
 
 @router.put("/config", response_model=TenantConfigResponse)
@@ -118,12 +127,14 @@ async def update_tenant_config(
             organization_id=auth_ctx.organization_id,
         )
         db.add(config)
-        
+    else:
+        _ensure_tenant_config_owner(config, auth_ctx)
+
     update_dict = update_data.model_dump(exclude_unset=True)
     validate_mail_config_update(update_dict, config)
     for key, value in update_dict.items():
         setattr(config, key, value)
-        
+
     await db.commit()
     await db.refresh(config)
 

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -403,24 +403,30 @@ def _verify_signed_session_payload(
 
 
 def _verify_signed_session_token(token: str) -> tuple[dict[str, Any], SessionVerifier]:
-    # OIDC RS256 verification is authoritative when configured.
     if settings.OIDC_ISSUER_URL:
-        if jwks_client is None:
-            raise _authentication_error()
-        try:
-            signing_key = _cached_oidc_signing_key_from_jwt(token)
-            payload = jwt.decode(
-                token,
-                signing_key.key,
-                algorithms=[OIDC_SIGNING_ALGORITHM],
-                audience=settings.OIDC_CLIENT_ID,
-                issuer=settings.OIDC_ISSUER_URL,
-            )
-            _reject_signed_session_system_admin_payload(payload)
-            return payload, "oidc"
-        except Exception:
-            raise _authentication_error() from None
+        return _verify_oidc_session_token(token)
+    return _verify_hmac_session_token(token)
 
+
+def _verify_oidc_session_token(token: str) -> tuple[dict[str, Any], SessionVerifier]:
+    if jwks_client is None:
+        raise _authentication_error()
+    try:
+        signing_key = _cached_oidc_signing_key_from_jwt(token)
+        payload = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=[OIDC_SIGNING_ALGORITHM],
+            audience=settings.OIDC_CLIENT_ID,
+            issuer=settings.OIDC_ISSUER_URL,
+        )
+        _reject_signed_session_system_admin_payload(payload)
+        return payload, "oidc"
+    except Exception:
+        raise _authentication_error() from None
+
+
+def _verify_hmac_session_token(token: str) -> tuple[dict[str, Any], SessionVerifier]:
     try:
         header = jwt.get_unverified_header(token)
     except jwt.PyJWTError:

--- a/backend/tests/test_accounts_api.py
+++ b/backend/tests/test_accounts_api.py
@@ -43,10 +43,11 @@ class MockResult:
         return self.config
 
 class MockSession:
-    def __init__(self):
+    def __init__(self, forced_config=None):
         self.configs = {}
         self.commits = 0
         self.execute_calls = 0
+        self.forced_config = forced_config
 
     def _query_key(self, stmt):
         params = dict(stmt.compile().params)
@@ -56,6 +57,8 @@ class MockSession:
 
     async def execute(self, stmt):
         self.execute_calls += 1
+        if self.forced_config is not None:
+            return MockResult(self.forced_config)
         return MockResult(self.configs.get(self._query_key(stmt)))
 
     def add(self, obj):
@@ -277,6 +280,34 @@ def test_accounts_config_preserves_scoped_signed_member_session():
     assert response.json()["user_id"] == "mailbox-owner"
     assert response.json()["smtp_server"] is None
     assert session.execute_calls == 1
+
+
+def test_accounts_config_rejects_mismatched_persisted_owner_on_read():
+    session = MockSession(forced_config=MockTenantConfig("other-user", "org-acme"))
+    response = _request_with_signed_session(
+        "GET",
+        "/api/accounts/config",
+        session,
+        _valid_session_payload(),
+    )
+
+    assert response.status_code == 403
+    assert session.execute_calls == 1
+
+
+def test_accounts_config_rejects_mismatched_persisted_owner_on_write():
+    session = MockSession(forced_config=MockTenantConfig("other-user", "org-acme"))
+    response = _request_with_signed_session(
+        "PUT",
+        "/api/accounts/config",
+        session,
+        _valid_session_payload(),
+        {"smtp_server": "smtp.example.com", "smtp_port": 587},
+    )
+
+    assert response.status_code == 403
+    assert session.execute_calls == 1
+    assert session.commits == 0
 
 
 def test_accounts_config_rejects_private_imap_host(client: TestClient):


### PR DESCRIPTION
## Summary
- split OIDC and HMAC session verification into separate verifier functions so OIDC deployments never appear to fall through to HMAC validation
- assert persisted `/api/accounts/config` rows still match the authenticated user and organization before returning or mutating them
- add regression tests for mismatched account-config owners

## Evidence
- master Strix run `27448642229` on `0979e774da120a5baef514409856695ff63afa5d` reported accounts-config ownership hardening and a verifier-shape finding
- `python3 -m py_compile backend/api/auth.py backend/api/accounts.py backend/tests/test_auth_real.py backend/tests/test_accounts_api.py`
- `git diff --check -- backend/api/auth.py backend/api/accounts.py backend/tests/test_auth_real.py backend/tests/test_accounts_api.py`
- `PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q backend/tests/test_auth_real.py backend/tests/test_accounts_api.py`
- `PYTHONWARNINGS=error /tmp/naruon-py312-venv/bin/python -m pytest -q -m 'not postgres' backend/tests`