### PR TITLE
Fix services.archive import usage, Strix PR concurrency, and trusted-base fallback diagnosis

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -464,6 +464,8 @@ jobs:
           OPENCODE_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-primary.md
           OPENCODE_REVIEW_WORKDIR: ${{ runner.temp }}/opencode-review-project
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -1110,6 +1112,36 @@ jobs:
             strix_evidence_file="$(mktemp)"
             extract_strix_failed_check_block "$evidence_file" "$strix_evidence_file"
 
+            # Keep this inline fallback logic in sync with
+            # scripts/ci/emit_opencode_failed_check_fallback_findings.sh.
+            pr_changes_trusted_strix_inputs() {
+              local diff_status
+
+              if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+                return 1
+              fi
+              if [ -z "${PR_BASE_SHA:-}" ] || [ -z "${PR_HEAD_SHA:-}" ]; then
+                return 1
+              fi
+              if ! git -C "$repo_root" rev-parse --verify "${PR_BASE_SHA}^{commit}" >/dev/null 2>&1; then
+                return 1
+              fi
+              if ! git -C "$repo_root" rev-parse --verify "${PR_HEAD_SHA}^{commit}" >/dev/null 2>&1; then
+                return 1
+              fi
+
+              set +e
+              git -C "$repo_root" diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" -- \
+                .github/workflows/strix.yml \
+                scripts/ci/strix_quick_gate.sh \
+                scripts/ci/test_strix_quick_gate.sh \
+                requirements-strix-ci.txt
+              diff_status=$?
+              set -e
+
+              [ "$diff_status" -eq 1 ]
+            }
+
             emit_known_missing_string_finding() {
               local needle="$1"
               local title="$2"
@@ -1213,9 +1245,15 @@ jobs:
               finding_index=$((finding_index + 1))
               printf '### %s. HIGH %s:%s - Current-head Strix evidence is missing because the workflow run was cancelled before logs\n' "$finding_index" "$path" "$line"
               printf -- '- Problem: Strix Security Scan reported a current-head workflow_run conclusion of cancelled, but GitHub emitted no failed job log and no Strix Vulnerability Report window.\n'
-              printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This is a workflow execution/queue state, not an application vulnerability finding, so OpenCode must not invent a source-code fix.\n'
-              printf -- '- Fix: Do not approve from this cancelled run. Re-run the current-head Strix Security Scan after stale runs complete or are cancelled, then review the resulting job log; keep the workflow concurrency line at %s:%s so stale runs do not silently replace current-head evidence.\n' "$path" "$line"
-              printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log so reviewers see that the blocker is missing scanner evidence.\n\n'
+              if pr_changes_trusted_strix_inputs; then
+                printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This PR changes trusted Strix workflow or gate inputs, but the cancelled pull_request_target run still used the base branch copies, so current-head edits cannot affect this run.\n'
+                printf -- '- Fix: Do not invent an application code fix from this cancelled run. Re-run Strix after the trusted base branch contains the workflow/gate change or capture equivalent temporary evidence tied to this head SHA; keep the workflow concurrency line at %s:%s aligned with the intended queue isolation.\n' "$path" "$line"
+                printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log and cover self-modifying Strix workflow PRs so reviews explain trusted-base execution semantics.\n\n'
+              else
+                printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This is a workflow execution/queue state, not an application vulnerability finding, so OpenCode must not invent a source-code fix.\n'
+                printf -- '- Fix: Do not approve from this cancelled run. Re-run the current-head Strix Security Scan after stale runs complete or are cancelled, then review the resulting job log; keep the workflow concurrency line at %s:%s so stale runs do not silently replace current-head evidence.\n' "$path" "$line"
+                printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log so reviewers see that the blocker is missing scanner evidence.\n\n'
+              fi
             }
 
             emit_strix_cancelled_without_log_finding

--- a/backend/tests/test_archive.py
+++ b/backend/tests/test_archive.py
@@ -2,8 +2,8 @@ import os
 import zipfile
 import pytest
 import asyncio
+import services.archive as archive_module
 
