### PR TITLE
Publish naruon image through GHCR workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
   pull_request:
     branches:
+      - develop
       - master
       - "release/**"
 
@@ -30,6 +31,12 @@ jobs:
         include:
           - component: backend
             image: ai_email_client-backend
+            dockerfile: Dockerfile
+            context: .
+            build_args: |
+              BUILDKIT_INLINE_CACHE=1
+          - component: naruon
+            image: naruon
             dockerfile: Dockerfile
             context: .
             build_args: |
@@ -75,6 +82,12 @@ jobs:
         include:
           - component: backend
             image: ai_email_client-backend
+            dockerfile: Dockerfile
+            context: .
+            build_args: |
+              BUILDKIT_INLINE_CACHE=1
+          - component: naruon
+            image: naruon
             dockerfile: Dockerfile
             context: .
             build_args: |

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -170,10 +170,13 @@ def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_
         == 2
     )
     push_block = workflow.split("push:", 1)[1].split("pull_request:", 1)[0]
+    pull_request_block = workflow.split("pull_request:", 1)[1].split("permissions:", 1)[0]
     assert "tags:" in push_block
     assert "branches:" not in push_block
+    assert "develop" in pull_request_block
     assert "ai_email_client-backend" in workflow
     assert "ai_email_client-frontend" in workflow
+    assert workflow.count("image: naruon") == 2
     assert "push: false" in workflow
     assert "push: true" in workflow
     assert "type=semver" in workflow


### PR DESCRIPTION
## Summary
- add the `naruon` combined image to Docker publish validation and tag publishing matrices
- run Docker image validation for develop-targeted PRs so the default branch path exercises this workflow
- add release-governance assertions for the `naruon` image contract

This avoids relying on a long-running local Podman push for the public GHCR release image.

## Verification
- `git diff --check`
- `python -m pytest backend/tests/test_release_governance.py::test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_tags -q`
- `actionlint .github/workflows/docker-publish.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build pipeline to support pull request validation for the develop branch and added a new image component to the build configuration.

* **Tests**
  * Enhanced release governance tests to validate the updated build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->