### PR TITLE
🔒 Sentinel: DAV 경로 탐색(Path Traversal) 우회 취약점 수정

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,9 @@
 **Vulnerability:** The API proxy's `sameOriginStateChangingRequest` function previously allowed state-changing requests if both `sec-fetch-site` and `origin` headers were missing, creating a potential CSRF vector if an attacker suppressed the Origin header.
 **Learning:** Default-allow fallbacks for missing security metadata can silently bypass critical protections, especially when relying solely on cookie-based authentication.
 **Prevention:** Always fail securely by defaulting to `false` when required origin/referer security metadata is absent, ensuring strict enforcement for state-changing operations.
+
+## 2026-06-24 - Prevent URL-Encoded and Windows Path Traversal Bypass
+
+**Vulnerability:** Path traversal in `_dav_path_owner_user_id` could be bypassed using doubly URL-encoded sequences (for example, `%252e%252e%252f`) and Windows-style backslashes.
+**Learning:** Checking for traversal sequences after a single `/` split is insufficient if the input path can contain encoded payloads or alternative path separators.
+**Prevention:** Recursively unquote DAV paths until stable, standardize backslashes to forward slashes, and reject `.` or `..` path segments before extracting authorization scope.

--- a/backend/api/dav.py
+++ b/backend/api/dav.py
@@ -1,5 +1,6 @@
 import logging
 from html import escape as escape_xml_text
+from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,8 +14,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/dav", tags=["dav"])
 
 
+def _normalize_dav_authorization_path(path: str) -> str:
+    normalized_path = path.replace("\\", "/")
+    while True:
+        decoded_path = unquote(normalized_path).replace("\\", "/")
+        if decoded_path == normalized_path:
+            return normalized_path
+        normalized_path = decoded_path
+
+
 def _dav_path_owner_user_id(path: str) -> str | None:
-    if ".." in path.split("/"):
+    path = _normalize_dav_authorization_path(path)
+    if any(segment in {".", ".."} for segment in path.split("/")):
         return None
     normalized_path = path.strip("/")
     if not normalized_path:

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -6,6 +6,7 @@ from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from api.auth import get_auth_context
+from api.dav import _dav_path_owner_user_id
 from db.models import ProjectFolder
 from db.session import get_db
 from main import app
@@ -113,6 +114,42 @@ def test_dav_rejects_path_traversal(dev_auth_dependency_overrides):
         )
         assert response.status_code == 403
         assert response.json()["detail"] == "DAV path must include an owner user"
+
+
+def test_dav_owner_parser_rejects_backslash_traversal():
+    owner_user_id = _dav_path_owner_user_id("user123/..\\other-user/projects")
+
+    assert owner_user_id is None
+
+
+def test_dav_rejects_backslash_traversal(dev_auth_dependency_overrides):
+    with TestClient(app) as client:
+        response = client.request(
+            "PROPFIND", "/dav/user123/..\\other-user/projects/", headers=AUTH_HEADERS
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "DAV path must include an owner user"
+
+
+def test_dav_owner_parser_rejects_double_encoded_traversal():
+    owner_user_id = _dav_path_owner_user_id(
+        "user123/%252e%252e%252fother-user/projects"
+    )
+
+    assert owner_user_id is None
+
+
+def test_dav_rejects_double_encoded_traversal(dev_auth_dependency_overrides):
+    with TestClient(app) as client:
+        response = client.request(
+            "PROPFIND",
+            "/dav/user123/%252e%252e%252fother-user/projects/",
+            headers=AUTH_HEADERS,
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "DAV path must include an owner user"
 
 
 def test_dav_rejects_ownerless_path(dev_auth_dependency_overrides):


### PR DESCRIPTION
🎯 **What:** `backend/api/dav.py`의 `_dav_path_owner_user_id` 함수 내 경로 탐색(Path Traversal) 취약점을 수정했습니다.

⚠️ **Risk:** 이전 구현은 단일 슬래시('/') 분리 이후의 '..'만 확인했기 때문에, 이중 URL 인코딩(예: `%252e%252e%252f`)을 이용하거나 윈도우 스타일의 백슬래시(`\`)를 이용한 우회 공격에 취약했습니다. 이를 방치하면 공격자가 디렉토리 경로를 조작하여 다른 사용자의 DAV 데이터에 무단으로 접근하거나 정보 노출이 일어날 잠재적 위험이 존재했습니다.

🛡️ **Solution:**
1. `urllib.parse.unquote()`를 사용하여 더 이상 변경이 없을 때까지 재귀적으로 경로의 URL 인코딩을 해제하여 다중 인코딩 우회를 차단했습니다.
2. `\` 문자를 `/` 문자로 변환하여 백슬래시를 통한 탐색 우회를 무력화했습니다.
3. 생성된 세그먼트에 '..' 뿐만 아니라 '.'이 포함된 경우에도 유효하지 않은 경로로 간주하도록 검증을 강화했습니다.
4. 해당 공격 벡터에 대한 명시적 보안 테스트 코드(`test_dav_security.py`)를 작성하여 방어를 검증했습니다.

---
*PR created automatically by Jules for task [4089478294287857265](https://jules.google.com/task/4089478294287857265) started by @seonghobae*