### PR TITLE
🎨 Palette: Add aria-busy to async operation buttons for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-06-20 - Use semantic `type="search"` with custom clear buttons
 **Learning:** Using `type="search"` on input fields improves mobile UX by rendering a semantic search keyboard (with a "Search" submit button instead of "Go/Enter"). However, when adding a custom clear button ('X') using UI components or Tailwind CSS, the native webkit clear button overlaps with it.
 **Action:** When implementing search fields, always use `type="search"` instead of `type="text"` to get the semantic keyboard benefits. To prevent visual overlaps with custom clear icons, add the `[&::-webkit-search-cancel-button]:hidden` Tailwind utility class to hide the native webkit clear button.
+## 2024-05-24 - Ensure aria-busy accompanies disabled for async UI buttons
+**Learning:** Action buttons triggering asynchronous network operations that already implement `disabled={loading}` and visual spinners MUST also include an `aria-busy={loading}` attribute to correctly communicate the active loading state to screen reader users without requiring focus shifts.
+**Action:** When adding or auditing buttons for async operations like '동기화 중', '전송 중', or '검색 중', ensure `aria-busy={loadingVariable}` is explicitly added alongside existing spinner and disabled states.

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -397,6 +397,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
                     size="sm"
                     onClick={handleSyncCalendar}
                     disabled={isSyncing}
+                    aria-busy={isSyncing}
                     className="h-9 rounded-xl bg-emerald-600 px-4 text-white hover:bg-emerald-700"
                   >
                     {isSyncing && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
@@ -409,6 +410,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
                     variant="outline"
                     onClick={handleCreateTask}
                     disabled={isCreatingTask}
+                    aria-busy={isCreatingTask}
                     className="h-9 rounded-xl border-emerald-500/30 px-4 text-emerald-700 hover:bg-emerald-500/10"
                   >
                     {isCreatingTask && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
@@ -506,6 +508,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
               <Button 
                 onClick={handleDraftReply} 
                 disabled={isDrafting || !instruction}
+                aria-busy={isDrafting}
                 variant="outline"
                 size="sm"
                 className="h-10 rounded-xl border-purple-500/30 px-4 text-purple-700 hover:bg-purple-500/10"
@@ -549,6 +552,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
                 <Button 
                   onClick={handleSendReply} 
                   disabled={isSending || !draft}
+                  aria-busy={isSending}
                   size="sm"
                   className="h-9 rounded-xl px-4"
                 >

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -238,7 +238,7 @@ export function EmailList({
               </button>
             )}
           </div>
-          <Button type="submit" disabled={searchBusy} className="h-10 rounded-xl px-4">
+          <Button type="submit" disabled={searchBusy} aria-busy={searchBusy} className="h-10 rounded-xl px-4">
             {searchBusy && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
             {searchBusy ? "맥락 검색 중" : "맥락 검색"}
           </Button>


### PR DESCRIPTION
### 💡 What:
Added the `aria-busy` attribute to multiple action buttons that trigger asynchronous network operations in `EmailDetail` and `EmailList`.

### 🎯 Why:
While these buttons correctly implement visual loading spinners and disable themselves to prevent duplicate clicks, they lacked the `aria-busy` attribute. Without `aria-busy`, screen readers may only announce that the button has become disabled, but won't clearly communicate that a background process is actively running (e.g. "동기화 중", "전송 중"). Adding `aria-busy` provides immediate context to assistive technologies.

### ♿ Accessibility:
- Added `aria-busy={isSyncing}` to Calendar Sync button.
- Added `aria-busy={isCreatingTask}` to Task Creation button.
- Added `aria-busy={isDrafting}` to AI Draft Reply button.
- Added `aria-busy={isSending}` to Send Reply button.
- Added `aria-busy={searchBusy}` to Context Search button.

---
*PR created automatically by Jules for task [103413931579931654](https://jules.google.com/task/103413931579931654) started by @seonghobae*