-from services.archive import extract_backup, extract_backup_async
 from services.exceptions import (
     InvalidArchiveError,
     ArchiveSizeExceededError,
@@ -19,7 +19,7 @@ def test_extract_backup_success(tmp_path):
         z.writestr("folder/test2.eml", b"Subject: Test Email 2")
 
     out_dir = tmp_path / "output"
-    extracted_files = extract_backup(zip_path, out_dir)
+    extracted_files = archive_module.extract_backup(zip_path, out_dir)
 
     # Check only files are returned, not directories
     assert len(extracted_files) == 2
@@ -34,7 +34,7 @@ def test_extract_backup_success(tmp_path):
 
 def test_extract_backup_file_not_found(tmp_path):
     with pytest.raises(InvalidArchiveError, match="Failed to extract archive"):
-        extract_backup(tmp_path / "missing.zip", tmp_path / "output")
+        archive_module.extract_backup(tmp_path / "missing.zip", tmp_path / "output")
 
 
 def test_extract_backup_bad_zip_file(tmp_path):
@@ -42,11 +42,11 @@ def test_extract_backup_bad_zip_file(tmp_path):
     bad_zip.write_text("This is not a zip file")
 
     with pytest.raises(InvalidArchiveError, match="Failed to extract archive"):
-        extract_backup(bad_zip, tmp_path / "output")
+        archive_module.extract_backup(bad_zip, tmp_path / "output")
 
 
 def test_extract_backup_size_exceeded(tmp_path, monkeypatch):
-    monkeypatch.setattr("services.archive.MAX_EXTRACT_SIZE", 10)  # 10 bytes limit
+    monkeypatch.setattr(archive_module, "MAX_EXTRACT_SIZE", 10)  # 10 bytes limit
 
     zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, "w") as z:
@@ -56,7 +56,7 @@ def test_extract_backup_size_exceeded(tmp_path, monkeypatch):
         ArchiveSizeExceededError,
         match="Archive exceeds maximum allowed extraction size",
     ):
-        extract_backup(zip_path, tmp_path / "output")
+        archive_module.extract_backup(zip_path, tmp_path / "output")
 
 
 def test_extract_backup_malformed_path(tmp_path):
@@ -66,7 +66,7 @@ def test_extract_backup_malformed_path(tmp_path):
         z.writestr("../malformed.eml", b"Subject: Malformed Email")
 
     with pytest.raises(InvalidArchiveError, match="Unsafe archive path"):
-        extract_backup(zip_path, tmp_path / "output")
+        archive_module.extract_backup(zip_path, tmp_path / "output")
 
     assert not (tmp_path / "malformed.eml").exists()
 
@@ -78,7 +78,7 @@ def test_extract_backup_rejects_absolute_path(tmp_path):
         z.writestr(str(escaped_path), b"Subject: Absolute Email")
 
     with pytest.raises(InvalidArchiveError, match="Unsafe archive path"):
-        extract_backup(zip_path, tmp_path / "output")
+        archive_module.extract_backup(zip_path, tmp_path / "output")
 
     assert not escaped_path.exists()
 
@@ -92,7 +92,7 @@ def test_extract_backup_rejects_symlink_zip_entry(tmp_path):
         z.writestr(link_info, "../..")
 
     with pytest.raises(InvalidArchiveError, match="Unsafe archive path"):
-        extract_backup(zip_path, tmp_path / "output")
+        archive_module.extract_backup(zip_path, tmp_path / "output")
 
 
 def test_extract_backup_rejects_preexisting_symlink_escape(tmp_path):
@@ -106,13 +106,13 @@ def test_extract_backup_rejects_preexisting_symlink_escape(tmp_path):
         z.writestr("link/escaped.eml", b"Subject: Escaped Email")
 
     with pytest.raises(InvalidArchiveError, match="Unsafe archive path"):
-        extract_backup(zip_path, out_dir)
+        archive_module.extract_backup(zip_path, out_dir)
 
     assert not (outside_dir / "escaped.eml").exists()
 
 
 def test_extract_backup_file_count_exceeded(tmp_path, monkeypatch):
-    monkeypatch.setattr("services.archive.MAX_FILE_COUNT", 2)
+    monkeypatch.setattr(archive_module, "MAX_FILE_COUNT", 2)
 
     zip_path = tmp_path / "test_count.zip"
     with zipfile.ZipFile(zip_path, "w") as z:
