### PR TITLE
Align README Strix model contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,17 @@ mail/calendar/file systems.
 - PR automation is metadata-only and uses current-head robot-review evidence plus
   required checks. Human approval is not awaited by default under repo policy.
 - Strix PR/security evidence defaults to GitHub Models through
-  `STRIX_LLM=openai/openai/gpt-4.1`, `models: read`, `github.token`, and
-  `LLM_API_BASE_FILE` pointing at a trusted file containing
+  `STRIX_LLM=openai/gpt-5`, `STRIX_GITHUB_MODELS_TOKEN`, `models: read`,
+  `github.token`, and `LLM_API_BASE_FILE` pointing at a trusted file containing
   `https://models.github.ai/inference`. The workflow keeps that endpoint in a
-  trusted input file and passes the token only through the
-  provider-scoped Strix child-process key path. Legacy `STRIX_LLM` secrets do
-  not override PR, push, or scheduled Strix defaults. Vertex remains available
-  only for manual `workflow_dispatch` evidence when `strix_llm` explicitly
-  selects `vertex_ai/gemini-3.1-pro-preview-customtools` or
+  trusted input file, tries the configured GPT-5-or-newer GitHub Models primary
+  first, and may fall back only to the explicit GitHub Models fallback list:
+  `deepseek/deepseek-r1-0528` and `deepseek/deepseek-v3-0324`. The workflow
+  passes the token only through the provider-scoped Strix child-process key path.
+  Legacy `STRIX_LLM` secrets do not override PR, push, or scheduled Strix
+  defaults. Vertex remains available only for manual `workflow_dispatch`
+  evidence when `strix_llm` explicitly selects
+  `vertex_ai/gemini-3.1-pro-preview-customtools` or
   `vertex_ai/gemini-2.5-flash` with `GCP_SA_KEY`; direct OpenAI
   GPT-5.4-or-newer remains supported only for manual `strix_llm` selections
   with `STRIX_OPENAI_API_KEY`. The workflow fails closed rather than using generic


### PR DESCRIPTION
## Summary
- update README Strix PR/security evidence text from stale GPT-4.1 wording to the current GitHub Models GPT-5 default
- document the explicit DeepSeek fallback list used by the workflow

## Verification
- git diff --check
- python -m pytest backend/tests/test_release_governance.py::test_strix_workflow_uses_github_models_default_and_narrow_warning_filter backend/tests/test_repo_hygiene.py -q
- LIVE_BASE_URL=http://127.0.0.1:18080 RUN_LIVE_MODEL_E2E=1 RUN_LIVE_E2E=1 corepack pnpm@11.5.3 --dir frontend exec playwright test tests/e2e/nano.spec.ts tests/e2e/nano-live-model.spec.ts --project=desktop --workers=1 --reporter=line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to specify newer default model and clarify model selection and fallback behavior.
  * Enhanced explanation of token security scope and legacy secret handling.
  * Added clarity on manual workflow customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->