### PR TITLE
🧪 테스트 개선: toMailBodyText 메서드의 줄바꿈 처리 엣지 케이스 추가

### DIFF
--- a/frontend/src/lib/mail-text.test.ts
+++ b/frontend/src/lib/mail-text.test.ts
@@ -83,6 +83,18 @@ describe('toMailBodyText', () => {
     expect(toMailBodyText('Line 1\n\n\n\nLine 2')).toBe('Line 1\n\nLine 2');
   });
 
+  it('collapses CRLF newlines down to preserved paragraph breaks', () => {
+    expect(toMailBodyText('Line 1\r\n\r\n\r\nLine 2')).toBe('Line 1\n\nLine 2');
+  });
+
+  it('collapses whitespace-only blank lines down to preserved paragraph breaks', () => {
+    expect(toMailBodyText('Line 1\n \n \nLine 2')).toBe('Line 1\n\nLine 2');
+  });
+
+  it('collapses mixed CRLF, tabs, and spaces down to preserved paragraph breaks', () => {
+    expect(toMailBodyText('Line 1\r\n  \t  \r\n \r\nLine 2')).toBe('Line 1\n\nLine 2');
+  });
+
   it('preserves single and double newlines', () => {
     expect(toMailBodyText('Line 1\nLine 2\n\nLine 3')).toBe('Line 1\nLine 2\n\nLine 3');
   });

--- a/frontend/src/lib/mail-text.ts
+++ b/frontend/src/lib/mail-text.ts
@@ -40,8 +40,9 @@ export function toMailDisplayText(value: string | null | undefined, fallback = '
 export function toMailBodyText(value: string | null | undefined, fallback = '') {
   const rawText = toSafeReactText(value?.trim() || null, fallback);
   const displayText = stripHtmlLikeSegments(rawText)
+    .replace(/\r\n?/g, '\n')
     .replace(/[ \t]+/g, ' ')
-    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\n(?: *\n){2,}/g, '\n\n')
     .trim();
   return displayText || fallback;
 }


### PR DESCRIPTION
🎯 **What:**
`toMailBodyText`가 CRLF와 공백만 포함된 빈 줄을 일관되게 정규화하도록 보강하고, 해당 엣지 케이스를 테스트로 고정했습니다.

📊 **Coverage:**
* CRLF(`\r\n`)가 반복되는 본문을 LF 기반 문단 구분으로 정규화
* 공백 문자만 있는 빈 줄(`\n \n \n`)을 보존 가능한 문단 구분으로 병합
* CRLF, 스페이스, 탭이 섞인 입력을 `\n\n` 문단 구분으로 정규화

✨ **Result:**
메일 본문 표시가 플랫폼별 줄바꿈/공백 입력에서도 동일하게 동작하며, 향후 리팩토링에서 해당 정규화 동작이 회귀되지 않도록 테스트가 보강되었습니다.

---
*PR created automatically by Jules for task [12806732013424553810](https://jules.google.com/task/12806732013424553810) started by @seonghobae*