### PR TITLE
fix: allow nginx startup notices in compose log scan

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -8,6 +8,8 @@ workflow governance before a release branch can land.
 from __future__ import annotations
 
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -236,6 +238,31 @@ def test_compose_log_scanner_exists_for_warning_policy() -> None:
     assert "unexpected_count" in scanner
     assert "Use --ui/--no-ui" in scanner
     assert "or deprecated --webui/--no-webui" in scanner
+
+
+def test_compose_log_scanner_allows_nginx_stderr_startup_notices() -> None:
+    nginx_startup_lines = "\n".join(
+        [
+            '2026/06/13 06:25:27 [notice] 1#1: using the "epoll" event method',
+            "2026/06/13 06:25:27 [notice] 1#1: nginx/1.27.5",
+            "2026/06/13 06:25:27 [notice] 1#1: built by gcc 14.2.0 (Alpine 14.2.0)",
+            "2026/06/13 06:25:27 [notice] 1#1: OS: Linux 6.19.7-200.fc43.aarch64",
+            "2026/06/13 06:25:27 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 524288:524288",
+            "2026/06/13 06:25:27 [notice] 1#1: start worker processes",
+            "2026/06/13 06:25:27 [notice] 1#1: start worker process 16",
+        ]
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts/check_compose_logs.py")],
+        input=nginx_startup_lines,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PASS compose log policy: allowed_count=7" in result.stdout
 
 
 def test_strix_workflow_uses_github_models_default_and_narrow_warning_filter() -> (

--- a/scripts/check_compose_logs.py
+++ b/scripts/check_compose_logs.py
@@ -31,7 +31,8 @@ ALLOWLIST: tuple[AllowedLogPattern, ...] = (
         version="1.27.x-alpine",
         rationale="Nginx emits notice-level worker startup lines before serving traffic.",
         pattern=re.compile(
-            r"nginx.*\[notice\].*(using the .* event method|nginx/|built by gcc|"
+            r"(?:nginx.*)?\[notice\]\s+\d+#\d+:\s+"
+            r"(using the .* event method|nginx/|built by gcc|"
             r"OS:|getrlimit\(RLIMIT_NOFILE\)|start worker processes|"
             r"start worker process \d+)",
             re.IGNORECASE,


### PR DESCRIPTION
## Summary
- allow the compose log scanner to recognize nginx stderr startup notice lines
- add a release-governance regression for the raw nginx 1.27 startup format

## Verification
- PYTHONWARNINGS=error python -m pytest backend/tests/test_release_governance.py -q
- live Docker/Podman Compose stack on da0ce03 with backend/frontend images and Ollama image containing gemma4:e2b-it-qat + embeddinggemma
- LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=<redacted> PYTHONWARNINGS=error python -m pytest backend/tests/live/test_live_api_sequence.py -q
- env -u NO_COLOR -u FORCE_COLOR RUN_LIVE_MODEL_E2E=1 LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=<redacted> pnpm --dir frontend exec playwright test tests/e2e/nano.spec.ts -g "nano live model" --project=desktop
- stderr-aware live compose log scan: PASS compose log policy: allowed_count=12

## Live model evidence
- backend returned 200 for /api/llm/draft and /api/search through nginx
- Ollama returned 200 for /v1/chat/completions using gemma4:e2b-it-qat and /v1/embeddings using embeddinggemma
