### PR TITLE
🔒 fix: remove hardcoded secrets from tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** A path traversal vulnerability existed in the `/dav/{path:path}` endpoint where `_dav_path_owner_user_id` extracted the owner user ID using `path.partition("/")` without validating or normalizing `..` segments.
 **Learning:** This allowed an attacker to supply a path like `my_user_id/../other_user_id/projects`, tricking the authorization check `_ensure_dav_owner_scope` into passing because the first segment matched their authenticated `user_id`. The remaining path could then be used downstream to access resources of `other_user_id`. When testing this against FastAPI's TestClient, the TestClient normalizes `../` automatically; `..%2F` must be used to test the router correctly.
 **Prevention:** Always validate or normalize dynamic paths used for authorization constraints, explicitly rejecting paths containing traversal segments like `..` before parsing hierarchical data.
+## 2026-06-20 - Hardcoded API Key for Testing
+**Vulnerability:** Hardcoded API keys and passwords were found in `backend/tests/test_tenant_config_model.py` and `backend/tests/test_email_client_smtp.py`.
+**Learning:** Hardcoded secrets in testing files can still leak into version control and potentially be used in production or misconfigured systems.
+**Prevention:** Avoid hardcoding any secrets, even in test files. Use environment variables with default fallback values (e.g. `os.environ.get("TEST_KEY", "dummy-value")`).

--- a/backend/tests/test_email_client_smtp.py
+++ b/backend/tests/test_email_client_smtp.py
@@ -5,7 +5,9 @@ import socket
 import pytest
 import services.email_client as email_client
 
-TEST_SMTP_PASSWORD = "secret"  # noqa: S105 - test fixture password
+import os
+
+TEST_SMTP_PASSWORD = os.environ.get("TEST_SMTP_PASSWORD", "dummy-smtp-password")
 
 
 def _make_socket() -> socket.socket:
@@ -180,7 +182,9 @@ def test_inbound_mail_hosts_reject_legacy_numeric_ip_literals_before_dns(
     monkeypatch.setattr(email_client.settings, allowed_setting, numeric_host)
 
     def fail_getaddrinfo(*args, **kwargs):
-        raise AssertionError(f"legacy numeric {protocol_name} host must fail before DNS")
+        raise AssertionError(
+            f"legacy numeric {protocol_name} host must fail before DNS"
+        )
 
     monkeypatch.setattr(email_client.socket, "getaddrinfo", fail_getaddrinfo)
 

--- a/backend/tests/test_tenant_config_model.py
+++ b/backend/tests/test_tenant_config_model.py
@@ -1,4 +1,5 @@
 import base64
+import os
 
 import pytest
 from cryptography.fernet import Fernet
@@ -8,10 +9,10 @@ from sqlalchemy.orm import Session
 from db.models import EncryptedString, TenantConfig, get_fernet
 from core.config import settings
 
-TEST_OPENAI_KEY = "test_key2"  # noqa: S105
-TEST_IMAP_PASSWORD = "imap-secret"  # noqa: S105
-TEST_POP3_PASSWORD = "pop3-secret"  # noqa: S105
-TEST_SMTP_PASSWORD = "smtp-secret"  # noqa: S105
+TEST_OPENAI_KEY = os.environ.get("TEST_OPENAI_KEY", "dummy-openai-key")
+TEST_IMAP_PASSWORD = os.environ.get("TEST_IMAP_PASSWORD", "dummy-imap-password")
+TEST_POP3_PASSWORD = os.environ.get("TEST_POP3_PASSWORD", "dummy-pop3-password")
+TEST_SMTP_PASSWORD = os.environ.get("TEST_SMTP_PASSWORD", "dummy-smtp-password")
 
 
 @pytest.fixture(autouse=True)
@@ -37,11 +38,11 @@ def test_tenant_config_model_exists():
     config = TenantConfig(
         user_id="test_user",
         organization_id="org_acme",
-        openai_api_key="test_key",
+        openai_api_key=TEST_OPENAI_KEY,
     )
     assert config.user_id == "test_user"
     assert config.organization_id == "org_acme"
-    assert config.openai_api_key == "test_key"
+    assert config.openai_api_key == TEST_OPENAI_KEY
 
 
 def test_tenant_config_allows_same_user_in_different_organizations(db_session):
@@ -141,7 +142,7 @@ def test_tenant_config_model_encryption(db_session):
     result = db_session.execute(
         text("SELECT openai_api_key FROM tenant_configs WHERE user_id='test_user2'")
     ).scalar()
-    assert result != "test_key2"
+    assert result != TEST_OPENAI_KEY
     assert result is not None
     assert isinstance(result, str)
 


### PR DESCRIPTION
🎯 **What:** Hardcoded API keys and passwords were removed from test files (`backend/tests/test_tenant_config_model.py`, `backend/tests/test_email_client_smtp.py`).
⚠️ **Risk:** Hardcoded secrets in tests can leak into version control and potentially be used in production environments or misused.
🛡️ **Solution:** Used environment variables with dummy fallbacks to ensure secure and functional testing.

기능이 변경되지 않고 보안 취약점만 수정되었습니다.

---
*PR created automatically by Jules for task [5706299528792303935](https://jules.google.com/task/5706299528792303935) started by @seonghobae*