@@ -124,7 +124,7 @@ def test_extract_backup_file_count_exceeded(tmp_path, monkeypatch):
         ArchiveFileCountExceededError,
         match="Archive exceeds maximum allowed file count",
     ):
-        extract_backup(zip_path, tmp_path / "output")
+        archive_module.extract_backup(zip_path, tmp_path / "output")
 
 
 def test_extract_backup_async(tmp_path):
@@ -133,7 +133,7 @@ def test_extract_backup_async(tmp_path):
         z.writestr("test.eml", b"Subject: Test Email")
 
     out_dir = tmp_path / "output"
-    extracted_files = asyncio.run(extract_backup_async(zip_path, out_dir))
+    extracted_files = asyncio.run(archive_module.extract_backup_async(zip_path, out_dir))
 
     assert len(extracted_files) == 1
     assert extracted_files[0].name == "test.eml"
@@ -156,8 +156,8 @@ async def test_extract_backup_async_calls_to_thread(tmp_path, monkeypatch):
     zip_path = tmp_path / "test.zip"
     out_dir = tmp_path / "output"
 
-    result = await extract_backup_async(zip_path, out_dir)
+    result = await archive_module.extract_backup_async(zip_path, out_dir)
 
     assert called is True
-    assert passed_args == (extract_backup, zip_path, out_dir)
+    assert passed_args == (archive_module.extract_backup, zip_path, out_dir)
     assert result == [tmp_path / "dummy.txt"]

--- a/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
+++ b/scripts/ci/emit_opencode_failed_check_fallback_findings.sh
@@ -55,6 +55,47 @@ first_existing_line() {
 	printf '1'
 }
 
