### PR TITLE
🧪 테스트 커버리지 개선: toConfidencePercent 엣지 케이스 추가

### DIFF
--- a/frontend/src/lib/confidence.test.ts
+++ b/frontend/src/lib/confidence.test.ts
@@ -29,4 +29,39 @@ describe('toConfidencePercent', () => {
     expect(toConfidencePercent(150)).toBe(100);
     expect(toConfidencePercent(-0.1)).toBe(0);
   });
+
+  it('handles values just outside the 0-1 fraction range as literal percentages', () => {
+    expect(toConfidencePercent(1)).toBe(100);
+    // 1.01 is > 1, so it is treated as a percentage (1.01%) and rounded to 1
+    expect(toConfidencePercent(1.01)).toBe(1);
+    // 1.5 is > 1, so treated as 1.5% -> rounded to 2%
+    expect(toConfidencePercent(1.5)).toBe(2);
+    // 99.5 is > 1, treated as 99.5% -> rounded to 100%
+    expect(toConfidencePercent(99.5)).toBe(100);
+  });
+
+  it('handles floating point precision gracefully', () => {
+    // 0.1 + 0.2 = 0.30000000000000004
+    expect(toConfidencePercent(0.1 + 0.2)).toBe(30);
+    // 0.14 * 100 = 14.000000000000002
+    expect(toConfidencePercent(0.14)).toBe(14);
+  });
+
+  it('handles exact rounding thresholds correctly', () => {
+    // 0.854 * 100 = 85.4 -> 85
+    expect(toConfidencePercent(0.854)).toBe(85);
+    // 0.855 * 100 = 85.5 -> 86
+    expect(toConfidencePercent(0.855)).toBe(86);
+    // 85.4 -> 85
+    expect(toConfidencePercent(85.4)).toBe(85);
+    // 85.5 -> 86
+    expect(toConfidencePercent(85.5)).toBe(86);
+  });
+
+  it('normalizes negative zero to positive zero', () => {
+    const percent = toConfidencePercent(-0);
+
+    expect(Object.is(percent, 0)).toBe(true);
+    expect(Object.is(percent, -0)).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 **What:** `frontend/src/lib/confidence.test.ts` 파일의 테스트 커버리지 갭을 해소하기 위해 수학적 변환 함수의 엣지 케이스 테스트를 추가했습니다.
📊 **Coverage:** 다음과 같은 시나리오들이 추가로 테스트됩니다:
- 범위를 약간 벗어난 백분율 값 (e.g., `1.01`, `1.5`)
- 부동 소수점 연산 정밀도 문제 (e.g., `0.1 + 0.2` 가 정확히 30으로 반올림되는지)
- 소수점 반올림 경계 값 (e.g., `.855` -> 86, `.854` -> 85)
- `-0` 입력 시 양수 `0`으로 정규화되는지
✨ **Result:** 다양한 입력 값과 JS 연산의 한계 속에서도 퍼센티지 변환 함수가 예상대로 동작함을 검증하여 코드의 신뢰성과 테스트 커버리지를 강화했습니다.

---
*PR created automatically by Jules for task [12868885430865253811](https://jules.google.com/task/12868885430865253811) started by @seonghobae*