### PR TITLE
⚡ Bolt: Fetch AI Hub queries concurrently

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2026-06-10 - Optimize redundant dictionary lookups in tight loops
  **Learning:** Using `dict.setdefault` and multiple `dict.get` or `key in dict` checks inside tight loops significantly impacts performance due to repeated dictionary lookups and unnecessary list allocations. Caching dictionary lookups (e.g., using a single `dict.get(key)`) and conditionally handling the logic based on the result is much more performant.
  **Action:** When aggregating or grouping items in a loop, avoid `setdefault`. Instead, check if the key exists using a single `.get()`, and perform initialization/updates conditionally. Additionally, hoist loop-invariant checks (e.g., `folder == "sent"`) outside the loop to avoid redundant evaluations.
+
+## 2026-06-12 - Asyncio gather over sequential awaits
+**Learning:** In the `get_ai_hub_surface` endpoint, `_list_prompts`, `_list_providers`, and `_list_audit_events` were executed sequentially using `await`. Since these are independent database queries, executing them sequentially incurs unnecessary overhead and latency.
+**Action:** Use `asyncio.gather` to execute independent async database queries concurrently. This reduces the overall execution time to the duration of the longest query, significantly improving API response times.

--- a/backend/api/ai_hub.py
+++ b/backend/api/ai_hub.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import hashlib
 
@@ -320,11 +319,9 @@ async def get_ai_hub_surface(
     auth_context: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ) -> AiHubSurfaceResponse:
-    prompts, providers, audit_events = await asyncio.gather(
-        _list_prompts(db, auth_context),
-        _list_providers(db, auth_context),
-        _list_audit_events(db, auth_context),
-    )
+    prompts = await _list_prompts(db, auth_context)
+    providers = await _list_providers(db, auth_context)
+    audit_events = await _list_audit_events(db, auth_context)
 
     prompt_cards = [_prompt_card(prompt) for prompt in prompts]
     active_provider_count = sum(

--- a/backend/api/ai_hub.py
+++ b/backend/api/ai_hub.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import hashlib
 
@@ -319,9 +320,11 @@ async def get_ai_hub_surface(
     auth_context: AuthContext = Depends(get_auth_context),
     db: AsyncSession = Depends(get_db),
 ) -> AiHubSurfaceResponse:
-    prompts = await _list_prompts(db, auth_context)
-    providers = await _list_providers(db, auth_context)
-    audit_events = await _list_audit_events(db, auth_context)
+    prompts, providers, audit_events = await asyncio.gather(
+        _list_prompts(db, auth_context),
+        _list_providers(db, auth_context),
+        _list_audit_events(db, auth_context),
+    )
 
     prompt_cards = [_prompt_card(prompt) for prompt in prompts]
     active_provider_count = sum(


### PR DESCRIPTION
💡 What: Refactored `get_ai_hub_surface` in `backend/api/ai_hub.py` to fetch independent queries (`_list_prompts`, `_list_providers`, `_list_audit_events`) concurrently using `asyncio.gather` instead of sequentially.
🎯 Why: `get_ai_hub_surface` previously awaited each database fetch sequentially, which incurred unnecessary overhead and latency since the queries are independent and don't rely on each other.
📊 Impact: Reduces the overall database query execution time for this endpoint to the duration of the single longest query rather than the sum of all three queries.
🔬 Measurement: Use APM tracing or `pytest backend/tests/test_ai_hub_api.py` and profiling to observe shorter endpoint response times when rendering the AI Hub.

---
*PR created automatically by Jules for task [7424139992910117615](https://jules.google.com/task/7424139992910117615) started by @seonghobae*