### PR TITLE
🛡️ Sentinel: [HIGH] Remove hardcoded local CORS origins for secure deployment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Vulnerability:** Found `xml.etree.ElementTree.fromstring` being used to parse HTTP responses in `backend/tests/test_dav_api.py`.
 **Learning:** Using the standard library `xml.etree` module for parsing untrusted or external XML data exposes the application to XML External Entity (XXE) and XML bomb attacks (CWE-20). This was flagged by static analysis tools (Bandit B314).
 **Prevention:** Always use `defusedxml.ElementTree` instead of `xml.etree.ElementTree` when parsing XML to ensure protection against XML vulnerabilities. Ensure `defusedxml` is listed in `requirements.txt`.
+## 2024-06-13 - Strict CORS Configurations
+
+**Vulnerability:** Hardcoded local fallbacks (e.g., `localhost:3000`, `127.0.0.1:3000`) for CORS origins in FastAPI configuration (`backend/main.py`).
+**Learning:** Hardcoding relaxed CORS origins for development inside production initialization logic introduces a risk of overly permissive CORS behavior, particularly if the expected configuration variable (`ALLOWED_CORS_ORIGINS`) is accidentally left unset.
+**Prevention:** Strictly rely on environment variables for CORS configurations. Local development needs should be supplied via `.env` files rather than embedded as implicit defaults in the application entrypoint.

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,13 +78,6 @@ cors_origins = [
     for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
     if origin.strip()
 ]
-if not cors_origins:
-    cors_origins = [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "http://localhost:8000",
-        "http://127.0.0.1:8000",
-    ]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hardcoded local fallback URLs (`localhost:3000`, `127.0.0.1:3000`, etc.) were configured for CORS origins in the primary FastAPI configuration (`backend/main.py`) when `ALLOWED_CORS_ORIGINS` was unset.
🎯 Impact: If the `ALLOWED_CORS_ORIGINS` environment variable is accidentally left blank or omitted in production, the system defaults to allowing potentially unsafe cross-origin requests from these default hostnames, introducing security risk.
🔧 Fix: Removed the fallback conditional block completely. The CORS configuration now strictly relies on the split value of `ALLOWED_CORS_ORIGINS`. If unconfigured, the application "fails closed" by denying cross-origin traffic rather than granting it to hardcoded addresses.
✅ Verification: Ran `cat backend/main.py` and executed the full backend `pytest` test suite to ensure the system is stable and the changes introduce no regressions. Evaluated logs and verified Sentinel learning was added.

---
*PR created automatically by Jules for task [11149884888781111541](https://jules.google.com/task/11149884888781111541) started by @seonghobae*