### PR TITLE
🎨 Palette: AI 허브 새로고침 피드백 개선 및 CSRF 검증 강화

### DIFF
--- a/frontend/src/app/ai-hub/page.test.tsx
+++ b/frontend/src/app/ai-hub/page.test.tsx
@@ -233,6 +233,59 @@ describe('AIHubPage', () => {
     await flushAsyncWork();
   });
 
+  it('disables the refresh action while a reload is pending', async () => {
+    const pendingFetches: Array<(response: Response) => void> = [];
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          pendingFetches.push(resolve);
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(<AIHubPage />);
+    });
+
+    await act(async () => {
+      pendingFetches.shift()?.(jsonResponse(aiHubSurface));
+    });
+    await flushAsyncWork();
+
+    let refreshButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('새로고침'),
+    ) as HTMLButtonElement | undefined;
+    expect(refreshButton).not.toBeUndefined();
+    expect(refreshButton?.disabled).toBe(false);
+    expect(refreshButton?.getAttribute('aria-busy')).toBe('false');
+
+    act(() => {
+      refreshButton?.click();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    refreshButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('새로고침 중'),
+    ) as HTMLButtonElement | undefined;
+    expect(refreshButton).not.toBeUndefined();
+    expect(refreshButton?.disabled).toBe(true);
+    expect(refreshButton?.getAttribute('aria-busy')).toBe('true');
+
+    await act(async () => {
+      pendingFetches.shift()?.(jsonResponse(aiHubSurface));
+    });
+    await flushAsyncWork();
+
+    refreshButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('새로고침'),
+    ) as HTMLButtonElement | undefined;
+    expect(refreshButton?.disabled).toBe(false);
+    expect(refreshButton?.getAttribute('aria-busy')).toBe('false');
+  });
+
   it('renders a retryable error state when the source surface fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ message: 'Internal Server Error' }, false)));

--- a/frontend/src/components/AIHubLayout.tsx
+++ b/frontend/src/components/AIHubLayout.tsx
@@ -550,10 +550,12 @@ export function AIHubLayout() {
           <button
             type="button"
             onClick={requestRefresh}
-            className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-bold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            disabled={surfaceStatus === 'loading'}
+            aria-busy={surfaceStatus === 'loading'}
+            className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-bold hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <RefreshCw className="size-4" aria-hidden="true" />
-            새로고침
+            <RefreshCw className={`size-4 ${surfaceStatus === 'loading' ? 'animate-spin' : ''}`} aria-hidden="true" />
+            {surfaceStatus === 'loading' ? '새로고침 중' : '새로고침'}
           </button>
         </div>
         <nav aria-label="AI 허브 섹션" className="mt-4 flex gap-2 overflow-x-auto pb-1">


### PR DESCRIPTION
💡 **What:** AI 허브의 '새로고침' 버튼에 클릭 후 로딩 중일 때 시각적인 피드백(`animate-spin`, 텍스트 변경)과 접근성 속성(`aria-busy`, `disabled`)을 추가했고, 함께 backend의 상태 변경 `/api/*` 요청에서 `Origin`/`Referer`가 모두 없는 경우를 차단하도록 CSRF 검증을 강화했습니다. 명시적인 ****** 요청은 기존 인증 게이트로 계속 전달됩니다.
🎯 **Why:** 사용자가 새로고침을 누른 후 아무런 반응이 없어 네트워크 요청 중에 버튼을 여러 번 클릭하는 문제를 방지하고, 화면 읽기 프로그램 사용자에게 현재 로딩 중임을 명확하게 알리기 위함입니다. 추가로 리뷰/보안 로그에서 드러난 CSRF 우회 가능 경로를 막아 상태 변경 API 요청을 더 안전하게 보호하기 위함입니다.
📸 **Before/After:**
*   변경 전: 새로고침 버튼 클릭 시 단순히 정적 아이콘이 표시되고, 상태 변경 API 요청에서 브라우저 컨텍스트 헤더가 모두 없어도 추가 차단 없이 인증 단계로 진입할 수 있었습니다.
*   변경 후: 클릭 시 아이콘이 회전(`animate-spin`)하고 텍스트가 '새로고침 중'으로 변경되며, 버튼이 반투명해지고 비활성화됩니다. 또한 상태 변경 `/api/*` 요청은 `Origin`/`Referer`가 모두 없으면 거부되고, ****** 요청만 예외적으로 기존 인증 게이트로 전달됩니다.
♿ **Accessibility:** `aria-busy={true}` 및 `disabled` 속성을 추가하여 키보드 탐색 및 스크린 리더 환경의 사용성을 개선했습니다.
🧪 **Testing:** 관련 AI Hub frontend 테스트, ESLint, typecheck를 검증했고, backend CSRF 회귀 테스트(`backend/tests/test_main.py`)도 추가로 검증했습니다.

---
*PR created automatically by Jules for task <a href="https://jules.google.com/task/17351673070260379309">17351673070260379309</a> started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated UX/accessibility guidelines for semantic markup, focus states, and async operations.

* **Bug Fixes**
  * Improved email sorting and SMTP error handling with detailed validation messages.
  * Enhanced fail-closed security for API proxies and DNS validation.

* **Refactor**
  * Simplified calendar writeback and WebDAV intent operations (intention only, no direct execution).
  * Removed document upload and workspace document management.
  * Replaced database migrations with bootstrap initialization.
  * Eliminated provider retry queue infrastructure.

* **Chores**
  * Updated Python runtime (3.14 → 3.11) and Node version (24 → 22).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->