### PR TITLE
🧪 테스트 커버리지 개선: verifySessionToken의 edge case 테스트 추가

### DIFF
--- a/frontend/src/app/auth/session/route.test.ts
+++ b/frontend/src/app/auth/session/route.test.ts
@@ -183,6 +183,62 @@ describe("/auth/session route", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns anonymous claims when backend session verification returns non-OK", async () => {
+    const token = signedFixtureToken({
+      sub: "user-2",
+      org: "org-beta",
+      workspace: "workspace-beta",
+    });
+    const fetchMock = vi.fn(async () => new Response(null, { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("https://app.naruon.net/auth/session", {
+      headers: { Cookie: `naruon_session=${token}` },
+    });
+
+    const response = await GET(request);
+
+    await expect(response.json()).resolves.toEqual({
+      authenticated: false,
+      claims: {
+        userId: null,
+        organizationId: null,
+        workspaceId: null,
+      },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns anonymous claims when backend session verification throws", async () => {
+    const token = signedFixtureToken({
+      sub: "user-2",
+      org: "org-beta",
+      workspace: "workspace-beta",
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network unavailable");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("https://app.naruon.net/auth/session", {
+      headers: { Cookie: `naruon_session=${token}` },
+    });
+
+    const response = await GET(request);
+
+    await expect(response.json()).resolves.toEqual({
+      authenticated: false,
+      claims: {
+        userId: null,
+        organizationId: null,
+        workspaceId: null,
+      },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects forged tokens that the backend verifier does not accept", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => Response.json(
       { detail: "Authentication required" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses missing test coverage for `verifySessionToken` in `frontend/src/app/auth/session/route.ts`. Since the helper isn't exported, we added new tests targeting the `/api/auth/session` GET endpoint to explicitly verify its error handling.

📊 **Coverage:** What scenarios are now tested
- The scenario where backend returns a non-OK status (HTTP 500 in this case).
- The scenario where backend `fetch` encountered a network error or threw an exception.

✨ **Result:** The improvement in test coverage
Both newly added test scenarios now pass properly and `verifySessionToken` test coverage has increased and guarantees it falls back safely to returning anonymous claims.

---
*PR created automatically by Jules for task [1223463075782499174](https://jules.google.com/task/1223463075782499174) started by @seonghobae*