### PR TITLE
Harden OpenCode review failure handling

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -282,6 +282,15 @@ jobs:
             local sleep_seconds="${FAILED_CHECK_EVIDENCE_SLEEP_SECONDS:-10}"
             local attempt=1
 
+            if [ ! -x scripts/ci/collect_failed_check_evidence.sh ]; then
+              {
+                printf 'Failed-check evidence collector is not installed in this repository.\n'
+                printf 'No completed failed GitHub Checks were present in this bounded evidence file.\n'
+                printf 'The approval gate will re-query current-head GitHub Checks before approving.\n'
+              } >"$evidence_file"
+              return 0
+            fi
+
             while [ "$attempt" -le "$attempts" ]; do
               if scripts/ci/collect_failed_check_evidence.sh "$evidence_file"; then
                 if ! grep -Fq "No completed failed GitHub Checks were present" "$evidence_file"; then
@@ -714,6 +723,7 @@ jobs:
           SHARE: "false"
           NPM_CONFIG_IGNORE_SCRIPTS: "true"
           NO_COLOR: "1"
+          OPENCODE_MODEL_ATTEMPTS: "2"
           OPENCODE_EVIDENCE_FILE: ${{ runner.temp }}/opencode-review-evidence.md
           OPENCODE_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-primary.md
           OPENCODE_REVIEW_WORKDIR: ${{ runner.temp }}/opencode-review-project
@@ -757,15 +767,30 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
-          set +e
-          timeout 600 opencode run "$(cat "$prompt_file")" \
-            --pure \
-            --agent ci-review \
-            --model "$MODEL" \
-            --format json \
-            --title "PR #${PR_NUMBER} OpenCode bounded review ${MODEL}" >"$opencode_json_file"
-          opencode_run_status=$?
-          set -e
+          opencode_attempts="${OPENCODE_MODEL_ATTEMPTS:-2}"
+          opencode_run_status=1
+          for opencode_attempt in $(seq 1 "$opencode_attempts"); do
+            rm -f "$opencode_json_file"
+            set +e
+            timeout 600 opencode run "$(cat "$prompt_file")" \
+              --pure \
+              --agent ci-review \
+              --model "$MODEL" \
+              --format json \
+              --title "PR #${PR_NUMBER} OpenCode bounded review ${MODEL} attempt ${opencode_attempt}/${opencode_attempts}" >"$opencode_json_file"
+            opencode_run_status=$?
+            set -e
+            if [ "$opencode_run_status" -eq 0 ]; then
+              break
+            fi
+            printf 'OpenCode %s attempt %s/%s failed with exit %s.\n' "$MODEL" "$opencode_attempt" "$opencode_attempts" "$opencode_run_status"
+            case "$opencode_run_status" in
+              124|137|143) break ;;
+            esac
+            if [ "$opencode_attempt" -lt "$opencode_attempts" ]; then
+              sleep 10
+            fi
+          done
           if [ "$opencode_run_status" -ne 0 ]; then
             echo "OpenCode primary review attempt did not complete; fallback review will run."
             record_review_status "failed"
@@ -826,6 +851,7 @@ jobs:
           SHARE: "false"
           NPM_CONFIG_IGNORE_SCRIPTS: "true"
           NO_COLOR: "1"
+          OPENCODE_MODEL_ATTEMPTS: "2"
           OPENCODE_EVIDENCE_FILE: ${{ runner.temp }}/opencode-review-evidence.md
           OPENCODE_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-fallback.md
           OPENCODE_REVIEW_WORKDIR: ${{ runner.temp }}/opencode-review-project
@@ -867,15 +893,30 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
-          set +e
-          timeout 300 opencode run "$(cat "$prompt_file")" \
-            --pure \
-            --agent ci-review-fallback \
-            --model "$MODEL" \
-            --format json \
-            --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL}" >"$opencode_json_file"
-          opencode_run_status=$?
-          set -e
+          opencode_attempts="${OPENCODE_MODEL_ATTEMPTS:-2}"
+          opencode_run_status=1
+          for opencode_attempt in $(seq 1 "$opencode_attempts"); do
+            rm -f "$opencode_json_file"
+            set +e
+            timeout 300 opencode run "$(cat "$prompt_file")" \
+              --pure \
+              --agent ci-review-fallback \
+              --model "$MODEL" \
+              --format json \
+              --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL} attempt ${opencode_attempt}/${opencode_attempts}" >"$opencode_json_file"
+            opencode_run_status=$?
+            set -e
+            if [ "$opencode_run_status" -eq 0 ]; then
+              break
+            fi
+            printf 'OpenCode %s attempt %s/%s failed with exit %s.\n' "$MODEL" "$opencode_attempt" "$opencode_attempts" "$opencode_run_status"
+            case "$opencode_run_status" in
+              124|137|143) break ;;
+            esac
+            if [ "$opencode_attempt" -lt "$opencode_attempts" ]; then
+              sleep 10
+            fi
+          done
           if [ "$opencode_run_status" -ne 0 ]; then
             echo "OpenCode DeepSeek R1 review attempt did not complete; next fallback review will run."
             record_review_status "failed"
