### PR TITLE
fix: pass compose runtime secrets explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN PIP_ROOT_USER_ACTION=ignore PIP_DISABLE_PIP_VERSION_CHECK=1 \
 # Copy Backend
 COPY backend /app/
 
+RUN useradd --system --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8000
 
 CMD ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]
@@ -43,6 +47,7 @@ RUN pnpm run build
 
 # Stage 3: Combined image (Python + Node.js)
 FROM backend-runtime
+USER root
 
 # Runtime Node is copied from the frontend builder so apt does not install a
 # distro Node package with noisy alternatives output.
@@ -60,10 +65,8 @@ COPY --from=frontend-builder /app/next.config.ts /app/frontend/next.config.ts
 # AUTH_SESSION_HMAC_SECRET, and a valid Fernet ENCRYPTION_KEY — never generated
 # at runtime), then starts backend and frontend together and reports which
 # service exits. Secrets must be supplied by the operator or orchestrator.
-RUN chmod +x /app/scripts/docker_entrypoint.sh
-
-# Create non-root user
-RUN useradd -m -s /bin/bash appuser && chown -R appuser:appuser /app
+RUN chmod +x /app/scripts/docker_entrypoint.sh \
+    && chown -R appuser:appuser /app/frontend /app/scripts/docker_entrypoint.sh
 USER appuser
 
 # Environment variables for Frontend proxying inside the combined image

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -157,6 +157,7 @@ MAX_SIGNED_SESSION_EXPIRATION_SECONDS = 12 * 60 * 60
 MAX_SIGNED_SESSION_CLOCK_SKEW_SECONDS = 60
 SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS = 60
 SESSION_AUTH_RATE_LIMIT_MAX_FAILURES = 10
+SESSION_AUTH_RATE_LIMIT_MAX_BUCKETS = 4096
 _session_auth_failure_buckets: dict[str, tuple[int, float]] = {}
 
 
@@ -315,6 +316,15 @@ def _prune_session_auth_failure_buckets(now: float) -> None:
         _session_auth_failure_buckets.pop(key, None)
 
 
+def _ensure_session_auth_failure_bucket_capacity(key: str) -> None:
+    if (
+        key in _session_auth_failure_buckets
+        or len(_session_auth_failure_buckets) < SESSION_AUTH_RATE_LIMIT_MAX_BUCKETS
+    ):
+        return
+    _session_auth_failure_buckets.pop(next(iter(_session_auth_failure_buckets)), None)
+
+
 def _reject_if_session_auth_rate_limited(token: str) -> None:
     now = time.monotonic()
     _prune_session_auth_failure_buckets(now)
@@ -331,6 +341,7 @@ def _record_session_auth_failure(token: str) -> None:
     now = time.monotonic()
     _prune_session_auth_failure_buckets(now)
     key = _session_auth_failure_key(token)
