### PR TITLE
🛡️ Sentinel: 인증 세션 검증 누락 해결

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -65,3 +65,8 @@
 **Vulnerability:** `xml.etree.ElementTree.fromstring` was used to parse XML responses in tests (`backend/tests/test_dav_api.py`), triggering Bandit B314 (vulnerable to XML attacks).
 **Learning:** Even in test environments parsing trusted responses, standard XML parsers trigger security scanners because they are inherently vulnerable to XML external entity (XXE) and billion laughs attacks.
 **Prevention:** Always use `defusedxml` (`import defusedxml.ElementTree as ET`) as a drop-in replacement when parsing XML anywhere in the codebase to pass static analysis and enforce secure-by-default habits.
+
+## 2026-06-24 - Missing Auth Session Verification for OIDC
+**Vulnerability:** Session metadata validation skipped explicit issuer (`iss`) and audience (`aud`) checks whenever OIDC was globally configured, rather than checking claims against the verifier that actually accepted the token.
+**Learning:** Security validation functions must use contextual verifier evidence instead of assuming that a global configuration flag describes the token path.
+**Prevention:** Pass the session verifier into metadata validation, fail closed when OIDC issuer/client configuration is incomplete, and normalize OIDC audiences before checking membership.

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -451,9 +451,33 @@ def _tuple_string_claim(payload: dict[str, Any], name: str) -> tuple[str, ...]:
     return tuple(normalized)
 
 
-def _validate_session_metadata(payload: dict[str, Any]) -> None:
-    # If OIDC is configured, the issuer/audience might be verified by jwt.decode
-    if not settings.OIDC_ISSUER_URL:
+def _session_audience_claim(payload: dict[str, Any]) -> tuple[str, ...]:
+    value = payload.get("aud")
+    if isinstance(value, str):
+        if not value.strip() or not value.isascii():
+            raise _authentication_error()
+        return (value.strip(),)
+    if isinstance(value, list | tuple):
+        normalized: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip() or not item.isascii():
+                raise _authentication_error()
+            normalized.append(item.strip())
+        return tuple(normalized)
+    raise _authentication_error()
+
+
+def _validate_session_metadata(
+    payload: dict[str, Any], session_verifier: SessionVerifier
+) -> None:
+    if session_verifier == "oidc":
+        if not settings.OIDC_ISSUER_URL or not settings.OIDC_CLIENT_ID:
+            raise _authentication_error()
+        if payload.get("iss") != settings.OIDC_ISSUER_URL:
+            raise _authentication_error()
+        if settings.OIDC_CLIENT_ID not in _session_audience_claim(payload):
+            raise _authentication_error()
+    else:
         if payload.get("ver") != 1:
             raise _authentication_error()
         if payload.get("iss") != SESSION_ISSUER:
@@ -487,7 +511,7 @@ def _validate_session_metadata(payload: dict[str, Any]) -> None:
 def _auth_context_from_session_payload(
     payload: dict[str, Any], session_verifier: SessionVerifier
 ) -> AuthContext:
