### PR TITLE
test: align Python governance pins with repaired locks

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -148,14 +148,14 @@ def test_python_314_backend_image_uses_binary_wheel_dependencies() -> None:
 def test_backend_runtime_toolchain_uses_image_scan_clean_security_pins() -> None:
     requirements = read_repo_text("backend/requirements.txt")
 
-    assert "sqlalchemy==2.0.51" in requirements
+    assert "sqlalchemy==2.0.50" in requirements
     assert "asyncpg==0.31.0" in requirements
     assert "tiktoken==0.13.0" in requirements
-    assert "protobuf==7.35.1" in requirements
+    assert "protobuf==6.33.6" in requirements
     assert "setuptools==82.0.1" in requirements
     assert "wheel==0.47.0" in requirements
-    assert "opentelemetry-api==1.42.1" in requirements
-    assert "opentelemetry-instrumentation-fastapi==0.63b1" in requirements
+    assert "opentelemetry-api==1.41.1" in requirements
+    assert "opentelemetry-instrumentation-fastapi==0.62b1" in requirements
 
 
 def test_strix_ci_requirements_use_security_quality_clean_pins() -> None:
@@ -163,7 +163,7 @@ def test_strix_ci_requirements_use_security_quality_clean_pins() -> None:
 
     assert "strix-agent==1.0.4" in strix_ci_requirements
     assert "cryptography==49.0.0" in strix_ci_requirements
-    assert "python-multipart==0.0.32" in strix_ci_requirements
+    assert "python-multipart==0.0.31" in strix_ci_requirements
 
 
 def test_changelog_follows_keep_a_changelog_for_initial_korean_release() -> None:


### PR DESCRIPTION
## Summary
- align release-governance dependency assertions with the repaired reproducible Python lock state
- restore the clean-pin expectations for SQLAlchemy, protobuf/OpenTelemetry, and Strix python-multipart after the invalid dependency bump was reverted

## Validation
- python3 -m pytest backend/tests/test_release_governance.py -q
- git diff --check