### PR TITLE
🧪 테스트 커버리지 개선: 캘린더 동기화 `blocked` 상태 엣지 케이스 추가

### DIFF
--- a/backend/tests/test_calendar_sync.py
+++ b/backend/tests/test_calendar_sync.py
@@ -44,3 +44,17 @@ def test_generate_ics_from_task_escapes_summary_text():
     ics_content = generate_ics_from_task(task)
 
     assert "SUMMARY:Review\\, Q2\\; follow\\\\up\\nnotes" in ics_content
+
+
+def test_generate_ics_from_task_blocked_status():
+    task = CalendarTask(
+        task_uid="blocked-1",
+        title="Blocked Task",
+        status="blocked",
+        created_at=datetime.datetime(2026, 5, 23, 10, 0, tzinfo=datetime.timezone.utc),
+        updated_at=datetime.datetime(2026, 5, 23, 11, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    ics_content = generate_ics_from_task(task)
+
+    assert "STATUS:NEEDS-ACTION" in ics_content


### PR DESCRIPTION
🎯 **무엇을:** `calendar_sync.py`의 `generate_ics_from_task` 함수에서 태스크 상태가 `blocked`일 때 `NEEDS-ACTION`으로 올바르게 맵핑되는지를 확인하는 엣지 케이스 테스트를 추가했습니다.

📊 **커버리지:** `status="blocked"` 인 `CalendarTask`를 통해 ics가 올바른 `STATUS` 필드를 가지고 생성되는지 확인하는 시나리오가 추가되었습니다.

✨ **결과:** 기존 `in_progress` 관련 테스트에 이어서 추가적인 상태 분기를 점검함으로써 신뢰성을 높이고 테스트 커버리지를 개선했습니다.

---
*PR created automatically by Jules for task [8017901303746440591](https://jules.google.com/task/8017901303746440591) started by @seonghobae*