### PR TITLE
fix: keep live frontend proxy same-origin

### DIFF
--- a/frontend/src/app/api/[...path]/route.test.ts
+++ b/frontend/src/app/api/[...path]/route.test.ts
@@ -118,6 +118,45 @@ describe("/api runtime proxy route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("accepts browser same-origin state changes when the runtime URL is internal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+        const headers = init?.headers as Headers;
+        return Response.json({
+          target_url: String(input),
+          auth_header: headers.get("authorization"),
+          request_body: await new Response(init?.body).text(),
+        });
+      }),
+    );
+
+    const request = new NextRequest(
+      "http://internal-frontend:3000/api/search",
+      {
+        method: "POST",
+        headers: {
+          Cookie: `naruon_session=${SIGNED_SESSION_TOKEN}`,
+          Host: "127.0.0.1:3000",
+          Origin: "http://127.0.0.1:3000",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: "일정 충돌 일정 조율 회의 후보", limit: 3 }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ path: ["search"] }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      target_url: "https://api.naruon.net/api/search",
+      auth_header: "Bearer signed.session.token",
+      request_body: '{"query":"일정 충돌 일정 조율 회의 후보","limit":3}',
+    });
+  });
+
   it("rejects cross-site fetch metadata before proxying", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -109,6 +109,36 @@ function safeBackendQuery(searchParams: URLSearchParams): string {
   return query ? `?${query}` : "";
 }
 
+function firstHeaderValue(value: string | null): string | null {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+function forwardedProtocol(request: NextRequest): string {
+  const proto = firstHeaderValue(request.headers.get("x-forwarded-proto"));
+  if (proto === "http" || proto === "https") return proto;
+  return request.nextUrl.protocol.replace(":", "");
+}
+
+function requestOriginCandidates(request: NextRequest): Set<string> {
+  const origins = new Set([request.nextUrl.origin]);
+  const proto = forwardedProtocol(request);
+  const hosts = [
+    firstHeaderValue(request.headers.get("x-forwarded-host")),
+    firstHeaderValue(request.headers.get("host")),
+  ];
+
+  for (const host of hosts) {
+    if (!host || CONTROL_CHARACTER_PATTERN.test(host)) continue;
+    try {
+      origins.add(new URL(`${proto}://${host}`).origin);
+    } catch {
+      // Ignore malformed proxy host metadata and keep the stricter origin set.
+    }
+  }
+
+  return origins;
+}
+
 function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!STATE_CHANGING_METHODS.has(request.method.toUpperCase())) return true;
 
@@ -119,7 +149,7 @@ function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!origin) return true;
 
   try {
-    return new URL(origin).origin === request.nextUrl.origin;
+    return requestOriginCandidates(request).has(new URL(origin).origin);
   } catch {
     return false;
   }

