### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/backend/tests/test_archive.py
+++ b/backend/tests/test_archive.py
@@ -3,7 +3,7 @@ import zipfile
 import pytest
 import asyncio
 
-from services.archive import extract_backup, extract_backup_async, MAX_EXTRACT_SIZE
+from services.archive import extract_backup, extract_backup_async
 from services.exceptions import (
     InvalidArchiveError,
     ArchiveSizeExceededError,
@@ -112,9 +112,7 @@ def test_extract_backup_rejects_preexisting_symlink_escape(tmp_path):
 
 
 def test_extract_backup_file_count_exceeded(tmp_path, monkeypatch):
-    import services.archive
-
-    monkeypatch.setattr(services.archive, "MAX_FILE_COUNT", 2)
+    monkeypatch.setattr("services.archive.MAX_FILE_COUNT", 2)
 
     zip_path = tmp_path / "test_count.zip"
     with zipfile.ZipFile(zip_path, "w") as z:

--- a/backend/tests/test_archive.py
+++ b/backend/tests/test_archive.py
@@ -3,7 +3,7 @@ import zipfile
 import pytest
 import asyncio
 
-from services.archive import extract_backup, extract_backup_async
+from services.archive import extract_backup, extract_backup_async, MAX_EXTRACT_SIZE
 from services.exceptions import (
     InvalidArchiveError,
     ArchiveSizeExceededError,
@@ -46,9 +46,7 @@ def test_extract_backup_bad_zip_file(tmp_path):
 
 
 def test_extract_backup_size_exceeded(tmp_path, monkeypatch):
-    import services.archive
-
-    monkeypatch.setattr(services.archive, "MAX_EXTRACT_SIZE", 10)  # 10 bytes limit
+    monkeypatch.setattr("services.archive.MAX_EXTRACT_SIZE", 10)  # 10 bytes limit
 
     zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, "w") as z:


### PR DESCRIPTION
Use only one import style for `services.archive` in this test file. Since the file already uses `from services.archive import ...`, the cleanest fix is:

- Add `MAX_EXTRACT_SIZE` to the existing `from services.archive import ...` statement at the top.
- Remove the local `import services.archive` inside `test_extract_backup_size_exceeded`.
- Update monkeypatch target from module attribute access to the already-imported symbol path string:  
  `monkeypatch.setattr("services.archive.MAX_EXTRACT_SIZE", 10)`.

This keeps functionality unchanged (it still patches the constant in the `services.archive` module) and resolves the mixed-import warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._