### PR TITLE
🧪 Add tests for entropy and character class calculation functions

### DIFF
--- a/backend/tests/test_runtime_secrets.py
+++ b/backend/tests/test_runtime_secrets.py
@@ -1,8 +1,12 @@
+import math
+
 import pytest
 from core.runtime_secrets import (
-    validate_auth_session_hmac_secret_value,
     _KNOWN_PUBLIC_AUTH_SESSION_HMAC_SECRETS,
     _LOW_ENTROPY_PLACEHOLDER_TERMS,
+    _character_class_count,
+    _shannon_entropy_bits,
+    validate_auth_session_hmac_secret_value,
 )
 
 
@@ -86,3 +90,38 @@ def test_validate_auth_session_hmac_secret_value_multibyte_length():
 
     with pytest.raises(ValueError, match="at least three character classes"):
         validate_auth_session_hmac_secret_value("가나다라마바사아자차카타파하")
+
+
+def test_character_class_count():
+    assert _character_class_count("alllower") == 1
+    assert _character_class_count("ALLUPPER") == 1
+    assert _character_class_count("12345678") == 1
+    assert _character_class_count("!@#$%^&*") == 1
+
+    assert _character_class_count("LowerAndUpper") == 2
+    assert _character_class_count("lower123") == 2
+    assert _character_class_count("UPPER123") == 2
+    assert _character_class_count("lower!@#") == 2
+
+    assert _character_class_count("LowerAndUpper123") == 3
+    assert _character_class_count("LowerAndUpper!@#") == 3
+
+    assert _character_class_count("All4Classes123!@#") == 4
+    assert _character_class_count("aaAA11!!") == 4
+
+    assert _character_class_count("") == 0
+
+
+def test_shannon_entropy_bits():
+    assert _shannon_entropy_bits("") == 0.0
+
+    assert _shannon_entropy_bits("a") == 0.0
+    assert _shannon_entropy_bits("aaaaa") == 0.0
+
+    assert _shannon_entropy_bits("ab") == 2.0
+    assert _shannon_entropy_bits("abab") == 4.0
+
+    assert math.isclose(_shannon_entropy_bits("aab"), 3 * math.log2(3) - 2)
+    assert math.isclose(_shannon_entropy_bits("abcd"), 8.0)
+    assert math.isclose(_shannon_entropy_bits("abc"), 4.754887502163468)
+    assert math.isclose(_shannon_entropy_bits("abcabc"), 9.509775004326936)


### PR DESCRIPTION
🎯 **무엇을:** `runtime_secrets.py` 내의 `_shannon_entropy_bits` 및 `_character_class_count` 함수에 대한 테스트 코드 누락 해결.
📊 **커버리지:** 빈 문자열, 다양한 문자 조합, 단일 문자, 모든 문자 클래스 조합에 대한 엔트로피 계산 및 클래스 카운트 예상치와 실제 결과를 엄격히 비교하는 엣지 케이스들을 추가.
✨ **결과:** 핵심적인 보안 엔트로피 계산 함수의 동작을 증명하는 테스트를 도입하여 결함 예방 및 코드 신뢰도 상승.

---
*PR created automatically by Jules for task [10509755082662818066](https://jules.google.com/task/10509755082662818066) started by @seonghobae*