--- a/frontend/src/app/auth/session/route.test.ts
+++ b/frontend/src/app/auth/session/route.test.ts
@@ -80,6 +80,40 @@ describe("/auth/session route", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("stores a session when browser origin matches the forwarded host", async () => {
+    const token = signedFixtureToken({
+      sub: "user-1",
+      org: "org-acme",
+      workspace: "workspace-acme",
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+    const fetchMock = vi.fn(async () => verifiedSessionResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new NextRequest("http://internal-frontend:3000/auth/session", {
+        method: "POST",
+        headers: {
+          Host: "127.0.0.1:3000",
+          Origin: "http://127.0.0.1:3000",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ access_token: token }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      authenticated: true,
+      claims: {
+        userId: "user-1",
+        organizationId: "org-acme",
+        workspaceId: "workspace-acme",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns public claims without exposing the cookie value", async () => {
     const token = signedFixtureToken({
       sub: "user-2",

--- a/frontend/src/app/auth/session/route.ts
+++ b/frontend/src/app/auth/session/route.ts
@@ -23,6 +23,7 @@ const NO_STORE_HEADERS = {
 const SESSION_VERIFICATION_RATE_LIMIT_WINDOW_MS = 60_000;
 const SESSION_VERIFICATION_RATE_LIMIT_MAX_ATTEMPTS = 10;
 const SESSION_VERIFICATION_RATE_LIMIT_MAX_BUCKETS = 4096;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 
 type SessionVerificationBucket = {
   count: number;
@@ -30,6 +31,36 @@ type SessionVerificationBucket = {
 };
 
 const sessionVerificationBuckets = new Map<string, SessionVerificationBucket>();
+
+function firstHeaderValue(value: string | null): string | null {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+function forwardedProtocol(request: NextRequest): string {
+  const proto = firstHeaderValue(request.headers.get("x-forwarded-proto"));
+  if (proto === "http" || proto === "https") return proto;
+  return request.nextUrl.protocol.replace(":", "");
+}
+
+function requestOriginCandidates(request: NextRequest): Set<string> {
+  const origins = new Set([request.nextUrl.origin]);
+  const proto = forwardedProtocol(request);
+  const hosts = [
+    firstHeaderValue(request.headers.get("x-forwarded-host")),
+    firstHeaderValue(request.headers.get("host")),
+  ];
+
+  for (const host of hosts) {
+    if (!host || CONTROL_CHARACTER_PATTERN.test(host)) continue;
+    try {
+      origins.add(new URL(`${proto}://${host}`).origin);
+    } catch {
+      // Ignore malformed proxy host metadata and keep the stricter origin set.
+    }
+  }
+
+  return origins;
+}
 
 function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!STATE_CHANGING_METHODS.has(request.method.toUpperCase())) return true;
@@ -41,7 +72,7 @@ function sameOriginStateChangingRequest(request: NextRequest): boolean {
   if (!origin) return true;
 
   try {
-    return new URL(origin).origin === request.nextUrl.origin;
+    return requestOriginCandidates(request).has(new URL(origin).origin);
   } catch {
     return false;
   }

--- a/frontend/tests/e2e/live-smoke.spec.ts
+++ b/frontend/tests/e2e/live-smoke.spec.ts
@@ -35,6 +35,21 @@ function signLiveSession(): string {
   return `${header}.${payload}.${signature}`;
 }
 
+async function hasVisibleSeededInboxText(page: import('@playwright/test').Page): Promise<boolean> {
+  return page.getByText('Live E2E Release').evaluateAll((elements) =>
+    elements.some((element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    }),
+  );
+}
+
 test.skip(
   !process.env.LIVE_BASE_URL && process.env.RUN_LIVE_E2E !== '1',
   'Requires a live frontend/backend environment with seeded data.',
@@ -60,8 +75,8 @@ test('live dashboard renders seeded inbox through real HTTP', async ({ page }) =
   await page.goto('/');
 
   await expect(page.getByRole('img', { name: 'Naruon' })).toBeVisible();
-  await expect(page.getByText('Live E2E Release').first()).toBeVisible({
+  await expect.poll(() => hasVisibleSeededInboxText(page), {
     timeout: 15_000,
-  });
+  }).toBe(true);
   await expect(page.getByText('Failed to load emails.')).toHaveCount(0);
 });

--- a/frontend/tests/e2e/nano-live-model.spec.ts
+++ b/frontend/tests/e2e/nano-live-model.spec.ts
@@ -10,8 +10,9 @@ import crypto from 'node:crypto';
 //   - chat:      POST /api/llm/draft  -> gemma4:e2b-it-qat (답장 초안)
 //   - embedding: POST /api/search     -> embeddinggemma    (맥락 검색)
 //
-// Requests go through the frontend same-origin /api proxy, which forwards the
-// Authorization header to the backend, mirroring how the app authenticates.
+// Requests go through the frontend same-origin /api proxy. The proxy strips
+// client authority headers and forwards the signed naruon_session cookie as a
+// backend Authorization bearer token, mirroring browser authentication.
 
 const liveSessionPayload = {
   ver: 1,
@@ -45,6 +46,10 @@ function signLiveSession(): string {
   return `${header}.${payload}.${signature}`;
 }
 
+function liveSessionCookie(token: string): string {
+  return `naruon_session=${token}`;
+}
+
 test.skip(
   !process.env.LIVE_BASE_URL && process.env.RUN_LIVE_E2E !== '1',
   'Requires a live stack with ollama serving gemma4:e2b-it-qat + embeddinggemma.',
@@ -56,7 +61,7 @@ test.setTimeout(600_000);
 test('nano live: 답장 초안 reaches the gemma4 e2b chat model', async ({ request }) => {
   const token = signLiveSession();
   const response = await request.post('/api/llm/draft', {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Cookie: liveSessionCookie(token) },
     data: {
       email_body:
         '다음 주 화요일 오후 2시에 프로젝트 킥오프 미팅을 제안드립니다. 가능하신지 회신 부탁드립니다.',
@@ -75,7 +80,7 @@ test('nano live: 답장 초안 reaches the gemma4 e2b chat model', async ({ requ
 test('nano live: 맥락 검색 exercises the embeddinggemma model', async ({ request }) => {
   const token = signLiveSession();
   const response = await request.post('/api/search', {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Cookie: liveSessionCookie(token) },
     data: { query: '프로젝트 킥오프 일정' },
     timeout: 120_000,
   });

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -46,6 +46,10 @@ function signLiveSession(expiresInSeconds = 300): string {
   return `${header}.${payload}.${signature}`;
 }
 
+function liveSessionCookie(token: string): string {
+  return `naruon_session=${token}`;
+}
+
 test('nano test: verify user requested features', async ({ page }) => {
   const sessionToken = 'signed.nano.session';
   const providerRequestHeaders: Record<string, string>[] = [];
@@ -91,10 +95,10 @@ test('nano live model: ollama gemma4 e2b chat and embedding search complete', as
   );
 
   const token = signLiveSession(1_200);
-  const authorization = `Bearer ${token}`;
+  const cookie = liveSessionCookie(token);
 
   const draftResponse = await request.post('/api/llm/draft', {
-    headers: { Authorization: authorization },
+    headers: { Cookie: cookie },
     data: {
       email_body: 'Live Gemma4 verification request from Naruon E2E.',
       instruction: 'Reply with one concise Korean sentence confirming receipt.',
@@ -106,7 +110,7 @@ test('nano live model: ollama gemma4 e2b chat and embedding search complete', as
   expect(String(draftBody.draft ?? '').trim().length).toBeGreaterThan(0);
 
   const searchResponse = await request.post('/api/search', {
-    headers: { Authorization: authorization },
+    headers: { Cookie: cookie },
     data: { query: 'Live E2E Release', limit: 3 },
     timeout: 600_000,
   });


### PR DESCRIPTION
## Summary
- allow same-origin state-changing requests when the frontend runtime URL is internal but the browser Origin matches Host / forwarded host
- keep client authority headers stripped while forwarding the signed `naruon_session` cookie as backend bearer auth
- update live nano E2E to exercise the browser cookie path and visible seeded inbox evidence

## Root Cause
Docker/Podman live E2E serves the browser at `127.0.0.1:3000`, while Next.js may resolve `request.nextUrl.origin` from an internal runtime URL. The API proxy compared POST origins only to `request.nextUrl.origin`, so the Home dashboard automatic `맥락 검색` POST was rejected with `csrf_origin_rejected` before reaching the backend.

## UI/UX Audit Notes
- `docs/ui-ux/naruon-ui-ux-mapping.md` requires the 10 GNB areas and Korean-first terminology such as `맥락 종합`, `판단 포인트`, `실행 항목`, `답장 초안`, `맥락 검색`, `관계 맥락`, `일정 반영`, and `판단 보조`. The current route/component inventory contains those areas and terms.
- The nano E2E now proves model registration UI, local model registration, embedding model designation, and email file import controls while preserving the signed-session cookie path.
- The live Compose E2E proves packaged `gemma4:e2b-it-qat` chat and `embeddinggemma` embedding paths through the frontend proxy.

## Validation
- `pnpm vitest run src/app/api/[...path]/route.test.ts src/app/auth/session/route.test.ts`
- `NARUON_ENV_FILE=/private/tmp/naruon-live-e2e.env ./scripts/naruon_compose.sh -p naruon_goal_live up --build -d frontend` (Next production build passed; podman-compose reported existing dependency container name collisions after image build, then frontend was recreated with the new image)
- `env -u NO_COLOR -u FORCE_COLOR LIVE_BASE_URL=http://127.0.0.1:3000 RUN_LIVE_MODEL_E2E=1 RUN_LIVE_E2E=1 LIVE_E2E_SESSION_SECRET=... pnpm test:e2e --project=desktop nano.spec.ts nano-live-model.spec.ts live-smoke.spec.ts`
- `pnpm lint`
- `pnpm typecheck`
- `podman exec naruon_goal_live_ollama_1 ollama list` showed `gemma4:e2b-it-qat` and `embeddinggemma:latest`

## Notes
- Left unrelated local `.Jules/palette.md` case-only worktree noise unstaged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSRF/origin validation to properly accept same-origin requests when using internal proxy configurations.
  * Enhanced session authentication to correctly handle forwarded protocol and host headers.

* **Tests**
  * Added test coverage for same-origin proxy requests with internal frontend URLs.
  * Added test coverage for session storage with matched origin headers.
  * Improved E2E test reliability with better visibility detection for rendered content.
  * Updated E2E tests to use cookie-based session authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->