### PR TITLE
Enable Bandit on develop

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -2,9 +2,9 @@ name: Bandit Security Scan
 
 on:
   push:
-    branches: [ master ]
+    branches: [ develop, master ]
   pull_request:
-    branches: [ master ]
+    branches: [ develop, master ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- include develop in Bandit push and pull_request branch filters

## Root cause
- the repository default branch is develop, but Bandit only triggered on master, so it stayed active in GitHub Actions while not running for develop pushes or PRs

## Validation
- git diff --check -- .github/workflows/bandit.yml
- actionlint .github/workflows/bandit.yml