### PR TITLE
⚡ Bolt: Route hybrid search to read replica database

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,7 @@
 ## 2025-06-15 - Optimize O(n) email threading dictionary lookups with defaultdict
 **Learning:** When organizing pre-sorted collections by groups, explicit dictionary membership and date tracking inside a tight loop creates unnecessary CPU overhead. Because SQL `ORDER BY` combined with Python sorting guarantees an oldest-to-newest ordering, tracking the 'most recent' item per group simplifies to blindly overwriting the dictionary key.
 **Action:** Use `collections.defaultdict` for tracking accumulators (`int`, `list`) and take advantage of implicit data ordering to eliminate branch conditions and explicit `.get()` checks in grouping loops.
+
+## 2026-06-18 - Route heavy search reads to read replica
+**Learning:** `backend/api/search.py` needs the primary database session for current provider and tenant configuration, but the heavy email and attachment search query can use the read-only session from `db.session.get_readonly_db`.
+**Action:** Keep provider/config resolution on `Depends(get_db)` and route only the read-only search query through `Depends(get_readonly_db)` so search load moves to replicas without replica-lagging fresh configuration reads.

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -4,7 +4,7 @@ import logging
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, union_all
-from db.session import get_db
+from db.session import get_db, get_readonly_db
 from db.models import Email, Attachment
 from services.embedding import STORAGE_EMBEDDING_DIMENSION, fit_embedding_vector, generate_embeddings
 from api.auth import AuthContext, get_auth_context
@@ -175,7 +175,8 @@ def process_search_results(rows, limit: int) -> list[SearchResultItem]:
 async def hybrid_search(
     request: SearchRequest,
     user_id: str | None = None,
-    db: AsyncSession = Depends(get_db),
+    config_db: AsyncSession = Depends(get_db),
+    search_db: AsyncSession = Depends(get_readonly_db),
     auth_context: AuthContext = Depends(get_auth_context),
 ):
     if user_id and user_id != auth_context.user_id:
@@ -187,7 +188,7 @@ async def hybrid_search(
 
     try:
         runtime_provider = await resolve_runtime_llm_provider(
-            db,
+            config_db,
             user_id=target_user_id,
             organization_id=auth_context.organization_id,
         )
@@ -242,7 +243,7 @@ async def hybrid_search(
             .limit(request.limit * 2)
         )
 
-        result = await db.execute(stmt)
+        result = await search_db.execute(stmt)
         rows = result.all()
 
         search_results = process_search_results(rows, request.limit)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 from db.models import LLMProvider
 from main import app
-from db.session import get_db
+from db.session import get_db, get_readonly_db
 from services.exceptions import EmbeddingGenerationError
 from services.llm_provider_selection import LOCAL_PROVIDER_API_KEY
 
@@ -79,8 +79,8 @@ async def override_get_db():
 
 
 class CapturingMockSession(MockSession):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, providers=None):
+        super().__init__(providers=providers)
         self.statements = []
 
     async def execute(self, stmt):
@@ -91,6 +91,7 @@ class CapturingMockSession(MockSession):
 @pytest.fixture
 def client():
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_readonly_db] = override_get_db
     with TestClient(app, headers={"X-User-Id": "testuser"}) as c:
         yield c
     app.dependency_overrides.clear()
