### PR TITLE
Preflight combined image auth secret

### DIFF
--- a/backend/scripts/docker_entrypoint.sh
+++ b/backend/scripts/docker_entrypoint.sh
@@ -29,6 +29,16 @@ if ! python -c "import os; from cryptography.fernet import Fernet; Fernet(os.env
   fail "ENCRYPTION_KEY is not a valid Fernet key. Generate one with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'."
 fi
 
+# 1c. Match the backend runtime preflight for the signed-session HMAC secret.
+#     Without this, weak secrets fail during bootstrap imports and produce a
+#     Pydantic traceback before the operator sees the actionable rule.
+if ! python -c "import os; from core.runtime_secrets import validate_auth_session_hmac_secret_value; validate_auth_session_hmac_secret_value(os.environ['AUTH_SESSION_HMAC_SECRET'])" 2>/tmp/naruon-auth-secret-check.log; then
+  auth_secret_error="$(tail -n 1 /tmp/naruon-auth-secret-check.log 2>/dev/null || true)"
+  rm -f /tmp/naruon-auth-secret-check.log
+  fail "${auth_secret_error:-AUTH_SESSION_HMAC_SECRET is invalid. It must be at least 32 bytes, contain at least 12 distinct characters, and use at least three character classes.}"
+fi
+rm -f /tmp/naruon-auth-secret-check.log
+
 # 2. Bootstrap the database schema. A failure here must be reported with an
 #    actionable message rather than just an asyncpg/SQLAlchemy traceback.
 log "Bootstrapping database schema..."

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -209,6 +209,8 @@ def test_combined_image_start_script_preflights_env_and_logs_service_exit() -> N
 
     assert "for var in DATABASE_URL AUTH_SESSION_HMAC_SECRET ENCRYPTION_KEY" in start_script
     assert "Fernet.generate_key()" in start_script
+    assert "validate_auth_session_hmac_secret_value" in start_script
+    assert "AUTH_SESSION_HMAC_SECRET is invalid" in start_script
     assert "database bootstrap failed" in start_script
     assert "Backend and frontend will not start." in start_script
     assert "Starting backend (uvicorn :8000)" in start_script


### PR DESCRIPTION
## Summary
- Add combined-image `AUTH_SESSION_HMAC_SECRET` strength preflight before DB bootstrap.
- Keep the operator-facing failure actionable instead of allowing a Pydantic/bootstrap traceback for weak placeholder secrets.
- Extend release governance coverage for the combined image entrypoint contract.

## Line-level changes
- `backend/scripts/docker_entrypoint.sh`: validate `AUTH_SESSION_HMAC_SECRET` with `core.runtime_secrets.validate_auth_session_hmac_secret_value` immediately after Fernet key validation and before `scripts/bootstrap_db.py` runs.
- `backend/scripts/docker_entrypoint.sh`: surface the validator's final `ValueError` line through `fail` and remove the temporary validation log.
- `backend/tests/test_release_governance.py`: assert the combined image start script includes the HMAC validator and fallback actionable error text.

## Verification
- `bash -n backend/scripts/docker_entrypoint.sh`
- `cd backend && python -m pytest tests/test_release_governance.py::test_combined_image_start_script_preflights_env_and_logs_service_exit tests/test_repo_hygiene.py::test_backend_dockerfile_runtime_stages_run_as_non_root_user tests/test_repo_hygiene.py::test_ollama_dockerfile_keeps_pulled_models_available_to_runtime_user -q`
- `docker build -t naruon-current-combined:cbad225-preflight .`
- invalid-secret combined image smoke: exits 1 with `AUTH_SESSION_HMAC_SECRET must not be a repeated character` and no traceback.
- valid combined image smoke with `pgvector/pgvector:pg16`: backend `/` returned `{"status":"ok","message":"AI Email Client API"}`, frontend returned 63616 bytes.
- `docker build --target backend-runtime -t naruon-current-backend:cbad225-preflight .`
- `docker build -f frontend/Dockerfile -t naruon-current-frontend:cbad225-preflight .`
- live compose stack using `docker-compose.live-e2e.yml`, `gemma4:e2b-it-qat`, and `embeddinggemma`.
- `env -u FORCE_COLOR -u NO_COLOR LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=... RUN_LIVE_MODEL_E2E=1 pnpm exec playwright test tests/e2e/nano.spec.ts --project=desktop` -> 2 passed.
- `env -u FORCE_COLOR -u NO_COLOR LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=... RUN_LIVE_E2E=1 pnpm exec playwright test tests/e2e/nano-live-model.spec.ts --project=desktop` -> 2 passed.
- `env -u FORCE_COLOR -u NO_COLOR pnpm exec vitest run src/components/SettingsLayout.test.tsx src/app/data/page.test.tsx` -> 15 passed.
- collected individual live stack `podman logs` and found no `Timeout`, `Fatal`, `Warn`, or `Denied` output.
