### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Bandit XML Parsing (B314) and Test Vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,9 +55,13 @@
 **Vulnerability:** The API proxy's `sameOriginStateChangingRequest` function previously allowed state-changing requests if both `sec-fetch-site` and `origin` headers were missing, creating a potential CSRF vector if an attacker suppressed the Origin header.
 **Learning:** Default-allow fallbacks for missing security metadata can silently bypass critical protections, especially when relying solely on cookie-based authentication.
 **Prevention:** Always fail securely by defaulting to `false` when required origin/referer security metadata is absent, ensuring strict enforcement for state-changing operations.
-
 ## 2026-06-24 - Prevent URL-Encoded and Windows Path Traversal Bypass
 
 **Vulnerability:** Path traversal in `_dav_path_owner_user_id` could be bypassed using doubly URL-encoded sequences (for example, `%252e%252e%252f`) and Windows-style backslashes.
 **Learning:** Checking for traversal sequences after a single `/` split is insufficient if the input path can contain encoded payloads or alternative path separators.
 **Prevention:** Recursively unquote DAV paths until stable, standardize backslashes to forward slashes, and reject `.` or `..` path segments before extracting authorization scope.
+
+## 2026-06-22 - [Bandit B314: Insecure XML Parsing in Tests]
+**Vulnerability:** `xml.etree.ElementTree.fromstring` was used to parse XML responses in tests (`backend/tests/test_dav_api.py`), triggering Bandit B314 (vulnerable to XML attacks).
+**Learning:** Even in test environments parsing trusted responses, standard XML parsers trigger security scanners because they are inherently vulnerable to XML external entity (XXE) and billion laughs attacks.
+**Prevention:** Always use `defusedxml` (`import defusedxml.ElementTree as ET`) as a drop-in replacement when parsing XML anywhere in the codebase to pass static analysis and enforce secure-by-default habits.

--- a/backend/requirements-hashes.txt
+++ b/backend/requirements-hashes.txt
@@ -368,6 +368,10 @@ cryptography==49.0.0 \
     # via
     #   -r backend/requirements.txt
     #   google-auth
+defusedxml==0.7.1 \
+    --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \
+    --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+    # via -r backend/requirements.txt
 distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,4 @@ websockets==16.0
 PyJWT==2.13.0  # latest verified 2026-06-12; do not downgrade to 2.8.0
 icalendar==7.1.3
 ruff==0.15.18
+defusedxml==0.7.1

--- a/backend/tests/test_dav_api.py
+++ b/backend/tests/test_dav_api.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from contextlib import contextmanager
 from urllib.parse import unquote
 

--- a/backend/tests/test_email_import_service.py
+++ b/backend/tests/test_email_import_service.py
@@ -25,7 +25,7 @@ from services.email_import_service import (
         ("/", "upload"),
         (".", "upload"),
         ("..", "upload"),
-        ("/tmp/..", "upload"),
+        ("/tmp/..", "upload"),  # nosec B108
     ]
 )
 def test_safe_upload_filename(input_name, expected):

--- a/backend/tests/test_llm_provider_urls.py
+++ b/backend/tests/test_llm_provider_urls.py
@@ -87,7 +87,7 @@ def test_validate_global_address_private_rejected_without_hostname(monkeypatch):
     "candidate, expected",
     [
         ("192.168.1.1", True),
-        ("0.0.0.0", True),
+        ("0.0.0.0", True),  # nosec B104
         ("255.255.255.255", True),
         ("127.0.0.1", True),
         ("::1", True),


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bandit reported B314 (insecure XML parsing), B108 (hardcoded tmp directory usage), and B104 (hardcoded bind all interfaces).
🎯 Impact: Using `xml.etree` can lead to XML vulnerabilities (XXE), while the other issues were test-specific false positives triggering the security scanner.
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` in `test_dav_api.py`. Added `# nosec B108` and `# nosec B104` to explicitly dismiss false positives in `test_email_import_service.py` and `test_llm_provider_urls.py`. Added `defusedxml` to `requirements.txt`.
✅ Verification: Ran `bandit -r tests api services -lll` and `pytest` to confirm 0 issues and all tests passing.

---
*PR created automatically by Jules for task [5770835145825669537](https://jules.google.com/task/5770835145825669537) started by @seonghobae*