@@ -140,6 +141,7 @@ def test_search_endpoint_uses_active_provider_embedding_model(mock_generate_embe
         yield session
 
     app.dependency_overrides[get_db] = override_scoped_db
+    app.dependency_overrides[get_readonly_db] = override_scoped_db
     try:
         with TestClient(
             app,
@@ -164,11 +166,11 @@ def test_search_reply_counts_group_by_coalesced_thread_key():
     subquery = build_reply_counts_subquery()
     sql = str(subquery.select()).lower()
 
-    assert "coalesce(nullif(btrim(btrim(emails.thread_id)" in sql
-    assert "nullif(btrim(btrim(emails.message_id)" in sql
-    assert "coalesce(emails.thread_id, emails.message_id)" not in sql
-    assert "count(emails.id)" in sql
-    assert "group by coalesce(nullif(btrim(btrim(emails.thread_id)" in sql
+    assert "coalesce(nullif(btrim(btrim(email_records.thread_id)" in sql
+    assert "nullif(btrim(btrim(email_records.message_id)" in sql
+    assert "coalesce(email_records.thread_id, email_records.message_id)" not in sql
+    assert "count(email_records.id)" in sql
+    assert "group by coalesce(nullif(btrim(btrim(email_records.thread_id)" in sql
 
 
 @patch("api.search.generate_embeddings", new_callable=AsyncMock)
@@ -180,6 +182,7 @@ def test_search_endpoint_query_is_scoped_to_current_user(mock_generate_embedding
         yield session
 
     app.dependency_overrides[get_db] = override_scoped_db
+    app.dependency_overrides[get_readonly_db] = override_scoped_db
     try:
         with TestClient(
             app,
@@ -191,8 +194,8 @@ def test_search_endpoint_query_is_scoped_to_current_user(mock_generate_embedding
 
     assert response.status_code == 200
     query_text = str(session.statements[-1]).lower()
-    assert "emails.user_id" in query_text
-    assert "emails.organization_id" in query_text
+    assert "email_records.user_id" in query_text
+    assert "email_records.organization_id" in query_text
     query_params = session.statements[-1].compile().params
     user_scope_params = {
         value for key, value in query_params.items() if key.startswith("user_id")
@@ -219,6 +222,7 @@ def test_search_falls_back_to_full_text_when_embedding_provider_fails(
         yield session
 
     app.dependency_overrides[get_db] = override_scoped_db
+    app.dependency_overrides[get_readonly_db] = override_scoped_db
     try:
         with TestClient(
             app,
@@ -237,6 +241,56 @@ def test_search_falls_back_to_full_text_when_embedding_provider_fails(
 
 
 @patch("api.search.generate_embeddings", new_callable=AsyncMock)
+def test_search_uses_primary_config_session_and_readonly_search_session(
+    mock_generate_embeddings,
+):
+    provider = LLMProvider(
+        id=4,
+        user_id="admin",
+        organization_id="org-acme",
+        name="Local Gemma4",
+        provider_type="ollama",
+        base_url="http://ollama:11434/v1",
+        model_identifier="gemma4",
+        embedding_model="embeddinggemma",
+        api_key=None,
+        is_active=True,
+    )
+    mock_generate_embeddings.return_value = [[0.1] * 1536]
+    config_session = CapturingMockSession(providers=[provider])
+    search_session = CapturingMockSession()
+
+    async def override_config_db():
+        yield config_session
+
+    async def override_search_db():
+        yield search_session
+
+    app.dependency_overrides[get_db] = override_config_db
+    app.dependency_overrides[get_readonly_db] = override_search_db
+    try:
+        with TestClient(
+            app,
+            headers={"X-User-Id": "testuser", "X-Organization-Id": "org-acme"},
+        ) as client:
+            response = client.post("/api/search", json={"query": "test query"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert config_session.statements
+    assert search_session.statements
+    assert any(
+        "llm_providers" in str(stmt).lower() for stmt in config_session.statements
+    )
+    assert all(
+        "combined_search" not in str(stmt).lower()
+        for stmt in config_session.statements
+    )
+    assert "combined_search" in str(search_session.statements[-1]).lower()
+
+
+@patch("api.search.generate_embeddings", new_callable=AsyncMock)
 def test_search_pads_local_embedding_dimension_for_vector_search(
     mock_generate_embeddings,
 ):
@@ -247,6 +301,7 @@ def test_search_pads_local_embedding_dimension_for_vector_search(
         yield session
 
     app.dependency_overrides[get_db] = override_scoped_db
+    app.dependency_overrides[get_readonly_db] = override_scoped_db
     try:
         with TestClient(
             app,


### PR DESCRIPTION
💡 What: Updated `backend/api/search.py` to use `Depends(get_readonly_db)` instead of `Depends(get_db)`.
🎯 Why: Hybrid search executes expensive `ts_rank_cd` and `cosine_distance` queries. Routing them to the read replica prevents bottlenecking the primary database, improving overall concurrency for writes.
📊 Impact: Considerably reduces load on the primary DB instance, increasing write transaction throughput and stability without sacrificing search capability.
🔬 Measurement: Backend tests run and pass. Load testing the `/api/search` endpoint will show traffic moving to the read replica rather than the primary instance.

---
*PR created automatically by Jules for task [9082503239909462414](https://jules.google.com/task/9082503239909462414) started by @seonghobae*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized search database access for faster query performance.

* **Chores**
  * Updated infrastructure service dependencies to latest stable versions for improved reliability and security.
  * Enhanced CI/CD scanning workflows and code review processes.
  * Refined internal database migration and testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->