### PR TITLE
ci: preserve Strix model findings in OpenCode reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,15 @@
   completed check run or status context failed, or the check rollup cannot be
   verified, the OpenCode review must request changes or explain the verification
   failure instead of approving.
+- When OpenCode requests changes because Strix or another GitHub Check failed,
+  it must access the failed check logs and annotations, cite the exact failure
+  phrase, map each actionable failure to a concrete repository `path:line`, and
+  provide root cause, fix direction, regression-test direction, and a
+  source-backed suggested diff. A review that only cites a workflow URL, check
+  name, or generic failure summary is not sufficient. If Strix output contains
+  multiple model vulnerability reports, include every model-reported
+  vulnerability separately with the model name, title, severity, endpoint, and
+  Code Locations/path:line evidence when present.
 - OpenCode Agent PR reviews must be general-purpose and meticulous rather than
   narrowly scenario-specific. Configure the review prompt to use all relevant
   MCP sources: CodeGraph for structural source evidence, DeepWiki for repo docs,

--- a/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
+++ b/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
@@ -99,6 +99,14 @@ derive_location_from_report() {
 			path="frontend/src/app/prompt-studio/page.tsx"
 			line="$(first_existing_line "$path" "apiClient\\.post|testResult|setTestResult")"
 			;;
+		*"Frontend Security Issues"*|*"Hardcoded Credentials"*|*"Insecure Data Handling"*)
+			path="frontend/next.config.ts"
+			line="$(first_existing_line "$path" 'const nextConfig|headers|Content-Security-Policy')"
+			if [ ! -f "${REPO_ROOT%/}/$path" ]; then
+				path="frontend/src/app/page.tsx"
+				line="$(first_existing_line "$path")"
+			fi
+			;;
 		*"Content Security Policy"*|*"security headers"*|*"Security Headers"*)
 			path="frontend/next.config.ts"
 			line="$(first_existing_line "$path" 'const nextConfig|headers')"
@@ -146,6 +154,10 @@ extract_strix_reports() {
 			$line =~ s/^[[:space:]]+|[[:space:]]+$//g;
 			return $line;
 		}
