### PR TITLE
fix: allow compose image builds without runtime secrets

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -236,7 +236,29 @@ jobs:
           import sys
 
           credentials_path = pathlib.Path(sys.argv[1])
-          credentials = json.loads(credentials_path.read_text())
+
+          def reject_duplicate_json_keys(pairs):
+              parsed = {}
+              for key, value in pairs:
+                  if key in parsed:
+                      raise ValueError("duplicate credential key")
+                  parsed[key] = value
+              return parsed
+
+          try:
+              credentials_text = credentials_path.read_text(encoding="utf-8")
+              credentials = json.loads(
+                  credentials_text,
+                  object_pairs_hook=reject_duplicate_json_keys,
+              )
+          except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+              raise SystemExit(
+                  "GCP_SA_KEY must be valid service account JSON for Vertex AI Strix scans."
+              )
+          if not isinstance(credentials, dict):
+              raise SystemExit(
+                  "GCP_SA_KEY must be a JSON object for Vertex AI Strix scans."
+              )
           project_id = str(credentials.get("project_id", "")).strip()
           if not project_id:
               raise SystemExit("GCP_SA_KEY must include project_id for Vertex AI Strix scans.")

--- a/README.md
+++ b/README.md
@@ -184,12 +184,17 @@ threading proof path works offline.
 
 Backend settings read environment variables first, then `.env`, `../.env`, and
 `~/.env`. `DATABASE_URL`, `AUTH_SESSION_HMAC_SECRET`, and `ENCRYPTION_KEY` still
-have no code defaults; Compose and Kubernetes must inject them explicitly. For Compose,
-`./scripts/naruon_compose.sh` reads `${NARUON_ENV_FILE}` when set, otherwise
-uses `~/.env` if present, and falls back to the project `.env`. It passes that
-file to Docker Compose only as an interpolation source so the backend service
-receives the whitelisted variables in `docker-compose*.yml`, not every local
-secret present in `~/.env`. The backend image starts through
+have no code defaults; Compose and Kubernetes must inject them explicitly before
+runtime. `docker compose build backend frontend` is intentionally allowed to
+parse without local secrets because image builds do not need database or session
+credentials. `docker compose up` still fails closed inside the database/backend
+startup path when `POSTGRES_PASSWORD`, `AUTH_SESSION_HMAC_SECRET`, or
+`ENCRYPTION_KEY` are missing. For Compose, `./scripts/naruon_compose.sh` reads
+`${NARUON_ENV_FILE}` when set, otherwise uses `~/.env` if present, and falls back
+to the project `.env`. It passes that file to Docker Compose only as an
+interpolation source so the backend service receives the whitelisted variables
+in `docker-compose*.yml`, not every local secret present in `~/.env`. The
+backend image starts through
 `python scripts/start_backend.py`, which checks the same required settings before
 `uvicorn` imports the app. A direct `docker run` therefore still needs explicit
 environment injection through `--env`, an orchestrator secret, or a minimal

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -151,7 +151,9 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
 
 def test_frontend_dockerfile_builds_and_starts_production_artifact() -> None:
     dockerfile = read_repo_text("frontend/Dockerfile")
+    package_json = read_repo_text("frontend/package.json")
 
+    assert '"packageManager": "pnpm@11.5.3"' in package_json
     assert dockerfile.index("ARG NEXT_PUBLIC_API_URL") < dockerfile.index(
         "RUN pnpm run build"
     )
@@ -208,8 +210,8 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
 
     backend_block = compose.split("  backend:", 1)[1].split("  frontend:", 1)[0]
     assert "target: backend-runtime" in backend_block
-    assert 'DEBUG: "false"' in backend_block
-    assert 'DEBUG: "true"' not in backend_block
+    assert "DEBUG=false" in backend_block
+    assert "DEBUG=true" not in backend_block
     assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
     assert '"scripts/start_backend.py"' in live_e2e_compose
     assert "Dockerfile.ollama" in live_e2e_compose

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -280,6 +280,25 @@ def test_strix_workflow_uses_github_models_default_and_narrow_warning_filter() -
     assert "ignore::UserWarning" not in workflow
 
 
+def test_strix_workflow_validates_vertex_credentials_before_export() -> None:
+    workflow = read_repo_text(".github/workflows/strix.yml")
+
+    assert "credentials_path.read_text(encoding=\"utf-8\")" in workflow
+    assert "object_pairs_hook=reject_duplicate_json_keys" in workflow
+    assert "raise ValueError(\"duplicate credential key\")" in workflow
+    assert (
+        "except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):"
+        in workflow
+    )
+    assert (
+        "GCP_SA_KEY must be valid service account JSON for Vertex AI Strix scans."
+        in workflow
+    )
+    assert "if not isinstance(credentials, dict):" in workflow
+    assert "GCP_SA_KEY must be a JSON object for Vertex AI Strix scans." in workflow
+    assert "json.loads(credentials_path.read_text())" not in workflow
+
+
 def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge() -> (
     None
 ):

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -118,22 +118,37 @@ def test_compose_allows_only_the_local_ollama_provider_host():
     local_compose = (REPO_ROOT / "docker-compose.yml").read_text()
     live_compose = (REPO_ROOT / "docker-compose.live-e2e.yml").read_text()
 
