### PR TITLE
Document GHCR public visibility runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,7 +414,13 @@
   exact image name, tag, local image ID, push result, and registry verification
   from GitHub Packages or an equivalent manifest/API query. Publish the package
   with public visibility unless a repository policy explicitly says otherwise.
-  Do not treat a local tag as published evidence.
+  Do not treat a local tag as published evidence. GitHub's REST Packages API and
+  GraphQL package mutations currently do not expose a supported package
+  visibility change operation for GHCR container packages; when API checks show
+  `visibility: private`, complete the public conversion through the logged-in
+  GitHub package settings UI (`Package settings` -> `Danger Zone` -> `Change
+  visibility`) and then verify anonymous pull/token access before declaring the
+  image public.
 - Docker image security inspection is part of release evidence. Use a current
   container scanner such as Trivy or Grype against the exact pushed image tag
   and treat high/critical actionable findings as blockers until fixed or

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -485,3 +485,17 @@ def test_coderabbit_approval_is_decoupled_from_github_checks() -> None:
     assert "enabled: false" in config
     assert "GitHub Checks integration stays disabled" in policy
     assert "GitHub Checks integration disabled" in agents
+
+
+def test_agents_records_ghcr_visibility_publication_runbook() -> None:
+    agents = read_repo_text("AGENTS.md")
+    normalized_agents = " ".join(agents.split())
+
+    assert "GHCR publishing evidence for the combined `naruon` image" in agents
+    assert "REST Packages API" in agents
+    assert "GraphQL package mutations" in agents
+    assert "visibility: private" in agents
+    assert "Package settings" in agents
+    assert "Danger Zone" in agents
+    assert "Change visibility" in normalized_agents
+    assert "anonymous pull/token access" in agents


### PR DESCRIPTION
## Summary
- record that GHCR container package visibility cannot currently be changed through supported REST/GraphQL package APIs
- document the logged-in GitHub Package settings UI path and anonymous pull/token verification requirement
- add release-governance coverage so the GHCR visibility publication runbook remains available to future committers

## Verification
- python -m pytest backend/tests/test_release_governance.py::test_agents_records_ghcr_visibility_publication_runbook backend/tests/test_release_governance.py::test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_tags -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced release governance documentation with expanded procedures for Docker image public verification processes.

* **Tests**
  * Added regression test to validate release governance documentation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->