### PR TITLE
ci: reduce scheduler token permissions

### DIFF
--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -33,9 +33,9 @@ jobs:
   scan-pr-queue:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
+      actions: read
       checks: read
-      contents: write
+      contents: read
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -488,6 +488,21 @@ def test_app_ci_runs_backend_and_frontend_checks_without_duplicate_release_pushe
     assert "release/**" not in push_block
 
 
+def test_pr_review_merge_scheduler_uses_minimal_token_permissions() -> None:
+    workflow = read_repo_text(".github/workflows/pr-review-merge-scheduler.yml")
+
+    assert (
+        "permissions:\n"
+        "      actions: read\n"
+        "      checks: read\n"
+        "      contents: read\n"
+        "      pull-requests: write"
+        in workflow
+    )
+    assert "actions: write" not in workflow
+    assert "contents: write" not in workflow
+
+
 def test_docker_publish_validates_pr_images_and_publishes_semver_images_only_on_tags() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Reduce PR review merge scheduler token permissions from write to read for actions and contents.
- Keep pull-requests: write for the scheduler's auto-merge path.
- Add release governance coverage for the minimal scheduler permission set.

## Verification
- python -m pytest backend/tests/test_release_governance.py -q
- python3 scripts/ci/pr_review_merge_scheduler.py --self-test