### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in DAV endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Vulnerability:** The CORS configuration in FastAPI allowed wildcards (`*`) for `allow_methods` and `allow_headers`.
 **Learning:** This could permit unintended cross-origin interaction, potentially exposing the API to Cross-Site Request Forgery (CSRF) or unintended data exposure, particularly via custom headers or unconventional methods.
 **Prevention:** Always restrict `allow_methods` and `allow_headers` in CORS policies to the exact methods and headers required by the application.
+## 2025-02-24 - [DAV Path Traversal Vulnerability]
+**Vulnerability:** A path traversal vulnerability existed in the `/dav/{path:path}` endpoint where `_dav_path_owner_user_id` extracted the owner user ID using `path.partition("/")` without validating or normalizing `..` segments.
+**Learning:** This allowed an attacker to supply a path like `my_user_id/../other_user_id/projects`, tricking the authorization check `_ensure_dav_owner_scope` into passing because the first segment matched their authenticated `user_id`. The remaining path could then be used downstream to access resources of `other_user_id`. When testing this against FastAPI's TestClient, the TestClient normalizes `../` automatically; `..%2F` must be used to test the router correctly.
+**Prevention:** Always validate or normalize dynamic paths used for authorization constraints, explicitly rejecting paths containing traversal segments like `..` before parsing hierarchical data.

--- a/backend/api/dav.py
+++ b/backend/api/dav.py
@@ -11,6 +11,8 @@ router = APIRouter(prefix="/dav", tags=["dav"])
 
 
 def _dav_path_owner_user_id(path: str) -> str | None:
+    if ".." in path.split("/"):
+        return None
     normalized_path = path.strip("/")
     if not normalized_path:
         return None

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -46,6 +46,15 @@ def test_dav_rejects_different_user_path(dev_auth_dependency_overrides):
         assert response.json()["detail"] == "DAV path belongs to a different user"
 
 
+def test_dav_rejects_path_traversal(dev_auth_dependency_overrides):
+    with TestClient(app) as client:
+        response = client.request(
+            "PROPFIND", "/dav/user123/..%2Fother-user/projects/", headers=AUTH_HEADERS
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "DAV path must include an owner user"
+
+
 def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):
     with TestClient(app) as client:
         response = client.request("PROPFIND", "/dav/", headers=AUTH_HEADERS)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal in DAV endpoint allowed bypassing owner authorization constraints.
🎯 Impact: An attacker could bypass `_ensure_dav_owner_scope` by formatting paths as `my_user_id/../other_user_id/`, potentially accessing or modifying resources of other users once DAV writeback is fully implemented.
🔧 Fix: Updated `_dav_path_owner_user_id` to explicitly return `None` if the path contains `..` segments, ensuring such paths are rejected with a 403 Forbidden. Added test case using `..%2F` to verify behavior.
✅ Verification: Ran unit tests and verified `test_dav_rejects_path_traversal` passes.

---
*PR created automatically by Jules for task [9988266012074916196](https://jules.google.com/task/9988266012074916196) started by @seonghobae*