### PR TITLE
fix(e2e): serialize live compose startup

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -682,7 +682,7 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     assert "- AUTH_SESSION_HMAC_SECRET" not in backend_block
     assert "- ENCRYPTION_KEY" not in backend_block
     assert "python scripts/migrate_db.py && python scripts/start_backend.py" in compose
-    assert '"scripts/start_backend.py"' in live_e2e_compose
+    assert "scripts/start_backend.py" in live_e2e_compose
     assert "Dockerfile.ollama" in live_e2e_compose
     assert "DATABASE_URL: ${DATABASE_URL:?Set DATABASE_URL for live E2E}" in live_e2e_compose
     assert "postgresql+asyncpg://" not in live_e2e_compose
@@ -692,6 +692,11 @@ def test_backend_compose_commands_use_startup_preflight() -> None:
     assert "OPENAI_BASE_URL: http://ollama:11434/v1" in live_e2e_compose
     assert "OPENAI_MODEL: gemma4:e2b-it-qat" in live_e2e_compose
     assert "OPENAI_EMBEDDING_MODEL: embeddinggemma" in live_e2e_compose
+    assert "live-e2e-state:/live-e2e-state" in live_e2e_compose
+    assert "touch /live-e2e-state/migrated" in live_e2e_compose
+    assert "touch /live-e2e-state/seeded" in live_e2e_compose
+    assert "Required startup marker missing: $$marker" in live_e2e_compose
+    assert "  live-e2e-state:" in live_e2e_compose
     live_backend_block = live_e2e_compose.split("  backend:", 1)[1].split(
         "  frontend:", 1
     )[0]

--- a/docker-compose.live-e2e.yml
+++ b/docker-compose.live-e2e.yml
@@ -35,7 +35,15 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: ["python", "scripts/bootstrap_db.py"]
+    volumes:
+      - live-e2e-state:/live-e2e-state
+    command:
+      - sh
+      - -c
+      - |
+        rm -f /live-e2e-state/migrated /live-e2e-state/seeded
+        python scripts/bootstrap_db.py
+        touch /live-e2e-state/migrated
 
   live-seed:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
@@ -49,7 +57,23 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
-    command: ["python", "tests/live/seed_live_data.py"]
+    volumes:
+      - live-e2e-state:/live-e2e-state
+    command:
+      - sh
+      - -c
+      - |
+        marker=/live-e2e-state/migrated
+        for attempt in $(seq 1 120); do
+          [ -f "$$marker" ] && break
+          sleep 1
+        done
+        if [ ! -f "$$marker" ]; then
+          echo "Required startup marker missing: $$marker" >&2
+          exit 1
+        fi
+        python tests/live/seed_live_data.py
+        touch /live-e2e-state/seeded
 
   backend:
     image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE to a pre-built backend image}
@@ -71,9 +95,24 @@ services:
         condition: service_completed_successfully
       ollama:
         condition: service_started
+    volumes:
+      - live-e2e-state:/live-e2e-state
     expose:
       - "8000"
-    command: ["python", "scripts/start_backend.py", "--host", "0.0.0.0", "--port", "8000"]
+    command:
+      - sh
+      - -c
+      - |
+        marker=/live-e2e-state/seeded
+        for attempt in $(seq 1 120); do
+          [ -f "$$marker" ] && break
+          sleep 1
+        done
+        if [ ! -f "$$marker" ]; then
+          echo "Required startup marker missing: $$marker" >&2
+          exit 1
+        fi
+        exec python scripts/start_backend.py --host 0.0.0.0 --port 8000
 
   frontend:
     image: ${FRONTEND_IMAGE:?Set FRONTEND_IMAGE to a pre-built frontend image}
@@ -99,3 +138,4 @@ services:
 
 volumes:
   live-postgres-data:
+  live-e2e-state:


### PR DESCRIPTION
## Summary
- Add live E2E sentinel markers so migrate, seed, and backend startup cannot overlap when podman-compose ignores service_completed_successfully semantics.
- Keep Docker Compose completion conditions intact while adding a shared live-e2e-state volume fallback.
- Lock the live Compose startup contract in release-governance tests.

## Verification
- docker compose --env-file /tmp/naruon-live-e2e-20260620.env -f docker-compose.live-e2e.yml config
- python3 -m pytest backend/tests/test_release_governance.py -q
- docker compose --env-file /tmp/naruon-live-e2e-20260620.env -f docker-compose.live-e2e.yml up -d --build
- LIVE_BASE_URL=http://127.0.0.1:18080 RUN_LIVE_MODEL_E2E=1 LIVE_E2E_SESSION_SECRET=<AUTH_SESSION_HMAC_SECRET> env -u FORCE_COLOR -u NO_COLOR corepack pnpm exec playwright test tests/e2e/nano.spec.ts --project=desktop
- direct podman logs for live stack piped through scripts/check_compose_logs.py