### PR TITLE
🧪 LocalDavAdapters의 DNS 해상도 실패에 대한 테스트 추가

### DIFF
--- a/backend/tests/test_runner_dav_adapters.py
+++ b/backend/tests/test_runner_dav_adapters.py
@@ -47,7 +47,9 @@ def stub_dav_dns(monkeypatch):
             )
         ]
 
-    monkeypatch.setattr("runner.local_dav_adapters.socket.getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        "runner.local_dav_adapters.socket.getaddrinfo", fake_getaddrinfo
+    )
 
 
 @pytest.mark.asyncio
@@ -283,3 +285,45 @@ async def test_caldav_adapter_puts_icalendar_content_with_if_match():
         "Content-Type": "text/calendar; charset=utf-8",
         "If-Match": "caldav-before",
     }
+
+
+@pytest.mark.asyncio
+async def test_webdav_adapter_rejects_unresolvable_source_url_before_network_request(
+    monkeypatch,
+):
+    def fake_unresolvable_getaddrinfo(host, port, type=socket.SOCK_STREAM):
+        raise OSError("Name or service not known")
+
+    monkeypatch.setattr(
+        "runner.local_dav_adapters.socket.getaddrinfo",
+        fake_unresolvable_getaddrinfo,
+    )
+    fake_client = FakeDavClient(FakeDavResponse(204))
+    adapters = LocalDavAdapters(
+        [
+            LocalDavSourceConfig(
+                source_id="webdav_src_1",
+                protocol="webdav",
+                base_url="https://webdav.example.com",
+                writeback_enabled=True,
+            )
+        ],
+        http_client_factory=lambda: fake_client,
+    )
+
+    result = await adapters.write_webdav(
+        {
+            "source_id": "webdav_src_1",
+            "target_path": "/Naruon/Notes/task.md",
+            "content": "# Note\n",
+            "if_match": "etag-before-write",
+        }
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "invalid_source_url",
+        "error_code": "invalid_source_url",
+        "provider_write_executed": False,
+    }
+    assert fake_client.requests == []


### PR DESCRIPTION
🎯 **What:** WebDAV URL의 호스트 이름이 DNS에서 확인되지 않을 때 발생하는 `OSError` 처리 경로에 대한 테스트입니다.
📊 **Coverage:** `backend/runner/local_dav_adapters.py`의 `socket.getaddrinfo` 호출 중 `OSError` 예외 발생 시 `ValueError("invalid_source_url")`가 올바르게 발생하여 클라이언트 측 오류 코드로 반환되는지 확인합니다.
✨ **Result:** 네트워크 오류로 인한 예외가 누락되지 않고 의도한 에러 응답으로 변환됨을 보장하는 테스트 커버리지가 추가되었습니다.

---
*PR created automatically by Jules for task [10200929794785736703](https://jules.google.com/task/10200929794785736703) started by @seonghobae*