### PR TITLE
🛡️ Sentinel: Fix overly permissive CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ POSTGRES_PASSWORD=change-me-local-only
 DATABASE_URL=postgresql+asyncpg://postgres:change-me-local-only@localhost:5432/ai_email
 DEBUG=false
 AUTH_SESSION_HMAC_SECRET=
+ALLOWED_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8000,http://127.0.0.1:8000
 ENCRYPTION_KEY=
 ENABLE_PROMETHEUS_METRICS=false
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -82,13 +82,6 @@ cors_origins = [
     for origin in settings.ALLOWED_CORS_ORIGINS.split(",")
     if origin.strip()
 ]
-if not cors_origins:
-    cors_origins = [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "http://localhost:8000",
-        "http://127.0.0.1:8000",
-    ]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The backend `main.py` had a default CORS origin fallback that trusted `localhost` and `127.0.0.1` ports even in production if `ALLOWED_CORS_ORIGINS` wasn't explicitly provided, opening a risk for cross-origin attacks from malicious local services.
🎯 Impact: Unauthorized requests might bypass CORS restrictions if the environment variable is unconfigured in production.
🔧 Fix: Removed the fallback inside `backend/main.py`. Local configurations were correctly moved into `.env.example` as the appropriate configuration vehicle.
✅ Verification: Backend unit tests and formatters pass cleanly. Local development origins are provided as default in `.env.example`.

---
*PR created automatically by Jules for task [17727059205735313216](https://jules.google.com/task/17727059205735313216) started by @seonghobae*