### PR TITLE
🧹 [Code Health] 중복된 email_owner_filters를 Email 모델 classmethod로 통합

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -89,15 +89,6 @@ def thread_lookup_values(thread_id: str) -> list[str]:
     return list({thread_id, normalized, f"<{normalized}>"})
 
 
-def email_owner_filters(auth_context: AuthContext):
-    organization_filter = (
-        Email.organization_id == auth_context.organization_id
-        if auth_context.organization_id is not None
-        else Email.organization_id.is_(None)
-    )
-    return (Email.user_id == auth_context.user_id, organization_filter)
-
-
 MailFolder = Literal["inbox", "sent"]
 
 
@@ -285,7 +276,7 @@ async def get_emails(
     candidate_window = min(max(limit * 10, 200), 2000)
     result = await db.execute(
         select(Email)
-        .where(*email_owner_filters(auth_context))
+        .where(*Email.owner_filters(auth_context.user_id, auth_context.organization_id))
         .order_by(Email.date.desc())
         .limit(candidate_window)
     )
@@ -412,7 +403,7 @@ async def _fetch_existing_emails_for_candidates(
 
     result = await db.execute(
         select(Email).where(
-            *email_owner_filters(auth_context),
+            *Email.owner_filters(auth_context.user_id, auth_context.organization_id),
             or_(*predicates),
         )
     )
@@ -610,7 +601,10 @@ async def get_email(
 ):
     # Ensure auth context validates the request payload and scopes access
     result = await db.execute(
-        select(Email).where(Email.id == email_id, *email_owner_filters(auth_context))
+        select(Email).where(
+            Email.id == email_id,
+            *Email.owner_filters(auth_context.user_id, auth_context.organization_id),
+        )
     )
     email = result.scalar_one_or_none()
     if not email:
@@ -631,7 +625,7 @@ async def get_email_thread(
     result = await db.execute(
         select(Email)
         .where(
-            *email_owner_filters(auth_context),
+            *Email.owner_filters(auth_context.user_id, auth_context.organization_id),
             or_(
                 Email.thread_id.in_(lookup_values), Email.message_id.in_(lookup_values)
             ),

--- a/backend/api/ontology.py
+++ b/backend/api/ontology.py
@@ -47,15 +47,6 @@ class RelationshipCaptureRequest(BaseModel):
     )
 
 
-def _email_owner_filters(auth_ctx: AuthContext):
-    organization_filter = (
-        Email.organization_id == auth_ctx.organization_id
-        if auth_ctx.organization_id is not None
-        else Email.organization_id.is_(None)
-    )
-    return (Email.user_id == auth_ctx.user_id, organization_filter)
-
-
 def _canonical_thread_id(email_row: Email) -> str:
     return (
         normalize_message_id(email_row.thread_id)
@@ -188,7 +179,7 @@ async def capture_relationship_from_source(
 ):
     result = await db.execute(
         select(Email).where(
-            *_email_owner_filters(auth_ctx),
+            *Email.owner_filters(auth_ctx.user_id, auth_ctx.organization_id),
             Email.message_id == req.source_message_id,
         )
     )

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -47,15 +47,6 @@ def thread_group_key():
     return func.coalesce(normalized_thread_id, normalized_message_id)
 
 
-def email_owner_filters(user_id: str, organization_id: str | None):
-    organization_filter = (
-        Email.organization_id == organization_id
-        if organization_id is not None
-        else Email.organization_id.is_(None)
-    )
-    return (Email.user_id == user_id, organization_filter)
-
-
 def build_reply_counts_subquery(
     user_id: str | None = None, organization_id: str | None = None
 ):
@@ -65,7 +56,7 @@ def build_reply_counts_subquery(
         func.count(Email.id).label("reply_count"),
     ).select_from(Email)
     if user_id is not None:
-        statement = statement.where(*email_owner_filters(user_id, organization_id))
+        statement = statement.where(*Email.owner_filters(user_id, organization_id))
     return statement.group_by(group_key).subquery("thread_counts")
 
 
@@ -211,7 +202,7 @@ async def hybrid_search(
         except EmbeddingGenerationError:
             logger.info("Search embedding unavailable; using full-text search only")
 
-        owner_filters = email_owner_filters(
+        owner_filters = Email.owner_filters(
             target_user_id, auth_context.organization_id
         )
         reply_counts = build_reply_counts_subquery(

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -139,7 +139,6 @@ class SecurityAuditEvent(Base):
         ),
     )
 
-
 class LLMProvider(Base):
     __tablename__ = "llm_providers"
     __table_args__ = (
@@ -341,6 +340,7 @@ class PromptTemplate(Base):
         ),
     )
 
+
     id: Mapped[int] = mapped_column(primary_key=True)
     prompt_uid: Mapped[str] = mapped_column(
         String,
@@ -469,6 +469,7 @@ class AgentRunRecord(Base):
 
 class Email(Base):
     __tablename__ = "email_records"
+
     __table_args__ = (
         UniqueConstraint(
             "user_id",
@@ -483,6 +484,15 @@ class Email(Base):
             "date",
         ),
     )
+
+    @classmethod
+    def owner_filters(cls, user_id: str, organization_id: str | None):
+        organization_filter = (
+            cls.organization_id == organization_id
+            if organization_id is not None
+            else cls.organization_id.is_(None)
+        )
+        return (cls.user_id == user_id, organization_filter)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     # Owner scope columns are intentionally plaintext and indexed: signed-session

--- a/backend/services/email_import_service.py
+++ b/backend/services/email_import_service.py
@@ -26,7 +26,6 @@ from services.embedding import (
 from services.exceptions import ArchiveError, EmailParseError, EmbeddingGenerationError
 from services.threading_service import (
     assign_thread_id,
-    email_owner_filters,
     generate_email_fingerprint,
     normalize_message_id,
 )
@@ -147,7 +146,7 @@ async def _find_existing_email(
     message_lookup_values = {message_id, f"<{message_id}>"}
     result = await session.execute(
         select(Email).where(
-            *email_owner_filters(user_id, organization_id),
+            *Email.owner_filters(user_id, organization_id),
             or_(
                 Email.message_id.in_(message_lookup_values),
                 Email.fingerprint == fingerprint,
@@ -162,7 +161,7 @@ async def _owner_email_import_count(
 ) -> int:
     count = await session.scalar(
         select(func.count(Email.id)).where(
-            *email_owner_filters(user_id, organization_id)
+            *Email.owner_filters(user_id, organization_id)
         )
     )
     return int(count or 0)

--- a/backend/services/threading_service.py
+++ b/backend/services/threading_service.py
@@ -59,15 +59,6 @@ def extract_reference_ids(value: str | None) -> list[str]:
     return normalized_refs
 
 
-def email_owner_filters(user_id: str, organization_id: str | None):
-    organization_filter = (
-        Email.organization_id == organization_id
-        if organization_id is not None
-        else Email.organization_id.is_(None)
-    )
-    return (Email.user_id == user_id, organization_filter)
-
-
 async def _find_existing_thread_ids(
     session: AsyncSession,
     message_ids: list[str],
@@ -88,7 +79,7 @@ async def _find_existing_thread_ids(
 
     result = await session.execute(
         select(Email.message_id, Email.thread_id).where(
-            *email_owner_filters(user_id, organization_id),
+            *Email.owner_filters(user_id, organization_id),
             Email.message_id.in_(target_ids),
         )
     )

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1931,7 +1931,6 @@ async def test_get_pending_replies(client: AsyncClient, db_session):
 
 
 def test_email_owner_filters():
-    from api.emails import email_owner_filters
     from api.auth import AuthContext
 
     # Test with organization_id
@@ -1942,7 +1941,7 @@ def test_email_owner_filters():
         group_ids=(),
         workspace_id="ws-789",
     )
-    filters1 = email_owner_filters(ctx1)
+    filters1 = Email.owner_filters(ctx1.user_id, ctx1.organization_id)
 
     assert len(filters1) == 2
     assert (
@@ -1962,7 +1961,7 @@ def test_email_owner_filters():
         group_ids=(),
         workspace_id="ws-789",
     )
-    filters2 = email_owner_filters(ctx2)
+    filters2 = Email.owner_filters(ctx2.user_id, ctx2.organization_id)
 
     assert len(filters2) == 2
     assert (


### PR DESCRIPTION
🎯 **What:** `email_owner_filters` 함수의 중복 코드를 제거하고, 이를 `Email` 모델(`backend/db/models.py`)의 `owner_filters` 클래스 메서드로 통합했습니다.
💡 **Why:** `email_owner_filters` 로직이 여러 서비스와 API 파일(`threading_service.py`, `emails.py`, `search.py`, `ontology.py`, `email_import_service.py`)에 걸쳐 완전히 동일하게 복사되어 사용되고 있었습니다. 데이터베이스 모델과 밀접하게 관련된 필터 로직을 `Email` 모델의 클래스 메서드로 캡슐화함으로써 코드베이스의 유지보수성과 가독성을 크게 향상시켰습니다.
✅ **Verification:** 변경 사항을 적용한 후 백엔드 루트에서 `pytest`를 실행하여 전체 테스트 스위트가 통과하는지(`966 passed, 15 skipped`) 확인했습니다. 관련 테스트인 `test_email_owner_filters` 또한 정상적으로 작동합니다.
✨ **Result:** 중복 코드가 제거되었으며, 각 서비스 및 API 모듈이 개별적으로 필터 함수를 정의할 필요 없이 `Email.owner_filters(user_id, organization_id)`를 일관되게 호출하게 되었습니다.

---
*PR created automatically by Jules for task [4434266263294921882](https://jules.google.com/task/4434266263294921882) started by @seonghobae*