### PR TITLE
🧪 parse_allowed_cors_origins 테스트 추가

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -13,7 +13,7 @@ TEST_AUTH_SESSION_HMAC_SECRET = os.environ.setdefault(
 # Set required environment variables before importing settings
 os.environ["DATABASE_URL"] = "postgresql+asyncpg://test:test@localhost:5432/test_db"
 
-from core.config import Settings, settings  # noqa: E402
+from core.config import Settings, parse_allowed_cors_origins, settings  # noqa: E402
 
 
 def _settings_without_env_file() -> Settings:
@@ -110,6 +110,49 @@ def test_allowed_cors_origins_are_validated_and_normalized(monkeypatch):
         "http://example.com",
         "https://example.com:8443",
     ]
+
+
+def test_parse_allowed_cors_origins_normalizes_entries_and_ignores_empty_items():
+    origins = parse_allowed_cors_origins(
+        " https://Example.com:443 , http://localhost:3000 ,  ,, https://test.net "
+    )
+
+    assert origins == [
+        "https://example.com",
+        "http://localhost:3000",
+        "https://test.net",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("allowed_origins", "error_match"),
+    [
+        ("*", "must not include wildcards"),
+        ("https://*.example.com", "must not include wildcards"),
+        ("ws://example.com", "entries must use http or https"),
+        ("ftp://example.com", "entries must use http or https"),
+        ("https://user:pass@example.com", "entries must not include userinfo"),
+        ("https://", "entries must include a host"),
+        (
+            "https://example.com/path",
+            "entries must be origins without path, query, or fragment",
+        ),
+        (
+            "https://example.com?query=1",
+            "entries must be origins without path, query, or fragment",
+        ),
+        (
+            "https://example.com#fragment",
+            "entries must be origins without path, query, or fragment",
+        ),
+        ("https://example.com:invalid_port", "entries must include a valid port"),
+    ],
+)
+def test_parse_allowed_cors_origins_rejects_unsafe_entries(
+    allowed_origins: str, error_match: str
+):
+    with pytest.raises(ValueError, match=error_match):
+        parse_allowed_cors_origins(allowed_origins)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
🎯 **What:** `backend/core/config.py`의 `parse_allowed_cors_origins` 함수에 대한 테스트가 누락되어 있었던 문제를 해결했습니다.
📊 **Coverage:**
  - Happy path (단일 및 다중 출처, 공백 처리, 빈 문자열 무시)
  - 에러 처리 (와일드카드 `*` 포함 거부)
  - 에러 처리 (`http` 및 `https` 이외의 스킴 거부)
  - 에러 처리 (`userinfo` 포함 거부)
  - 에러 처리 (호스트 누락 거부)
  - 에러 처리 (`path`, `query`, `fragment` 포함 거부)
  - 에러 처리 (잘못된 포트 번호 거부)
✨ **Result:** `parse_allowed_cors_origins` 함수의 모든 `ValueError` 분기에 대한 테스트 커버리지를 100% 확보하여 코드 신뢰성을 향상시켰습니다.

---
*PR created automatically by Jules for task [2596494482251682579](https://jules.google.com/task/2596494482251682579) started by @seonghobae*