### PR TITLE
🧪 Add tests for clearOidcTransientState function

### DIFF
--- a/frontend/src/lib/oidc-session.test.ts
+++ b/frontend/src/lib/oidc-session.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildOidcAuthorizationUrl,
+  clearOidcTransientState,
   clearOidcSession,
   completeOidcRedirect,
   getOidcBrowserConfig,
@@ -135,5 +136,23 @@ describe('oidc-session', () => {
     const authorizationUrl = await buildOidcAuthorizationUrl(config!, 'state-123', 'verifier-123');
 
     expect(new URL(authorizationUrl).searchParams.get('state')).toBe('state-123');
+  });
+
+  it('clears transient OIDC state from sessionStorage', () => {
+    sessionStorage.setItem('naruon_oidc_state', 'state-123');
+    sessionStorage.setItem('naruon_oidc_pkce_verifier', 'verifier-123');
+    sessionStorage.setItem('naruon_oidc_return_to', '/settings');
+
+    clearOidcTransientState();
+
+    expect(sessionStorage.getItem('naruon_oidc_state')).toBeNull();
+    expect(sessionStorage.getItem('naruon_oidc_pkce_verifier')).toBeNull();
+    expect(sessionStorage.getItem('naruon_oidc_return_to')).toBeNull();
+  });
+
+  it('safely handles environments without browser storage', () => {
+    vi.stubGlobal('window', undefined);
+
+    expect(() => clearOidcTransientState()).not.toThrow();
   });
 });


### PR DESCRIPTION
🎯 What: Adds unit tests for the previously untested clearOidcTransientState function in oidc-session.ts.
📊 Coverage: Tests verifying that LEGACY_OIDC_STORAGE_KEYS are correctly cleared from sessionStorage and covers the edge case where the global window is undefined.
✨ Result: Improved test coverage and reliability for OIDC session management functions.

---
*PR created automatically by Jules for task [7451970889342428410](https://jules.google.com/task/7451970889342428410) started by @seonghobae*