### PR TITLE
🎨 Palette: Use type=text for custom search inputs to prevent native clear buttons

### DIFF
--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -439,7 +439,7 @@ describe("SearchPage", () => {
 
     const input = container.querySelector("#search-input") as HTMLInputElement | null;
     expect(input).not.toBeNull();
-    expect(input?.type).toBe("search");
+    expect(input?.type).toBe("text");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
     expect(

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -137,7 +137,7 @@ describe("TasksPage", () => {
 
     const taskSearchInput = container.querySelector<HTMLInputElement>('input[aria-label="작업 맥락 검색"]');
     expect(taskSearchInput).not.toBeNull();
-    expect(taskSearchInput?.type).toBe("search");
+    expect(taskSearchInput?.type).toBe("text");
     expect(taskSearchInput?.inputMode).toBe("search");
     expect(taskSearchInput?.getAttribute("role")).toBe("searchbox");
     await act(async () => {

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -92,7 +92,7 @@ describe("DashboardLayout", () => {
     expect(main).not.toBeNull();
     expect(skipLink).not.toBeNull();
     expect(logo?.getAttribute("src")).toBe("/brand/naruon-symbol.svg");
-    expect(globalSearchInput?.getAttribute("type")).toBe("search");
+    expect(globalSearchInput?.getAttribute("type")).toBe("text");
     expect(globalSearchInput?.getAttribute("inputmode")).toBe("search");
     expect(globalSearchInput?.getAttribute("role")).toBe("searchbox");
     expect(headerActionButtons).toEqual(["일정 반영", "답장 초안", "실행 항목 생성"]);
@@ -222,7 +222,7 @@ describe("DashboardLayout", () => {
 
     const input = container.querySelector<HTMLInputElement>("#global-search-input");
     expect(input).not.toBeNull();
-    expect(input?.getAttribute("type")).toBe("search");
+    expect(input?.getAttribute("type")).toBe("text");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
 

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -364,13 +364,13 @@ export function DashboardLayout({
             <input
               id="global-search-input"
               ref={globalSearchInputRef}
-              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:hidden"
+              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground"
               inputMode="search"
               role="searchbox"
               value={globalSearchQuery}
               onChange={(event) => setGlobalSearchQuery(event.target.value)}
               placeholder="맥락, 사람, 파일, 판단 포인트 맥락 검색..."
-              type="search"
+              type="text"
             />
             {globalSearchQuery ? (
               <button

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -220,8 +220,10 @@ export function EmailList({
               placeholder="메일, 사람, 키워드 맥락 검색..."
               value={searchQuery}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
-              type="search"
-              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02] [&::-webkit-search-cancel-button]:hidden"
+              type="text"
+              inputMode="search"
+              role="searchbox"
+              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02]"
             />
             {searchQuery && (
               <button

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -509,14 +509,14 @@ export function SearchLayout() {
             <input
               id="search-input"
               ref={searchInputRef}
-              type="search"
+              type="text"
               inputMode="search"
               role="searchbox"
               aria-label="맥락 검색어 입력"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="메일, 일정, 파일, 사람, 의사결정 로그 맥락 검색..."
-              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10 [&::-webkit-search-cancel-button]:hidden"
+              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
             />
             {query && (
               <button

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -326,14 +326,14 @@ export function TasksLayout() {
             <input
               ref={taskSearchInputRef}
               id="task-search-input"
-              type="search"
+              type="text"
               inputMode="search"
               role="searchbox"
               value={taskSearch}
               onChange={(event) => setTaskSearch(event.target.value)}
               placeholder="작업 맥락 검색..."
               aria-label="작업 맥락 검색"
-              className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64 [&::-webkit-search-cancel-button]:hidden"
+              className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64"
             />
             {taskSearch.length > 0 && (
               <button


### PR DESCRIPTION
🎨 Palette: Use type=text for custom search inputs to prevent native clear buttons

💡 What:
Replaced `<input type="search">` with `<input type="text" role="searchbox" inputMode="search">` and removed the `[&::-webkit-search-cancel-button]:hidden` CSS trick across `DashboardLayout`, `EmailList`, `SearchLayout`, and `TasksLayout`.

🎯 Why:
Using `type="search"` can often cause inconsistent native browser styling (e.g., forced padding or native clear buttons in Safari that conflict with our custom ones), which standard CSS/Tailwind struggles to override completely. By using `type="text"` along with the proper ARIA role and mobile keyboard hint, we ensure cross-browser styling consistency without sacrificing any accessibility or mobile UX.

♿ Accessibility:
Maintained full accessibility by explicitly adding `role="searchbox"` and `inputMode="search"`, preserving screen reader context and proper mobile keyboards while achieving the desired visual UI.

---
*PR created automatically by Jules for task [2121682214024365024](https://jules.google.com/task/2121682214024365024) started by @seonghobae*