### PR TITLE
Check session token length guard behavior

### DIFF
--- a/frontend/src/lib/session-cookie.ts
+++ b/frontend/src/lib/session-cookie.ts
@@ -20,7 +20,6 @@ export function normalizeSessionToken(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const token = value.trim();
   if (!token) return null;
-  if (token.length > MAX_SESSION_TOKEN_LENGTH) return null;
   if (CONTROL_CHARACTER_PATTERN.test(token)) return null;
   if (!COMPACT_JWT_PATTERN.test(token)) return null;
   return token;


### PR DESCRIPTION
## Summary
- Remove the max-length guard from session token normalization.
- Leave the existing session-cookie tests unchanged so review and CI can evaluate the behavior.

## Local check
- pnpm --dir frontend test -- src/lib/session-cookie.test.ts
- Result: fails at src/lib/session-cookie.test.ts:51 because 4097-character tokens are no longer rejected.