-    _validate_session_metadata(payload)
+    _validate_session_metadata(payload, session_verifier)
     role_value = _required_string_claim(payload, "role")
     if role_value not in ALLOWED_ROLES:
         raise _authentication_error()

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -20,6 +20,7 @@ from api.auth import (
     SESSION_ALLOWED_ALGORITHMS,
     SESSION_AUTH_RATE_LIMIT_MAX_FAILURES,
     _session_auth_failure_buckets,
+    _auth_context_from_session_payload,
     ensure_organization_access,
     get_auth_context,
     get_current_user,
@@ -971,6 +972,127 @@ async def test_signed_bearer_session_with_oidc(monkeypatch):
     assert decode_options == [
         {"require": ("exp", "iss", "aud"), "verify_signature": True}
     ]
+
+
+@pytest.mark.asyncio
+async def test_oidc_session_accepts_tuple_audience(monkeypatch):
+    import jwt
+
+    previous_issuer_url = settings.OIDC_ISSUER_URL
+    previous_client_id = settings.OIDC_CLIENT_ID
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.OIDC_ISSUER_URL = "https://login.example.test/realms/naruon"
+    settings.OIDC_CLIENT_ID = "naruon-api"
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+
+    class MockKey:
+        key_id = "test-key"
+        key = "public_key"
+
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (MockKey(),))
+
+    def mock_jwt_decode(*args, **kwargs):
+        return {
+            "iss": "https://login.example.test/realms/naruon",
+            "aud": ("naruon-api", "naruon-admin"),
+            "sub": "alice",
+            "role": "member",
+            "org": "org-acme",
+            "groups": ["group-1", "group-2"],
+            "workspace": "workspace-org-acme",
+            "exp": int(time.time()) + 300,
+        }
+
+    monkeypatch.setattr(jwt, "decode", mock_jwt_decode)
+
+    try:
+        token = _signed_session_token(
+            _valid_session_payload(),
+            header={"alg": "RS256", "typ": "JWT", "kid": "test-key"},
+        )
+        context = await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        settings.OIDC_ISSUER_URL = previous_issuer_url
+        settings.OIDC_CLIENT_ID = previous_client_id
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+
+    assert context.session_verifier == "oidc"
+    assert context.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_oidc_session_rejects_missing_client_id_after_decode(monkeypatch):
+    import jwt
+
+    previous_issuer_url = settings.OIDC_ISSUER_URL
+    previous_client_id = settings.OIDC_CLIENT_ID
+    previous_secret = settings.AUTH_SESSION_HMAC_SECRET
+    settings.OIDC_ISSUER_URL = "https://login.example.test/realms/naruon"
+    settings.OIDC_CLIENT_ID = None
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+
+    class MockKey:
+        key_id = "test-key"
+        key = "public_key"
+
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (MockKey(),))
+
+    def mock_jwt_decode(*args, **kwargs):
+        return {
+            "iss": "https://login.example.test/realms/naruon",
+            "sub": "alice",
+            "role": "member",
+            "org": "org-acme",
+            "groups": ["group-1", "group-2"],
+            "workspace": "workspace-org-acme",
+            "exp": int(time.time()) + 300,
+        }
+
+    monkeypatch.setattr(jwt, "decode", mock_jwt_decode)
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={"alg": "RS256", "typ": "JWT", "kid": "test-key"},
+    )
+
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        settings.OIDC_ISSUER_URL = previous_issuer_url
+        settings.OIDC_CLIENT_ID = previous_client_id
+        settings.AUTH_SESSION_HMAC_SECRET = previous_secret
+
+    assert exc.value.status_code == 401
+
+
+def test_oidc_session_metadata_rejects_missing_issuer_configuration():
+    previous_issuer_url = settings.OIDC_ISSUER_URL
+    previous_client_id = settings.OIDC_CLIENT_ID
+    settings.OIDC_ISSUER_URL = None
+    settings.OIDC_CLIENT_ID = "naruon-api"
+
+    try:
+        with pytest.raises(HTTPException) as exc:
+            _auth_context_from_session_payload(
+                {
+                    "iss": "https://login.example.test/realms/naruon",
+                    "aud": ["naruon-api"],
+                    "sub": "alice",
+                    "role": "member",
+                    "org": "org-acme",
+                    "groups": [],
+                    "workspace": "workspace-org-acme",
+                    "exp": int(time.time()) + 300,
+                },
+                "oidc",
+            )
+    finally:
+        settings.OIDC_ISSUER_URL = previous_issuer_url
+        settings.OIDC_CLIENT_ID = previous_client_id
+
+    assert exc.value.status_code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🎯 **What:** `_validate_session_metadata` 함수가 OIDC가 설정된 경우 발급자(Issuer) 및 대상(Audience) 클레임 검증을 전면 생략하던 문제를 해결했습니다.

⚠️ **Risk:** OIDC 검증 과정에서 클레임이 누락되거나 예상치 못한 경로로 토큰이 검증을 우회할 경우, 잘못된 발급자나 대상을 가진 토큰이 유효한 세션으로 승인될 수 있는 세션 스푸핑 취약점이 발생할 위험이 있었습니다.

🛡️ **Solution:** 유효성 검사 함수가 `session_verifier` 매개변수를 명시적으로 받아들이도록 업데이트했습니다. 이제 OIDC 세션의 경우 OIDC 설정과 대조하여 클레임을 명시적으로 검증하고, 그 외의 모든 세션 유형에 대해서는 표준 `SESSION_ISSUER`/`SESSION_AUDIENCE` 검증으로 대체하여 모든 토큰 유형에서 클레임 검증이 누락되지 않도록 보장합니다.

---
*PR created automatically by Jules for task [3850587205361184843](https://jules.google.com/task/3850587205361184843) started by @seonghobae*