### PR TITLE
🧪 Add tests for empty/whitespace BACKEND_INTERNAL_URL

### DIFF
--- a/frontend/src/lib/backend-url.test.ts
+++ b/frontend/src/lib/backend-url.test.ts
@@ -103,6 +103,15 @@ describe("backend URL guard", () => {
     expect(backendApiBaseUrl().origin).toBe("https://backend.example.com");
   });
 
+  it.each(["", "   "])(
+    "ignores empty BACKEND_INTERNAL_URL value %j",
+    (backendInternalUrl) => {
+      vi.stubEnv("BACKEND_INTERNAL_URL", backendInternalUrl);
+
+      expect(backendApiBaseUrl().origin).toBe("http://127.0.0.1:8000");
+    },
+  );
+
   it("falls back to local backend in development", () => {
     expect(backendApiBaseUrl().origin).toBe("http://127.0.0.1:8000");
   });


### PR DESCRIPTION
🎯 **What:** The testing gap for `parseBackendInternalUrl` without `process.env.BACKEND_INTERNAL_URL` is addressed by covering the empty string and whitespace scenarios.

📊 **Coverage:** Scenarios where `BACKEND_INTERNAL_URL` is `""` or `"   "` are now correctly tested.

✨ **Result:** Improved test coverage validating that empty URL strings gracefully fall back to default development URLs.

---
*PR created automatically by Jules for task [15253629442554994411](https://jules.google.com/task/15253629442554994411) started by @seonghobae*