### PR TITLE
Harden live Gemma model verification

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlsplit, urlunsplit
 
 from openai import AsyncOpenAI
 from core.config import settings
@@ -7,6 +8,14 @@ from pydantic import BaseModel, Field
 from services.llm_provider_urls import build_llm_provider_http_client
 
 logger = logging.getLogger(__name__)
+
+OLLAMA_DRAFT_REPLY_MAX_TOKENS = 64
+OLLAMA_NATIVE_CHAT_TIMEOUT_SECONDS = 600.0
+OLLAMA_NATIVE_CHAT_HOSTS = frozenset({"ollama"})
+OLLAMA_NATIVE_CHAT_LOOPBACK_HOSTS = frozenset(
+    {"localhost", "localhost.localdomain", "127.0.0.1", "::1"}
+)
+OLLAMA_NATIVE_CHAT_PORT = 11434
 
 
 class ExtractionResult(BaseModel):
@@ -85,22 +94,38 @@ async def draft_reply(
     validated_base_url, http_client = await build_llm_provider_http_client(
         configured_base_url
     )
+    selected_model = model or settings.OPENAI_MODEL
+    messages = [
+        {
+            "role": "system",
+            "content": f"You are drafting a professional reply. Instruction: {instruction}",
+        },
+        {"role": "user", "content": email_body},
+    ]
+    native_chat_url = _ollama_native_chat_url(validated_base_url)
+    if native_chat_url is not None:
+        try:
+            return await _draft_reply_with_ollama_native_chat(
+                http_client,
+                native_chat_url,
+                selected_model,
+                messages,
+            )
+        except Exception as e:
+            logger.error(f"Error calling LLM API for drafting: {e}")
+            raise LLMServiceError(f"LLM API error during drafting: {e}") from e
+        finally:
+            await http_client.aclose()
+
     client = AsyncOpenAI(
         api_key=openai_api_key,
         base_url=validated_base_url,
         http_client=http_client,
     )
-    selected_model = model or settings.OPENAI_MODEL
     try:
         response = await client.chat.completions.create(
             model=selected_model,
-            messages=[
-                {
-                    "role": "system",
-                    "content": f"You are drafting a professional reply. Instruction: {instruction}",
-                },
-                {"role": "user", "content": email_body},
-            ],
+            messages=messages,
         )
     except Exception as e:
         logger.error(f"Error calling LLM API for drafting: {e}")
@@ -110,3 +135,42 @@ async def draft_reply(
 
     content = response.choices[0].message.content
     return content if content is not None else ""
+
+
+def _ollama_native_chat_url(validated_base_url: str | None) -> str | None:
+    if validated_base_url is None:
+        return None
+    parsed = urlsplit(validated_base_url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname in OLLAMA_NATIVE_CHAT_LOOPBACK_HOSTS:
+        if parsed.port != OLLAMA_NATIVE_CHAT_PORT:
+            return None
+    elif hostname not in OLLAMA_NATIVE_CHAT_HOSTS:
+        return None
+    if parsed.path.rstrip("/") != "/v1":
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, "/api/chat", "", ""))
+
+
+async def _draft_reply_with_ollama_native_chat(
+    http_client,
+    native_chat_url: str,
+    selected_model: str,
+    messages: list[dict[str, str]],
+) -> str:
+    response = await http_client.post(
+        native_chat_url,
+        json={
+            "model": selected_model,
+            "messages": messages,
+            "stream": False,
+            "think": False,
+            "options": {"num_predict": OLLAMA_DRAFT_REPLY_MAX_TOKENS},
+        },
+        timeout=OLLAMA_NATIVE_CHAT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    body = response.json()
+    message = body.get("message") if isinstance(body, dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    return content if isinstance(content, str) else ""

--- a/backend/tests/live/test_live_api_sequence.py
+++ b/backend/tests/live/test_live_api_sequence.py
@@ -101,6 +101,7 @@ def read_json(
             request_path = parsed_url.path or "/"
             if parsed_url.query:
                 request_path = f"{request_path}?{parsed_url.query}"
+            request_origin = f"{parsed_url.scheme}://{parsed_url.netloc}"
             connection = connection_cls(
                 parsed_url.hostname,
                 parsed_url.port,
@@ -110,6 +111,8 @@ def read_json(
                 headers = {
                     "Authorization": f"Bearer {token}",
                     "Cookie": f"{SESSION_COOKIE_NAME}={token}",
+                    "Origin": request_origin,
+                    "Referer": f"{request_origin}/",
                 }
                 if request_body is not None:
                     headers["Content-Type"] = "application/json"

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -10,6 +10,8 @@ from services.llm_service import (
     extract_todos_and_summary,
     draft_reply,
     ExtractionResult,
+    OLLAMA_DRAFT_REPLY_MAX_TOKENS,
+    OLLAMA_NATIVE_CHAT_TIMEOUT_SECONDS,
 )
 
 
@@ -456,6 +458,7 @@ async def test_draft_reply_success(mock_openai):
         mock_openai.chat.completions.create.call_args.kwargs["model"]
         == settings.OPENAI_MODEL
     )
+    assert "max_tokens" not in mock_openai.chat.completions.create.call_args.kwargs
 
 
 @pytest.mark.asyncio
@@ -478,6 +481,101 @@ async def test_draft_reply_uses_selected_provider_model(mock_openai):
 
     assert result == "Drafted reply text"
     assert mock_openai.chat.completions.create.call_args.kwargs["model"] == "gemma4"
+
+
+@pytest.mark.parametrize(
+    ("validated_base_url", "native_chat_url"),
+    [
+        ("http://ollama:11434/v1", "http://ollama:11434/api/chat"),
+        ("http://localhost:11434/v1", "http://localhost:11434/api/chat"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_draft_reply_uses_ollama_native_chat_without_thinking(
+    validated_base_url,
+    native_chat_url,
+):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"message": {"content": "초대해주셔서 감사합니다. 참석하겠습니다."}}
+
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock(return_value=FakeResponse())
+    fake_http_client.aclose = AsyncMock()
+
+    with (
+        patch(
+            "services.llm_service.build_llm_provider_http_client",
+            new=AsyncMock(return_value=(validated_base_url, fake_http_client)),
+        ),
+        patch("services.llm_service.AsyncOpenAI") as mock_async_openai,
+    ):
+        result = await draft_reply(
+            "Test email",
+            "Draft a positive reply",
+            "test-key",
+            base_url=validated_base_url,
+            model="gemma4:e2b-it-qat",
+        )
+
+    assert result == "초대해주셔서 감사합니다. 참석하겠습니다."
+    mock_async_openai.assert_not_called()
+    fake_http_client.post.assert_awaited_once()
+    assert fake_http_client.post.await_args.args == (native_chat_url,)
+    payload = fake_http_client.post.await_args.kwargs["json"]
+    assert payload["model"] == "gemma4:e2b-it-qat"
+    assert payload["think"] is False
+    assert payload["stream"] is False
+    assert payload["options"] == {"num_predict": OLLAMA_DRAFT_REPLY_MAX_TOKENS}
+    assert (
+        fake_http_client.post.await_args.kwargs["timeout"]
+        == OLLAMA_NATIVE_CHAT_TIMEOUT_SECONDS
+    )
+    fake_http_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_draft_reply_keeps_non_ollama_localhost_openai_compatible():
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock()
+    mock_response = MagicMock()
+    mock_message = MagicMock()
+    mock_message.content = "Drafted reply text"
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    with (
+        patch(
+            "services.llm_service.build_llm_provider_http_client",
+            new=AsyncMock(return_value=("http://localhost:8000/v1", fake_http_client)),
+        ),
+        patch("services.llm_service.AsyncOpenAI") as mock_async_openai,
+    ):
+        mock_client = MagicMock()
+        mock_client.close = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_async_openai.return_value = mock_client
+
+        result = await draft_reply(
+            "Test email",
+            "Draft a positive reply",
+            "test-key",
+            base_url="http://localhost:8000/v1",
+            model="local-openai-compatible",
+        )
+
+    assert result == "Drafted reply text"
+    fake_http_client.post.assert_not_called()
+    mock_async_openai.assert_called_once()
+    assert (
+        mock_client.chat.completions.create.call_args.kwargs["model"]
+        == "local-openai-compatible"
+    )
+    mock_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/frontend/tests/e2e/nano-live-model.spec.ts
+++ b/frontend/tests/e2e/nano-live-model.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type APIResponse } from '@playwright/test';
 import crypto from 'node:crypto';
 
 // Live model-path E2E (companion to the mocked nano.spec.ts).
@@ -50,6 +50,25 @@ function liveSessionCookie(token: string): string {
   return `naruon_session=${token}`;
 }
 
+function sameOriginRequestHeaders(token: string): Record<string, string> {
+  const origin = new URL(process.env.LIVE_BASE_URL ?? 'http://127.0.0.1:18080').origin;
+  return {
+    Cookie: liveSessionCookie(token),
+    Origin: origin,
+    Referer: `${origin}/`,
+  };
+}
+
+async function responseSummary(response: APIResponse): Promise<string> {
+  return `${response.status()} ${response.statusText()}: ${await response.text()}`;
+}
+
+async function expectOkResponse(response: APIResponse): Promise<void> {
+  if (!response.ok()) {
+    expect(response.ok(), await responseSummary(response)).toBeTruthy();
+  }
+}
+
 test.skip(
   !process.env.LIVE_BASE_URL && process.env.RUN_LIVE_E2E !== '1',
   'Requires a live stack with ollama serving gemma4:e2b-it-qat + embeddinggemma.',
@@ -61,7 +80,7 @@ test.setTimeout(600_000);
 test('nano live: 답장 초안 reaches the gemma4 e2b chat model', async ({ request }) => {
   const token = signLiveSession();
   const response = await request.post('/api/llm/draft', {
-    headers: { Cookie: liveSessionCookie(token) },
+    headers: sameOriginRequestHeaders(token),
     data: {
       email_body:
         '다음 주 화요일 오후 2시에 프로젝트 킥오프 미팅을 제안드립니다. 가능하신지 회신 부탁드립니다.',
@@ -69,7 +88,7 @@ test('nano live: 답장 초안 reaches the gemma4 e2b chat model', async ({ requ
     },
     timeout: 600_000,
   });
-  expect(response.ok()).toBeTruthy();
+  await expectOkResponse(response);
   const body = await response.json();
   const draft =
     typeof body?.draft === 'string' ? body.draft : JSON.stringify(body ?? {});
@@ -80,13 +99,13 @@ test('nano live: 답장 초안 reaches the gemma4 e2b chat model', async ({ requ
 test('nano live: 맥락 검색 exercises the embeddinggemma model', async ({ request }) => {
   const token = signLiveSession();
   const response = await request.post('/api/search', {
-    headers: { Cookie: liveSessionCookie(token) },
+    headers: sameOriginRequestHeaders(token),
     data: { query: '프로젝트 킥오프 일정' },
     timeout: 120_000,
   });
   // The query is embedded server-side before the vector search runs; a 2xx proves
   // the embedding model answered, regardless of how many seeded rows match.
-  expect(response.ok()).toBeTruthy();
+  await expectOkResponse(response);
   const body = await response.json();
   const results = Array.isArray(body) ? body : body?.results;
   expect(Array.isArray(results)).toBeTruthy();

--- a/frontend/tests/e2e/nano.spec.ts
+++ b/frontend/tests/e2e/nano.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type APIResponse } from '@playwright/test';
 import crypto from 'node:crypto';
 
 import { mockDashboardApi } from './helpers';
@@ -48,6 +48,25 @@ function signLiveSession(expiresInSeconds = 300): string {
 
 function liveSessionCookie(token: string): string {
   return `naruon_session=${token}`;
+}
+
+function sameOriginRequestHeaders(token: string): Record<string, string> {
+  const origin = new URL(process.env.LIVE_BASE_URL ?? 'http://127.0.0.1:18080').origin;
+  return {
+    Cookie: liveSessionCookie(token),
+    Origin: origin,
+    Referer: `${origin}/`,
+  };
+}
+
+async function responseSummary(response: APIResponse): Promise<string> {
+  return `${response.status()} ${response.statusText()}: ${await response.text()}`;
+}
+
+async function expectOkResponse(response: APIResponse): Promise<void> {
+  if (!response.ok()) {
+    expect(response.ok(), await responseSummary(response)).toBeTruthy();
+  }
 }
 
 test('nano test: verify user requested features', async ({ page }) => {
@@ -104,26 +123,26 @@ test('nano live model: ollama gemma4 e2b chat and embedding search complete', as
   );
 
   const token = signLiveSession(1_200);
-  const cookie = liveSessionCookie(token);
+  const headers = sameOriginRequestHeaders(token);
 
   const draftResponse = await request.post('/api/llm/draft', {
-    headers: { Cookie: cookie },
+    headers,
     data: {
       email_body: 'Live Gemma4 verification request from Naruon E2E.',
       instruction: 'Reply with one concise Korean sentence confirming receipt.',
     },
     timeout: 600_000,
   });
-  expect(draftResponse.ok()).toBeTruthy();
+  await expectOkResponse(draftResponse);
   const draftBody = await draftResponse.json();
   expect(String(draftBody.draft ?? '').trim().length).toBeGreaterThan(0);
 
   const searchResponse = await request.post('/api/search', {
-    headers: { Cookie: cookie },
+    headers,
     data: { query: 'Live E2E Release', limit: 3 },
     timeout: 600_000,
   });
-  expect(searchResponse.ok()).toBeTruthy();
+  await expectOkResponse(searchResponse);
   const searchBody = await searchResponse.json();
   const subjects = new Set(
     (searchBody.results ?? []).map((item: { subject?: string | null }) => item.subject),


### PR DESCRIPTION
## Summary
- send same-origin Origin/Referer headers from live API and Playwright model tests so they exercise the frontend CSRF boundary correctly
- use Ollama native /api/chat with think:false for the local Gemma4 draft path so draft content is returned instead of reasoning-only OpenAI-compatible output
- bound local draft generation and add diagnostics for failed live model responses

## Verification
- python3 -m pytest -q tests/test_llm_service.py::test_draft_reply_success tests/test_llm_service.py::test_draft_reply_uses_selected_provider_model tests/test_llm_service.py::test_draft_reply_uses_ollama_native_chat_without_thinking tests/test_llm_service.py::test_draft_reply_api_error
- LIVE_BASE_URL=http://127.0.0.1:18080 LIVE_E2E_SESSION_SECRET=... LIVE_E2E_HTTP_TIMEOUT_SECONDS=180 python3 -m pytest -q tests/live/test_live_api_sequence.py
- env -u FORCE_COLOR -u NO_COLOR LIVE_BASE_URL=http://127.0.0.1:18080 RUN_LIVE_E2E=1 RUN_LIVE_MODEL_E2E=1 LIVE_E2E_SESSION_SECRET=... NODE_OPTIONS="--throw-deprecation --trace-warnings" pnpm exec playwright test tests/e2e/nano-live-model.spec.ts --project=desktop --workers=1 --reporter=line
- env -u FORCE_COLOR -u NO_COLOR NODE_OPTIONS="--throw-deprecation --trace-warnings" pnpm exec playwright test tests/e2e/nano.spec.ts --project=desktop --workers=1 --reporter=line