@@ -936,6 +977,7 @@ jobs:
           SHARE: "false"
           NPM_CONFIG_IGNORE_SCRIPTS: "true"
           NO_COLOR: "1"
+          OPENCODE_MODEL_ATTEMPTS: "2"
           OPENCODE_EVIDENCE_FILE: ${{ runner.temp }}/opencode-review-evidence.md
           OPENCODE_OUTPUT_FILE: ${{ runner.temp }}/opencode-review-second-fallback.md
           OPENCODE_REVIEW_WORKDIR: ${{ runner.temp }}/opencode-review-project
@@ -977,15 +1019,30 @@ jobs:
           cd "$OPENCODE_REVIEW_WORKDIR"
           opencode_json_file="${OPENCODE_OUTPUT_FILE}.jsonl"
           opencode_export_file="${OPENCODE_OUTPUT_FILE}.session.json"
-          set +e
-          timeout 300 opencode run "$(cat "$prompt_file")" \
-            --pure \
-            --agent ci-review-fallback \
-            --model "$MODEL" \
-            --format json \
-            --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL}" >"$opencode_json_file"
-          opencode_run_status=$?
-          set -e
+          opencode_attempts="${OPENCODE_MODEL_ATTEMPTS:-2}"
+          opencode_run_status=1
+          for opencode_attempt in $(seq 1 "$opencode_attempts"); do
+            rm -f "$opencode_json_file"
+            set +e
+            timeout 300 opencode run "$(cat "$prompt_file")" \
+              --pure \
+              --agent ci-review-fallback \
+              --model "$MODEL" \
+              --format json \
+              --title "PR #${PR_NUMBER} OpenCode bounded fallback review ${MODEL} attempt ${opencode_attempt}/${opencode_attempts}" >"$opencode_json_file"
+            opencode_run_status=$?
+            set -e
+            if [ "$opencode_run_status" -eq 0 ]; then
+              break
+            fi
+            printf 'OpenCode %s attempt %s/%s failed with exit %s.\n' "$MODEL" "$opencode_attempt" "$opencode_attempts" "$opencode_run_status"
+            case "$opencode_run_status" in
+              124|137|143) break ;;
+            esac
+            if [ "$opencode_attempt" -lt "$opencode_attempts" ]; then
+              sleep 10
+            fi
+          done
           if [ "$opencode_run_status" -ne 0 ]; then
             echo "OpenCode DeepSeek V3 review attempt did not complete."
             record_review_status "failed"
@@ -2446,6 +2503,17 @@ jobs:
             return 0
           }
 
+          collect_failed_check_evidence_or_note() {
+            local evidence_file="$1"
+
+            if [ ! -x scripts/ci/collect_failed_check_evidence.sh ]; then
+              printf "Failed GitHub Check evidence collector is not installed in this repository for current head \`%s\`.\n" "$HEAD_SHA" >"$evidence_file"
+              return 0
+            fi
+
+            scripts/ci/collect_failed_check_evidence.sh "$evidence_file"
+          }
+
           live_head_sha="$(gh api -X GET "repos/${GH_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
           if [ "$live_head_sha" != "$HEAD_SHA" ]; then
             echo "stale OpenCode run: event head=${HEAD_SHA}, live head=${live_head_sha}; skipping review side effects."
@@ -2476,7 +2544,7 @@ jobs:
             }
             trap cleanup_failed_outcome_files EXIT
             if collect_github_checks_with_retry collect_failed_github_checks "$failed_checks_file" && [ -s "$failed_checks_file" ]; then
-              if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+              if ! collect_failed_check_evidence_or_note "$failed_check_evidence_file"; then
                 printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
               fi
 
