### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/backend/services/archive.py
+++ b/backend/services/archive.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from zipfile import ZipInfo
+from zipfile import BadZipFile, ZipFile, ZipInfo
 
 from .exceptions import (
     InvalidArchiveError,
@@ -69,7 +69,7 @@ def extract_backup(zip_path: str | Path, output_dir: str | Path) -> list[Path]:
     extracted_paths = []
 
     try:
-        with zipfile.ZipFile(zip_path, "r") as z:
+        with ZipFile(zip_path, "r") as z:
             total_size = 0
             file_count = 0
 
@@ -98,7 +98,7 @@ def extract_backup(zip_path: str | Path, output_dir: str | Path) -> list[Path]:
 
                 extracted_paths.append(target_path)
 
-    except (zipfile.BadZipFile, FileNotFoundError) as e:
+    except (BadZipFile, FileNotFoundError) as e:
         raise InvalidArchiveError(f"Failed to extract archive: {e}") from e
 
     return extracted_paths

--- a/backend/services/archive.py
+++ b/backend/services/archive.py
@@ -1,5 +1,4 @@
 import asyncio
-import zipfile
 from pathlib import Path
 from zipfile import ZipInfo
 


### PR DESCRIPTION
Use a single import style for `zipfile` in `backend/services/archive.py`.  
The least disruptive fix is to remove `import zipfile` and keep `from zipfile import ZipInfo`, **if** only `ZipInfo` is needed from that module in this file.

In the shown snippet, this means editing the import block near lines 1–4:
- Delete `import zipfile` (line 2).
- Keep `from zipfile import ZipInfo` (line 4) unchanged.

No behavioral change is introduced by this edit; it only resolves the duplicate import-style warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._