### PR TITLE
🧪 Add tests for runtime config error metadata

### DIFF
--- a/frontend/src/lib/runtime-config.test.ts
+++ b/frontend/src/lib/runtime-config.test.ts
@@ -128,4 +128,82 @@ describe("fetchRuntimeConfig", () => {
     expect(JSON.stringify(loggedArgs)).not.toContain("Network Error");
     expect(config).toEqual(fallbackConfig);
   });
+
+  it("returns fallback config and logs string error type correctly", async () => {
+    const fetchMock = vi.fn().mockRejectedValue("String Error");
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", {
+      error_type: "string",
+    });
+    expect(config).toEqual(fallbackConfig);
+  });
+
+  it("returns fallback config and logs custom error name correctly", async () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "MyCustomError";
+      }
+    }
+    const fetchMock = vi.fn().mockRejectedValue(new CustomError("Custom error message"));
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", {
+      error_type: "MyCustomError",
+    });
+    expect(config).toEqual(fallbackConfig);
+  });
+
+  it("returns fallback config and logs default Error type for error without name", async () => {
+    const unnamedError = new Error("Unnamed");
+    unnamedError.name = "";
+    const fetchMock = vi.fn().mockRejectedValue(unnamedError);
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", {
+      error_type: "Error",
+    });
+    expect(config).toEqual(fallbackConfig);
+  });
+
+  it("returns fallback config and logs object error type for null correctly", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(null);
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", {
+      error_type: "object",
+    });
+    expect(config).toEqual(fallbackConfig);
+  });
+
+  it("returns fallback config and logs object error type for generic objects", async () => {
+    const fetchMock = vi.fn().mockRejectedValue({});
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const config = await fetchRuntimeConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Runtime config fetch failed, using fallback", {
+      error_type: "object",
+    });
+    expect(config).toEqual(fallbackConfig);
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `getRuntimeConfigErrorLogMetadata` function's behavior in `runtime-config.ts` when handling different types of rejected values returned by the `fetch` mock.

📊 **Coverage:** The tests now explicitly cover:
- String error values
- Custom Error classes with a defined name
- Standard Error objects without a name
- Null or generic object values

✨ **Result:** Enhanced the test suite reliability by fully exercising the edge cases of the runtime config error logger metadata builder.

---
*PR created automatically by Jules for task [5931716429401365374](https://jules.google.com/task/5931716429401365374) started by @seonghobae*