@@ -2496,9 +2564,13 @@ jobs:
             fi
 
             pending_checks_file="$(mktemp)"
-            if ! collect_github_checks_with_retry collect_pending_github_checks "$pending_checks_file"; then
+            set +e
+            wait_for_peer_github_checks "$pending_checks_file"
+            pending_wait_status=$?
+            set -e
+            if [ "$pending_wait_status" -eq 1 ]; then
               request_changes_for_gate_failure "GitHub Checks statusCheckRollup could not be read after OpenCode model output failure."
-            elif [ -s "$pending_checks_file" ]; then
+            elif [ "$pending_wait_status" -ne 0 ]; then
               build_pending_check_body "$pending_checks_file" "$failed_check_review_body_file"
               create_pull_review "REQUEST_CHANGES" "$(cat "$failed_check_review_body_file")"
             else
@@ -2692,7 +2764,7 @@ jobs:
                 failed_check_review_body_file="$(mktemp)"
                 failed_check_review_payload_file="$(mktemp)"
                 failed_check_inline_failure_body_file="$(mktemp)"
-                if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+                if ! collect_failed_check_evidence_or_note "$failed_check_evidence_file"; then
                   printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
                 fi
                 if comment_for_billing_lock_if_present "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"; then
@@ -2759,7 +2831,7 @@ jobs:
 
               if [ -s "$failed_checks_file" ]; then
                 failed_check_evidence_file="$(mktemp)"
-                if ! scripts/ci/collect_failed_check_evidence.sh "$failed_check_evidence_file"; then
+                if ! collect_failed_check_evidence_or_note "$failed_check_evidence_file"; then
                   printf "Failed GitHub Check evidence could not be collected for current head \`%s\`.\n" "$HEAD_SHA" >"$failed_check_evidence_file"
                 fi
                 if comment_for_billing_lock_if_present "$failed_checks_file" "$failed_check_evidence_file" "$failed_check_review_body_file"; then

--- a/scripts/ci/opencode_review_normalize_output.py
+++ b/scripts/ci/opencode_review_normalize_output.py
@@ -93,6 +93,7 @@ def mentions_changed_file_evidence(reason: str, summary: str) -> bool:
 
 
 def check_structural_approval(control_file: Path) -> int:
