### PR TITLE
🧪 Add tests for email filename sanitation

### DIFF
--- a/backend/tests/test_email_import_service.py
+++ b/backend/tests/test_email_import_service.py
@@ -1,0 +1,39 @@
+import pytest
+from pathlib import Path
+from services.email_import_service import _safe_item_filename, _safe_upload_filename
+
+@pytest.mark.parametrize(
+    "input_name,expected",
+    [
+        ("file.zip", "file.zip"),
+        ("", "upload"),
+        (None, "upload"),
+        ("/some/path/file.zip", "file.zip"),
+        ("  spaced.zip  ", "spaced.zip"),
+        ("/", "upload"),
+    ]
+)
+def test_safe_upload_filename(input_name, expected):
+    assert _safe_upload_filename(input_name) == expected
+
+@pytest.mark.parametrize(
+    "upload_name,eml_path,expected",
+    [
+        # without eml_path
+        ("my_archive.zip", None, "my_archive.zip"),
+        ("", None, "upload"),
+        ("/path/to/my_archive.zip", None, "my_archive.zip"),
+
+        # matching eml_path
+        ("my_file.eml", Path("my_file.eml"), "my_file.eml"),
+        ("/path/my_file.eml", Path("/other/path/my_file.eml"), "my_file.eml"),
+        ("  my_file.eml  ", Path("my_file.eml"), "my_file.eml"),
+
+        # differing eml_path
+        ("my_archive.zip", Path("email_1.eml"), "my_archive.zip:email_1.eml"),
+        ("/path/my_archive.zip", Path("/some/folder/email_1.eml"), "my_archive.zip:email_1.eml"),
+        ("", Path("email_1.eml"), "upload:email_1.eml"),
+    ]
+)
+def test_safe_item_filename(upload_name, eml_path, expected):
+    assert _safe_item_filename(upload_name, eml_path) == expected


### PR DESCRIPTION
🎯 What: Tested the _safe_upload_filename and _safe_item_filename functions in backend/services/email_import_service.py.
📊 Coverage: Added parameterized tests covering null values, empty strings, absolute paths, whitespace strings, and cases where the sanitized path matches or diverges from the expected eml path.
✨ Result: Ensured filename edge cases are correctly sanitized before file persistence, avoiding unexpected behavior during zip/eml extraction.

---
*PR created automatically by Jules for task [7268453011531789194](https://jules.google.com/task/7268453011531789194) started by @seonghobae*