### PR TITLE
test: allow live search embedding cold starts

### DIFF
--- a/backend/tests/live/test_live_api_sequence.py
+++ b/backend/tests/live/test_live_api_sequence.py
@@ -17,6 +17,7 @@ import pytest
 
 
 SESSION_COOKIE_NAME = "naruon_session"
+DEFAULT_LIVE_HTTP_TIMEOUT_SECONDS = 30.0
 
 
 def _encode_json(value: dict[str, Any]) -> str:
@@ -61,6 +62,21 @@ def _live_base_url() -> str:
     return live_base_url.rstrip("/")
 
 
+def _live_http_timeout_seconds() -> float:
+    configured = os.environ.get("LIVE_E2E_HTTP_TIMEOUT_SECONDS")
+    if not configured:
+        return DEFAULT_LIVE_HTTP_TIMEOUT_SECONDS
+    try:
+        timeout_seconds = float(configured)
+    except ValueError as exc:
+        raise AssertionError(
+            "LIVE_E2E_HTTP_TIMEOUT_SECONDS must be a number"
+        ) from exc
+    if timeout_seconds <= 0:
+        raise AssertionError("LIVE_E2E_HTTP_TIMEOUT_SECONDS must be positive")
+    return timeout_seconds
+
+
 def read_json(
     url: str,
     token: str,
@@ -70,6 +86,7 @@ def read_json(
     attempts: int = 12,
 ) -> dict[str, Any]:
     last_error: Exception | None = None
+    timeout_seconds = _live_http_timeout_seconds()
     request_body = json.dumps(body).encode("utf-8") if body is not None else None
     for _ in range(attempts):
         try:
@@ -87,7 +104,7 @@ def read_json(
             connection = connection_cls(
                 parsed_url.hostname,
                 parsed_url.port,
-                timeout=5,
+                timeout=timeout_seconds,
             )
             try:
                 headers = {


### PR DESCRIPTION
## Summary
- Increase the live HTTP smoke client timeout from 5s to a configurable 30s default
- Keep the smoke path on real HTTP while allowing local Ollama embedding cold starts to complete

## Verification
- LIVE_E2E_HTTP_TIMEOUT_SECONDS=45 LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=*** python -m pytest backend/tests/live/test_live_api_sequence.py -q (4 passed)

## Notes
- Diagnosed against a live backend/frontend stack: backend returned 200 for /api/search, but local embedding cold-start responses exceeded the former 5s client timeout.