### PR TITLE
🧪 [프론트엔드] utils.ts cn 함수 단위 테스트 추가

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from './utils';
+
+describe('cn utility', () => {
+  it('merges basic class names', () => {
+    expect(cn('class1', 'class2')).toBe('class1 class2');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn({ 'class1': true, 'class2': false, 'class3': true })).toBe('class1 class3');
+  });
+
+  it('resolves conflicting tailwind classes via twMerge', () => {
+    // text-blue-500 should override text-red-500
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+    // p-4 overrides px-2 and py-1
+    expect(cn('px-2 py-1', 'p-4')).toBe('p-4');
+  });
+
+  it('handles arrays of classes', () => {
+    expect(cn(['class1', 'class2'], ['class3'])).toBe('class1 class2 class3');
+  });
+
+  it('ignores falsy values', () => {
+    expect(cn('class1', null, undefined, false, 0, '', 'class2')).toBe('class1 class2');
+  });
+
+  it('handles complex combinations', () => {
+    expect(
+      cn(
+        'base-class',
+        { 'conditional-class': true, 'ignored-class': false },
+        ['array-class', 'text-red-500'],
+        null,
+        'text-blue-500' // Should override text-red-500
+      )
+    ).toBe('base-class conditional-class array-class text-blue-500');
+  });
+});


### PR DESCRIPTION
🎯 **What:** 
`frontend/src/lib/utils.ts`의 `cn` 유틸리티 함수에 대한 단위 테스트가 누락되어 있었습니다. 이를 해결하기 위해 새로운 테스트 파일을 작성했습니다.

📊 **Coverage:**
- 기본 문자열 결합 기능
- Tailwind CSS 클래스의 올바른 병합 (`tailwind-merge` 활용)
- 객체를 이용한 조건부 클래스 핸들링 (`clsx` 활용)
- 배열 형태의 클래스 핸들링
- `undefined`, `null`, `false` 등 falsy 값들의 안전한 무시
- 위의 모든 사례들을 포함하는 복합적인 시나리오

✨ **Result:**
- `cn` 함수에 대한 테스트 커버리지 달성
- `clsx`와 `tailwind-merge`의 결합이 의도대로 동작함을 보장
- 추후 유틸리티 함수 리팩토링 시 안전망 확보

---
*PR created automatically by Jules for task [13382070290411149700](https://jules.google.com/task/13382070290411149700) started by @seonghobae*