### PR TITLE
Validation: OpenCode merge conflict guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,3 +529,5 @@
 - **Goal**: Actively manage tasks to ensure open PR counts converge to 0.
 
 - When the gate exhausts fallbacks after the primary model produces a finding at or above threshold and then fails with a retryable error (like `NOT_FOUND`), ensure the final output explicitly reports `Strix quick scan failed with a non-recoverable error.` to prevent downgrading the finding to pass or misleadingly reporting an unavailability error.
+
+<!-- opencode-conflict-guidance-validation: head -->


### PR DESCRIPTION
Temporary validation PR for OpenCode merge-conflict guidance.

This intentionally creates a conflict between temporary base/head branches to verify the OpenCode Review Overview appends Merge Conflict Guidance when GitHub reports mergeStateStatus=DIRTY. This PR will be closed after validation.