### PR TITLE
🧪 Add tests for mail-text.ts

### DIFF
--- a/frontend/src/lib/mail-text.test.ts
+++ b/frontend/src/lib/mail-text.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { toMailDisplayText, toMailBodyText } from './mail-text';
+
+describe('toMailDisplayText', () => {
+  it('handles regular text correctly', () => {
+    expect(toMailDisplayText('Hello world')).toBe('Hello world');
+  });
+
+  it('handles null values returning fallback or empty string', () => {
+    expect(toMailDisplayText(null)).toBe('');
+    expect(toMailDisplayText(null, 'fallback')).toBe('fallback');
+  });
+
+  it('handles undefined values', () => {
+    expect(toMailDisplayText(undefined)).toBe('');
+    expect(toMailDisplayText(undefined, 'fallback')).toBe('fallback');
+  });
+
+  it('handles empty strings', () => {
+    expect(toMailDisplayText('')).toBe('');
+    expect(toMailDisplayText('', 'fallback')).toBe('fallback'); // if empty string -> fallback in the implementation `return displayText || fallback`
+  });
+
+  it('replaces multiple whitespaces (including newlines and tabs) with a single space', () => {
+    expect(toMailDisplayText('Hello \n \t world')).toBe('Hello world');
+  });
+
+  it('strips normal HTML tags', () => {
+    expect(toMailDisplayText('<b>Bold</b> and <a href="link">link</a>')).toBe('Bold and link');
+  });
+
+  it('strips <script> tags and their content', () => {
+    expect(toMailDisplayText('Before <script>alert("xss")</script> After')).toBe('Before After');
+  });
+
+  it('handles unclosed tags correctly', () => {
+    expect(toMailDisplayText('Unclosed <div tag')).toBe('Unclosed div tag'); // implementation keeps it
+  });
+
+  it('handles unclosed <script> tags without throwing errors', () => {
+    expect(toMailDisplayText('Unclosed <script> var a = 1;')).toBe('Unclosed');
+  });
+
+  it('trims leading and trailing spaces', () => {
+      expect(toMailDisplayText('  Text  ')).toBe('Text');
+  });
+});
+
+describe('toMailBodyText', () => {
+  it('handles regular text correctly', () => {
+    expect(toMailBodyText('Hello world')).toBe('Hello world');
+  });
+
+  it('handles null values', () => {
+    expect(toMailBodyText(null)).toBe('');
+    expect(toMailBodyText(null, 'fallback')).toBe('fallback');
+  });
+
+  it('handles undefined values', () => {
+    expect(toMailBodyText(undefined)).toBe('');
+    expect(toMailBodyText(undefined, 'fallback')).toBe('fallback');
+  });
+
+  it('handles empty strings', () => {
+    expect(toMailBodyText('')).toBe('');
+    expect(toMailBodyText('', 'fallback')).toBe('fallback');
+  });
+
+  it('strips normal HTML tags', () => {
+    expect(toMailBodyText('<b>Bold</b> and <a href="link">link</a>')).toBe('Bold and link');
+  });
+
+  it('strips <script> tags and their content', () => {
+    expect(toMailBodyText('Before <script>alert("xss")</script> After')).toBe('Before After');
+  });
+
+  it('collapses horizontal whitespace (spaces, tabs) to a single space', () => {
+    expect(toMailBodyText('Hello \t  world')).toBe('Hello world');
+  });
+
+  it('collapses 3 or more consecutive newlines down to 2 newlines (preserves paragraphs)', () => {
+    expect(toMailBodyText('Line 1\n\n\n\nLine 2')).toBe('Line 1\n\nLine 2');
+  });
+
+  it('preserves single and double newlines', () => {
+    expect(toMailBodyText('Line 1\nLine 2\n\nLine 3')).toBe('Line 1\nLine 2\n\nLine 3');
+  });
+
+  it('trims leading and trailing spaces', () => {
+      expect(toMailBodyText('  Text  ')).toBe('Text');
+  });
+});


### PR DESCRIPTION
**What:** The testing gap addressed
This PR addresses the testing gap for `frontend/src/lib/mail-text.ts`. Tests were added to ensure robustness of text manipulation and display formatting when parsing emails.

**Coverage:** What scenarios are now tested
The `toMailDisplayText` and `toMailBodyText` functions are thoroughly tested for:
- Happy path behaviors.
- Handling of `null`, `undefined`, and empty string inputs, including custom fallback usage.
- Stripping out HTML-like tags, especially testing for proper removal of `<script>` tags without breaking on unclosed tags.
- Expected whitespace normalization for text displays and specific line-break collapsing logic for email body texts.

**Result:** The improvement in test coverage
Test suite now covers all functions in `mail-text.ts` preventing future regressions regarding UI display logic for incoming emails.

---
*PR created automatically by Jules for task [12256775919055799657](https://jules.google.com/task/12256775919055799657) started by @seonghobae*