+get_validated_pr_diff_range() {
+	local repo_root="${REPO_ROOT%/}"
+	local base_sha="${PR_BASE_SHA:-}"
+	local head_sha="${PR_HEAD_SHA:-${HEAD_SHA:-HEAD}}"
+
+	if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		return 1
+	fi
+	if [ -z "$base_sha" ]; then
+		return 1
+	fi
+	if ! git -C "$repo_root" rev-parse --verify "${base_sha}^{commit}" >/dev/null 2>&1; then
+		return 1
+	fi
+	if ! git -C "$repo_root" rev-parse --verify "${head_sha}^{commit}" >/dev/null 2>&1; then
+		return 1
+	fi
+
+	printf '%s...%s' "$base_sha" "$head_sha"
+}
+
+pr_changes_trusted_strix_inputs() {
+	local diff_range
+	local diff_status
+
+	diff_range="$(get_validated_pr_diff_range)" || return 1
+	set +e
+	git -C "${REPO_ROOT%/}" diff --quiet "$diff_range" -- \
+		.github/workflows/strix.yml \
+		scripts/ci/strix_quick_gate.sh \
+		scripts/ci/test_strix_quick_gate.sh \
+		requirements-strix-ci.txt
+	diff_status=$?
+	set -e
+
+	if [ "$diff_status" -eq 1 ]; then
+		return 0
+	fi
+	return 1
+}
+
 derive_location_from_report() {
 	local title="$1"
 	local endpoint="$2"
@@ -437,9 +478,15 @@ emit_strix_cancelled_without_log_finding() {
 	finding_index=$((finding_index + 1))
 	printf '### %s. HIGH %s:%s - Current-head Strix evidence is missing because the workflow run was cancelled before logs\n' "$finding_index" "$path" "$line"
 	printf -- '- Problem: Strix Security Scan reported a current-head workflow_run conclusion of cancelled, but GitHub emitted no failed job log and no Strix Vulnerability Report window.\n'
-	printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This is a workflow execution/queue state, not an application vulnerability finding, so OpenCode must not invent a source-code fix.\n'
-	printf -- '- Fix: Do not approve from this cancelled run. Re-run the current-head Strix Security Scan after stale runs complete or are cancelled, then review the resulting job log; keep the workflow concurrency line at %s:%s so stale runs do not silently replace current-head evidence.\n' "$path" "$line"
-	printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log so reviewers see that the blocker is missing scanner evidence.\n\n'
+	if pr_changes_trusted_strix_inputs; then
+		printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This PR changes trusted Strix workflow or gate inputs, but the cancelled pull_request_target run still used the base branch copies, so current-head edits cannot affect this run.\n'
+		printf -- '- Fix: Do not invent an application code fix from this cancelled run. Re-run Strix after the trusted base branch contains the workflow/gate change or capture equivalent temporary evidence tied to this head SHA; keep the workflow concurrency line at %s:%s aligned with the intended queue isolation.\n' "$path" "$line"
+		printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log and cover self-modifying Strix workflow PRs so reviews explain trusted-base execution semantics.\n\n'
+	else
+		printf -- '- Root cause: The security gate has no usable Strix evidence for this head SHA. This is a workflow execution/queue state, not an application vulnerability finding, so OpenCode must not invent a source-code fix.\n'
+		printf -- '- Fix: Do not approve from this cancelled run. Re-run the current-head Strix Security Scan after stale runs complete or are cancelled, then review the resulting job log; keep the workflow concurrency line at %s:%s so stale runs do not silently replace current-head evidence.\n' "$path" "$line"
+		printf -- '- Regression test: Keep failed-check evidence collection explicit for cancelled workflow runs with no job log so reviewers see that the blocker is missing scanner evidence.\n\n'
+	fi
 	printf -- '- Suggested edit: preserve `%s:%s` with `cancel-in-progress: false`, cancel only superseded non-current-head runs when needed, and rerun current-head Strix until logs exist.\n\n' "$path" "$line"
 }
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -531,6 +531,12 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "OpenCode failed-check fallback helper exited non-zero; using inline fallback." "opencode failed-check fallback handles helper failures without aborting under set -e"
 	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "emit_strix_report_findings" "failed-check fallback emits every Strix vulnerability report as a separate finding"
 	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "Strix provider signal left current-head security evidence incomplete" "failed-check fallback does not claim reports are absent after Strix emitted vulnerabilities"
+	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "cancelled pull_request_target run still used the base branch copies" "failed-check fallback explains trusted-base Strix workflow semantics for self-modifying PRs"
+	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "get_validated_pr_diff_range" "failed-check fallback validates PR diff range before comparing trusted Strix inputs"
+	assert_file_contains "$workflow_file" ".github/workflows/strix.yml" "opencode inline fallback watches Strix workflow changes"
+	assert_file_contains "$workflow_file" "scripts/ci/strix_quick_gate.sh" "opencode inline fallback watches trusted Strix gate changes"
+	assert_file_contains "$workflow_file" "scripts/ci/test_strix_quick_gate.sh" "opencode inline fallback watches trusted Strix self-test changes"
+	assert_file_contains "$workflow_file" "requirements-strix-ci.txt" "opencode inline fallback watches trusted Strix dependency changes"
 	assert_file_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "Strix provider failure blocked current-head security evidence" "failed-check fallback does not label non-quota provider routing/auth failures as quota"
 	assert_file_not_contains "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" "Strix provider quota blocked current-head security evidence" "failed-check fallback avoids misleading quota-only provider blocker title"
 	assert_file_contains "$workflow_file" "- Root cause:" "opencode review request-changes body includes root cause per finding"
@@ -950,6 +956,60 @@ EOF
 	assert_file_contains "$output_file" "Suggested edit: change \`frontend/next.config.ts:10\`" "fallback provides a concrete suggested edit for model reports"
 	assert_file_contains "$output_file" "Strix provider signal left current-head security evidence incomplete" "fallback still reports provider failure after vulnerability reports"
 	assert_file_not_contains "$output_file" "failed before producing vulnerability reports" "fallback does not contradict preserved Strix report windows"
+
+	rm -rf "$tmp_dir"
+}
+
+assert_opencode_failed_check_fallback_explains_trusted_base_strix_prs() {
+	local tmp_dir
+	local fixture_repo
+	local evidence_file
+	local output_file
+	local base_sha
+	local head_sha
+	tmp_dir="$(mktemp -d)"
+	fixture_repo="$tmp_dir/repo"
+	evidence_file="$tmp_dir/failed-check-evidence.md"
+	output_file="$tmp_dir/fallback.md"
+
+	mkdir -p "$fixture_repo/.github/workflows"
+	cat >"$fixture_repo/.github/workflows/strix.yml" <<'EOF'
+name: Strix Security Scan
+concurrency:
+  cancel-in-progress: false
+EOF
+
+	git init "$fixture_repo" >/dev/null
+	git -C "$fixture_repo" config user.email "copilot@example.com"
+	git -C "$fixture_repo" config user.name "copilot"
+	git -C "$fixture_repo" add .github/workflows/strix.yml
+	git -C "$fixture_repo" commit -m "base" >/dev/null
+	base_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+	cat >"$fixture_repo/.github/workflows/strix.yml" <<'EOF'
+name: Strix Security Scan
+concurrency:
+  group: strix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+EOF
+	git -C "$fixture_repo" add .github/workflows/strix.yml
+	git -C "$fixture_repo" commit -m "head" >/dev/null
+	head_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+	cat >"$evidence_file" <<'EOF'
+## Failed check: Strix Security Scan/strix
+
+Conclusion: cancelled
+
+No GitHub Actions job log is available for this failed workflow run.
+EOF
+
+	PR_BASE_SHA="$base_sha" PR_HEAD_SHA="$head_sha" \
+		bash "$REPO_ROOT/scripts/ci/emit_opencode_failed_check_fallback_findings.sh" \
+		"$evidence_file" "$fixture_repo" >"$output_file"
+
+	assert_file_contains "$output_file" "cancelled pull_request_target run still used the base branch copies" "fallback explains trusted-base workflow execution"
+	assert_file_contains "$output_file" "Re-run Strix after the trusted base branch contains the workflow/gate change or capture equivalent temporary evidence tied to this head SHA" "fallback directs reviewers to trusted-base rerun or equivalent evidence"
 
 	rm -rf "$tmp_dir"
 }
