### PR TITLE
🧪 get_release_version 함수에 대한 단위 테스트 추가

### DIFF
--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,36 @@
+import pytest
+
+from core.version import get_release_version
+
+
+@pytest.fixture(autouse=True)
+def clear_version_cache():
+    get_release_version.cache_clear()
+    yield
+    get_release_version.cache_clear()
+
+
+def test_get_release_version_success(tmp_path, monkeypatch):
+    missing_candidate = tmp_path / "VERSION1"
+    present_candidate = tmp_path / "VERSION2"
+
+    present_candidate.write_text(" 1.2.3 \n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "core.version._version_file_candidates",
+        lambda: (missing_candidate, present_candidate),
+    )
+
+    assert get_release_version() == "1.2.3"
+
+
+def test_get_release_version_failure(tmp_path, monkeypatch):
+    missing_candidate = tmp_path / "VERSION1"
+
+    monkeypatch.setattr(
+        "core.version._version_file_candidates",
+        lambda: (missing_candidate,),
+    )
+
+    with pytest.raises(RuntimeError, match="release VERSION file is missing; checked:"):
+        get_release_version()


### PR DESCRIPTION
🎯 **What:** `backend/core/version.py`의 `get_release_version` 함수에 대한 단위 테스트 누락 문제를 해결했습니다.
📊 **Coverage:** 파일 시스템에서 VERSION 파일을 성공적으로 읽어오는 경우와 파일이 누락되어 RuntimeError가 발생하는 두 가지 시나리오를 모두 테스트합니다. monkeypatch를 활용해 안전하게 테스트하도록 구성했습니다.
✨ **Result:** 버전 관련 핵심 유틸리티의 동작 안정성이 확보되고, 테스트 커버리지가 향상되었습니다.

---
*PR created automatically by Jules for task [16897889250572229338](https://jules.google.com/task/16897889250572229338) started by @seonghobae*