+    """Validate an already-normalized control block before publishing approval."""
     try:
         value = json.loads(control_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -126,6 +127,7 @@ def valid_control(
     expected_run_id: str,
     expected_run_attempt: str,
 ) -> dict[str, Any] | None:
+    """Return a normalized control block when it matches the current run."""
     if not isinstance(value, dict):
         return None
 
@@ -174,7 +176,8 @@ def valid_control(
     for finding in findings:
         if not isinstance(finding, dict):
             return None
-        if not isinstance(finding.get("line"), int) or finding["line"] <= 0:
+        line = finding.get("line")
+        if isinstance(line, bool) or not isinstance(line, int) or line <= 0:
             return None
         for field in required_finding_fields:
             if not isinstance(finding.get(field), str) or not finding[field].strip():
@@ -192,6 +195,7 @@ def valid_control(
 
 
 def iter_json_objects(text: str) -> list[Any]:
+    """Extract JSON objects from raw OpenCode output that may include prose."""
     decoder = json.JSONDecoder()
     values: list[Any] = []
 
@@ -214,6 +218,7 @@ def iter_json_objects(text: str) -> list[Any]:
 
 
 def main(argv: list[str]) -> int:
+    """Run the normalizer CLI and write the publishable control block."""
     if len(argv) == 3 and argv[1] == "--check-structural-approval":
         return check_structural_approval(Path(argv[2]))
 

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -405,6 +405,9 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "Do not spend the session listing every changed path before reviewing" "opencode review prompt prevents fallback sessions from exhausting steps on file listing"
 	assert_file_contains "$workflow_file" "always return a final control block instead of a progress summary" "opencode review prompt requires a gate conclusion instead of a progress summary"
 	assert_file_contains "$workflow_file" "timeout 600 opencode run" "opencode review primary model has a bounded timeout so fallback review can publish promptly"
+	assert_file_contains "$workflow_file" 'OPENCODE_MODEL_ATTEMPTS: "2"' "opencode review retries transient model execution failures before exhausting a model"
+	assert_file_contains "$workflow_file" 'OpenCode %s attempt %s/%s failed with exit %s.' "opencode review logs per-model retry attempts"
+	assert_file_contains "$workflow_file" 'case "$opencode_run_status" in' "opencode review sends timeout-class failures directly to fallback instead of retrying the same stuck model"
 	assert_file_contains "$workflow_file" '"ci-review-fallback"' "opencode review workflow declares a dedicated fallback agent"
 	assert_file_contains "$workflow_file" '"steps": 12' "opencode review fallback agent has enough bounded steps to conclude after MCP inspection"
 	assert_file_contains "$workflow_file" '"read": "allow"' "opencode review allows read-only file inspection"
@@ -522,6 +525,8 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$workflow_file" "FAILED_CHECK_EVIDENCE_ATTEMPTS" "opencode review workflow bounds waiting for peer check failures before model review"
 	assert_file_contains "$workflow_file" 'FAILED_CHECK_EVIDENCE_ATTEMPTS: "31"' "opencode review workflow waits long enough for slow Strix self-test failures"
 	assert_file_contains "$workflow_file" "collect_failed_check_evidence_with_wait" "opencode review workflow waits briefly for failed checks before building model evidence"
+	assert_file_contains "$workflow_file" "Failed-check evidence collector is not installed in this repository." "opencode review evidence handles repos without the failed-check helper instead of retrying a missing script"
+	assert_file_contains "$workflow_file" "collect_failed_check_evidence_or_note()" "opencode approval handles repos without the failed-check helper before publishing fallback reviews"
 	assert_file_contains "$workflow_file" "current_peer_checks_still_running" "opencode review workflow distinguishes pending peer checks from completed check state"
 	assert_file_contains "$workflow_file" 'select((.name // "") != "opencode-review")' "opencode review evidence wait excludes its own check run"
 	assert_file_contains "$workflow_file" 'select((.checkSuite.workflowRun.workflow.name // "") != "OpenCode PR Review")' "opencode review evidence wait excludes its own workflow"
@@ -559,7 +564,8 @@ assert_opencode_review_uses_codegraph_and_gpt5_fallback() {
 	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" 'startswith("cannot provide diff")' "opencode approval gate rejects placeholder suggested diffs"
 	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" "source_file.is_file()" "opencode approval gate requires finding paths to exist"
 	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" "removed_line not in source_line_set" "opencode approval gate rejects suggested diffs that remove code absent from the cited file"
-	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" 'finding["line"] <= 0' "opencode normalizer rejects line zero findings"
+	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" "isinstance(line, bool)" "opencode normalizer rejects boolean line findings"
+	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" "line <= 0" "opencode normalizer rejects line zero findings"
 	assert_file_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" "--check-structural-approval" "opencode approval gate delegates structural approval rejection to the normalizer"
 	assert_file_not_contains "$REPO_ROOT/scripts/ci/opencode_review_approve_gate.sh" "structural exploration was not possible" "opencode approval gate does not duplicate structural failure phrases"
 	assert_file_contains "$workflow_file" "validate_opencode_failed_check_review.sh" "opencode approval gate validates request-changes reviews against failed-check evidence"
@@ -666,7 +672,7 @@ assert_opencode_review_normalizer_accepts_transcript_json() {
 	cat >"$output_file" <<'EOF'
 OpenCode transcript text before the review control block.
 
-{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"APPROVE","reason":"No blockers found after inspecting .github/workflows/opencode-review.yml.","summary":"Reviewed current head evidence including scripts/ci/test_strix_quick_gate.sh and no blocking review findings were identified.","findings":[]}
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"APPROVE","reason":"No blockers found after inspecting .github/workflows/opencode-review.yml.","summary":"Reviewed scripts/ci/opencode_review_normalize_output.py, scripts/ci/test_strix_quick_gate.sh, and current head evidence; no blocking review findings were identified.","findings":[]}
 EOF
 
 	set +e
@@ -711,7 +717,7 @@ assert_opencode_review_publish_body_discards_trailing_model_prose() {
 <!-- opencode-review-gate head_sha=abc123 run_id=42 run_attempt=1 -->
 
 <!-- opencode-review-control-v1
-{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"APPROVE","reason":"No blockers found after inspecting .github/workflows/opencode-review.yml.","summary":"Reviewed current head evidence including scripts/ci/test_strix_quick_gate.sh and no blocking review findings were identified.","findings":[]}
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"APPROVE","reason":"No blockers found after inspecting .github/workflows/opencode-review.yml.","summary":"Reviewed scripts/ci/opencode_review_normalize_output.py, scripts/ci/test_strix_quick_gate.sh, and current head evidence; no blocking review findings were identified.","findings":[]}
 -->
 
 But that is not meticulous.
@@ -944,6 +950,21 @@ EOF
 
 	assert_equals "4" "$rc" "opencode normalizer rejects line zero findings"
 	assert_file_contains "$tmp_dir/normalize.err" "NO_CONCLUSION" "opencode normalizer reports no valid conclusion for line zero findings"
+
+	cat >"$output_file" <<'EOF'
+OpenCode transcript text before the review control block.
+
+{"head_sha":"abc123","run_id":"42","run_attempt":"1","result":"REQUEST_CHANGES","reason":"Boolean line blocker","summary":"Boolean line values are not concrete source locations.","findings":[{"path":"scripts/ci/example.sh","line":true,"severity":"HIGH","title":"Boolean line","problem":"Boolean line values are not actionable.","root_cause":"The review did not inspect a concrete line.","fix_direction":"Inspect the actual file and cite a positive integer line number.","regression_test_direction":"Add a gate test for boolean line rejection.","suggested_diff":"diff --git a/scripts/ci/example.sh b/scripts/ci/example.sh\n--- a/scripts/ci/example.sh\n+++ b/scripts/ci/example.sh\n@@ -1 +1 @@\n-old\n+new"}]}
+EOF
+
+	set +e
+	python3 "$REPO_ROOT/scripts/ci/opencode_review_normalize_output.py" \
+		"abc123" "42" "1" "$output_file" >"$tmp_dir/bool-line.out" 2>"$tmp_dir/bool-line.err"
+	rc=$?
+	set -e
+
+	assert_equals "4" "$rc" "opencode normalizer rejects boolean line findings"
+	assert_file_contains "$tmp_dir/bool-line.err" "NO_CONCLUSION" "opencode normalizer reports no valid conclusion for boolean line findings"
 
 	rm -rf "$tmp_dir"
 }
@@ -5263,7 +5284,7 @@ run_total_timeout_case() {
 set -euo pipefail
 
 echo "1" >> "${FAKE_STRIX_CALL_COUNT_FILE:?}"
-sleep 5
+sleep 30
 EOF
 	chmod +x "$fake_strix"
 	printf '%s' 'vertex_ai/total-timeout-primary' >"$strix_llm_file"
@@ -5279,8 +5300,8 @@ EOF
 			FAKE_STRIX_CALL_COUNT_FILE="$call_count_file" \
 			STRIX_LLM_FILE="$strix_llm_file" \
 			LLM_API_KEY_FILE="$llm_api_key_file" \
-			STRIX_PROCESS_TIMEOUT_SECONDS="10" \
-			STRIX_TOTAL_TIMEOUT_SECONDS="3" \
+			STRIX_PROCESS_TIMEOUT_SECONDS="30" \
+			STRIX_TOTAL_TIMEOUT_SECONDS="8" \
 			STRIX_VERTEX_FALLBACK_MODELS="vertex_ai/fallback-one" \
 			STRIX_TRANSIENT_RETRY_PER_MODEL="2" \
 			STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS="0" \
@@ -5292,7 +5313,7 @@ EOF
 	set -e
 
 	assert_equals "1" "$rc" "total timeout exit code"
-	assert_file_contains "$output_log" "Strix quick scan exceeded total timeout of 3s." "total timeout output"
+	assert_file_contains "$output_log" "Strix quick scan exceeded total timeout of 8s." "total timeout output"
 	local actual_calls="0"
 	if [ -f "$call_count_file" ]; then
 		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"


### PR DESCRIPTION
## Summary
- reject invalid boolean-only OpenCode finding lines before approval
- handle repositories without scripts/ci/collect_failed_check_evidence.sh instead of retrying a missing helper into model failure
- retry transient OpenCode model execution failures once while sending timeout-class failures directly to fallback models
- make model-output failure handling wait for peer GitHub Checks before posting a pending-check REQUEST_CHANGES review
- stabilize the Strix total-timeout self-test so one slow setup path does not block bootstrap work

## Verification
- bash -n scripts/ci/test_strix_quick_gate.sh && bash -n scripts/ci/strix_quick_gate.sh && python3 -m py_compile scripts/ci/opencode_review_normalize_output.py
- actionlint -shellcheck= -pyflakes= .github/workflows/opencode-review.yml .github/workflows/strix.yml
- git diff --check