### PR TITLE
⚡ Bolt: Defer large vector columns in SQLAlchemy models

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 ## 2026-06-20 - Optimize N+1 Query in ReplySlaScheduler Loop
 **Learning:** Sequential await loops on query results cause N+1 query and execution blocking issues.
 **Action:** Use asyncio.gather to concurrently process independent tasks instead of a for-loop await block to improve throughput significantly.
+
+## 2026-06-24 - Defer large SQLAlchemy vector payloads
+**Learning:** Mapping large `Vector(1536)` embedding columns as eager default loads inflates row payloads and network transfer for routine list/detail queries that do not need the vector values.
+**Action:** Mark large embedding columns with `deferred=True` when callers rarely need them by default, and use explicit undefer/loading options only in code paths that intentionally consume embeddings. Avoid describing this as an N+1 fix; deferred columns can create extra SELECTs if accessed later in a loop.

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -504,7 +504,8 @@ class Email(Base):
     references: Mapped[str | None] = mapped_column(String, nullable=True)
     date: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), index=True)
     body: Mapped[str] = mapped_column(Text)
-    embedding = mapped_column(Vector(1536))
+    # Defer large pgvector payloads on default entity loads.
+    embedding = mapped_column(Vector(1536), deferred=True)
     attachments: Mapped[list["Attachment"]] = relationship(
         back_populates="email", cascade="all, delete-orphan"
     )
@@ -572,7 +573,8 @@ class Attachment(Base):
     email_id: Mapped[int] = mapped_column(ForeignKey("email_records.id"))
     filename: Mapped[str] = mapped_column(String)
     content: Mapped[str] = mapped_column(Text)
-    embedding = mapped_column(Vector(1536))
+    # Defer large pgvector payloads on default entity loads.
+    embedding = mapped_column(Vector(1536), deferred=True)
 
     email: Mapped["Email"] = relationship(back_populates="attachments")
 

--- a/backend/tests/test_performance_date_index.py
+++ b/backend/tests/test_performance_date_index.py
@@ -1,5 +1,12 @@
-from db.models import Email
+from sqlalchemy import inspect
+
+from db.models import Attachment, Email
 
 
 def test_email_date_has_index():
     assert Email.__table__.c.date.index is True
+
+
+def test_large_embedding_columns_are_deferred_by_default():
+    assert inspect(Email).attrs.embedding.deferred is True
+    assert inspect(Attachment).attrs.embedding.deferred is True


### PR DESCRIPTION
💡 What: Added `deferred=True` to the `embedding = mapped_column(Vector(1536))` declarations on the `Email` and `Attachment` database models.

🎯 Why: By default, SQLAlchemy fetches all un-deferred mapped columns whenever a model is selected. Fetching massive 1536-dimensional vectors for every single email in queries that return hundreds of records (e.g. getting the inbox or checking for missing replies over the last 7 days) causes significant and avoidable memory allocation and network bottlenecks.

📊 Impact: Massive latency reduction and lower memory pressure on both the database and the backend service during routine API calls, as vectors are no longer continuously ferried over the network unnecessarily.

🔬 Measurement: Local tests pass completely. In production, observing the query execution latency on endpoints like `/pending-replies` and memory consumption per-request will reflect the improvement.

---
*PR created automatically by Jules for task [18240689041418266122](https://jules.google.com/task/18240689041418266122) started by @seonghobae*