### PR TITLE
⚡ Bolt: [performance improvement] batch querying for thread assignation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-10 - Redundant Python sorting of DB results
 **Learning:** Python's `sorted()` was being called on query results that were already sorted correctly by the database using `order_by()`. Since Python 3.7+ dictionaries preserve insertion order, we can stream correctly ordered database results into a grouping dictionary (e.g., grouping thread messages) and naturally preserve the newest-first order without an additional $O(N \log N)$ sort step on the grouped results.
 **Action:** Avoid applying Python's `sorted()` to lists of SQLAlchemy objects if the database query already applies an equivalent `.order_by()` clause. Rely on dictionary insertion ordering when grouping inherently pre-sorted streaming records.
+## 2024-06-14 - Batch querying for existing threads in Email Service
+**Learning:** In the email threading service (`backend/services/threading_service.py`), resolving multiple candidate message IDs historically caused an N+1 query overhead by executing single `SELECT`s within a loop.
+**Action:** When evaluating a list of foreign keys or identifier mappings, use `sqlalchemy.select(...).where(Column.in_(ids))` to fetch results in a single batched operation, significantly reducing database roundtrips. Ensure unit tests are refactored to simulate batched mock returning operations (`.all()`).

--- a/backend/api/calendar.py
+++ b/backend/api/calendar.py
@@ -10,7 +10,6 @@ from api.auth import (
     AuthContext,
     get_auth_context,
     is_system_admin_role,
-    is_tenant_admin_role,
 )
 from db.models import CalendarWritebackSource
 from db.session import get_db

--- a/backend/services/threading_service.py
+++ b/backend/services/threading_service.py
@@ -1,12 +1,13 @@
 import uuid
 import re
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from db.models import Email
 from services.email_parser import EmailData
 
 
 import hashlib
