### PR TITLE
fix: align live smoke with HttpOnly sessions

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -437,12 +437,17 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     assert "OPENAI_BASE_URL: http://ollama:11434/v1" in live_e2e_compose
     assert "OPENAI_MODEL: gemma4:e2b-it-qat" in live_e2e_compose
     assert "OPENAI_EMBEDDING_MODEL: embeddinggemma" in live_e2e_compose
+    live_backend_block = live_e2e_compose.split("  backend:", 1)[1].split(
+        "  frontend:", 1
+    )[0]
+    assert "ALLOWED_CORS_ORIGINS: http://127.0.0.1:18080" in live_backend_block
     live_frontend_block = live_e2e_compose.split("  frontend:", 1)[1].split(
         "  nginx:", 1
     )[0]
     assert "NEXT_PUBLIC_API_URL: http://127.0.0.1:18080" in live_frontend_block
     assert "BACKEND_INTERNAL_URL: http://backend:8000" in live_frontend_block
     assert 'ALLOW_DOCKER_BACKEND_INTERNAL_URL: "1"' in live_frontend_block
+    assert "TRUSTED_FRONTEND_ORIGINS: http://127.0.0.1:18080" in live_frontend_block
     live_nginx = read_repo_text("tests/live/nginx.conf")
     assert "proxy_read_timeout 600s" in live_nginx
     assert 'add_header Referrer-Policy "strict-origin-when-cross-origin" always;' in live_nginx
@@ -452,7 +457,8 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     api_location = live_nginx.split("    location /api/ {", 1)[1].split("    }", 1)[0]
     root_location = live_nginx.split("    location / {", 1)[1].split("    }", 1)[0]
     for location in (api_location, root_location):
-        assert "proxy_set_header Host $host;" in location
+        assert "proxy_set_header Host $http_host;" in location
+        assert "proxy_set_header X-Forwarded-Host $http_host;" in location
         assert "proxy_set_header X-Real-IP $remote_addr;" in location
         assert (
             "proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;"

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -60,6 +60,7 @@ services:
       TRUST_DEV_HEADERS: "false"
       DEBUG: "false"
       ALLOW_LOCAL_LLM_PROVIDERS: "true"
+      ALLOWED_CORS_ORIGINS: http://127.0.0.1:18080
       ALLOWED_LLM_BASE_URL_HOSTS: "ollama"
       OPENAI_API_KEY: ollama
       OPENAI_BASE_URL: http://ollama:11434/v1
@@ -80,6 +81,7 @@ services:
       NEXT_PUBLIC_API_URL: http://127.0.0.1:18080
       BACKEND_INTERNAL_URL: http://backend:8000
       ALLOW_DOCKER_BACKEND_INTERNAL_URL: "1"
+      TRUSTED_FRONTEND_ORIGINS: http://127.0.0.1:18080
     depends_on:
       - backend
     expose:

--- a/frontend/tests/e2e/live-smoke.spec.ts
+++ b/frontend/tests/e2e/live-smoke.spec.ts
@@ -89,7 +89,7 @@ test('live dashboard renders seeded inbox through real HTTP', async ({ page }) =
 test('live data workspace reaches backend-backed WebDAV and document APIs without 503', async ({
   page,
 }) => {
-  const sessionToken = await installLiveSession(page);
+  await installLiveSession(page);
 
   const failedResponses: string[] = [];
   page.on('response', (response) => {
@@ -125,10 +125,8 @@ test('live data workspace reaches backend-backed WebDAV and document APIs withou
   });
   await page.getByRole('button', { name: 'WebDAV 반영 의도 점검' }).click();
   const webdavIntentResponse = await intentResponse;
-  expect(webdavIntentResponse.status()).toBeLessThan(500);
-  expect(webdavIntentResponse.request().headers().authorization).toBe(
-    `Bearer ${sessionToken}`,
-  );
+  expect(webdavIntentResponse.status()).toBeLessThan(400);
+  expect(webdavIntentResponse.request().headers().authorization).toBeUndefined();
 
   const materializationResponse = page.waitForResponse((response) => {
     const url = new URL(response.url());
@@ -140,10 +138,10 @@ test('live data workspace reaches backend-backed WebDAV and document APIs withou
     .getByRole('button', { name: 'WebDAV 문서 실행 요청' })
     .click();
   const webdavMaterializationResponse = await materializationResponse;
-  expect(webdavMaterializationResponse.status()).toBeLessThan(500);
-  expect(webdavMaterializationResponse.request().headers().authorization).toBe(
-    `Bearer ${sessionToken}`,
-  );
+  expect(webdavMaterializationResponse.status()).toBeLessThan(400);
+  expect(
+    webdavMaterializationResponse.request().headers().authorization
+  ).toBeUndefined();
 
   expect(failedResponses).toEqual([]);
 });

--- a/tests/live/nginx.conf
+++ b/tests/live/nginx.conf
@@ -7,7 +7,8 @@ server {
     server_name _;
 
     proxy_http_version 1.1;
-    proxy_set_header Host $host;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -19,7 +20,8 @@ server {
 
     location /api/ {
         proxy_pass http://live_frontend;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -29,7 +31,8 @@ server {
 
     location / {
         proxy_pass http://live_frontend;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- Update the live smoke spec to verify HttpOnly-cookie browser requests do not expose Authorization headers while still succeeding through the frontend proxy.
- Preserve live-e2e origin and forwarded-host state so the real backend/frontend stack accepts same-origin API calls instead of returning CORS/session 403s.
- Add release-governance coverage for the live compose/nginx contract.

## Test Plan
- [x] git diff --check
- [x] python3 -m pytest backend/tests/test_release_governance.py::test_backend_compose_commands_use_startup_preflight
- [x] LIVE_BASE_URL=http://127.0.0.1:18081 LIVE_E2E_SESSION_SECRET=*** npx playwright test tests/e2e/live-smoke.spec.ts --project=desktop