@@ -5669,6 +5729,8 @@ assert_opencode_review_gate_rejects_non_source_backed_findings
 assert_opencode_failed_check_review_validator_rejects_unrelated_findings
 
 assert_opencode_failed_check_fallback_emits_each_strix_report
+
+assert_opencode_failed_check_fallback_explains_trusted_base_strix_prs
 
 assert_opencode_failed_check_fallback_does_not_treat_no_report_summary_as_report
 


### PR DESCRIPTION
This PR now covers three related fixes that are present in the current branch state:

- Keep `backend/tests/test_archive.py` on one consistent import style for `services.archive`.
- Fix the current-head CI blocker by scoping Strix workflow concurrency to the active PR/ref instead of the whole repository.
- Fix OpenCode/Strix failed-check fallback diagnosis for self-modifying Strix PRs so cancelled trusted `pull_request_target` runs are reported as trusted-base execution blockers instead of application code bugs.

Best approach:
- Keep the top-level module import alias: `import services.archive as archive_module`.
- Remove direct `from services.archive import ...` imports.
- Update archive function calls to use `archive_module.extract_backup(...)` and `archive_module.extract_backup_async(...)`.
- Update monkeypatch references from `services.archive` to `archive_module`.
- Change `.github/workflows/strix.yml` concurrency from a repository-wide key to a PR/ref-scoped key so concurrent PR Strix runs do not cancel each other before jobs start.
- Update the Strix workflow contract checks in `scripts/ci/test_strix_quick_gate.sh` and `backend/tests/test_release_governance.py` to match the new concurrency key.
- Update OpenCode failed-check fallback handling in `.github/workflows/opencode-review.yml` and `scripts/ci/emit_opencode_failed_check_fallback_findings.sh` so self-modifying Strix workflow PRs recognize trusted-base execution semantics.
- Add regression shell coverage to keep the trusted-base Strix watched-file and fallback diagnosis contract in sync.

This keeps:
- Monkeypatching of module constants (`MAX_EXTRACT_SIZE`, `MAX_FILE_COUNT`) working exactly as before.
- Test behavior unchanged for the archive import cleanup.
- Strix security evidence isolated per PR/ref, avoiding stale OpenCode review failures caused by repository-wide Strix run contention.
- Cancelled no-log Strix runs on self-modifying workflow PRs explained as trusted-base workflow blockers rather than misdiagnosed source-code defects.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._