### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -377,7 +377,7 @@ def test_prompt_test_rejects_abusive_preview_inputs(auth_client, payload):
 async def test_execute_prompt_with_llm_disables_redirect_following_for_custom_base_url(
     monkeypatch,
 ):
-    import api.prompts as prompts_module
+    from api.prompts import execute_prompt_with_llm
 
     monkeypatch.setattr(
         settings, "ALLOWED_LLM_BASE_URL_HOSTS", "llm-gateway.example.com"
@@ -404,7 +404,7 @@ async def test_execute_prompt_with_llm_disables_redirect_following_for_custom_ba
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
         mock_async_openai.return_value = mock_client
 
-        result = await prompts_module.execute_prompt_with_llm(
+        result = await execute_prompt_with_llm(
             "Summarize this",
             "test-key",
             base_url="https://llm-gateway.example.com/v1",


### PR DESCRIPTION
Use a single import style for `api.prompts` throughout `backend/tests/test_prompts_api.py`.  
Best fix with minimal behavior risk: keep the existing top-level `from api.prompts import PromptTestRequest` unchanged, remove the function-local `import api.prompts as prompts_module`, and call `execute_prompt_with_llm` via a direct function import inside the test (`from api.prompts import execute_prompt_with_llm`). This preserves late import timing inside the test while eliminating mixed-style import usage for the same module.

Change region:
- `backend/tests/test_prompts_api.py` around lines 377–408:
  - Replace the local module import line.
  - Update the call site from `prompts_module.execute_prompt_with_llm(...)` to `execute_prompt_with_llm(...)`.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._