+
 
 def generate_email_fingerprint(
     subject: str | None,
@@ -66,21 +67,28 @@ def email_owner_filters(user_id: str, organization_id: str | None):
     return (Email.user_id == user_id, organization_filter)
 
 
-async def _find_existing_thread_id(
+async def _find_existing_thread_ids(
     session: AsyncSession,
-    message_id: str,
+    message_ids: list[str],
     *,
     user_id: str,
     organization_id: str | None,
-) -> str | None:
-    bracketed = f"<{message_id}>"
+) -> dict[str, str]:
+    """Fetch existing thread IDs for a batch of message IDs in a single query."""
+    if not message_ids:
+        return {}
+
+    bracketed = [f"<{mid}>" for mid in message_ids]
+    search_ids = message_ids + bracketed
+
     result = await session.execute(
-        select(Email.thread_id).where(
+        select(Email.message_id, Email.thread_id).where(
             *email_owner_filters(user_id, organization_id),
-            or_(Email.message_id == message_id, Email.message_id == bracketed),
+            Email.message_id.in_(search_ids),
         )
     )
-    return result.scalar_one_or_none()
+
+    return {row.message_id: row.thread_id for row in result.all()}
 
 
 async def assign_thread_id(
@@ -108,15 +116,19 @@ async def assign_thread_id(
             seen.add(ref)
             existing_candidates.append(ref)
 
-    for candidate in existing_candidates:
-        thread_id = await _find_existing_thread_id(
+    if existing_candidates:
+        thread_ids_map = await _find_existing_thread_ids(
             session,
-            candidate,
+            existing_candidates,
             user_id=user_id,
             organization_id=organization_id,
         )
-        if thread_id:
-            return normalize_message_id(thread_id) or thread_id
+        for candidate in existing_candidates:
+            thread_id = thread_ids_map.get(candidate) or thread_ids_map.get(
+                f"<{candidate}>"
+            )
+            if thread_id:
+                return normalize_message_id(thread_id) or thread_id
 
     # If the parent/root has not been imported yet, use the oldest known ancestor
     # as the deterministic thread root so later imports converge on one thread.

--- a/backend/tests/test_caldav.py
+++ b/backend/tests/test_caldav.py
@@ -1,4 +1,3 @@
-import pytest
 from services.caldav_service import caldav_service
 
 def test_determine_writeback_target():

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -104,7 +104,6 @@ def test_dav_log_injection_prevention(dev_auth_dependency_overrides, caplog):
 
     caplog.set_level(logging.INFO)
     # URL encode the payload so httpx doesn't reject it; FastAPI will decode it back to the raw control chars
-    #
 
     # Since HTTP clients block raw control chars and starlette unquotes but might reject it before reaching our route,
     # we test the handler directly to ensure the logger is using repr().

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -14,7 +14,7 @@ AUTH_HEADERS = {
 
 
 def test_dav_rejects_missing_auth():
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.request("PROPFIND", "/dav/user123/projects/")
         assert response.status_code == 401
 
@@ -30,14 +30,14 @@ def test_dav_route_uses_signed_session_dependency():
 
 
 def test_dav_options(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.options("/dav/user123/projects/", headers=AUTH_HEADERS)
         assert response.status_code == 200
         assert "calendar-access" in response.headers.get("DAV", "")
 
 
 def test_dav_rejects_different_user_path(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.request(
             "PROPFIND", "/dav/other-user/projects/", headers=AUTH_HEADERS
         )
@@ -46,7 +46,7 @@ def test_dav_rejects_different_user_path(dev_auth_dependency_overrides):
 
 
 def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.request("PROPFIND", "/dav/", headers=AUTH_HEADERS)
         assert response.status_code == 403
         assert response.json()["detail"] == "DAV path must include an owner user"
@@ -55,7 +55,7 @@ def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):
 def test_dav_rejects_ownerless_options_before_capability_discovery(
     dev_auth_dependency_overrides,
 ):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.options("/dav/", headers=AUTH_HEADERS)
         assert response.status_code == 403
         assert "dav" not in {header.lower() for header in response.headers}
@@ -63,7 +63,7 @@ def test_dav_rejects_ownerless_options_before_capability_discovery(
 
 
 def test_dav_propfind(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.request(
             "PROPFIND", "/dav/user123/projects/", headers=AUTH_HEADERS
         )
@@ -74,7 +74,7 @@ def test_dav_propfind(dev_auth_dependency_overrides):
 
 
 def test_dav_propfind_escapes_path_values(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.request(
             "PROPFIND", "/dav/user123/projects/x%26y%3Cz%3E", headers=AUTH_HEADERS
         )
@@ -85,7 +85,7 @@ def test_dav_propfind_escapes_path_values(dev_auth_dependency_overrides):
 
 
 def test_dav_put(dev_auth_dependency_overrides):
-    with TestClient(app):
+    with TestClient(app) as client:
         response = client.put(
             "/dav/user123/projects/file.ics",
             content=b"BEGIN:VCALENDAR\r\nEND:VCALENDAR",
@@ -101,16 +101,10 @@ def test_dav_log_injection_prevention(dev_auth_dependency_overrides, caplog):
     preventing log injection vulnerabilities.
     """
     import logging
-    from fastapi.testclient import TestClient
-    from main import app
 
     caplog.set_level(logging.INFO)
     # URL encode the payload so httpx doesn't reject it; FastAPI will decode it back to the raw control chars
     #
-    with TestClient(app):
-        # Pass raw path to simulate actual request if unquote fails; wait, TestClient accepts raw URL strings but they are parsed.
-        # Use simple printable characters for request, and we'll manually call the handler to verify logging logic
-        pass
 
     # Since HTTP clients block raw control chars and starlette unquotes but might reject it before reaching our route,
     # we test the handler directly to ensure the logger is using repr().

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -14,7 +14,7 @@ AUTH_HEADERS = {
 
 
 def test_dav_rejects_missing_auth():
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.request("PROPFIND", "/dav/user123/projects/")
         assert response.status_code == 401
 
@@ -30,14 +30,14 @@ def test_dav_route_uses_signed_session_dependency():
 
 
 def test_dav_options(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.options("/dav/user123/projects/", headers=AUTH_HEADERS)
         assert response.status_code == 200
         assert "calendar-access" in response.headers.get("DAV", "")
 
 
 def test_dav_rejects_different_user_path(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.request(
             "PROPFIND", "/dav/other-user/projects/", headers=AUTH_HEADERS
         )
@@ -46,7 +46,7 @@ def test_dav_rejects_different_user_path(dev_auth_dependency_overrides):
 
 
 def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.request("PROPFIND", "/dav/", headers=AUTH_HEADERS)
         assert response.status_code == 403
         assert response.json()["detail"] == "DAV path must include an owner user"
@@ -55,7 +55,7 @@ def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):
 def test_dav_rejects_ownerless_options_before_capability_discovery(
     dev_auth_dependency_overrides,
 ):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.options("/dav/", headers=AUTH_HEADERS)
         assert response.status_code == 403
         assert "dav" not in {header.lower() for header in response.headers}
@@ -63,7 +63,7 @@ def test_dav_rejects_ownerless_options_before_capability_discovery(
 
 
 def test_dav_propfind(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.request(
             "PROPFIND", "/dav/user123/projects/", headers=AUTH_HEADERS
         )
@@ -74,7 +74,7 @@ def test_dav_propfind(dev_auth_dependency_overrides):
 
 
 def test_dav_propfind_escapes_path_values(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.request(
             "PROPFIND", "/dav/user123/projects/x%26y%3Cz%3E", headers=AUTH_HEADERS
         )
@@ -85,7 +85,7 @@ def test_dav_propfind_escapes_path_values(dev_auth_dependency_overrides):
 
 
 def test_dav_put(dev_auth_dependency_overrides):
-    with TestClient(app) as client:
+    with TestClient(app):
         response = client.put(
             "/dav/user123/projects/file.ics",
             content=b"BEGIN:VCALENDAR\r\nEND:VCALENDAR",
@@ -106,15 +106,14 @@ def test_dav_log_injection_prevention(dev_auth_dependency_overrides, caplog):
 
     caplog.set_level(logging.INFO)
     # URL encode the payload so httpx doesn't reject it; FastAPI will decode it back to the raw control chars
-    malicious_path = "user123/projects/test%1B%5B31minjected%0A%0D"
-    with TestClient(app) as client:
+    #
+    with TestClient(app):
         # Pass raw path to simulate actual request if unquote fails; wait, TestClient accepts raw URL strings but they are parsed.
         # Use simple printable characters for request, and we'll manually call the handler to verify logging logic
         pass
 
     # Since HTTP clients block raw control chars and starlette unquotes but might reject it before reaching our route,
     # we test the handler directly to ensure the logger is using repr().
-    from api.dav import _ensure_dav_owner_scope
 
     # We can invoke the route logic through the actual function or simply check the string formatting manually,
     # but since this is an integration test, we can use the app but pass standard requests. Wait, the logger logic

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -2,7 +2,6 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 from core.config import settings
-from db.models import Base
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1214,7 +1214,6 @@ async def test_get_pending_replies(client: AsyncClient, db_session):
 def test_email_owner_filters():
     from api.emails import email_owner_filters
     from api.auth import AuthContext
-    from db.models import Email
 
     # Test with organization_id
     ctx1 = AuthContext(

--- a/backend/tests/test_ontology.py
+++ b/backend/tests/test_ontology.py
@@ -1,4 +1,3 @@
-import pytest
 from services.ontology_service import ontology_service
 
 def test_analyze_sender_relationship():

--- a/backend/tests/test_threading_service.py
+++ b/backend/tests/test_threading_service.py
@@ -3,28 +3,33 @@ import pytest
 from services.threading_service import assign_thread_id
 
 
-class _ScalarResult:
-    def __init__(self, value):
-        self._value = value
-
-    def scalar_one_or_none(self):
-        return self._value
+class _MockRow:
+    def __init__(self, message_id, thread_id):
+        self.message_id = message_id
+        self.thread_id = thread_id
 
 
-class _SequentialSession:
-    def __init__(self, values):
-        self._values = list(values)
+class _MockResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _MockSession:
+    def __init__(self, rows):
+        self._rows = rows
         self.execute_count = 0
 
     async def execute(self, _query):
         self.execute_count += 1
-        value = self._values.pop(0) if self._values else None
-        return _ScalarResult(value)
+        return _MockResult(self._rows)
 
 
-class _QueryCapturingSession(_SequentialSession):
-    def __init__(self, values):
-        super().__init__(values)
+class _QueryCapturingSession(_MockSession):
+    def __init__(self, rows):
+        super().__init__(rows)
         self.queries = []
 
     async def execute(self, query):
@@ -34,7 +39,7 @@ class _QueryCapturingSession(_SequentialSession):
 
 @pytest.mark.asyncio
 async def test_reply_before_root_uses_first_reference_as_deterministic_thread_id():
-    session = _SequentialSession([None, None, None])
+    session = _MockSession([])
 
     thread_id = await assign_thread_id(
         session,
@@ -52,7 +57,7 @@ async def test_reply_before_root_uses_first_reference_as_deterministic_thread_id
 
 @pytest.mark.asyncio
 async def test_reply_without_references_uses_in_reply_to_as_deterministic_thread_id():
-    session = _SequentialSession([None, None])
+    session = _MockSession([])
 
     thread_id = await assign_thread_id(
         session,
@@ -70,7 +75,7 @@ async def test_reply_without_references_uses_in_reply_to_as_deterministic_thread
 
 @pytest.mark.asyncio
 async def test_existing_parent_thread_id_wins_over_deterministic_fallback():
-    session = _SequentialSession(["thread-123"])
+    session = _MockSession([_MockRow("parent@example.com", "thread-123")])
 
     thread_id = await assign_thread_id(
         session,
@@ -88,7 +93,7 @@ async def test_existing_parent_thread_id_wins_over_deterministic_fallback():
 
 @pytest.mark.asyncio
 async def test_existing_legacy_bracketed_thread_id_is_normalized():
-    session = _SequentialSession(["<root@example.com>"])
+    session = _MockSession([_MockRow("root@example.com", "<root@example.com>")])
 
     thread_id = await assign_thread_id(
         session,
@@ -106,7 +111,7 @@ async def test_existing_legacy_bracketed_thread_id_is_normalized():
 
 @pytest.mark.asyncio
 async def test_forwarded_subject_alone_does_not_merge_unrelated_thread():
-    session = _SequentialSession(["unrelated-thread"])
+    session = _MockSession([])
 
     thread_id = await assign_thread_id(
         session,
@@ -126,7 +131,7 @@ async def test_forwarded_subject_alone_does_not_merge_unrelated_thread():
 
 @pytest.mark.asyncio
 async def test_existing_thread_lookup_is_scoped_to_owner_and_organization():
-    session = _QueryCapturingSession(["thread-123"])
+    session = _QueryCapturingSession([_MockRow("parent@example.com", "thread-123")])
 
     thread_id = await assign_thread_id(
         session,


### PR DESCRIPTION
💡 What: Refactored `assign_thread_id` to use a single `IN (...)` database query via `_find_existing_thread_ids` instead of individual database lookups for every email reference candidate.
🎯 Why: Resolves an N+1 query problem that caused unnecessary sequential database round-trips when assigning an email to a thread.
📊 Impact: Database round-trips for thread assignment on emails with long reference lists drop from O(N) to O(1).
🔬 Measurement: Verified with updated unit tests (`backend/tests/test_threading_service.py`) that successfully validate the single-query batch map lookup behavior.

---
*PR created automatically by Jules for task [12843111898385608553](https://jules.google.com/task/12843111898385608553) started by @seonghobae*