+		sub starts_new_field {
+			my ($line) = @_;
+			return $line =~ /^(Title|Severity|CVSS Score|CVSS Vector|Target|Endpoint|Method|Description|Impact|Technical Analysis|PoC Description|PoC Code|Code Locations|Remediation)\b/i;
+		}
 		sub finish_report {
 			return unless defined $title && length $title;
 			push @reports, {
@@ -186,13 +198,30 @@ extract_strix_reports() {
 			$line =~ m{Strix run failed for model '\''([^'\'']+)'\''}) {
 			$current_model = $1;
 			$window_model ||= $1 if $in_window;
-			$report_model ||= $1 if defined $title && length $title;
+			$report_model = $1 if defined $title && length $title;
 		}
 		next unless $in_window;
+		if (defined $continuation_field && length $continuation_field) {
+			if (!length $line) {
+				$continuation_field = "";
+			} elsif (!starts_new_field($line) && $line !~ /^[╭╰─]+/ && $line !~ /^Vulnerability Report$/i) {
+				if ($continuation_field eq "title") {
+					$title .= " " . $line;
+				} elsif ($continuation_field eq "endpoint") {
+					$endpoint .= " " . $line;
+				} elsif ($continuation_field eq "target") {
+					$target .= " " . $line;
+				}
+				next;
+			} else {
+				$continuation_field = "";
+			}
+		}
 		if ($line =~ /^Title:[[:space:]]+(.+)/i) {
 			finish_report();
 			$title = $1;
 			$report_model = $window_model || $current_model || "";
+			$continuation_field = "title";
 			next;
 		}
 		if ($line =~ /^Severity:[[:space:]]+(CRITICAL|HIGH|MEDIUM|LOW|NONE)\b/i) {
@@ -201,14 +230,17 @@ extract_strix_reports() {
 		}
 		if ($line =~ /^Endpoint:[[:space:]]+(.+)/i) {
 			$endpoint = $1;
+			$continuation_field = "endpoint";
 			next;
 		}
 		if ($line =~ /^Method:[[:space:]]+(.+)/i) {
 			$method = $1;
+			$continuation_field = "";
 			next;
 		}
 		if ($line =~ /^Target:[[:space:]]+(.+)/i) {
 			$target = $1;
+			$continuation_field = "target";
 			next;
 		}
 		if ($line =~ /(?:Code[[:space:]]+)?Location(?:s)?(?:[[:space:]]+[0-9]+)?[[:space:]]*:[[:space:]]*(.+?:[0-9]+(?:-[0-9]+)?)/i) {
@@ -312,7 +344,7 @@ emit_strix_provider_failure_finding() {
 	local path=".github/workflows/strix.yml"
 	local line="1"
 
-	if ! grep -Eq "LLM CONNECTION FAILED|RateLimitError|Too many requests|budget limit|Configured model and fallback models were unavailable|provider infrastructure" "$strix_evidence_file"; then
+	if ! grep -Eq "LLM CONNECTION FAILED|RateLimitError|Too many requests|budget limit|Configured model and fallback models were unavailable|provider infrastructure|Below-threshold findings detected|Unable to map Strix findings" "$strix_evidence_file"; then
 		return 0
 	fi
 
@@ -326,7 +358,7 @@ emit_strix_provider_failure_finding() {
 	finding_index=$((finding_index + 1))
 	if grep -Fq "Strix vulnerability report window" "$strix_evidence_file"; then
 		printf '### %s. HIGH %s:%s - Strix provider signal left current-head security evidence incomplete\n' "$finding_index" "$path" "$line"
-		printf -- '- Problem: Strix produced one or more vulnerability report windows, then the failed log still reported provider infrastructure/failure-signal output such as LLM CONNECTION FAILED, RateLimitError, budget-limit, or fallback provider signal.\n'
+		printf -- '- Problem: Strix produced one or more vulnerability report windows, then the failed log still reported provider infrastructure/failure-signal output such as LLM CONNECTION FAILED, RateLimitError, budget-limit, "Below-threshold findings detected", "Unable to map Strix findings", or fallback provider signal.\n'
 		printf -- '- Root cause: The scanner evidence is incomplete even after model reports were emitted; OpenCode must include every model report above and must not approve until a clean current-head Strix run or equivalent manual evidence exists.\n'
 		printf -- '- Fix: Re-run Strix after GitHub Models capacity recovers or run an explicitly configured manual provider evidence scan with valid credentials; keep %s:%s aligned with the approved fallback model list.\n' "$path" "$line"
 		printf -- '- Regression test: Keep failed-check evidence and validation covering provider-signal failures after vulnerability reports so partial reports cannot be downgraded to approval.\n\n'

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -867,6 +867,82 @@ EOF
 	rm -rf "$tmp_dir"
 }
 
+assert_opencode_failed_check_fallback_handles_pg_erd_cloud_strix_log_shape() {
+	local tmp_dir
+	local fixture_repo
+	local evidence_file
+	local output_file
+	tmp_dir="$(mktemp -d)"
+	fixture_repo="$tmp_dir/repo"
+	evidence_file="$tmp_dir/failed-check-evidence.md"
+	output_file="$tmp_dir/fallback.md"
+
+	mkdir -p "$fixture_repo/backend/app" "$fixture_repo/frontend"
+	for line_number in $(seq 1 150); do
+		printf '# auth fixture line %s\n' "$line_number"
+	done >"$fixture_repo/backend/app/auth.py"
+	cat >"$fixture_repo/frontend/next.config.ts" <<'EOF'
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [];
+  },
+};
+
+export default nextConfig;
+EOF
+
+	cat >"$evidence_file" <<'EOF'
+## Failed check: Strix Security Scan/strix
+
+### Failed log signal summary
+
+```text
+strix	Run Strix (quick)	Strix run failed for model 'deepseek/deepseek-r1-0528' after 206s (exit code 2).
+strix	Run Strix (quick)	Below-threshold findings detected, but infrastructure errors occurred during this pipeline run; refusing bypass due to potentially incomplete scan.
+strix	Run Strix (quick)	Unable to map Strix findings to changed files; failing closed for pull request.
+```
+
+### Strix vulnerability report window 1
+
+│  Vulnerability Report                                                        │
+│  Title: Authentication Bypass via X-Dev-User Header                          │
+│  Severity: CRITICAL                                                          │
+│  Target: /workspace/strix-pr-scope.I4RF8w                                    │
+│  Endpoint: /api/me                                                           │
+│  Method: GET                                                                 │
+│  Code Locations                                                              │
+│    Location 1: backend/app/auth.py:132-135                                   │
+│  Model deepseek/deepseek-r1-0528                                             │
+│  Vulnerabilities 1                                                           │
+
+### Strix vulnerability report window 2
+
+│  Vulnerability Report                                                        │
+│  Title: Frontend Security Issues: XSS, Hardcoded Credentials, and Insecure   │
+│  Data Handling                                                               │
+│  Severity: HIGH                                                              │
+│  Target: /workspace/strix-pr-scope.I4RF8w/frontend                           │
+│  Model deepseek/deepseek-v3-0324                                             │
+│  Vulnerabilities 1                                                           │
+EOF
+
+	bash "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" \
+		"$evidence_file" "$fixture_repo" >"$output_file"
+
+	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-r1-0528: Authentication Bypass via X-Dev-User Header" "fallback includes pg-erd-cloud first model report"
+	assert_file_contains "$output_file" "backend/app/auth.py:132" "fallback maps pg-erd-cloud auth report to exact line"
+	assert_file_contains "$output_file" "Endpoint: /api/me. Method: GET" "fallback preserves pg-erd-cloud endpoint and method"
+	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-v3-0324: Frontend Security Issues: XSS, Hardcoded Credentials, and Insecure Data Handling" "fallback preserves wrapped pg-erd-cloud frontend title"
+	assert_file_contains "$output_file" "frontend/next.config.ts:3" "fallback anchors locationless frontend report to a concrete frontend hardening line"
+	assert_file_contains "$output_file" "Unable to map Strix findings" "fallback preserves failed Strix mapping signal"
+	assert_file_contains "$output_file" "Strix provider signal left current-head security evidence incomplete" "fallback reports incomplete Strix evidence after model findings"
+	assert_file_not_contains "$output_file" "failed before producing vulnerability reports" "fallback does not erase model findings after provider signals"
+
+	rm -rf "$tmp_dir"
+}
+
 assert_internal_pr_scope_targets() {
 	local target_log_file="$1"
 	local repo_root_dir="$2"
@@ -5261,6 +5337,8 @@ assert_opencode_review_gate_rejects_non_source_backed_findings
 assert_opencode_failed_check_review_validator_rejects_unrelated_findings
 
 assert_opencode_failed_check_fallback_emits_each_strix_report
+
+assert_opencode_failed_check_fallback_handles_pg_erd_cloud_strix_log_shape
 
 run_pull_request_target_head_scope_case \
 	"pull-request-target-modified-file-uses-head-blob" \


### PR DESCRIPTION
## Summary
- Preserve every Strix model vulnerability report in OpenCode failed-check fallback findings instead of collapsing reports by the first model.
- Handle Strix log shapes where `Model deepseek/...` appears after the `Vulnerability Report`, and preserve wrapped report titles such as the pg-erd-cloud frontend finding.
- Document that OpenCode failed-check reviews must cite exact logs, map actionable failures to concrete `path:line`, and include source-backed fix/test directions.

## Evidence
- Checked PR #471 OpenCode failure review and the failed Strix check contract.
- Checked pg-erd-cloud Strix run `27391155711`, job `80948709918`, where deepseek-r1 and deepseek-v3 each emitted vulnerability reports.

## Tests
- `bash scripts/ci/test_strix_quick_gate.sh`
- `actionlint .github/workflows/opencode-review.yml .github/workflows/strix.yml`
- `python3 -m pytest backend/tests/test_release_governance.py -q`
- `bash -n scripts/ci/emit_opencode_failed_check_fallback_findings.sh && bash -n scripts/ci/test_strix_quick_gate.sh && git diff --check`
