### PR TITLE
fix: expand Strix failed-check fallback findings

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -432,7 +432,6 @@ jobs:
       - name: Run OpenCode PR Review (GPT-5)
         id: opencode_review_primary
         timeout-minutes: 60
-        continue-on-error: true
         env:
           STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -450,6 +449,9 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          record_review_status() {
+            printf 'review_status=%s\n' "$1" >>"$GITHUB_OUTPUT"
+          }
           prompt_file="${RUNNER_TEMP}/opencode-review-prompt.md"
           cat >"$prompt_file" <<EOF
           Review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE}. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
@@ -477,24 +479,38 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
+          set +e
           timeout 1200 opencode run "$(cat "$prompt_file")" \
             --pure \
             --agent ci-review \
             --model "$MODEL" \
             --format json \
             --title "PR #${PR_NUMBER} OpenCode bounded review ${MODEL}" >"$opencode_json_file"
+          opencode_run_status=$?
+          set -e
+          if [ "$opencode_run_status" -ne 0 ]; then
+            echo "OpenCode primary review attempt did not complete; fallback review will run."
+            record_review_status "failed"
+            exit 0
+          fi
           session_id="$(jq -r 'select(.type == "step_start") | .sessionID' "$opencode_json_file" | tail -n 1)"
           if [ -z "$session_id" ] || [ "$session_id" = "null" ]; then
             echo "OpenCode JSON output did not include a session id."
             cat "$opencode_json_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
-          opencode export "$session_id" --pure >"$opencode_export_file"
+          if ! opencode export "$session_id" --pure >"$opencode_export_file"; then
+            echo "OpenCode session export did not complete."
+            record_review_status "failed"
+            exit 0
+          fi
           jq -r '.messages[] | select(.info.role == "assistant") | .parts[]? | select(.type == "text") | .text' "$opencode_export_file" >"$OPENCODE_OUTPUT_FILE"
           if [ ! -s "$OPENCODE_OUTPUT_FILE" ]; then
             echo "OpenCode session export did not include assistant text."
             cat "$opencode_export_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
           normalize_opencode_output() {
             local output_file="$1"
@@ -515,14 +531,15 @@ jobs:
           if ! normalize_opencode_output "$OPENCODE_OUTPUT_FILE"; then
             echo "OpenCode output did not include a valid control conclusion."
             cat "$OPENCODE_OUTPUT_FILE"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
+          record_review_status "success"
 
       - name: Run OpenCode PR Review fallback (DeepSeek R1)
         id: opencode_review_fallback
-        if: steps.opencode_review_primary.outcome != 'success'
+        if: steps.opencode_review_primary.outputs.review_status != 'success'
         timeout-minutes: 60
-        continue-on-error: true
         env:
           STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -540,6 +557,9 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          record_review_status() {
+            printf 'review_status=%s\n' "$1" >>"$GITHUB_OUTPUT"
+          }
           prompt_file="${RUNNER_TEMP}/opencode-review-prompt.md"
           cat >"$prompt_file" <<EOF
           GPT-5 failed; review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE} with DeepSeek R1-0528. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
@@ -567,24 +587,38 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
+          set +e
           timeout 300 opencode run "$(cat "$prompt_file")" \
             --pure \
             --agent ci-review-fallback \
             --model "$MODEL" \
             --format json \
             --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL}" >"$opencode_json_file"
+          opencode_run_status=$?
+          set -e
+          if [ "$opencode_run_status" -ne 0 ]; then
+            echo "OpenCode DeepSeek R1 review attempt did not complete; next fallback review will run."
+            record_review_status "failed"
+            exit 0
+          fi
           session_id="$(jq -r 'select(.type == "step_start") | .sessionID' "$opencode_json_file" | tail -n 1)"
           if [ -z "$session_id" ] || [ "$session_id" = "null" ]; then
             echo "OpenCode JSON output did not include a session id."
             cat "$opencode_json_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
