### PR TITLE
🎨 Palette: 통합 검색 페이지 검색어 지우기 기능 및 접근성 개선

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-06-12 - Adding a11y Roles to InsightCard Status States
 **Learning:** Generic wrapper components like `InsightCard` which dynamically load and present data often conditionally render a generic loader or error state. Screen readers may ignore these visual cues unless they are accompanied by proper semantic roles, such as `role="status"` and `aria-live="polite"` for loading spinners, and `role="alert"` for error messages. Also adding `aria-hidden="true"` to visual icons within these states reduces noise.
 **Action:** When creating reusable data-fetching card components, always annotate loading and error state container elements with the appropriate ARIA roles and live regions, and hide purely decorative elements.
+
+## 2026-06-13 - Use type=text for Custom Search Inputs
+**Learning:** When implementing a custom clear button for search inputs, using `type="search"` causes WebKit browsers to display a native clear button, resulting in double buttons. While CSS `::-webkit-search-cancel-button` tricks exist, they can be unreliable across environments.
+**Action:** Use `<input type="text" inputMode="search" role="searchbox">`. This prevents the native clear button from rendering while perfectly preserving screen reader semantics and triggering the mobile search keyboard.

--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -16,6 +16,7 @@ vi.mock("lucide-react", () => ({
   AlertCircle: () => <svg aria-hidden="true" />,
   CornerDownRight: () => <svg aria-hidden="true" />,
   Loader2: () => <svg aria-hidden="true" className="lucide-loader-2" />,
+  X: () => <svg aria-hidden="true" />,
 }));
 
 vi.mock("vis-network", () => ({

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   CalendarDays,
@@ -14,6 +14,7 @@ import {
   Network,
   Search,
   Sparkles,
+  X,
 } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -242,6 +243,7 @@ function SenderDagPanel({
 
 export function SearchLayout() {
   const [query, setQuery] = useState(DEFAULT_QUERY);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [submittedQuery, setSubmittedQuery] = useState(DEFAULT_QUERY);
   const [activeFilter, setActiveFilter] = useState<ResultFilter>("all");
   const [results, setResults] = useState<SearchResultItem[]>([]);
@@ -494,13 +496,29 @@ export function SearchLayout() {
             />
             <input
               id="search-input"
-              type="search"
+              ref={searchInputRef}
+              type="text"
+              inputMode="search"
+              role="searchbox"
               aria-label="맥락 검색어 입력"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="메일, 일정, 파일, 사람, 의사결정 로그 검색..."
-              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-4 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
+              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
             />
+            {query && (
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  searchInputRef.current?.focus();
+                }}
+                className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                aria-label="검색어 지우기"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            )}
           </div>
           <button
             type="submit"


### PR DESCRIPTION
💡 **What**: 통합 검색 페이지의 검색창에 검색어 초기화 기능(Clear button)을 추가했습니다.
🎯 **Why**: 검색어를 빠르게 수정하거나 초기화하고 싶을 때 매번 백스페이스를 누르거나 범위를 드래그해야 하는 불편함을 개선하기 위해 추가했습니다.
📸 **Before/After**: 검색어 입력 시 우측에 'X' 아이콘 버튼이 표시되며, 클릭 시 검색어가 지워지고 다시 입력창으로 커서(Focus)가 이동합니다.
♿ **Accessibility**:
- 스크린 리더에서 읽을 수 있도록 명확한 `aria-label`을 적용했습니다.
- 키보드 내비게이션을 통해 탭 이동 시 식별할 수 있는 포커스 링 스타일링을 추가했습니다.
- 네이티브 브라우저의 Clear 버튼과 중복으로 표시되는 문제를 해결하기 위해, `type="text"`를 활용하고 대신 `role="searchbox"`, `inputMode="search"`를 사용하여 접근성과 모바일 키보드 경험을 모두 지켰습니다.

---
*PR created automatically by Jules for task [8809139874572548239](https://jules.google.com/task/8809139874572548239) started by @seonghobae*