### PR TITLE
Fix README badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Naruon AI Email Workspace
 
-[![Application CI](https://github.com/Seongho-Bae/naruon/actions/workflows/app-ci.yml/badge.svg)](https://github.com/Seongho-Bae/naruon/actions/workflows/app-ci.yml)
-[![Bandit Security Scan](https://github.com/Seongho-Bae/naruon/actions/workflows/bandit.yml/badge.svg)](https://github.com/Seongho-Bae/naruon/actions/workflows/bandit.yml)
-[![Strix Security Scan](https://github.com/Seongho-Bae/naruon/actions/workflows/strix.yml/badge.svg)](https://github.com/Seongho-Bae/naruon/actions/workflows/strix.yml)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Seongho-Bae/naruon)
+[![Application CI](https://github.com/ContextualWisdomLab/naruon/actions/workflows/app-ci.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/app-ci.yml)
+[![Bandit Security Scan](https://github.com/ContextualWisdomLab/naruon/actions/workflows/bandit.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/bandit.yml)
+[![Strix Security Scan](https://github.com/ContextualWisdomLab/naruon/actions/workflows/strix.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/strix.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ContextualWisdomLab/naruon)
 
 Full-stack AI workspace with a FastAPI backend, Next.js frontend, vector search,
 AI summaries, hardened email threading, and relay/proxy contracts for external


### PR DESCRIPTION
## Summary
- point README badges at ContextualWisdomLab/naruon instead of the old Seongho-Bae/naruon owner
- update the DeepWiki link to the current repository path

## Root cause
- README badges still used the pre-transfer owner URL, so clicking badges could land on stale or misleading workflow pages instead of the current repository workflow pages.

## Validation
- git diff --check -- README.md
- curl checked Application CI, Bandit, Strix, and DeepWiki links return 200