-          opencode export "$session_id" --pure >"$opencode_export_file"
+          if ! opencode export "$session_id" --pure >"$opencode_export_file"; then
+            echo "OpenCode session export did not complete."
+            record_review_status "failed"
+            exit 0
+          fi
           jq -r '.messages[] | select(.info.role == "assistant") | .parts[]? | select(.type == "text") | .text' "$opencode_export_file" >"$OPENCODE_OUTPUT_FILE"
           if [ ! -s "$OPENCODE_OUTPUT_FILE" ]; then
             echo "OpenCode session export did not include assistant text."
             cat "$opencode_export_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
           normalize_opencode_output() {
             local output_file="$1"
@@ -605,14 +639,15 @@ jobs:
           if ! normalize_opencode_output "$OPENCODE_OUTPUT_FILE"; then
             echo "OpenCode output did not include a valid control conclusion."
             cat "$OPENCODE_OUTPUT_FILE"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
+          record_review_status "success"
 
       - name: Run OpenCode PR Review fallback (DeepSeek V3)
         id: opencode_review_second_fallback
-        if: steps.opencode_review_primary.outcome != 'success' && steps.opencode_review_fallback.outcome != 'success'
+        if: steps.opencode_review_primary.outputs.review_status != 'success' && steps.opencode_review_fallback.outputs.review_status != 'success'
         timeout-minutes: 60
-        continue-on-error: true
         env:
           STRIX_GITHUB_MODELS_TOKEN: ${{ secrets.STRIX_GITHUB_MODELS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -630,6 +665,9 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          record_review_status() {
+            printf 'review_status=%s\n' "$1" >>"$GITHUB_OUTPUT"
+          }
           prompt_file="${RUNNER_TEMP}/opencode-review-prompt.md"
           cat >"$prompt_file" <<EOF
           GPT-5 and DeepSeek R1-0528 failed; review PR #${PR_NUMBER} in ${GITHUB_WORKSPACE} with DeepSeek V3-0324. Be general-purpose and meticulous: use CodeGraph MCP for structural checks, DeepWiki for repo docs, Context7 for current library/API docs, and web_search for bounded external lookups when needed. Inspect changed files and focused hunks directly when MCP evidence is insufficient.
@@ -657,24 +695,38 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
+          set +e
           timeout 300 opencode run "$(cat "$prompt_file")" \
             --pure \
             --agent ci-review-fallback \
             --model "$MODEL" \
             --format json \
             --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL}" >"$opencode_json_file"
+          opencode_run_status=$?
+          set -e
+          if [ "$opencode_run_status" -ne 0 ]; then
+            echo "OpenCode DeepSeek V3 review attempt did not complete."
+            record_review_status "failed"
+            exit 0
+          fi
           session_id="$(jq -r 'select(.type == "step_start") | .sessionID' "$opencode_json_file" | tail -n 1)"
           if [ -z "$session_id" ] || [ "$session_id" = "null" ]; then
             echo "OpenCode JSON output did not include a session id."
             cat "$opencode_json_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
-          opencode export "$session_id" --pure >"$opencode_export_file"
+          if ! opencode export "$session_id" --pure >"$opencode_export_file"; then
+            echo "OpenCode session export did not complete."
+            record_review_status "failed"
+            exit 0
+          fi
           jq -r '.messages[] | select(.info.role == "assistant") | .parts[]? | select(.type == "text") | .text' "$opencode_export_file" >"$OPENCODE_OUTPUT_FILE"
           if [ ! -s "$OPENCODE_OUTPUT_FILE" ]; then
             echo "OpenCode session export did not include assistant text."
             cat "$opencode_export_file"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
           normalize_opencode_output() {
             local output_file="$1"
@@ -695,15 +747,17 @@ jobs:
           if ! normalize_opencode_output "$OPENCODE_OUTPUT_FILE"; then
             echo "OpenCode output did not include a valid control conclusion."
             cat "$OPENCODE_OUTPUT_FILE"
-            exit 1
+            record_review_status "failed"
+            exit 0
           fi
+          record_review_status "success"
 
       - name: Publish bounded OpenCode review comment
         if: >-
           always()
-          && (steps.opencode_review_primary.outcome == 'success'
-              || steps.opencode_review_fallback.outcome == 'success'
-              || steps.opencode_review_second_fallback.outcome == 'success')
+          && (steps.opencode_review_primary.outputs.review_status == 'success'
+              || steps.opencode_review_fallback.outputs.review_status == 'success'
+              || steps.opencode_review_second_fallback.outputs.review_status == 'success')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPOSITORY: ${{ github.repository }}
@@ -711,9 +765,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
-          OPENCODE_PRIMARY_OUTCOME: ${{ steps.opencode_review_primary.outcome }}
-          OPENCODE_FALLBACK_OUTCOME: ${{ steps.opencode_review_fallback.outcome }}
-          OPENCODE_SECOND_FALLBACK_OUTCOME: ${{ steps.opencode_review_second_fallback.outcome }}
+          OPENCODE_PRIMARY_OUTCOME: ${{ steps.opencode_review_primary.outputs.review_status }}
+          OPENCODE_FALLBACK_OUTCOME: ${{ steps.opencode_review_fallback.outputs.review_status }}
+          OPENCODE_SECOND_FALLBACK_OUTCOME: ${{ steps.opencode_review_second_fallback.outputs.review_status }}
           OPENCODE_PRIMARY_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-primary.md
           OPENCODE_FALLBACK_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-fallback.md
           OPENCODE_SECOND_FALLBACK_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-second-fallback.md
@@ -872,9 +926,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
-          OPENCODE_PRIMARY_OUTCOME: ${{ steps.opencode_review_primary.outcome }}
-          OPENCODE_FALLBACK_OUTCOME: ${{ steps.opencode_review_fallback.outcome }}
-          OPENCODE_SECOND_FALLBACK_OUTCOME: ${{ steps.opencode_review_second_fallback.outcome }}
+          OPENCODE_PRIMARY_OUTCOME: ${{ steps.opencode_review_primary.outputs.review_status }}
+          OPENCODE_FALLBACK_OUTCOME: ${{ steps.opencode_review_fallback.outputs.review_status }}
+          OPENCODE_SECOND_FALLBACK_OUTCOME: ${{ steps.opencode_review_second_fallback.outputs.review_status }}
           APPROVAL_CHECK_WAIT_ATTEMPTS: "241"
           APPROVAL_CHECK_WAIT_SLEEP_SECONDS: "30"
         run: |

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -994,8 +994,10 @@ jobs:
             local strix_evidence_file
 
             if [ -x "${repo_root%/}/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" ]; then
-              "${repo_root%/}/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "$evidence_file" "$repo_root"
-              return 0
+              if "${repo_root%/}/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "$evidence_file" "$repo_root"; then
+                return 0
+              fi
+              printf 'OpenCode failed-check fallback helper exited non-zero; using inline fallback.\n' >&2
             fi
 
             extract_strix_failed_check_block() {

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -993,6 +993,11 @@ jobs:
             local repo_root="${GITHUB_WORKSPACE:-$PWD}"
             local strix_evidence_file
 
+            if [ -x "${repo_root%/}/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" ]; then
+              "${repo_root%/}/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "$evidence_file" "$repo_root"
+              return 0
+            fi
+
             extract_strix_failed_check_block() {
               local source_file="$1"
               local output_file="$2"

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -326,6 +326,23 @@ def test_strix_workflow_validates_vertex_credentials_before_export() -> None:
     assert "json.loads(credentials_path.read_text())" not in workflow
 
 
+def test_opencode_review_fallbacks_do_not_emit_successful_error_annotations() -> None:
+    workflow = read_repo_text(".github/workflows/opencode-review.yml")
+
+    assert "continue-on-error: true" not in workflow
+    assert 'printf \'review_status=%s\\n\' "$1" >>"$GITHUB_OUTPUT"' in workflow
+    assert "record_review_status \"failed\"" in workflow
+    assert "record_review_status \"success\"" in workflow
+    assert "steps.opencode_review_primary.outputs.review_status != 'success'" in workflow
+    assert (
+        "steps.opencode_review_primary.outputs.review_status == 'success'"
+        in workflow
+    )
+    assert "steps.opencode_review_primary.outcome" not in workflow
+    assert "steps.opencode_review_fallback.outcome" not in workflow
+    assert "steps.opencode_review_second_fallback.outcome" not in workflow
+
+
 def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge() -> (
     None
 ):

--- a/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
+++ b/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+	echo "usage: $0 <failed-check-evidence-file> [repo-root]" >&2
+	exit 64
+fi
+
+EVIDENCE_FILE="$1"
+REPO_ROOT="${2:-${GITHUB_WORKSPACE:-$PWD}}"
+finding_index=0
+tmp_files=()
+
+cleanup() {
+	rm -f "${tmp_files[@]}"
+}
+trap cleanup EXIT
+
+normalize_source_path() {
+	local raw_path="$1"
+	local candidate
+
+	candidate="$(printf '%s' "$raw_path" | sed -E 's#^/workspace/[^/]+/##; s#^/tmp/strix-pr-scope\.[^/]+/##; s#^\./##; s#^/##')"
+	case "$candidate" in
+		services/*.py)
+			candidate="backend/$candidate"
+			;;
+		src/*)
+			if [ -e "${REPO_ROOT%/}/frontend/$candidate" ]; then
+				candidate="frontend/$candidate"
+			fi
+			;;
+	esac
+	printf '%s' "$candidate"
+}
+
+first_existing_line() {
+	local path="$1"
+	local pattern="${2:-}"
+	local match=""
+
+	if [ ! -f "${REPO_ROOT%/}/$path" ]; then
+		printf '1'
+		return 0
+	fi
+	if [ -n "$pattern" ]; then
+		match="$(grep -nE -- "$pattern" "${REPO_ROOT%/}/$path" | head -n 1 || true)"
+		if [ -n "$match" ]; then
+			printf '%s' "${match%%:*}"
+			return 0
+		fi
+	fi
+	printf '1'
+}
+
+derive_location_from_report() {
+	local title="$1"
+	local endpoint="$2"
+	local target="$3"
+	local raw_location="$4"
+	local clean_location=""
+	local path=""
+	local line=""
+	local line_range=""
+
+	if [ -n "$raw_location" ]; then
+		clean_location="$(normalize_source_path "$raw_location")"
+		path="${clean_location%:*}"
+		line_range="${clean_location##*:}"
+		line="${line_range%%-*}"
+		if [ -f "${REPO_ROOT%/}/$path" ] && [[ "$line" =~ ^[0-9]+$ ]]; then
+			printf '%s\t%s\t%s' "$path" "$line" "$raw_location"
+			return 0
+		fi
+	fi
+
+	if [[ "$target" =~ (backend/[^[:space:]]+|frontend/[^[:space:]]+|\.github/[^[:space:]]+|scripts/[^[:space:]]+) ]]; then
+		path="$(normalize_source_path "${BASH_REMATCH[1]}")"
+	elif [[ "$endpoint" =~ ^/services/.*\.py$ ]]; then
+		path="$(normalize_source_path "${endpoint#/}")"
+	fi
+
+	if [ -n "$path" ] && [ -f "${REPO_ROOT%/}/$path" ]; then
+		line="$(first_existing_line "$path")"
+		printf '%s\t%s\t%s' "$path" "$line" "target/endpoint: ${target:-$endpoint}"
+		return 0
+	fi
+
+	case "$title" in
+		*"Path Traversal"*Attachment*|*"attachment"*filename*)
+			path="backend/services/email_parser.py"
+			line="$(first_existing_line "$path" 'filename = part\.get_filename\(\)|"filename":')"
+			;;
+		*"OIDC"*|*"session token"*|*"Session Token"*)
+			path="frontend/src/lib/oidc-session.ts"
+			line="$(first_existing_line "$path" 'sessionStorage\.setItem')"
+			;;
+		*"Prompt"*Studio*|*"Prompt Injection"*)
+			path="frontend/src/app/prompt-studio/page.tsx"
+			line="$(first_existing_line "$path" "apiClient\\.post|testResult|setTestResult")"
+			;;
+		*"Content Security Policy"*|*"security headers"*|*"Security Headers"*)
+			path="frontend/next.config.ts"
+			line="$(first_existing_line "$path" 'const nextConfig|headers')"
+			;;
+		*"JWT"*|*"Authentication"*)
+			path="backend/api/auth.py"
+			line="$(first_existing_line "$path" 'jwt\.decode|JWT_DECODE_REQUIRED_CLAIMS|_build_oidc_jwks_client')"
+			;;
+	esac
+
+	if [ -n "$path" ] && [ -f "${REPO_ROOT%/}/$path" ] && [[ "$line" =~ ^[0-9]+$ ]]; then
+		printf '%s\t%s\t%s' "$path" "$line" "derived from Strix title: $title"
+		return 0
+	fi
+
+	printf 'unknown\t1\tStrix report did not include a mappable Code Location'
+}
+
+extract_strix_failed_check_block() {
+	local source_file="$1"
+	local output_file="$2"
+
+	awk '
+		/^## Failed check: / {
+			in_strix = ($0 ~ /^## Failed check: .*Strix/)
+		}
+		in_strix { print }
+	' "$source_file" >"$output_file"
+}
+
+extract_strix_reports() {
+	local source_file="$1"
+	perl -CS -ne '
+		sub clean {
+			my ($line) = @_;
+			$line =~ s/\r//g;
+			$line =~ s/\x1b\[[0-9;?]*[A-Za-z]//g;
+			if ($line =~ /│/) {
+				$line =~ s/^.*?│[[:space:]]*//;
+				$line =~ s/[[:space:]]*│.*$//;
+			} else {
+				$line =~ s/^.*?[0-9]Z[[:space:]]+//;
+			}
+			$line =~ s/[[:space:]]+/ /g;
+			$line =~ s/^[[:space:]]+|[[:space:]]+$//g;
+			return $line;
+		}
+		sub finish_report {
+			return unless defined $title && length $title;
+			push @reports, {
+				model => $report_model,
+				title => $title,
+				severity => $severity,
+				endpoint => $endpoint,
+				method => $method,
+				target => $target,
+				location => $location,
+			};
+			($report_model, $title, $severity, $endpoint, $method, $target, $location) = ("", "", "", "", "", "", "");
+		}
+		sub finish_window {
+			finish_report();
+			for my $report (@reports) {
+				my $model = $report->{model} || $window_model || $current_model || "unknown-model";
+				for my $field ($model, @$report{qw(title severity endpoint method target location)}) {
+					$field //= "";
+					$field =~ s/\t/ /g;
+				}
+				print join("\x1f", $model, @$report{qw(title severity endpoint method target location)}), "\n";
+			}
+			@reports = ();
+			$window_model = "";
+		}
+		my $line = clean($_);
+		if ($line =~ /^### Strix vulnerability report window/i) {
+			finish_window();
+			$in_window = 1;
+			if ($line =~ m{(?:model|for model)[[:space:]]+((?:github[-_]models|openai|deepseek|vertex_ai)/[A-Za-z0-9._/-]+)}i) {
+				$window_model = $1;
+				$current_model = $1;
+			}
+			next;
+		}
+		if ($line =~ m{(?:^|[[:space:]])Model[[:space:]]+((?:github[-_]models|openai|deepseek|vertex_ai)/[A-Za-z0-9._/-]+)}i ||
+			$line =~ m{Strix run failed for model '\''([^'\'']+)'\''}) {
+			$current_model = $1;
+			$window_model ||= $1 if $in_window;
+			$report_model ||= $1 if defined $title && length $title;
+		}
+		next unless $in_window;
+		if ($line =~ /^Title:[[:space:]]+(.+)/i) {
+			finish_report();
+			$title = $1;
+			$report_model = $window_model || $current_model || "";
+			next;
+		}
+		if ($line =~ /^Severity:[[:space:]]+(CRITICAL|HIGH|MEDIUM|LOW|NONE)\b/i) {
+			$severity = uc($1);
+			next;
+		}
+		if ($line =~ /^Endpoint:[[:space:]]+(.+)/i) {
+			$endpoint = $1;
+			next;
+		}
+		if ($line =~ /^Method:[[:space:]]+(.+)/i) {
+			$method = $1;
+			next;
+		}
+		if ($line =~ /^Target:[[:space:]]+(.+)/i) {
+			$target = $1;
+			next;
+		}
+		if ($line =~ /(?:Code[[:space:]]+)?Location(?:s)?(?:[[:space:]]+[0-9]+)?[[:space:]]*:[[:space:]]*(.+?:[0-9]+(?:-[0-9]+)?)/i) {
+			$location ||= $1;
+			next;
+		}
+		END {
+			finish_window();
+		}
+	' "$source_file"
+}
+
+emit_known_missing_string_finding() {
+	local evidence_file="$1"
+	local needle="$2"
+	local title="$3"
+	local preferred_path
+	local match=""
+	local path=""
+	local line=""
+
+	if ! grep -Fq -- "$needle" "$evidence_file"; then
+		return 0
+	fi
+
+	shift 3
+	for preferred_path in "$@"; do
+		if [ -f "${REPO_ROOT%/}/$preferred_path" ]; then
+			match="$(grep -nF -- "$needle" "${REPO_ROOT%/}/$preferred_path" | head -n 1 || true)"
+			if [ -n "$match" ]; then
+				path="$preferred_path"
+				line="${match%%:*}"
+				break
+			fi
+		fi
+	done
+
+	finding_index=$((finding_index + 1))
+	if [ -n "$path" ] && [ -n "$line" ]; then
+		printf '### %s. HIGH %s:%s - %s\n' "$finding_index" "$path" "$line" "$title"
+		printf -- '- Problem: Strix failed because the trusted self-test log reported missing "%s".\n' "$needle"
+		printf -- '- Root cause: The failed check is executing trusted-base workflow material, so this exact line must exist in the trusted workflow/test contract before the check can pass.\n'
+		printf -- '- Fix: Keep or add the current-head line at "%s:%s" so trusted-base Strix/OpenCode evidence contains "%s".\n' "$path" "$line" "$needle"
+		printf -- '- Regression test: Keep scripts/ci/test_strix_quick_gate.sh assertions covering this exact string.\n\n'
+	else
+		printf '### %s. HIGH unknown:1 - %s\n' "$finding_index" "$title"
+		printf -- '- Problem: Strix failed because the trusted self-test log reported missing "%s".\n' "$needle"
+		printf -- '- Root cause: No current-head line containing this exact string was found in the expected workflow/test files.\n'
+		printf -- '- Fix: Add the exact string "%s" to the relevant workflow or test contract line.\n' "$needle"
+		printf -- '- Regression test: Add a static assertion for this exact string.\n\n'
+	fi
+}
+
+emit_strix_report_findings() {
+	local strix_evidence_file="$1"
+	local reports_file
+	local model
+	local title
+	local severity
+	local endpoint
+	local method
+	local target
+	local location
+	local mapped
+	local path
+	local line
+	local source_detail
+
+	if ! grep -Fq "Strix vulnerability report window" "$strix_evidence_file"; then
+		return 0
+	fi
+
+	reports_file="$(mktemp)"
+	tmp_files+=("$reports_file")
+	extract_strix_reports "$strix_evidence_file" >"$reports_file"
+
+	while IFS=$'\037' read -r model title severity endpoint method target location; do
+		if [ -z "$title" ] || [ "$severity" = "NONE" ]; then
+			continue
+		fi
+		mapped="$(derive_location_from_report "$title" "$endpoint" "$target" "$location")"
+		IFS=$'\t' read -r path line source_detail <<<"$mapped"
+		if [ "$path" = "unknown" ]; then
+			path=".github/workflows/strix.yml"
+			line="$(first_existing_line "$path" 'STRIX_FAIL_ON_MIN_SEVERITY|STRIX_FALLBACK_MODELS')"
+			source_detail="$source_detail; fallback anchored to Strix workflow because the report omitted a repository Code Location"
+		fi
+
+		finding_index=$((finding_index + 1))
+		printf '### %s. %s %s:%s - Strix report from %s: %s\n' "$finding_index" "${severity:-HIGH}" "$path" "$line" "$model" "$title"
+		printf -- '- Problem: Strix Security Scan failed and %s reported "%s" with severity %s. Endpoint: %s. Method: %s. Code location evidence: %s.\n' "$model" "$title" "${severity:-UNKNOWN}" "${endpoint:-N/A}" "${method:-N/A}" "$source_detail"
+		printf -- '- Root cause: The failed Strix evidence contains a distinct model vulnerability report, so OpenCode must not collapse it into provider-quota or generic check-failure text.\n'
+		printf -- '- Fix: Inspect and patch %s:%s for this exact report before approval; apply the remediation described by Strix for "%s" and keep the review finding tied to this line.\n' "$path" "$line" "$title"
+		printf -- '- Regression test: Add or update coverage that exercises the reported endpoint/path and proves the %s finding cannot recur.\n\n' "${severity:-Strix}"
+	done <"$reports_file"
+}
+
+emit_strix_provider_failure_finding() {
+	local strix_evidence_file="$1"
+	local match=""
+	local path=".github/workflows/strix.yml"
+	local line="1"
+
+	if ! grep -Eq "LLM CONNECTION FAILED|RateLimitError|Too many requests|budget limit|Configured model and fallback models were unavailable|provider infrastructure" "$strix_evidence_file"; then
+		return 0
+	fi
+
+	if [ -f "${REPO_ROOT%/}/$path" ]; then
+		match="$(grep -nE -- "^[[:space:]]*STRIX_FALLBACK_MODELS:" "${REPO_ROOT%/}/$path" | head -n 1 || true)"
+		if [ -n "$match" ]; then
+			line="${match%%:*}"
+		fi
+	fi
+
+	finding_index=$((finding_index + 1))
+	if grep -Fq "Strix vulnerability report window" "$strix_evidence_file"; then
+		printf '### %s. HIGH %s:%s - Strix provider signal left current-head security evidence incomplete\n' "$finding_index" "$path" "$line"
+		printf -- '- Problem: Strix produced one or more vulnerability report windows, then the failed log still reported provider infrastructure/failure-signal output such as LLM CONNECTION FAILED, RateLimitError, budget-limit, or fallback provider signal.\n'
+		printf -- '- Root cause: The scanner evidence is incomplete even after model reports were emitted; OpenCode must include every model report above and must not approve until a clean current-head Strix run or equivalent manual evidence exists.\n'
+		printf -- '- Fix: Re-run Strix after GitHub Models capacity recovers or run an explicitly configured manual provider evidence scan with valid credentials; keep %s:%s aligned with the approved fallback model list.\n' "$path" "$line"
+		printf -- '- Regression test: Keep failed-check evidence and validation covering provider-signal failures after vulnerability reports so partial reports cannot be downgraded to approval.\n\n'
+	else
+		printf '### %s. HIGH %s:%s - Strix provider quota blocked current-head security evidence\n' "$finding_index" "$path" "$line"
+		printf -- '- Problem: Strix failed before producing vulnerability reports. The failed log reported LLM CONNECTION FAILED, RateLimitError or Too many requests for the primary model, budget-limit output for the DeepSeek fallbacks, and Configured model and fallback models were unavailable.\n'
+		printf -- '- Root cause: The configured GitHub Models primary/fallback provider capacity or budget was exhausted for this run; no Strix Vulnerability Report window was produced, so there is no application source line to patch from this evidence.\n'
+		printf -- '- Fix: Do not approve from this failed scan. Re-run Strix after GitHub Models quota recovers or run an explicitly configured manual provider evidence scan with valid credentials; keep the configured fallback line at %s:%s aligned with the approved model list.\n' "$path" "$line"
+		printf -- '- Regression test: Keep the failed-check evidence collector preserving RateLimitError, budget-limit, provider infrastructure, and unavailable-model lines so OpenCode reviews can distinguish external provider blockers from code vulnerabilities.\n\n'
+	fi
+}
+
+emit_strix_cancelled_without_log_finding() {
+	local strix_evidence_file="$1"
+	local match=""
+	local path=".github/workflows/strix.yml"
+	local line="1"
+
+	if ! grep -Fq "Conclusion:" "$strix_evidence_file" ||
+		! grep -Fq "cancelled" "$strix_evidence_file" ||
+		! grep -Fq "No GitHub Actions job log is available for this failed workflow run." "$strix_evidence_file"; then
+		return 0
+	fi
+
+	if [ -f "${REPO_ROOT%/}/$path" ]; then
+		match="$(grep -nF -- "cancel-in-progress: false" "${REPO_ROOT%/}/$path" | head -n 1 || true)"
+		if [ -n "$match" ]; then
+			line="${match%%:*}"
+		fi
+	fi
+
+	finding_index=$((finding_index + 1))
+	printf '### %s. HIGH %s:%s - Current-head Strix evidence is missing because the workflow run was cancelled before logs\n' "$finding_index" "$path" "$line"
+	printf -- '- Problem: Strix Security Scan reported a current-head workflow_run conclusion of cancelled, but GitHub emitted no failed job log and no Strix Vulnerability Report window.\n'
+	printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This is a workflow execution/queue state, not an application vulnerability finding, so OpenCode must not invent a source-code fix.\n'
+	printf -- '- Fix: Do not approve from this cancelled run. Re-run the current-head Strix Security Scan after stale runs complete or are cancelled, then review the resulting job log; keep the workflow concurrency line at %s:%s so stale runs do not silently replace current-head evidence.\n' "$path" "$line"
+	printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log so reviewers see that the blocker is missing scanner evidence.\n\n'
+}
+
+strix_evidence_file="$(mktemp)"
+tmp_files+=("$strix_evidence_file")
+extract_strix_failed_check_block "$EVIDENCE_FILE" "$strix_evidence_file"
+
+emit_known_missing_string_finding \
+	"$EVIDENCE_FILE" \
+	"github.event.inputs.strix_llm || 'openai/gpt-5'" \
+	"Strix PR scans must default to GitHub Models GPT-5" \
+	".github/workflows/strix.yml" \
+	"scripts/ci/test_strix_quick_gate.sh"
+emit_known_missing_string_finding \
+	"$EVIDENCE_FILE" \
+	"STRIX_LLM must select GitHub Models openai/gpt-5 or newer, direct OpenAI GPT-5.4 or newer, or an approved organization Vertex AI model" \
+	"Strix unsupported-model errors must name the allowed providers" \
+	".github/workflows/strix.yml" \
+	"scripts/ci/test_strix_quick_gate.sh"
+emit_known_missing_string_finding \
+	"$EVIDENCE_FILE" \
+	"MODEL: github-models/openai/gpt-5" \
+	"OpenCode review must try GitHub Models GPT-5 first" \
+	".github/workflows/opencode-review.yml" \
+	"scripts/ci/test_strix_quick_gate.sh"
+
+emit_strix_report_findings "$strix_evidence_file"
+emit_strix_provider_failure_finding "$strix_evidence_file"
+emit_strix_cancelled_without_log_finding "$strix_evidence_file"
+
+if [ "$finding_index" -eq 0 ]; then
+	printf 'No deterministic missing-string markers or Strix report locations were recognized. Use the failed-check evidence below to map each failed check to exact local source lines before approving.\n\n'
+fi

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -455,6 +455,7 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" 'repo_root="${GITHUB_WORKSPACE:-$PWD}"' "opencode failed-check fallback maps source lines from the repository root"
 	assert_file_contains "$workflow_file" "Line-specific fallback findings" "opencode failed-check fallback publishes line-specific repair findings"
 	assert_file_contains "$workflow_file" "emit_opencode_failed_check_fallback_findings.sh" "opencode failed-check fallback delegates deterministic Strix report expansion to tested helper"
+	assert_file_contains "$workflow_file" "OpenCode failed-check fallback helper exited non-zero; using inline fallback." "opencode failed-check fallback handles helper failures without aborting under set -e"
 	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "emit_strix_report_findings" "failed-check fallback emits every Strix vulnerability report as a separate finding"
 	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "Strix provider signal left current-head security evidence incomplete" "failed-check fallback does not claim reports are absent after Strix emitted vulnerabilities"
 	assert_file_contains "$workflow_file" "- Root cause:" "opencode review request-changes body includes root cause per finding"

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -454,6 +454,9 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "emit_line_specific_fallback_findings" "opencode failed-check fallback maps known Strix failures to source lines"
 	assert_file_contains "$workflow_file" 'repo_root="${GITHUB_WORKSPACE:-$PWD}"' "opencode failed-check fallback maps source lines from the repository root"
 	assert_file_contains "$workflow_file" "Line-specific fallback findings" "opencode failed-check fallback publishes line-specific repair findings"
+	assert_file_contains "$workflow_file" "emit_opencode_failed_check_fallback_findings.sh" "opencode failed-check fallback delegates deterministic Strix report expansion to tested helper"
+	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "emit_strix_report_findings" "failed-check fallback emits every Strix vulnerability report as a separate finding"
+	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "Strix provider signal left current-head security evidence incomplete" "failed-check fallback does not claim reports are absent after Strix emitted vulnerabilities"
 	assert_file_contains "$workflow_file" "- Root cause:" "opencode review request-changes body includes root cause per finding"
 	assert_file_contains "$workflow_file" "- Regression test:" "opencode review request-changes body includes regression test direction per finding"
 	assert_file_contains "$workflow_file" "- Suggested diff:" "opencode review request-changes body includes suggested diff per finding"
@@ -803,6 +806,62 @@ EOF
 	rc=$?
 	set -e
 	assert_equals "0" "$rc" "failed-check review validator accepts Strix log-backed findings"
+
+	rm -rf "$tmp_dir"
+}
+
+assert_opencode_failed_check_fallback_emits_each_strix_report() {
+	local tmp_dir
+	local evidence_file
+	local output_file
+	tmp_dir="$(mktemp -d)"
+	evidence_file="$tmp_dir/failed-check-evidence.md"
+	output_file="$tmp_dir/fallback.md"
+
+	cat >"$evidence_file" <<'EOF'
+## Failed check: Strix Security Scan/strix
+
+### Failed log signal summary
+
+```text
+strix	Run Strix (quick)	LLM CONNECTION FAILED
+strix	Run Strix (quick)	Strix fallback model 'deepseek/deepseek-r1-0528' emitted provider infrastructure or failure-signal output; trying next configured fallback if available.
+```
+
+### Strix vulnerability report window 1
+
+Model deepseek/deepseek-r1-0528 Vulnerabilities 2
+│  Vulnerability Report                                                        │
+│  Title: Path Traversal in Email Attachment Handling                          │
+│  Severity: CRITICAL                                                          │
+│  Endpoint: /services/email_parser.py                                         │
+│    Location 1: backend/services/email_parser.py:60-72                        │
+│  Vulnerability Report                                                        │
+│  Title: Prompt Injection and XSS in AI Prompt Studio                         │
+│  Severity: HIGH                                                              │
+│  Endpoint: /prompt-studio                                                    │
+│    Location 1: frontend/src/app/prompt-studio/page.tsx:29-32                 │
+
+### Strix vulnerability report window 2
+
+Model deepseek/deepseek-v3-0324 Vulnerabilities 1
+│  Vulnerability Report                                                        │
+│  Title: Missing Content Security Policy in Next.js Frontend                  │
+│  Severity: HIGH                                                              │
+│  Endpoint: all frontend pages                                                │
+EOF
+
+	bash "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" \
+		"$evidence_file" "$REPO_ROOT" >"$output_file"
+
+	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-r1-0528: Path Traversal in Email Attachment Handling" "fallback includes first model report"
+	assert_file_contains "$output_file" "backend/services/email_parser.py:60" "fallback maps first report to exact source line"
+	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-r1-0528: Prompt Injection and XSS in AI Prompt Studio" "fallback includes second report from same model"
+	assert_file_contains "$output_file" "frontend/src/app/prompt-studio/page.tsx:29" "fallback maps second report to exact source line"
+	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-v3-0324: Missing Content Security Policy in Next.js Frontend" "fallback includes report from second model"
+	assert_file_contains "$output_file" "frontend/next.config.ts:10" "fallback derives a concrete CSP hardening line"
+	assert_file_contains "$output_file" "Strix provider signal left current-head security evidence incomplete" "fallback still reports provider failure after vulnerability reports"
+	assert_file_not_contains "$output_file" "failed before producing vulnerability reports" "fallback does not contradict preserved Strix report windows"
 
 	rm -rf "$tmp_dir"
 }
@@ -5199,6 +5258,8 @@ assert_opencode_review_gate_rejects_placeholder_findings
 assert_opencode_review_gate_rejects_non_source_backed_findings
 
 assert_opencode_failed_check_review_validator_rejects_unrelated_findings
+
+assert_opencode_failed_check_fallback_emits_each_strix_report
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \


### PR DESCRIPTION
## Summary
- add a deterministic OpenCode failed-check fallback helper that expands every Strix vulnerability report window into separate model/title/severity/path:line findings
- keep provider-signal failures distinct when Strix emitted reports, so reviews no longer say no vulnerability report existed after reports were preserved
- wire the OpenCode review workflow to the helper and make model-attempt fallbacks use explicit `review_status` outputs so successful runs do not contain hard error annotations from fallback paths
- add self-test and release-governance coverage for multi-model Strix reports and OpenCode fallback status handling

## Verification
- `PYTHONWARNINGS=error python -m pytest backend/tests/test_release_governance.py -q`
- `bash -n scripts/ci/emit_opencode_failed_check_fallback_findings.sh && bash -n scripts/ci/test_strix_quick_gate.sh`
- targeted multi-report fixture through `scripts/ci/emit_opencode_failed_check_fallback_findings.sh`, asserting separate deepseek/deepseek-r1-0528 and deepseek/deepseek-v3-0324 findings plus exact lines `backend/services/email_parser.py:60`, `frontend/src/app/prompt-studio/page.tsx:29`, `frontend/next.config.ts:10`
- `git diff --check`

## Notes
- Left unrelated local `.Jules/palette.md` changes unstaged.
- The broad `scripts/ci/test_strix_quick_gate.sh` harness was interrupted after several minutes of silent execution; the touched helper behavior was verified with the targeted fixture above.
