### PR TITLE
🧪 [Testing] Add error path test for invalid port parsing in local DAV adapters

### DIFF
--- a/backend/tests/test_runner_dav_adapters.py
+++ b/backend/tests/test_runner_dav_adapters.py
@@ -327,3 +327,43 @@ async def test_webdav_adapter_rejects_unresolvable_source_url_before_network_req
         "provider_write_executed": False,
     }
     assert fake_client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_webdav_adapter_rejects_invalid_port_before_dns_lookup(monkeypatch):
+    def fail_getaddrinfo(host, port, type=socket.SOCK_STREAM):
+        raise AssertionError("invalid port URL should fail before DNS lookup")
+
+    monkeypatch.setattr(
+        "runner.local_dav_adapters.socket.getaddrinfo",
+        fail_getaddrinfo,
+    )
+    fake_client = FakeDavClient(FakeDavResponse(204))
+    adapters = LocalDavAdapters(
+        [
+            LocalDavSourceConfig(
+                source_id="webdav_src_1",
+                protocol="webdav",
+                base_url="https://webdav.example.com:abc",
+                writeback_enabled=True,
+            )
+        ],
+        http_client_factory=lambda: fake_client,
+    )
+
+    result = await adapters.write_webdav(
+        {
+            "source_id": "webdav_src_1",
+            "target_path": "/Naruon/Notes/task.md",
+            "content": "# Note\n",
+            "if_match": "etag-before-write",
+        }
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "invalid_source_url",
+        "error_code": "invalid_source_url",
+        "provider_write_executed": False,
+    }
+    assert fake_client.requests == []


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `LocalDavAdapters` to cover the scenario where a user provides a base URL with an unparseable (invalid integer) port number. The `urlsplit` function combined with accessing the `.port` property raises a `ValueError` for strings like `https://example.com:abc`. The code explicitly handles this error path to return a graceful `"invalid_source_url"` error dictionary.

📊 **Coverage:** The new test, `test_webdav_adapter_rejects_invalid_port_before_network_request`, explicitly verifies the `except ValueError` block under `try: source_port = parsed.port or 443`.

✨ **Result:** Improved test coverage and reliability by explicitly validating the error-handling branch, ensuring `LocalDavAdapters` fails safely and synchronously when configured with malformed connection URLs, without making any outgoing network requests.

---
*PR created automatically by Jules for task [16681960546583026941](https://jules.google.com/task/16681960546583026941) started by @seonghobae*