### PR TITLE
fix: exclude test fixtures from Tailwind output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,10 @@
   deployment rather than during `uvicorn main:app` import.
 - Python standard library `re` flags (`re.IGNORECASE`) must be passed via the `flags=` keyword argument. Do not use inline `(?i)` at the start of the expression, as it will trigger `DeprecationWarning` regressions in Python 3.11+ test suites.
 - Next.js builds in memory-constrained CI environments (e.g., GitHub Actions) can fail with OOM errors due to PostCSS worker explosion. Set `POSTCSS_WORKERS: "1"` and `DISABLE_POSTCSS_WORKERS: "true"` in the build environment to limit memory usage.
+- Tailwind v4 scans source text and can emit CSS for class-looking strings in
+  tests. Keep test paths excluded with `@source not` in `globals.css`, and do
+  not place hostile arbitrary utility payloads such as URL/style injection
+  examples as static class-looking strings in source or tests.
 
 ## Phase 10 development rules
 

--- a/frontend/src/app/ai-hub/page.test.tsx
+++ b/frontend/src/app/ai-hub/page.test.tsx
@@ -206,6 +206,36 @@ describe('AIHubPage', () => {
     await flushAsyncWork();
   });
 
+  it('clamps source metric scores before rendering inline style widths', async () => {
+    const hostileSurface = {
+      ...aiHubSurface,
+      evaluation_metrics: [
+        {
+          ...aiHubSurface.evaluation_metrics[0],
+          score_value: 'not-a-percent' as unknown as number,
+        },
+      ],
+    };
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(hostileSurface)));
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<AIHubPage />);
+    });
+    await flushAsyncWork();
+
+    clickButton(container, '평가');
+    const styleText = Array.from(container.querySelectorAll<HTMLElement>('[style]'))
+      .map((node) => node.getAttribute('style') ?? '')
+      .join(' ');
+    expect(styleText).not.toContain('not-a-percent');
+    expect(container.textContent).not.toContain('not-a-percent');
+    expect(container.textContent).toContain('Provider 준비도');
+    expect(container.textContent).toContain('0');
+  });
+
   it('renders a retryable error state when the source surface fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ message: 'Internal Server Error' }, false)));

--- a/frontend/src/app/calendar/page.test.tsx
+++ b/frontend/src/app/calendar/page.test.tsx
@@ -92,6 +92,9 @@ describe("CalendarPage", () => {
     expect(container.querySelector('button[aria-label="다음 달"]')).not.toBeNull();
     expect(container.querySelector('button[aria-label="설정"]')).not.toBeNull();
     expect(container.querySelector('button[aria-label="닫기"]')).not.toBeNull();
+    const calendarCheckboxes = Array.from(container.querySelectorAll<HTMLInputElement>('aside input[type="checkbox"]'));
+    expect(calendarCheckboxes.length).toBeGreaterThan(0);
+    expect(calendarCheckboxes.every((checkbox) => checkbox.getAttribute("style") === null)).toBe(true);
   });
 
   it("creates a signed customer-owned calendar writeback intent", async () => {

--- a/frontend/src/app/data/page.test.tsx
+++ b/frontend/src/app/data/page.test.tsx
@@ -361,6 +361,48 @@ describe("DataPage", () => {
     expect(container.textContent).not.toContain("<asset-ready@example.com>");
   });
 
+  it("clamps API progress values before rendering inline style widths", async () => {
+    const hostileSurface = {
+      ...dataQualitySurface,
+      pipeline_stages: dataQualitySurface.pipeline_stages.map((stage, index) => ({
+        ...stage,
+        progress_percent: index === 0
+          ? "not-a-percent"
+          : 150,
+      })),
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path === "/api/data/quality-surface") return jsonResponse(hostileSurface);
+      if (path === "/api/webdav/accounts") return jsonResponse([]);
+      if (path === "/api/webdav/folders") return jsonResponse([]);
+      throw new Error(`Unhandled fetch: ${path}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<DataPage />);
+    });
+
+    const pipelineTab = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("수집 파이프라인"),
+    );
+    await act(async () => {
+      pipelineTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const styleText = Array.from(container.querySelectorAll<HTMLElement>("[style]"))
+      .map((node) => node.getAttribute("style") ?? "")
+      .join(" ");
+    expect(styleText).not.toContain("not-a-percent");
+    expect(container.textContent).not.toContain("not-a-percent");
+    expect(container.textContent).toContain("0%");
+    expect(container.textContent).toContain("100%");
+  });
+
   it("renders API-backed pipeline embedding and quality tabs", async () => {
     vi.stubGlobal("fetch", mockWebdavFetch());
     container = document.createElement("div");

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,6 +2,12 @@
 @import "tw-animate-css";
 @import "./shadcn-tailwind.css";
 
+/* Test fixtures may contain hostile class-like text; never emit CSS from them. */
+@source not "../**/*.test.ts";
+@source not "../**/*.test.tsx";
+@source not "../test";
+@source not "../../tests";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -111,8 +111,8 @@ describe("ProjectsPage", () => {
           {
             id: "task-malicious-status",
             title: `<img src=x onerror="alert('task')">Naruon 2.0 런칭`,
-            status: "done bg-[url(javascript:alert(1))]",
-            priority: "urgent text-[url(javascript:alert(1))]",
+            status: "done malicious-extra-status-token",
+            priority: "urgent malicious-extra-priority-token",
             source_type: `<script>alert('source')</script>`,
             source_email_id: "<q2@example.com>",
             related_thread_id: "thread-malicious",
@@ -146,7 +146,8 @@ describe("ProjectsPage", () => {
     expect(container.querySelector("img")).toBeNull();
     expect(container.querySelector("script")).toBeNull();
     expect(container.innerHTML).toContain("&lt;img");
-    expect(container.innerHTML).not.toContain("bg-[url");
+    expect(container.innerHTML).not.toContain("malicious-extra-status-token");
+    expect(container.innerHTML).not.toContain("malicious-extra-priority-token");
   });
 
   it("renders an actionable fallback when project evidence fails", async () => {

--- a/frontend/src/components/AIHubLayout.tsx
+++ b/frontend/src/components/AIHubLayout.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
+import { boundedPercent, boundedPercentStyle } from '@/lib/safe-style';
 
 type SurfaceStatus = 'loading' | 'ready' | 'error';
 type TabId = 'prompts' | 'workflows' | 'agents' | 'evaluation' | 'runs';
@@ -241,18 +242,21 @@ function AgentsPanel({ agents }: { agents: AgentCard[] }) {
 function EvaluationPanel({ metrics }: { metrics: EvaluationMetric[] }) {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
-      {metrics.map((metric) => (
-        <article key={metric.metric_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
-          <div className="flex items-center justify-between gap-4">
-            <h2 className="text-base font-black">{metric.metric_label}</h2>
-            <span className="text-2xl font-black text-primary">{metric.score_value}</span>
-          </div>
-          <div className="mt-4 h-2 overflow-hidden rounded-full bg-secondary">
-            <div className="h-full rounded-full bg-primary" style={{ width: `${Math.max(0, Math.min(metric.score_value, 100))}%` }} />
-          </div>
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">{metric.trend_text}</p>
-        </article>
-      ))}
+      {metrics.map((metric) => {
+        const scoreValue = boundedPercent(metric.score_value);
+        return (
+          <article key={metric.metric_key} className="rounded-lg border border-border bg-card p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-base font-black">{metric.metric_label}</h2>
+              <span className="text-2xl font-black text-primary">{scoreValue}</span>
+            </div>
+            <div className="mt-4 h-2 overflow-hidden rounded-full bg-secondary">
+              <div className="h-full rounded-full bg-primary" style={boundedPercentStyle(metric.score_value)} />
+            </div>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{metric.trend_text}</p>
+          </article>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -29,6 +29,15 @@ type CalendarWritebackSource = {
 
 type WritebackStatus = 'idle' | 'loading' | 'success' | 'no_source' | 'conflict' | 'auth' | 'error';
 
+const calendarList = [
+  { name: '김나루 (나)', swatchClassName: 'bg-primary' },
+  { name: 'Naruon PM 팀', swatchClassName: 'bg-red-500' },
+  { name: '제품 개발팀', swatchClassName: 'bg-green-500' },
+  { name: '마케팅팀', swatchClassName: 'bg-purple-500' },
+  { name: '회사 공용', swatchClassName: 'bg-indigo-500' },
+  { name: '공휴일', swatchClassName: 'bg-slate-400' },
+] as const;
+
 function isCustomerOwnedWritableSource(source: CalendarWritebackSource) {
   return source.writeback_enabled
     && source.protocol !== 'local'
@@ -131,16 +140,10 @@ export function CalendarLayout() {
             <h2 className="text-xs font-bold text-muted-foreground">캘린더 목록</h2>
           </div>
           <ul className="space-y-3">
-            {[
-              { name: '김나루 (나)', color: 'bg-primary' },
-              { name: 'Naruon PM 팀', color: 'bg-red-500' },
-              { name: '제품 개발팀', color: 'bg-green-500' },
-              { name: '마케팅팀', color: 'bg-purple-500' },
-              { name: '회사 공용', color: 'bg-indigo-500' },
-              { name: '공휴일', color: 'bg-slate-400' },
-            ].map((cal) => (
+            {calendarList.map((cal) => (
               <li key={cal.name} className="flex items-center gap-3 text-sm">
-                <input type="checkbox" defaultChecked className={`size-4 rounded border-border text-primary focus:ring-primary`} style={{ accentColor: cal.color }} />
+                <input type="checkbox" defaultChecked className="size-4 rounded border-border accent-primary text-primary focus:ring-primary" />
+                <span className={`size-2.5 shrink-0 rounded-full ${cal.swatchClassName}`} aria-hidden="true" />
                 <span className="font-medium text-foreground">{cal.name}</span>
               </li>
             ))}

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import { Database, FileText, HardDrive, RefreshCw, FolderOpen, CheckCircle2, Server } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
+import { boundedPercentStyle, formatBoundedPercent } from '@/lib/safe-style';
 
 type WebdavWritebackIntentResponse = {
   intent: string;
@@ -350,7 +351,7 @@ export function DataLayout() {
                   <div className="h-2 w-full rounded-full bg-border overflow-hidden">
                     <div
                       className="h-full bg-blue-500 transition-all"
-                      style={{ width: `${embeddingStage?.progress_percent ?? 0}%` }}
+                      style={boundedPercentStyle(embeddingStage?.progress_percent)}
                     ></div>
                   </div>
                 </div>
@@ -752,13 +753,13 @@ export function DataLayout() {
                           <p className="mt-1 break-all font-mono text-[11px] font-semibold text-muted-foreground">{stage.evidence_source}</p>
                         </div>
                         <span className={`w-fit shrink-0 rounded-full px-2 py-1 text-xs font-bold ${getSurfaceStatusClass(stage.status_code)}`}>
-                          {getSurfaceStatusLabel(stage.status_code)} · {stage.progress_percent}%
+                          {getSurfaceStatusLabel(stage.status_code)} · {formatBoundedPercent(stage.progress_percent)}
                         </span>
                       </div>
                       <div className="h-2 w-full rounded-full bg-secondary overflow-hidden">
                         <div
                           className="h-full bg-primary transition-all"
-                          style={{ width: `${stage.progress_percent}%` }}
+                          style={boundedPercentStyle(stage.progress_percent)}
                         ></div>
                       </div>
                     </div>

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { CalendarDays, CheckCircle2, Clock, FolderOpen, ListChecks, Search, User } from 'lucide-react';
 
 import { apiClient } from '@/lib/api-client';
+import { boundedPercentStyle } from '@/lib/safe-style';
 import { toSafeReactText } from '@/lib/safe-text';
 
 type ProjectViewMode = '프로젝트 상세' | '마일스톤' | '의사결정 로그';
@@ -245,7 +246,7 @@ export function ProjectsLayout() {
               <h3 className="mt-1 line-clamp-2 font-bold text-sm text-foreground">{project.title}</h3>
               <div className="mt-3 flex items-center gap-2">
                 <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-border">
-                  <div className={`h-full ${project.progress === 100 ? 'bg-emerald-500' : 'bg-primary'}`} style={{ width: `${project.progress}%` }} />
+                  <div className={`h-full ${project.progress === 100 ? 'bg-emerald-500' : 'bg-primary'}`} style={boundedPercentStyle(project.progress)} />
                 </div>
                 <span className="text-xs font-semibold text-muted-foreground">{project.progress}%</span>
               </div>
@@ -405,7 +406,7 @@ export function ProjectsLayout() {
                   <dt className="mb-1 font-semibold text-muted-foreground">진행률</dt>
                   <dd className="flex items-center gap-3">
                     <div className="h-2 flex-1 overflow-hidden rounded-full bg-border">
-                      <div className="h-full bg-primary" style={{ width: `${activeProject.progress}%` }} />
+                      <div className="h-full bg-primary" style={boundedPercentStyle(activeProject.progress)} />
                     </div>
                     <span className="font-mono text-xs font-bold">{activeProject.progress}%</span>
                   </dd>

--- a/frontend/src/lib/safe-style.ts
+++ b/frontend/src/lib/safe-style.ts
@@ -1,0 +1,17 @@
+export function boundedPercent(value: unknown) {
+  const numericValue = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim() !== ''
+      ? Number(value)
+      : 0;
+  if (!Number.isFinite(numericValue)) return 0;
+  return Math.max(0, Math.min(100, numericValue));
+}
+
+export function boundedPercentStyle(value: unknown) {
+  return { width: `${boundedPercent(value)}%` };
+}
+
+export function formatBoundedPercent(value: unknown) {
+  return `${boundedPercent(value)}%`;
+}


### PR DESCRIPTION
## Summary
- exclude frontend test sources from Tailwind v4 source detection with @source not
- remove static hostile arbitrary Tailwind class fixtures from tests
- add bounded percent style helpers for frontend progress/score widths and remove raw accentColor string use

## Validation
- npm test -- --run src/app/calendar/page.test.tsx src/app/data/page.test.tsx src/app/ai-hub/page.test.tsx src/app/projects/page.test.tsx
- npm test
- npm run typecheck
- npm run lint
- POSTCSS_WORKERS=1 DISABLE_POSTCSS_WORKERS=true npm run build
- rg generated CSS/source for javascript: and arbitrary url class signatures