### PR TITLE
fix: align live smoke fixtures and frontend CSP

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 asyncio_default_fixture_loop_scope = function
 filterwarnings =
+    ignore:Using `httpx` with `starlette.testclient` is deprecated.*:starlette.exceptions.StarletteDeprecationWarning
     ignore:You are using a Python version.*which Google will stop supporting.*:FutureWarning
     ignore:Unclosed <MemoryObject:ResourceWarning
     ignore:pkg_resources is deprecated:UserWarning

--- a/backend/tests/test_data_api.py
+++ b/backend/tests/test_data_api.py
@@ -706,7 +706,7 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             first_email = await conn.execute(
                 text(
                     """
-                    INSERT INTO emails (
+                    INSERT INTO email_records (
                         user_id, organization_id, message_id, thread_id,
                         fingerprint, sender, recipients, subject, "date", body
                     )
@@ -732,7 +732,7 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             second_email = await conn.execute(
                 text(
                     """
-                    INSERT INTO emails (
+                    INSERT INTO email_records (
                         user_id, organization_id, message_id, sender, recipients,
                         subject, "date", body
                     )
@@ -756,7 +756,7 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             rival_email = await conn.execute(
                 text(
                     """
-                    INSERT INTO emails (
+                    INSERT INTO email_records (
                         user_id, organization_id, message_id, thread_id,
                         fingerprint, sender, recipients, subject, "date", body
                     )
@@ -785,7 +785,7 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             await conn.execute(
                 text(
                     """
-                    INSERT INTO attachments (email_id, filename, content)
+                    INSERT INTO email_attachments (email_id, filename, content)
                     VALUES
                     (:first_email_id, 'ready.txt', 'ready attachment'),
                     (:second_email_id, 'blank.txt', ''),
@@ -804,19 +804,20 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
                     INSERT INTO webdav_accounts (
                         source_uid, user_id, organization_id, workspace_id,
                         server_url, username, credentials_encrypted,
-                        writeback_enabled
+                        writeback_enabled,
+                        created_at
                     )
                     VALUES
                     (
                         :webdav_uid, :user_id, :organization_id, :workspace_id,
                         'https://data-files.example/dav', 'data@example.com',
-                        'encrypted-data-secret', true
+                        'encrypted-data-secret', true, now()
                     ),
                     (
                         :rival_webdav_uid, :rival_user_id, :rival_organization_id,
                         :rival_workspace_id,
                         'https://rival-files.example/dav', 'rival@example.com',
-                        'encrypted-rival-secret', true
+                        'encrypted-rival-secret', true, now()
                     )
                     """
                 ),
@@ -836,11 +837,12 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
                     """
                     INSERT INTO project_folders (
                         folder_uid, user_id, organization_id, project_name,
-                        webdav_path
+                        webdav_path,
+                        created_at
                     )
                     VALUES (
                         :folder_uid, :user_id, :organization_id,
-                        'Data Smoke Folder', '/Projects/Data_Smoke'
+                        'Data Smoke Folder', '/Projects/Data_Smoke', now()
                     )
                     """
                 ),
@@ -855,18 +857,18 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
                     """
                     INSERT INTO connector_signal_events (
                         event_uid, organization_id, workspace_id, signal_key,
-                        state_code, detail_text
+                        state_code, detail_text, observed_at
                     )
                     VALUES
                     (
                         :event_uid, :organization_id, :workspace_id,
                         'connector_heartbeat', 'heartbeat',
-                        'data smoke heartbeat'
+                        'data smoke heartbeat', now()
                     ),
                     (
                         :other_workspace_event_uid, :organization_id,
                         'other_workspace', 'connector_heartbeat', 'heartbeat',
-                        'other workspace heartbeat'
+                        'other workspace heartbeat', now()
                     )
                     """
                 ),
@@ -927,9 +929,9 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             await conn.execute(
                 text(
                     """
-                    DELETE FROM attachments
+                    DELETE FROM email_attachments
                     WHERE email_id IN (
-                        SELECT id FROM emails
+                        SELECT id FROM email_records
                         WHERE user_id IN (:user_id, :rival_user_id)
                     )
                     """
@@ -938,7 +940,7 @@ async def test_data_quality_surface_real_postgres_smoke_uses_signed_scope():
             )
             await conn.execute(
                 text(
-                    "DELETE FROM emails WHERE user_id IN (:user_id, :rival_user_id)"
+                    "DELETE FROM email_records WHERE user_id IN (:user_id, :rival_user_id)"
                 ),
                 {"user_id": user_id, "rival_user_id": rival_user_id},
             )

--- a/backend/tests/test_webdav_api.py
+++ b/backend/tests/test_webdav_api.py
@@ -732,7 +732,8 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                         username,
                         credentials_encrypted,
                         writeback_enabled,
-                        etag_value
+                        etag_value,
+                        created_at
                     )
                     VALUES (
                         :account_id,
@@ -744,7 +745,8 @@ async def test_webdav_writeback_intent_real_postgres_smoke(monkeypatch):
                         :username,
                         :credentials_encrypted,
                         :writeback_enabled,
-                        :etag_value
+                        :etag_value,
+                        now()
                     )
                     """
                 ),
@@ -894,7 +896,8 @@ async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
                         user_id,
                         organization_id,
                         project_name,
-                        webdav_path
+                        webdav_path,
+                        created_at
                     )
                     VALUES (
                         :folder_id,
@@ -902,7 +905,8 @@ async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
                         :user_id,
                         :organization_id,
                         :project_name,
-                        :webdav_path
+                        :webdav_path,
+                        now()
                     )
                     """
                 ),
@@ -924,7 +928,8 @@ async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
                         user_id,
                         organization_id,
                         project_name,
-                        webdav_path
+                        webdav_path,
+                        created_at
                     )
                     VALUES (
                         :folder_id,
@@ -932,7 +937,8 @@ async def test_webdav_folders_real_postgres_uses_opaque_folder_uid(monkeypatch):
                         :user_id,
                         :organization_id,
                         :project_name,
-                        :webdav_path
+                        :webdav_path,
+                        now()
                     )
                     """
                 ),
@@ -1081,7 +1087,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
             await conn.execute(
                 text(
                     """
-                    CREATE TABLE emails (
+                    CREATE TABLE email_records (
                         id INTEGER PRIMARY KEY,
                         user_id VARCHAR NOT NULL,
                         organization_id VARCHAR NOT NULL,
@@ -1133,7 +1139,7 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
             await conn.execute(
                 text(
                     """
-                    INSERT INTO emails (
+                    INSERT INTO email_records (
                         id,
                         user_id,
                         organization_id,
@@ -1209,7 +1215,8 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                         username,
                         credentials_encrypted,
                         writeback_enabled,
-                        etag_value
+                        etag_value,
+                        created_at
                     )
                     VALUES (
                         :account_id,
@@ -1221,7 +1228,8 @@ async def test_knowledge_materialization_intent_real_postgres_endpoint_smoke(
                         :username,
                         :credentials_encrypted,
                         :writeback_enabled,
-                        :etag_value
+                        :etag_value,
+                        now()
                     )
                     """
                 ),

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,30 @@
 import type { NextConfig } from "next";
 
+export function frontendCspHeaderValue(nodeEnv = process.env.NODE_ENV) {
+  const scriptSources = ["'self'", "'unsafe-inline'"];
+  const connectSources = ["'self'"];
+  if (nodeEnv === "development") {
+    scriptSources.push("'unsafe-eval'");
+    connectSources.push(
+      "http://127.0.0.1:*",
+      "http://localhost:*",
+      "ws://127.0.0.1:*",
+      "ws://localhost:*",
+    );
+  }
+
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSources.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    `connect-src ${connectSources.join(" ")}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+}
+
 function positiveIntegerFromEnv(name: string, fallback: number) {
   const rawValue = process.env[name];
   if (!rawValue) return fallback;
@@ -30,7 +55,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Content-Security-Policy",
-            value: "default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'",
+            value: frontendCspHeaderValue(),
           },
           {
             key: "X-Content-Type-Options",

--- a/frontend/src/app/prompt-studio/page.test.tsx
+++ b/frontend/src/app/prompt-studio/page.test.tsx
@@ -121,7 +121,9 @@ describe("PromptStudioPage", () => {
 
   it("shows disabled loading feedback while testing a prompt", async () => {
     const promptTest = deferred<Response>();
-    const fetchMock = vi.fn(() => promptTest.promise);
+    const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) =>
+      promptTest.promise,
+    );
     vi.stubGlobal("fetch", fetchMock);
     const page = await renderPage();
 
@@ -156,7 +158,9 @@ describe("PromptStudioPage", () => {
 
   it("shows disabled loading feedback while saving a prompt", async () => {
     const promptSave = deferred<Response>();
-    const fetchMock = vi.fn(() => promptSave.promise);
+    const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) =>
+      promptSave.promise,
+    );
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal("alert", vi.fn());
     const page = await renderPage();

--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -447,7 +447,7 @@ describe("SearchPage", () => {
     ).not.toBeNull();
 
     await act(async () => {
-      container
+      container!
         .querySelector('button[aria-label="검색어 지우기"]')
         ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });

--- a/frontend/src/lib/csp-headers.test.ts
+++ b/frontend/src/lib/csp-headers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig, { frontendCspHeaderValue } from "../../next.config";
+
+describe("frontend CSP headers", () => {
+  it("allows Next hydration and React inline styles without unsafe eval", async () => {
+    expect(nextConfig.headers).toBeDefined();
+
+    const headers = await nextConfig.headers?.();
+    const cspHeader = headers
+      ?.flatMap((entry) => entry.headers)
+      .find((header) => header.key === "Content-Security-Policy");
+
+    expect(cspHeader?.value).toContain("default-src 'self'");
+    expect(cspHeader?.value).toContain("script-src 'self' 'unsafe-inline'");
+    expect(cspHeader?.value).toContain("style-src 'self' 'unsafe-inline'");
+    expect(cspHeader?.value).not.toContain("'unsafe-eval'");
+  });
+
+  it("limits unsafe eval to the Next development runtime", () => {
+    expect(frontendCspHeaderValue("production")).not.toContain("'unsafe-eval'");
+    expect(frontendCspHeaderValue("development")).toContain(
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    );
+    expect(frontendCspHeaderValue("development")).toContain(
+      "connect-src 'self' http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*",
+    );
+  });
+});

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1034,8 +1034,8 @@ EOF
 	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-r1-0528: Prompt Injection and XSS in AI Prompt Studio" "fallback includes second report from same model"
 	assert_file_contains "$output_file" "frontend/src/app/prompt-studio/page.tsx:29" "fallback maps second report to exact source line"
 	assert_file_contains "$output_file" "Strix report from deepseek/deepseek-v3-0324: Missing Content Security Policy in Next.js Frontend" "fallback includes report from second model"
-	assert_file_contains "$output_file" "frontend/next.config.ts:10" "fallback derives a concrete CSP hardening line"
-	assert_file_contains "$output_file" "Suggested edit: change \`frontend/next.config.ts:10\`" "fallback provides a concrete suggested edit for model reports"
+	assert_file_contains "$output_file" "frontend/next.config.ts:35" "fallback derives a concrete CSP hardening line"
+	assert_file_contains "$output_file" "Suggested edit: change \`frontend/next.config.ts:35\`" "fallback provides a concrete suggested edit for model reports"
 	assert_file_contains "$output_file" "Strix provider signal left current-head security evidence incomplete" "fallback still reports provider failure after vulnerability reports"
 	assert_file_not_contains "$output_file" "failed before producing vulnerability reports" "fallback does not contradict preserved Strix report windows"
 


### PR DESCRIPTION
## Summary
- align live API smoke database fixtures with the current SQL table names and timestamp requirements
- add frontend CSP header coverage for Next hydration, React inline styles, and development-only React Refresh eval/connect behavior
- fix existing frontend test typing issues so `pnpm --dir frontend typecheck` passes

## Verification
- `git diff --check canonical/develop..HEAD`
- `python -m pytest backend/tests/test_data_api.py backend/tests/test_webdav_api.py backend/tests/test_runtime_config_api.py -q` -> 33 passed, 4 skipped
- `python -m pytest backend/tests/live/test_live_api_sequence.py -q` against live backend -> 4 passed
- `python -m pytest backend/tests/test_release_governance.py -q` -> 33 passed
- `pnpm --dir frontend exec vitest run src/lib/csp-headers.test.ts src/app/prompt-studio/page.test.tsx src/app/search/page.test.tsx` -> 10 passed
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend exec playwright test tests/e2e/live-smoke.spec.ts --project=desktop --project=tablet --project=mobile` with live backend and Next dev server -> 6 passed