+    _ensure_session_auth_failure_bucket_capacity(key)
     failure_count, reset_at = _session_auth_failure_buckets.get(
         key,
         (0, now + SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS),

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,5 @@
 from http.client import HTTPSConnection
+import hashlib
 import json
 import logging
 import math
@@ -152,6 +153,11 @@ SESSION_ALLOWED_ALGORITHMS = (SESSION_SIGNING_ALGORITHM,)
 OIDC_ALLOWED_ALGORITHMS = (OIDC_SIGNING_ALGORITHM,)
 JWT_DECODE_REQUIRED_CLAIMS = ("exp", "iss", "aud")
 MIN_SESSION_SECRET_BYTES = 32
+MAX_SIGNED_SESSION_EXPIRATION_SECONDS = 12 * 60 * 60
+MAX_SIGNED_SESSION_CLOCK_SKEW_SECONDS = 60
+SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS = 60
+SESSION_AUTH_RATE_LIMIT_MAX_FAILURES = 10
+_session_auth_failure_buckets: dict[str, tuple[int, float]] = {}
 
 
 @dataclass(frozen=True)
@@ -295,11 +301,66 @@ def _extract_bearer_token(authorization: str | None) -> str:
     return token.strip()
 
 
+def _session_auth_failure_key(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _prune_session_auth_failure_buckets(now: float) -> None:
+    expired_keys = [
+        key
+        for key, (_failure_count, reset_at) in _session_auth_failure_buckets.items()
+        if reset_at <= now
+    ]
+    for key in expired_keys:
+        _session_auth_failure_buckets.pop(key, None)
+
+
+def _reject_if_session_auth_rate_limited(token: str) -> None:
+    now = time.monotonic()
+    _prune_session_auth_failure_buckets(now)
+    key = _session_auth_failure_key(token)
+    failure_count, _reset_at = _session_auth_failure_buckets.get(
+        key,
+        (0, now + SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS),
+    )
+    if failure_count >= SESSION_AUTH_RATE_LIMIT_MAX_FAILURES:
+        raise _authentication_error()
+
+
+def _record_session_auth_failure(token: str) -> None:
+    now = time.monotonic()
+    _prune_session_auth_failure_buckets(now)
+    key = _session_auth_failure_key(token)
+    failure_count, reset_at = _session_auth_failure_buckets.get(
+        key,
+        (0, now + SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS),
+    )
+    if reset_at <= now:
+        failure_count = 0
+        reset_at = now + SESSION_AUTH_RATE_LIMIT_WINDOW_SECONDS
+    _session_auth_failure_buckets[key] = (failure_count + 1, reset_at)
+
+
+def _clear_session_auth_failures(token: str) -> None:
+    _session_auth_failure_buckets.pop(_session_auth_failure_key(token), None)
+
+
 def _verify_signed_session_payload(
     authorization: str | None,
 ) -> tuple[dict[str, Any], SessionVerifier]:
     token = _extract_bearer_token(authorization)
+    _reject_if_session_auth_rate_limited(token)
 
+    try:
+        payload, session_verifier = _verify_signed_session_token(token)
+    except HTTPException:
+        _record_session_auth_failure(token)
+        raise
+    _clear_session_auth_failures(token)
+    return payload, session_verifier
+
+
+def _verify_signed_session_token(token: str) -> tuple[dict[str, Any], SessionVerifier]:
     # OIDC RS256 verification is authoritative when configured.
     if settings.OIDC_ISSUER_URL:
         if jwks_client is None:
@@ -395,8 +456,23 @@ def _validate_session_metadata(payload: dict[str, Any]) -> None:
         raise _authentication_error()
     if not math.isfinite(expires_at):
         raise _authentication_error()
-    if expires_at <= time.time():
+    now = time.time()
+    if expires_at <= now:
         raise _authentication_error()
+    if expires_at > now + MAX_SIGNED_SESSION_EXPIRATION_SECONDS:
+        raise _authentication_error()
+    issued_at = payload.get("iat")
+    if issued_at is not None:
+        if isinstance(issued_at, bool) or not isinstance(issued_at, (int, float)):
+            raise _authentication_error()
+        if not math.isfinite(issued_at):
+            raise _authentication_error()
+        if issued_at > now + MAX_SIGNED_SESSION_CLOCK_SKEW_SECONDS:
+            raise _authentication_error()
+        if expires_at <= issued_at:
+            raise _authentication_error()
+        if expires_at - issued_at > MAX_SIGNED_SESSION_EXPIRATION_SECONDS:
+            raise _authentication_error()
 
 
 def _auth_context_from_session_payload(

--- a/backend/core/runtime_secrets.py
+++ b/backend/core/runtime_secrets.py
@@ -1,8 +1,21 @@
 MIN_AUTH_SESSION_HMAC_SECRET_BYTES = 32
+MIN_AUTH_SESSION_HMAC_SECRET_UNIQUE_CHARS = 12
+MIN_AUTH_SESSION_HMAC_SECRET_CHARACTER_CLASSES = 3
 _LOW_ENTROPY_PLACEHOLDER_TERMS = ("change", "example", "password", "secret")
 _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS = frozenset(
     {"naruon-session-hmac-token-32-byte-minimum"}
 )
+
+
+def _character_class_count(secret: str) -> int:
+    return sum(
+        (
+            any(char.islower() for char in secret),
+            any(char.isupper() for char in secret),
+            any(char.isdigit() for char in secret),
+            any(not char.isalnum() for char in secret),
+        )
+    )
 
 
 def validate_auth_session_hmac_secret_value(secret: str) -> None:
@@ -22,3 +35,11 @@ def validate_auth_session_hmac_secret_value(secret: str) -> None:
         raise ValueError("AUTH_SESSION_HMAC_SECRET must not use a public fixture value")
     if any(term in normalized_secret for term in _LOW_ENTROPY_PLACEHOLDER_TERMS):
         raise ValueError("AUTH_SESSION_HMAC_SECRET must not contain placeholder terms")
+    if len(set(secret)) < MIN_AUTH_SESSION_HMAC_SECRET_UNIQUE_CHARS:
+        raise ValueError(
+            "AUTH_SESSION_HMAC_SECRET must contain at least 12 distinct characters"
+        )
+    if _character_class_count(secret) < MIN_AUTH_SESSION_HMAC_SECRET_CHARACTER_CLASSES:
+        raise ValueError(
+            "AUTH_SESSION_HMAC_SECRET must use at least three character classes"
+        )

--- a/backend/services/access_policy.py
+++ b/backend/services/access_policy.py
@@ -129,6 +129,8 @@ def evaluate_access(request: AccessRequest, resource: ResourcePolicy) -> AccessD
 
     owns_resource = request.user_id == resource.owner_id
     has_delegation = request.user_id in resource.delegated_user_ids
+    # Self-service resources set require_owner_match=True to disable privileged
+    # role owner bypasses for personal mailbox and provider credential surfaces.
     owner_match_required = resource.require_owner_match or not system_admin_allowed
     if owner_match_required and not owns_resource and not has_delegation:
         return AccessDecision(allowed=False, reason="ownership_denied")

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -16,6 +16,8 @@ from api.auth import (
     AuthContext,
     OIDC_ALLOWED_ALGORITHMS,
     SESSION_ALLOWED_ALGORITHMS,
+    SESSION_AUTH_RATE_LIMIT_MAX_FAILURES,
+    _session_auth_failure_buckets,
     ensure_organization_access,
     get_auth_context,
     get_current_user,
@@ -122,6 +124,7 @@ def restore_auth_flags():
     previous_runtime_environment = getattr(settings, "RUNTIME_ENVIRONMENT", None)
     previous_session_hmac_secret = getattr(settings, "AUTH_SESSION_HMAC_SECRET", None)
     previous_oidc_signing_keys = sys.modules["api.auth"]._cached_oidc_signing_keys
+    _session_auth_failure_buckets.clear()
     yield
     settings.DEBUG = previous_debug
     if previous_runtime_environment is not None:
@@ -129,6 +132,7 @@ def restore_auth_flags():
     if hasattr(settings, "AUTH_SESSION_HMAC_SECRET"):
         settings.AUTH_SESSION_HMAC_SECRET = previous_session_hmac_secret
     sys.modules["api.auth"]._cached_oidc_signing_keys = previous_oidc_signing_keys
+    _session_auth_failure_buckets.clear()
 
 
 def _set_runtime_environment(value: str) -> None:
@@ -466,6 +470,77 @@ async def test_signed_bearer_session_rejects_expired_token():
         await get_auth_context(authorization=f"Bearer {token}")
 
     assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_signed_bearer_session_rejects_excessive_expiration():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(exp=int(time.time()) + (13 * 60 * 60))
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_signed_bearer_session_rejects_future_issued_at():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(
+            iat=int(time.time()) + 120,
+            exp=int(time.time()) + 300,
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_signed_bearer_session_rejects_issued_at_after_expiration():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(
+        _valid_session_payload(
+            iat=int(time.time()) + 240,
+            exp=int(time.time()) + 120,
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization=f"Bearer {token}")
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_signed_bearer_session_rate_limits_repeated_invalid_token(monkeypatch):
+    from api import auth as auth_module
+
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    decode_attempts = 0
+
+    def reject_header(token: str):
+        nonlocal decode_attempts
+        decode_attempts += 1
+        raise auth_module.jwt.PyJWTError("invalid")
+
+    monkeypatch.setattr(auth_module.jwt, "get_unverified_header", reject_header)
+
+    for _attempt in range(SESSION_AUTH_RATE_LIMIT_MAX_FAILURES):
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization="Bearer invalid.jwt.token")
+        assert exc.value.status_code == 401
+
+    with pytest.raises(HTTPException) as exc:
+        await get_auth_context(authorization="Bearer invalid.jwt.token")
+
+    assert exc.value.status_code == 401
+    assert decode_attempts == SESSION_AUTH_RATE_LIMIT_MAX_FAILURES
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -544,6 +544,21 @@ async def test_signed_bearer_session_rate_limits_repeated_invalid_token(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_signed_bearer_session_failure_buckets_are_bounded(monkeypatch):
+    from api import auth as auth_module
+
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    monkeypatch.setattr(auth_module, "SESSION_AUTH_RATE_LIMIT_MAX_BUCKETS", 3)
+
+    for index in range(5):
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer invalid.jwt.token{index}")
+        assert exc.value.status_code == 401
+
+    assert len(_session_auth_failure_buckets) == 3
+
+
+@pytest.mark.asyncio
 async def test_signed_bearer_session_requires_strong_configured_secret():
     token = _signed_session_token(_valid_session_payload())
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -212,8 +212,16 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
 
     backend_block = compose.split("  backend:", 1)[1].split("  frontend:", 1)[0]
     assert "target: backend-runtime" in backend_block
-    assert "DEBUG=false" in backend_block
-    assert "DEBUG=true" not in backend_block
+    assert 'DEBUG: "false"' in backend_block
+    assert "DEBUG: true" not in backend_block
+    assert (
+        "DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/ai_email"
+        in backend_block
+    )
+    assert "AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET}" in backend_block
+    assert "ENCRYPTION_KEY: ${ENCRYPTION_KEY}" in backend_block
+    assert "- AUTH_SESSION_HMAC_SECRET" not in backend_block
+    assert "- ENCRYPTION_KEY" not in backend_block
     assert "python scripts/bootstrap_db.py && python scripts/start_backend.py" in compose
     assert '"scripts/start_backend.py"' in live_e2e_compose
     assert "Dockerfile.ollama" in live_e2e_compose

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -186,7 +186,19 @@ def test_backend_dockerfile_uses_modern_env_syntax() -> None:
     assert "secrets.token_hex" not in dockerfile
     assert "ENV DATABASE_URL=" not in dockerfile
     assert '"/app/scripts/docker_entrypoint.sh"' in dockerfile
-    assert "RUN chmod +x /app/scripts/docker_entrypoint.sh" in dockerfile
+    assert (
+        "RUN chmod +x /app/scripts/docker_entrypoint.sh \\\n"
+        "    && chown -R appuser:appuser /app/frontend /app/scripts/docker_entrypoint.sh"
+        in dockerfile
+    )
+    assert "useradd --system --create-home --home-dir /home/appuser" in dockerfile
+    backend_cmd = (
+        'CMD ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]'
+    )
+    assert dockerfile.find("USER appuser") < dockerfile.find(backend_cmd)
+    assert dockerfile.rfind("USER appuser") < dockerfile.find(
+        'CMD ["/app/scripts/docker_entrypoint.sh"]'
+    )
     assert "COPY scripts/start_combined.sh" not in dockerfile
     assert "RUN echo '#!/bin/bash" not in dockerfile
     assert "uvicorn" not in dockerfile.split("CMD", 1)[1]

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -19,6 +19,19 @@ def test_backend_dockerfile_suppresses_pip_root_warning():
     assert "PIP_DISABLE_PIP_VERSION_CHECK=1" in dockerfile
 
 
+def test_backend_dockerfile_runtime_stages_run_as_non_root_user():
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+    backend_cmd = (
+        'CMD ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]'
+    )
+    combined_cmd = 'CMD ["/app/scripts/docker_entrypoint.sh"]'
+
+    assert "useradd --system --create-home --home-dir /home/appuser" in dockerfile
+    assert "chown -R appuser:appuser /app" in dockerfile
+    assert dockerfile.find("USER appuser") < dockerfile.find(backend_cmd)
+    assert dockerfile.rfind("USER appuser") < dockerfile.find(combined_cmd)
+
+
 def test_frontend_dockerfile_runs_as_non_root_user():
     dockerfile = (REPO_ROOT / "frontend" / "Dockerfile").read_text()
 

--- a/backend/tests/test_repo_hygiene.py
+++ b/backend/tests/test_repo_hygiene.py
@@ -99,17 +99,23 @@ def test_compose_externalizes_postgres_credentials():
 
     assert "POSTGRES_PASSWORD: postgres" not in compose
     assert "postgres:postgres@" not in compose
-    assert "POSTGRES_DB=ai_email" in compose
-    assert "POSTGRES_USER=postgres" in compose
+    assert "POSTGRES_DB: ai_email" in compose
+    assert "POSTGRES_USER: postgres" in compose
+    assert "POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}" in compose
+    assert "- POSTGRES_PASSWORD" not in compose
     assert "POSTGRES_PASSWORD:-postgres" not in compose
     assert "${POSTGRES_PASSWORD" in compose
     assert "${POSTGRES_PASSWORD:?" not in compose_without_runtime_preflights
     assert '$${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env before running Docker Compose}' in compose
     assert "127.0.0.1:15432:5432" in compose
     assert "AUTH_SESSION_HMAC_SECRET" in compose
+    assert "AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET}" in compose
+    assert "- AUTH_SESSION_HMAC_SECRET" not in compose
     assert "${AUTH_SESSION_HMAC_SECRET:?" not in compose_without_runtime_preflights
     assert '$${AUTH_SESSION_HMAC_SECRET:?Set AUTH_SESSION_HMAC_SECRET in .env before running Docker Compose}' in compose
     assert "ENCRYPTION_KEY" in compose
+    assert "ENCRYPTION_KEY: ${ENCRYPTION_KEY}" in compose
+    assert "- ENCRYPTION_KEY" not in compose
     assert "${ENCRYPTION_KEY:?" not in compose_without_runtime_preflights
     assert '$${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env before running Docker Compose}' in compose
 
@@ -138,6 +144,7 @@ def test_compose_allows_only_the_local_ollama_provider_host():
         assert has_exact_compose_line(
             compose,
             'ALLOWED_LLM_BASE_URL_HOSTS: "ollama"',
+            "ALLOWED_LLM_BASE_URL_HOSTS: ollama",
             "ALLOWED_LLM_BASE_URL_HOSTS=ollama",
         )
         assert has_exact_compose_line(

--- a/backend/tests/test_runtime_secrets.py
+++ b/backend/tests/test_runtime_secrets.py
@@ -2,23 +2,39 @@ import pytest
 from core.runtime_secrets import (
     validate_auth_session_hmac_secret_value,
     _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS,
-    _LOW_ENTROPY_PLACEHOLDER_TERMS
+    _LOW_ENTROPY_PLACEHOLDER_TERMS,
 )
+
 
 def test_validate_auth_session_hmac_secret_value_valid():
     validate_auth_session_hmac_secret_value("thisisaverylongandsecurestring123!")
 
+
 def test_validate_auth_session_hmac_secret_value_empty():
-    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+    with pytest.raises(
+        ValueError,
+        match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes",
+    ):
         validate_auth_session_hmac_secret_value("")
-    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+    with pytest.raises(
+        ValueError,
+        match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes",
+    ):
         validate_auth_session_hmac_secret_value(None)
 
+
 def test_validate_auth_session_hmac_secret_value_short():
-    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+    with pytest.raises(
+        ValueError,
+        match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes",
+    ):
         validate_auth_session_hmac_secret_value("short")
-    with pytest.raises(ValueError, match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes"):
+    with pytest.raises(
+        ValueError,
+        match="AUTH_SESSION_HMAC_SECRET must be at least 32 bytes",
+    ):
         validate_auth_session_hmac_secret_value("a" * 31)
+
 
 def test_validate_auth_session_hmac_secret_value_repeated():
     with pytest.raises(ValueError, match="must not be a repeated character"):
@@ -26,12 +42,28 @@ def test_validate_auth_session_hmac_secret_value_repeated():
     with pytest.raises(ValueError, match="must not be a repeated character"):
         validate_auth_session_hmac_secret_value("1" * 64)
 
+
+def test_validate_auth_session_hmac_secret_value_rejects_low_diversity():
+    with pytest.raises(ValueError, match="at least 12 distinct characters"):
+        validate_auth_session_hmac_secret_value("abcabcabcabcabcabcabcabcabcabcab")
+    with pytest.raises(ValueError, match="at least three character classes"):
+        validate_auth_session_hmac_secret_value("abcdefghijklmnopqrstuvwxyzabcdef")
+
+
 def test_validate_auth_session_hmac_secret_value_public_fixture():
     for public_fixture in _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS:
         with pytest.raises(ValueError, match="must not use a public fixture value"):
             validate_auth_session_hmac_secret_value(public_fixture)
 
+
 def test_validate_auth_session_hmac_secret_value_placeholder():
     for term in _LOW_ENTROPY_PLACEHOLDER_TERMS:
         with pytest.raises(ValueError, match="must not contain placeholder terms"):
-            validate_auth_session_hmac_secret_value(f"this_is_a_sufficiently_long_prefix_for_testing_purposes_{term}")
+            validate_auth_session_hmac_secret_value(
+                f"this_is_a_sufficiently_long_prefix_for_testing_purposes_{term}"
+            )
+
+
+def test_validate_auth_session_hmac_secret_value_rejects_strix_fixture():
+    with pytest.raises(ValueError, match="placeholder terms"):
+        validate_auth_session_hmac_secret_value("NaRuOnSeCrEtToKeN1234567890abcdef")

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -267,28 +267,6 @@ def test_legacy_tenant_config_endpoint_keeps_organization_scope(
     assert ("shared_user", "org-rival") in mock_db.objects
 
 
-@pytest.mark.parametrize(
-    "admin_role", ("system_admin", "platform_admin", "tenant_admin")
-)
-def test_tenant_config_post_stays_user_owned_even_for_admin_headers(
-    client, admin_role
-):
-    response = client.post(
-        "/api/config",
-        json={"user_id": "member-user", "smtp_server": "smtp.example.com"},
-        headers={
-            "X-User-Id": "admin",
-            "X-User-Role": admin_role,
-            "X-Organization-Id": "org-acme",
-        },
-    )
-
-    assert response.status_code == 403
-    assert response.json() == {
-        "detail": "Mailbox settings are personal and can only be managed by the authenticated user"
-    }
-
-
 def test_tenant_config_rejects_private_smtp_host(client):
     response = client.post(
         "/api/config",

--- a/backend/tests/test_tenant_config_api.py
+++ b/backend/tests/test_tenant_config_api.py
@@ -481,6 +481,26 @@ def test_tenant_config_get_rejects_cross_user_admin_access(client, admin_role):
     }
 
 
+@pytest.mark.parametrize(
+    "admin_role", ("system_admin", "platform_admin", "tenant_admin")
+)
+def test_tenant_config_post_rejects_cross_user_admin_access(client, admin_role):
+    response = client.post(
+        "/api/config",
+        json={"user_id": "member-user"},
+        headers={
+            "X-User-Id": "admin",
+            "X-User-Role": admin_role,
+            "X-Organization-Id": "org-acme",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Mailbox settings are personal and can only be managed by the authenticated user"
+    }
+
+
 @pytest.mark.parametrize("role", ("group_admin", "member"))
 def test_global_config_requires_admin(client, role):
     response = client.get(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   db:
     image: pgvector/pgvector:pg16
     environment:
-      - POSTGRES_DB=ai_email
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD
+      POSTGRES_DB: ai_email
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     entrypoint:
       - sh
       - -c
@@ -36,16 +36,16 @@ services:
       dockerfile: Dockerfile
       target: backend-runtime
     environment:
-      - DATABASE_URL=postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/ai_email
-      - DEBUG=false
-      - ALLOW_LOCAL_LLM_PROVIDERS=true
-      - ALLOWED_LLM_BASE_URL_HOSTS=ollama
-      - AUTH_SESSION_HMAC_SECRET
-      - ENCRYPTION_KEY
-      - OPENAI_API_KEY=ollama
-      - OPENAI_BASE_URL=http://ollama:11434/v1
-      - OPENAI_EMBEDDING_MODEL=embeddinggemma
-      - OPENAI_MODEL=gemma4:e2b-it-qat
+      DATABASE_URL: postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/ai_email
+      DEBUG: "false"
+      ALLOW_LOCAL_LLM_PROVIDERS: "true"
+      ALLOWED_LLM_BASE_URL_HOSTS: ollama
+      AUTH_SESSION_HMAC_SECRET: ${AUTH_SESSION_HMAC_SECRET}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      OPENAI_API_KEY: ollama
+      OPENAI_BASE_URL: http://ollama:11434/v1
+      OPENAI_EMBEDDING_MODEL: embeddinggemma
+      OPENAI_MODEL: gemma4:e2b-it-qat
     depends_on:
       db:
         condition: service_healthy

--- a/docs/assessment/cloud-native-deployability-assessment.md
+++ b/docs/assessment/cloud-native-deployability-assessment.md
@@ -165,7 +165,7 @@ graph LR
 
 | 영역 | 점검 내용 |
 |--------|--------|
-| Dockerfile | 루트 실행. (`useradd`가 Dockerfile 하단에 있으나, 프론트엔드는 확인 필요. K8s 매니페스트 내 `SecurityContext`로 강제하지 않음) |
+| Dockerfile | 백엔드/통합/프론트엔드 이미지 모두 non-root 사용자로 실행됨. K8s 매니페스트 내 `SecurityContext` 강제는 별도 보완 필요 |
 | Container | `readOnlyRootFilesystem`, `capabilities drop` 여부: **없음** |
 | Dependency | Dependabot 설정 등 명시적 구성 확인 안 됨 (`.github/dependabot.yml` 없음) |
 | SAST | `bandit.yml`, `strix.yml` (Security Scan) 등 사용 확인됨 |

--- a/frontend/src/app/api/[...path]/route.test.ts
+++ b/frontend/src/app/api/[...path]/route.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST, PUT } from "./route";
 
 const ORIGINAL_ENV = { ...process.env };
-const SIGNED_SESSION_TOKEN = "signed-session-token";
+const SIGNED_SESSION_TOKEN = "signed.session.token";
 
 describe("/api runtime proxy route", () => {
   beforeEach(() => {
@@ -54,7 +54,7 @@ describe("/api runtime proxy route", () => {
 
     await expect(response.json()).resolves.toEqual({
       target_url: "https://api.naruon.net/api/tasks?limit=1",
-      auth_header: "Bearer signed-session-token",
+      auth_header: "Bearer signed.session.token",
       cookie_header: null,
       user_header: null,
       request_body: '{"state":"open"}',

--- a/frontend/src/app/auth/session/route.test.ts
+++ b/frontend/src/app/auth/session/route.test.ts
@@ -49,12 +49,18 @@ describe("/auth/session route", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const response = await POST(new NextRequest("https://app.naruon.net/auth/session", {
-      method: "POST",
-      body: JSON.stringify({ access_token: token }),
-    }));
+    const response = await POST(
+      new NextRequest("https://app.naruon.net/auth/session", {
+        method: "POST",
+        headers: {
+          Cookie: "naruon_session=attacker-fixed-session",
+        },
+        body: JSON.stringify({ access_token: token }),
+      }),
+    );
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     await expect(response.json()).resolves.toEqual({
       authenticated: true,
       claims: {
@@ -68,7 +74,9 @@ describe("/auth/session route", () => {
     expect(setCookie).toContain("HttpOnly");
     expect(setCookie).toContain("Secure");
     expect(setCookie).toContain("SameSite=lax");
+    expect(setCookie).toContain("Max-Age=43200");
     expect(setCookie).not.toContain("access_token");
+    expect(setCookie).not.toContain("attacker-fixed-session");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -102,6 +110,7 @@ describe("/auth/session route", () => {
         workspaceId: "workspace-beta",
       },
     });
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("set-cookie")).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -181,6 +190,7 @@ describe("/auth/session route", () => {
     }));
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     const setCookie = response.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("naruon_session=");
     expect(setCookie).toContain("Max-Age=0");

--- a/frontend/src/app/auth/session/route.test.ts
+++ b/frontend/src/app/auth/session/route.test.ts
@@ -139,17 +139,36 @@ describe("/auth/session route", () => {
     expect(response.headers.get("set-cookie")).toBeNull();
   });
 
-  it("rejects backend session responses without organization scope", async () => {
+  it.each([
+    [
+      "user",
+      {
+        organization_id: "org-acme",
+        workspace_id: "workspace-acme",
+      },
+    ],
+    [
+      "organization",
+      {
+        user_id: "user-1",
+        workspace_id: "workspace-acme",
+      },
+    ],
+    [
+      "workspace",
+      {
+        user_id: "user-1",
+        organization_id: "org-acme",
+      },
+    ],
+  ])("rejects backend session responses without %s scope", async (_scope, body) => {
     const token = signedFixtureToken({
       sub: "user-1",
       org: "org-acme",
       workspace: "workspace-acme",
       exp: Math.floor(Date.now() / 1000) + 300,
     });
-    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
-      user_id: "user-1",
-      workspace_id: "workspace-acme",
-    })));
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(body)));
 
     const response = await POST(new NextRequest("https://app.naruon.net/auth/session", {
       method: "POST",
@@ -157,10 +176,61 @@ describe("/auth/session route", () => {
     }));
 
     expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     await expect(response.json()).resolves.toEqual({
       error_code: "invalid_session_token",
     });
     expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("rejects non-JWT session token formats before backend verification", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(new NextRequest("https://app.naruon.net/auth/session", {
+      method: "POST",
+      body: JSON.stringify({ access_token: "<script>alert(1)</script>" }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error_code: "invalid_session_token",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rate limits repeated session verification attempts before backend fanout", async () => {
+    const token = signedFixtureToken({
+      sub: "rate-limited-user",
+      org: "org-acme",
+      workspace: "workspace-acme",
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+    const fetchMock = vi.fn(async () => verifiedSessionResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await POST(new NextRequest("https://app.naruon.net/auth/session", {
+        method: "POST",
+        body: JSON.stringify({ access_token: token }),
+      }));
+
+      expect(response.status).toBe(200);
+    }
+
+    const response = await POST(new NextRequest("https://app.naruon.net/auth/session", {
+      method: "POST",
+      body: JSON.stringify({ access_token: token }),
+    }));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("retry-after")).toMatch(/^[1-9][0-9]*$/);
+    await expect(response.json()).resolves.toEqual({
+      error_code: "session_verification_rate_limited",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(10);
   });
 
   it("rejects cross-site session persistence before backend verification", async () => {

--- a/frontend/src/app/auth/session/route.ts
+++ b/frontend/src/app/auth/session/route.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { NextRequest, NextResponse } from "next/server";
 
 import {
@@ -18,6 +20,16 @@ const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const NO_STORE_HEADERS = {
   "Cache-Control": "no-store",
 };
+const SESSION_VERIFICATION_RATE_LIMIT_WINDOW_MS = 60_000;
+const SESSION_VERIFICATION_RATE_LIMIT_MAX_ATTEMPTS = 10;
+const SESSION_VERIFICATION_RATE_LIMIT_MAX_BUCKETS = 4096;
+
+type SessionVerificationBucket = {
+  count: number;
+  resetAt: number;
+};
+
+const sessionVerificationBuckets = new Map<string, SessionVerificationBucket>();
 
 function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!STATE_CHANGING_METHODS.has(request.method.toUpperCase())) return true;
@@ -44,7 +56,76 @@ function csrfRejectedResponse() {
     {
       status: 403,
       headers: {
+        ...NO_STORE_HEADERS,
         "Referrer-Policy": "no-referrer",
+      },
+    },
+  );
+}
+
+function sessionVerificationKey(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function pruneSessionVerificationBuckets(now: number) {
+  for (const [key, bucket] of sessionVerificationBuckets) {
+    if (bucket.resetAt <= now) {
+      sessionVerificationBuckets.delete(key);
+    }
+  }
+}
+
+function ensureSessionVerificationBucketCapacity(key: string) {
+  if (
+    sessionVerificationBuckets.has(key) ||
+    sessionVerificationBuckets.size < SESSION_VERIFICATION_RATE_LIMIT_MAX_BUCKETS
+  ) {
+    return;
+  }
+
+  const oldestKey = sessionVerificationBuckets.keys().next().value;
+  if (oldestKey) {
+    sessionVerificationBuckets.delete(oldestKey);
+  }
+}
+
+function recordSessionVerificationAttempt(token: string):
+  | { limited: false }
+  | { limited: true; retryAfterSeconds: number } {
+  const now = Date.now();
+  pruneSessionVerificationBuckets(now);
+
+  const key = sessionVerificationKey(token);
+  const bucket = sessionVerificationBuckets.get(key);
+  if (bucket && bucket.count >= SESSION_VERIFICATION_RATE_LIMIT_MAX_ATTEMPTS) {
+    return {
+      limited: true,
+      retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+
+  ensureSessionVerificationBucketCapacity(key);
+  const nextBucket =
+    bucket && bucket.resetAt > now
+      ? { count: bucket.count + 1, resetAt: bucket.resetAt }
+      : {
+          count: 1,
+          resetAt: now + SESSION_VERIFICATION_RATE_LIMIT_WINDOW_MS,
+        };
+  sessionVerificationBuckets.set(key, nextBucket);
+  return { limited: false };
+}
+
+function sessionRateLimitedResponse(retryAfterSeconds: number) {
+  return NextResponse.json(
+    { error_code: "session_verification_rate_limited" },
+    {
+      status: 429,
+      headers: {
+        ...NO_STORE_HEADERS,
+        "Retry-After": String(retryAfterSeconds),
+        "X-RateLimit-Limit": String(SESSION_VERIFICATION_RATE_LIMIT_MAX_ATTEMPTS),
+        "X-RateLimit-Remaining": "0",
       },
     },
   );
@@ -125,7 +206,7 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json(
       { error_code: "invalid_session_request" },
-      { status: 400 },
+      { status: 400, headers: NO_STORE_HEADERS },
     );
   }
 
@@ -137,14 +218,19 @@ export async function POST(request: NextRequest) {
   if (!accessToken) {
     return NextResponse.json(
       { error_code: "invalid_session_token" },
-      { status: 400 },
+      { status: 400, headers: NO_STORE_HEADERS },
     );
   }
+  const rateLimit = recordSessionVerificationAttempt(accessToken);
+  if (rateLimit.limited) {
+    return sessionRateLimitedResponse(rateLimit.retryAfterSeconds);
+  }
+
   const claims = await verifySessionToken(accessToken);
   if (!claims) {
     return NextResponse.json(
       { error_code: "invalid_session_token" },
-      { status: 401 },
+      { status: 401, headers: NO_STORE_HEADERS },
     );
   }
 

--- a/frontend/src/app/auth/session/route.ts
+++ b/frontend/src/app/auth/session/route.ts
@@ -15,6 +15,9 @@ export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+};
 
 function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!STATE_CHANGING_METHODS.has(request.method.toUpperCase())) return true;
@@ -108,7 +111,7 @@ function sessionJson(claims: SessionClaims | null) {
 export async function GET(request: NextRequest) {
   const token = normalizeSessionToken(request.cookies.get(SESSION_COOKIE_NAME)?.value);
   const claims = token ? await verifySessionToken(token) : null;
-  return NextResponse.json(sessionJson(claims));
+  return NextResponse.json(sessionJson(claims), { headers: NO_STORE_HEADERS });
 }
 
 export async function POST(request: NextRequest) {
@@ -145,7 +148,11 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const response = NextResponse.json(sessionJson(claims));
+  const response = NextResponse.json(sessionJson(claims), {
+    headers: NO_STORE_HEADERS,
+  });
+  // Do not promote an existing browser cookie; install only the backend-verified
+  // bearer session supplied in this request, replacing any previous session id.
   response.cookies.set(buildSessionCookieOptions(accessToken));
   return response;
 }
@@ -155,7 +162,7 @@ export async function DELETE(request: NextRequest) {
     return csrfRejectedResponse();
   }
 
-  const response = NextResponse.json(sessionJson(null));
+  const response = NextResponse.json(sessionJson(null), { headers: NO_STORE_HEADERS });
   response.cookies.set(buildExpiredSessionCookieOptions());
   return response;
 }

--- a/frontend/src/components/EmailList.test.tsx
+++ b/frontend/src/components/EmailList.test.tsx
@@ -123,7 +123,7 @@ describe("EmailList", () => {
 
   it("shows search loading feedback and clears the query back to inbox results", async () => {
     let resolveSearch: ((value: ReturnType<typeof jsonResponse>) => void) | null = null;
-    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/api/search")) {
         return new Promise((resolve) => {

--- a/frontend/src/components/NetworkGraph.test.tsx
+++ b/frontend/src/components/NetworkGraph.test.tsx
@@ -95,6 +95,41 @@ describe("NetworkGraph", () => {
     expect((edgeTitle as HTMLElement).innerHTML).not.toContain("<img");
   });
 
+  it("escapes graph labels before passing them to vis-network or text summaries", async () => {
+    const maliciousLabel = '<img src=x onerror="globalThis.__xss = true">';
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          nodes: [{ id: "n1", label: maliciousLabel, title: "Node" }],
+          edges: [{ from: "n1", to: "n1" }],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<NetworkGraph />);
+    });
+    await flushAsyncWork();
+
+    expect(Network).toHaveBeenCalledTimes(1);
+    const networkData = vi.mocked(Network).mock.calls[0]?.[1];
+    const nodes = Array.isArray(networkData?.nodes) ? networkData.nodes : [];
+
+    expect(nodes[0]?.label).toBe(
+      '&lt;img src=x onerror=&quot;globalThis.__xss = true&quot;&gt;',
+    );
+    expect(nodes[0]?.label).not.toContain("<img");
+    expect(container.innerHTML).not.toContain("<img");
+    expect(container.textContent).toContain(
+      '&lt;img src=x onerror=&quot;globalThis.__xss = true&quot;&gt;',
+    );
+  });
+
   it("renders a Korean text fallback for graph relationships", async () => {
     const fetchMock = vi.fn(() =>
       Promise.resolve(

--- a/frontend/src/components/NetworkGraph.test.tsx
+++ b/frontend/src/components/NetworkGraph.test.tsx
@@ -95,7 +95,7 @@ describe("NetworkGraph", () => {
     expect((edgeTitle as HTMLElement).innerHTML).not.toContain("<img");
   });
 
-  it("escapes graph labels before passing them to vis-network or text summaries", async () => {
+  it("escapes graph labels before passing them to vis-network while keeping React text plain", async () => {
     const maliciousLabel = '<img src=x onerror="globalThis.__xss = true">';
     const fetchMock = vi.fn(() =>
       Promise.resolve(
@@ -125,9 +125,7 @@ describe("NetworkGraph", () => {
     );
     expect(nodes[0]?.label).not.toContain("<img");
     expect(container.innerHTML).not.toContain("<img");
-    expect(container.textContent).toContain(
-      '&lt;img src=x onerror=&quot;globalThis.__xss = true&quot;&gt;',
-    );
+    expect(container.textContent).toContain(maliciousLabel);
   });
 
   it("renders a Korean text fallback for graph relationships", async () => {

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -58,15 +58,21 @@ function escapeGraphLabel(value: unknown): string {
 function sanitizeGraphItem<T extends Node | Edge>(item: T): T {
   const sanitized = { ...item };
 
-  if (Object.prototype.hasOwnProperty.call(item, 'label')) {
-    sanitized.label = escapeGraphLabel(item.label);
-  }
-
   if (Object.prototype.hasOwnProperty.call(item, 'title')) {
     sanitized.title = textOnlyTooltip(item.title);
   }
 
   return sanitized;
+}
+
+function escapeVisNetworkLabels<T extends Node | Edge>(items: T[]): T[] {
+  return items.map((item) => {
+    if (!Object.prototype.hasOwnProperty.call(item, 'label')) return item;
+    return {
+      ...item,
+      label: escapeGraphLabel(item.label),
+    };
+  });
 }
 
 function isGraphId(value: unknown): value is number | string {
@@ -127,7 +133,10 @@ export default function NetworkGraph() {
   useEffect(() => {
     if (containerRef.current && nodes.length > 0) {
       const container = containerRef.current;
-      const network = new Network(container, { nodes, edges }, {
+      const network = new Network(container, {
+        nodes: escapeVisNetworkLabels(nodes),
+        edges: escapeVisNetworkLabels(edges),
+      }, {
         nodes: { shape: 'dot', size: 16 },
         edges: { arrows: 'to' }
       });

--- a/frontend/src/components/NetworkGraph.tsx
+++ b/frontend/src/components/NetworkGraph.tsx
@@ -39,8 +39,28 @@ function textOnlyTooltip(value: unknown): HTMLElement {
   return tooltip;
 }
 
+const HTML_TEXT_ESCAPE_PATTERN = /[&<>"']/g;
+const HTML_TEXT_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeGraphLabel(value: unknown): string {
+  return String(value ?? '').replace(
+    HTML_TEXT_ESCAPE_PATTERN,
+    (character) => HTML_TEXT_ESCAPES[character] ?? character,
+  );
+}
+
 function sanitizeGraphItem<T extends Node | Edge>(item: T): T {
   const sanitized = { ...item };
+
+  if (Object.prototype.hasOwnProperty.call(item, 'label')) {
+    sanitized.label = escapeGraphLabel(item.label);
+  }
 
   if (Object.prototype.hasOwnProperty.call(item, 'title')) {
     sanitized.title = textOnlyTooltip(item.title);

--- a/frontend/src/lib/backend-url.test.ts
+++ b/frontend/src/lib/backend-url.test.ts
@@ -81,14 +81,15 @@ describe("backend URL guard", () => {
     // since Node.js newer URL parser rejects `https:///` and similar.
     const originalURL = global.URL;
     try {
-      global.URL = class extends URL {
+      const MockURL = class extends URL {
         constructor(input: string | URL, base?: string | URL) {
           super(input, base);
           if (input === "https:///empty") {
             Object.defineProperty(this, "hostname", { get: () => "" });
           }
         }
-      } as any;
+      };
+      global.URL = MockURL as unknown as typeof URL;
       expect(() => parseBackendInternalUrl("https:///empty")).toThrow(
         "BACKEND_INTERNAL_URL must include a hostname",
       );

--- a/frontend/src/lib/runtime-config.test.ts
+++ b/frontend/src/lib/runtime-config.test.ts
@@ -6,8 +6,8 @@ describe("fetchRuntimeConfig", () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    const module = await import("./runtime-config");
-    fetchRuntimeConfig = module.fetchRuntimeConfig;
+    const runtimeConfigModule = await import("./runtime-config");
+    fetchRuntimeConfig = runtimeConfigModule.fetchRuntimeConfig;
   });
 
   afterEach(() => {
@@ -71,8 +71,8 @@ describe("fetchRuntimeConfig", () => {
   });
 
   it("returns the in-flight promise if a fetch is already in progress", async () => {
-    let resolveJson: (value: any) => void;
-    const jsonPromise = new Promise((resolve) => {
+    let resolveJson: (value: RuntimeConfig) => void;
+    const jsonPromise = new Promise<RuntimeConfig>((resolve) => {
       resolveJson = resolve;
     });
 

--- a/frontend/src/lib/session-cookie.test.ts
+++ b/frontend/src/lib/session-cookie.test.ts
@@ -7,8 +7,8 @@ describe("normalizeSessionToken", () => {
     expect(normalizeSessionToken(" header.payload.signature ")).toBe(
       "header.payload.signature",
     );
-    expect(normalizeSessionToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig-123_abc")).toBe(
-      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig-123_abc",
+    expect(normalizeSessionToken("hdr_segment.payload_segment.sig_segment")).toBe(
+      "hdr_segment.payload_segment.sig_segment",
     );
   });
 

--- a/frontend/src/lib/session-cookie.test.ts
+++ b/frontend/src/lib/session-cookie.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSessionToken } from "./session-cookie";
+
+describe("normalizeSessionToken", () => {
+  it("accepts compact JWT-shaped bearer session tokens", () => {
+    expect(normalizeSessionToken(" header.payload.signature ")).toBe(
+      "header.payload.signature",
+    );
+    expect(normalizeSessionToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig-123_abc")).toBe(
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig-123_abc",
+    );
+  });
+
+  it("rejects empty, control-character, oversized, and non-JWT token values", () => {
+    expect(normalizeSessionToken("")).toBeNull();
+    expect(normalizeSessionToken("signed-session-token")).toBeNull();
+    expect(normalizeSessionToken("header.payload")).toBeNull();
+    expect(normalizeSessionToken("header.payload.signature.extra")).toBeNull();
+    expect(normalizeSessionToken("<script>alert(1)</script>")).toBeNull();
+    expect(normalizeSessionToken("header.pay\nload.signature")).toBeNull();
+    expect(normalizeSessionToken("a".repeat(4097))).toBeNull();
+    expect(normalizeSessionToken(null)).toBeNull();
+  });
+});

--- a/frontend/src/lib/session-cookie.ts
+++ b/frontend/src/lib/session-cookie.ts
@@ -5,6 +5,7 @@ export interface SessionClaims {
 }
 
 export const SESSION_COOKIE_NAME = "naruon_session";
+export const SESSION_COOKIE_MAX_AGE_SECONDS = 12 * 60 * 60;
 export const ANONYMOUS_SESSION_CLAIMS: SessionClaims = {
   userId: null,
   organizationId: null,
@@ -31,6 +32,7 @@ export function buildSessionCookieOptions(token: string) {
     secure: true,
     sameSite: "lax" as const,
     path: "/",
+    maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
   };
 }
 

--- a/frontend/src/lib/session-cookie.ts
+++ b/frontend/src/lib/session-cookie.ts
@@ -14,6 +14,7 @@ export const ANONYMOUS_SESSION_CLAIMS: SessionClaims = {
 
 const MAX_SESSION_TOKEN_LENGTH = 4096;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const COMPACT_JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
 export function normalizeSessionToken(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -21,6 +22,7 @@ export function normalizeSessionToken(value: unknown): string | null {
   if (!token) return null;
   if (token.length > MAX_SESSION_TOKEN_LENGTH) return null;
   if (CONTROL_CHARACTER_PATTERN.test(token)) return null;
+  if (!COMPACT_JWT_PATTERN.test(token)) return null;
   return token;
 }
 

--- a/frontend/tests/e2e/ai-hub-source-surface.spec.ts
+++ b/frontend/tests/e2e/ai-hub-source-surface.spec.ts
@@ -19,7 +19,7 @@ const viewports = [
 
 for (const viewport of viewports) {
   test(`renders source-backed AI Hub with scroll at ${viewport.name}`, async ({ page }, testInfo) => {
-    const sessionToken = `signed-ai-hub-${viewport.name}`;
+    const sessionToken = `signed-ai-hub.${viewport.name}.token`;
     const surfaceRequestHeaders: Record<string, string>[] = [];
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await mockDashboardApi(page, (path, request) => {

--- a/frontend/tests/e2e/dashboard-branding.spec.ts
+++ b/frontend/tests/e2e/dashboard-branding.spec.ts
@@ -75,7 +75,7 @@ test('renders the desktop Naruon shell with local brand assets', async ({ page }
 });
 
 test('renders Today dashboard pending reply lane with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-dashboard-pending-replies-token';
+  const expectedNaruonToken = 'signed-dashboard.pending-replies.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -382,7 +382,7 @@ test('renders source-backed Projects workspace with signed API headers and mobil
 });
 
 test('renders Security governance access audit sharing and policy with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-security-governance-e2e-token';
+  const expectedNaruonToken = 'signed-security.governance-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -481,7 +481,7 @@ test('renders Security governance access audit sharing and policy with signed AP
 });
 
 test('renders Data quality surface across viewports with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-data-quality-e2e-token';
+  const expectedNaruonToken = 'signed-data.quality-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -592,7 +592,7 @@ test('renders Data quality surface across viewports with signed API headers', as
 });
 
 test('renders sent mail reply tracking route with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-sent-mail-e2e-token';
+  const expectedNaruonToken = 'signed-sent.mail-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -652,7 +652,7 @@ test('renders sent mail reply tracking route with signed API headers', async ({ 
 });
 
 test('updates source-linked task ticket status with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-task-status-e2e-token';
+  const expectedNaruonToken = 'signed-task.status-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -713,7 +713,7 @@ test('updates source-linked task ticket status with signed API headers', async (
 });
 
 test('creates pending reply SLA task escalation with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-reply-sla-e2e-token';
+  const expectedNaruonToken = 'signed-reply.sla-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -788,7 +788,7 @@ test('creates pending reply SLA task escalation with signed API headers', async 
 });
 
 test('creates self-sent knowledge WebDAV intent with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-self-sent-knowledge-e2e-token';
+  const expectedNaruonToken = 'signed-self-sent.knowledge-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -940,7 +940,7 @@ test('renders source-backed mail account settings across desktop tablet and mobi
   }[] = [];
 
   await page.addInitScript(() => {
-    document.cookie = 'naruon_session=signed-settings-e2e-token; Path=/; SameSite=Lax';
+    document.cookie = 'naruon_session=signed-settings.e2e.token; Path=/; SameSite=Lax';
   });
   await mockDashboardApi(page, (path, request) => {
     if (path === '/api/accounts/config') {
@@ -1008,13 +1008,13 @@ test('renders source-backed mail account settings across desktop tablet and mobi
   await page.screenshot({ path: testInfo.outputPath('settings-mail-account-mobile-scroll.png'), fullPage: false });
 
   const getRequest = accountRequests.find((request) => request.method === 'GET');
-  expectBrowserCookieSession(getRequest?.headers, 'signed-settings-e2e-token');
+  expectBrowserCookieSession(getRequest?.headers, 'signed-settings.e2e.token');
   for (const header of ['x-user-id', 'x-organization-id', 'x-group-id', 'x-group-ids', 'x-user-role', 'x-dev-auth-token']) {
     expect(getRequest?.headers[header]).toBeUndefined();
   }
 
   const putRequest = accountRequests.find((request) => request.method === 'PUT');
-  expectBrowserCookieSession(putRequest?.headers, 'signed-settings-e2e-token');
+  expectBrowserCookieSession(putRequest?.headers, 'signed-settings.e2e.token');
   const putBody = JSON.parse(putRequest?.postData || '{}') as Record<string, unknown>;
   expect(putBody).toMatchObject({
     smtp_server: 'smtp.example.com',
@@ -1036,7 +1036,7 @@ test('renders source-backed mail account settings across desktop tablet and mobi
 });
 
 test('renders calendar writeback intent status without direct provider writes', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-calendar-e2e-token';
+  const expectedNaruonToken = 'signed-calendar.e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -1130,7 +1130,7 @@ test('renders calendar writeback intent status without direct provider writes', 
 });
 
 test('renders data WebDAV writeback intent status without direct provider writes', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-webdav-e2e-token';
+  const expectedNaruonToken = 'signed-webdav.e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -1222,7 +1222,7 @@ test('renders data WebDAV writeback intent status without direct provider writes
 });
 
 test('renders unique email canonical thread intent with signed API headers', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-email-dedupe-e2e-token';
+  const expectedNaruonToken = 'signed-email.dedupe-e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',
@@ -1302,7 +1302,7 @@ test('renders unique email canonical thread intent with signed API headers', asy
 });
 
 test('renders API-backed context search sender DAG and reply tracking', async ({ page }, testInfo) => {
-  const expectedNaruonToken = 'signed-search-e2e-token';
+  const expectedNaruonToken = 'signed-search.e2e.token';
   const publicIdentityHeaders = [
     'x-user-id',
     'x-organization-id',

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -47,7 +47,7 @@ function signLiveSession(expiresInSeconds = 300): string {
 }
 
 test('nano test: verify user requested features', async ({ page }) => {
-  const sessionToken = 'signed-nano-session';
+  const sessionToken = 'signed.nano.session';
   const providerRequestHeaders: Record<string, string>[] = [];
   await mockDashboardApi(page, (path, request) => {
     if (path === '/api/llm-providers' && request.method() === 'GET') {


### PR DESCRIPTION
## Summary
- Fix `docker-compose.yml` so local Compose passes required runtime secrets as explicit environment mappings instead of bare pass-through list entries.
- Preserve the existing container preflight guards while preventing `podman-compose config` from rendering `POSTGRES_PASSWORD`, `AUTH_SESSION_HMAC_SECRET`, and `ENCRYPTION_KEY` as `null`.
- Update release governance and repo hygiene tests to pin this contract line by line.

## Line-specific fix notes
- `docker-compose.yml` `db.environment`: changed `- POSTGRES_PASSWORD` to `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}` so the value from `./scripts/naruon_compose.sh --env-file` is actually injected into the PostgreSQL container.
- `docker-compose.yml` `backend.environment`: changed `- AUTH_SESSION_HMAC_SECRET` and `- ENCRYPTION_KEY` to explicit `${...}` mappings so backend startup receives signed-session and encryption settings instead of null values.
- `docker-compose.yml` `backend.environment`: kept `DATABASE_URL` derived from `${POSTGRES_PASSWORD}` and converted the block to YAML mapping syntax alongside the Gemma4/embeddinggemma local provider defaults.
- `backend/tests/test_release_governance.py`: added assertions that the backend compose block uses explicit secret mappings and no longer contains bare `- AUTH_SESSION_HMAC_SECRET` / `- ENCRYPTION_KEY` entries.
- `backend/tests/test_repo_hygiene.py`: updated compose hygiene assertions for mapping-style env entries and added checks that bare secret pass-through entries cannot return.

## Verification
- `NARUON_ENV_FILE=/tmp/naruon-compose.env ./scripts/naruon_compose.sh config` confirmed `POSTGRES_PASSWORD`, `AUTH_SESSION_HMAC_SECRET`, and `ENCRYPTION_KEY` render from env-file values, not `null`.
- `python -m pytest backend/tests/test_release_governance.py backend/tests/test_repo_hygiene.py -q` -> 32 passed.
- `python -m pytest backend/tests/test_emails_api.py -q` -> 42 passed, 1 skipped.
- `NARUON_ENV_FILE=/tmp/naruon-compose.env ./scripts/naruon_compose.sh build backend frontend` -> passed.
- `NARUON_ENV_FILE=/tmp/naruon-compose.env ./scripts/naruon_compose.sh build ollama` -> passed with cached Gemma4 and embeddinggemma model layers.
- `env -u FORCE_COLOR -u NO_COLOR pnpm exec playwright test tests/e2e/nano.spec.ts` -> 3 passed, 3 skipped.
- `LIVE_BASE_URL=http://127.0.0.1:18080 RUN_LIVE_MODEL_E2E=1 ... pnpm exec playwright test tests/e2e/nano-live-model.spec.ts tests/e2e/nano.spec.ts --project=desktop` -> 4 passed.
- `bash -o pipefail -c 'NARUON_ENV_FILE=/tmp/naruon-live-e2e.env ./scripts/naruon_compose.sh -p naruonliveaudit -f docker-compose.live-e2e.yml logs 2>&1 | python scripts/check_compose_logs.py'` -> PASS compose log policy.
- `podman build -t naruon-combined-verify:latest .` -> passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Compose and image runtime configuration standardized to YAML key/value format and non-root runtime user setup.

* **New Features**
  * Session handling: stricter signed-session validation, in-memory rate-limiting for failed session verifications, and longer explicit session cookie lifetime (12 hours).
  * Runtime secret validation now enforces higher entropy and character-class requirements.
  * UI graph labels are HTML-escaped to prevent injection.

* **Bug Fixes**
  * Tenant config API now rejects cross-user admin updates (403).

* **Documentation**
  * Note added clarifying Dockerfiles run as non-root; Kubernetes manifests need SecurityContext enforcement.

* **Tests**
  * Test suite expanded to cover env/config, session, rate-limiting, secret-strength, caching headers, and UI escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->