+    def has_exact_compose_line(compose: str, *expected_lines: str) -> bool:
+        normalized_lines = {
+            line.strip().removeprefix("- ").strip() for line in compose.splitlines()
+        }
+        return any(expected_line in normalized_lines for expected_line in expected_lines)
+
+    assert not has_exact_compose_line(
+        "ALLOWED_LLM_BASE_URL_HOSTS=ollama,evil.example",
+        "ALLOWED_LLM_BASE_URL_HOSTS=ollama",
+    )
+
     for compose in (local_compose, live_compose):
-        assert (
-            'ALLOW_LOCAL_LLM_PROVIDERS: "true"' in compose
-            or "ALLOW_LOCAL_LLM_PROVIDERS=true" in compose
+        assert has_exact_compose_line(
+            compose,
+            'ALLOW_LOCAL_LLM_PROVIDERS: "true"',
+            "ALLOW_LOCAL_LLM_PROVIDERS=true",
         )
-        assert (
-            'ALLOWED_LLM_BASE_URL_HOSTS: "ollama"' in compose
-            or "ALLOWED_LLM_BASE_URL_HOSTS=ollama" in compose
+        assert has_exact_compose_line(
+            compose,
+            'ALLOWED_LLM_BASE_URL_HOSTS: "ollama"',
+            "ALLOWED_LLM_BASE_URL_HOSTS=ollama",
         )
-        assert (
-            "OPENAI_BASE_URL: http://ollama:11434/v1" in compose
-            or "OPENAI_BASE_URL=http://ollama:11434/v1" in compose
+        assert has_exact_compose_line(
+            compose,
+            "OPENAI_BASE_URL: http://ollama:11434/v1",
+            "OPENAI_BASE_URL=http://ollama:11434/v1",
         )
-        assert (
-            "OPENAI_MODEL: gemma4:e2b-it-qat" in compose
-            or "OPENAI_MODEL=gemma4:e2b-it-qat" in compose
+        assert has_exact_compose_line(
+            compose,
+            "OPENAI_MODEL: gemma4:e2b-it-qat",
+            "OPENAI_MODEL=gemma4:e2b-it-qat",
         )
 
 

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -82,17 +82,36 @@ def test_traefik_compose_services_disable_privilege_escalation():
 
 def test_compose_externalizes_postgres_credentials():
     compose = (REPO_ROOT / "docker-compose.yml").read_text()
+    compose_without_runtime_preflights = (
+        compose.replace(
+            '$${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}',
+            "",
+        )
+        .replace(
+            '$${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}',
+            "",
+        )
+        .replace(
+            '$${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}',
+            "",
+        )
+    )
 
     assert "POSTGRES_PASSWORD: postgres" not in compose
     assert "postgres:postgres@" not in compose
-    assert "POSTGRES_DB: ai_email" in compose
-    assert "POSTGRES_USER: postgres" in compose
+    assert "POSTGRES_DB=ai_email" in compose
+    assert "POSTGRES_USER=postgres" in compose
+    assert "POSTGRES_PASSWORD:-postgres" not in compose
     assert "${POSTGRES_PASSWORD" in compose
+    assert "${POSTGRES_PASSWORD:?" not in compose_without_runtime_preflights
+    assert '$${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}' in compose
     assert "127.0.0.1:15432:5432" in compose
     assert "AUTH_SESSION_HMAC_SECRET" in compose
-    assert "${AUTH_SESSION_HMAC_SECRET:?" in compose
+    assert "${AUTH_SESSION_HMAC_SECRET:?" not in compose_without_runtime_preflights
+    assert '$${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}' in compose
     assert "ENCRYPTION_KEY" in compose
-    assert "${ENCRYPTION_KEY:?" in compose
+    assert "${ENCRYPTION_KEY:?" not in compose_without_runtime_preflights
+    assert '$${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}' in compose
 
 
 def test_compose_allows_only_the_local_ollama_provider_host():
@@ -100,10 +119,22 @@ def test_compose_allows_only_the_local_ollama_provider_host():
     live_compose = (REPO_ROOT / "docker-compose.live-e2e.yml").read_text()
 
     for compose in (local_compose, live_compose):
-        assert 'ALLOW_LOCAL_LLM_PROVIDERS: "true"' in compose
-        assert 'ALLOWED_LLM_BASE_URL_HOSTS: "ollama"' in compose
-        assert "OPENAI_BASE_URL: http://ollama:11434/v1" in compose
-        assert "OPENAI_MODEL: gemma4:e2b-it-qat" in compose
+        assert (
+            'ALLOW_LOCAL_LLM_PROVIDERS: "true"' in compose
+            or "ALLOW_LOCAL_LLM_PROVIDERS=true" in compose
+        )
+        assert (
+            'ALLOWED_LLM_BASE_URL_HOSTS: "ollama"' in compose
+            or "ALLOWED_LLM_BASE_URL_HOSTS=ollama" in compose
+        )
+        assert (
+            "OPENAI_BASE_URL: http://ollama:11434/v1" in compose
+            or "OPENAI_BASE_URL=http://ollama:11434/v1" in compose
+        )
+        assert (
+            "OPENAI_MODEL: gemma4:e2b-it-qat" in compose
+            or "OPENAI_MODEL=gemma4:e2b-it-qat" in compose
+        )
 
 
 def test_compose_wrapper_uses_operator_env_file_without_bulk_secret_injection():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,15 @@ services:
   db:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_DB: ai_email
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}
+      - POSTGRES_DB=ai_email
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD
+    entrypoint:
+      - sh
+      - -c
+      - |
+        : "$${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}"
+        exec docker-entrypoint.sh postgres
     ports:
       - "127.0.0.1:15432:5432"
     healthcheck:
@@ -30,16 +36,16 @@ services:
       dockerfile: Dockerfile
       target: backend-runtime
     environment:
-      DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}@db:5432/ai_email
-      DEBUG: "false"
-      ALLOW_LOCAL_LLM_PROVIDERS: "true"
-      ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
-      AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}
-      OPENAI_API_KEY: ollama
-      OPENAI_BASE_URL: http://ollama:11434/v1
-      OPENAI_EMBEDDING_MODEL: embeddinggemma
-      OPENAI_MODEL: gemma4:e2b-it-qat
+      - DATABASE_URL=postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/ai_email
+      - DEBUG=false
+      - ALLOW_LOCAL_LLM_PROVIDERS=true
+      - ALLOWED_LLM_BASE_URL_HOSTS=ollama
+      - AUTH_SESSION_HMAC_SECRET
+      - ENCRYPTION_KEY
+      - OPENAI_API_KEY=ollama
+      - OPENAI_BASE_URL=http://ollama:11434/v1
+      - OPENAI_EMBEDDING_MODEL=embeddinggemma
+      - OPENAI_MODEL=gemma4:e2b-it-qat
     depends_on:
       db:
         condition: service_healthy
@@ -47,7 +53,13 @@ services:
         condition: service_started
     ports:
       - "8000:8000"
-    command: ["sh", "-c", "python scripts/bootstrap_db.py && python scripts/start_backend.py --host 0.0.0.0 --port 8000"]
+    command:
+      - sh
+      - -c
+      - |
+        : "$${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}"
+        : "$${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}"
+        python scripts/bootstrap_db.py && python scripts/start_backend.py --host 0.0.0.0 --port 8000
 
   frontend:
     build:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.5.3",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- let `docker compose build backend frontend` parse without local runtime secrets
- keep runtime fail-closed checks for missing `POSTGRES_PASSWORD`, `AUTH_SESSION_HMAC_SECRET`, and `ENCRYPTION_KEY`
- pin frontend Corepack package manager metadata to `pnpm@11.5.3`

## Root Cause
`docker compose build backend frontend` failed before image builds because `docker-compose.yml` used build-time Compose interpolation guards such as `${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}`. The build does not need database/session secrets, but Podman Compose resolves all service environment values before running the selected build.

## Verification
- `PYTHONPATH=backend python -m pytest backend/tests/test_repo_hygiene.py backend/tests/test_release_governance.py -q`
- `docker compose config`
- `docker compose build backend frontend`
- `docker compose run --rm --no-deps db` fails closed with `POSTGRES_PASSWORD: Set POSTGRES_PASSWORD in .env before running Docker Compose`
- backend image preflight fails closed with `AUTH_SESSION_HMAC_SECRET: Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose`
- `git diff --check`

## Notes
- The local dirty `.Jules/palette.md` file was left unstaged and is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced credential validation during deployment with stricter JSON parsing and error handling.
  * Updated package manager specification to pnpm@11.5.3.
  * Restructured environment variable configuration in deployment files with improved runtime validation for sensitive credentials.

* **Documentation**
  * Reformatted environment settings injection documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->