### PR TITLE
🧪 build_auth_context 함수에 대한 단위 테스트 추가

### DIFF
--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -239,6 +239,7 @@ def test_build_auth_context_accepts_signed_bearer_session():
         workspace_id="workspace-org-acme",
         session_verifier="hmac",
     )
+    assert context.session_verifier == "hmac"
 
 
 def test_build_auth_context_rejects_missing_auth():

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -13,17 +13,18 @@ from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 from api.auth import (
-    is_tenant_admin_role,
-    is_admin_role,
     AuthContext,
     OIDC_ALLOWED_ALGORITHMS,
     SESSION_ALLOWED_ALGORITHMS,
     SESSION_AUTH_RATE_LIMIT_MAX_FAILURES,
     _session_auth_failure_buckets,
     _auth_context_from_session_payload,
+    build_auth_context,
     ensure_organization_access,
     get_auth_context,
     get_current_user,
+    is_admin_role,
+    is_tenant_admin_role,
 )
 from core.config import settings
 from db.session import get_db
@@ -222,6 +223,36 @@ def test_runtime_auth_dependencies_do_not_declare_dev_header_api_surface():
 
     assert RUNTIME_HEADER_PARAMS.isdisjoint(auth_context_params)
     assert RUNTIME_HEADER_PARAMS.isdisjoint(current_user_params)
+
+
+def test_build_auth_context_accepts_signed_bearer_session():
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+    token = _signed_session_token(_valid_session_payload())
+
+    context = build_auth_context(authorization=f"Bearer {token}")
+
+    assert context == AuthContext(
+        user_id="alice",
+        role="member",
+        organization_id="org-acme",
+        group_ids=("group-1", "group-2"),
+        workspace_id="workspace-org-acme",
+        session_verifier="hmac",
+    )
+
+
+def test_build_auth_context_rejects_missing_auth():
+    with pytest.raises(HTTPException) as exc:
+        build_auth_context(authorization=None)
+
+    assert exc.value.status_code == 401
+
+
+def test_build_auth_context_rejects_invalid_token():
+    with pytest.raises(HTTPException) as exc:
+        build_auth_context(authorization="Bearer invalid.jwt.token")
+
+    assert exc.value.status_code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🎯 **What:** api/auth.py의 build_auth_context 함수에 대한 테스트가 누락된 문제를 해결했습니다.
📊 **Coverage:** 유효한 서명된 토큰(happy path), 누락된 Authorization 헤더(error condition), 잘못된 토큰 문자열(error condition)에 대한 3가지 시나리오를 검증하는 테스트를 test_auth_real.py에 추가했습니다.
✨ **Result:** 인증 컨텍스트 생성 로직에 대한 테스트 커버리지가 향상되어 안정성이 강화되었습니다.

---
*PR created automatically by Jules for task [15463045109681480559](https://jules.google.com/task/15463045109681480559) started by @seonghobae*