### PR TITLE
🧹 [코드 헬스 개선] backend/api/data.py _quality_checks 리팩토링

### DIFF
--- a/backend/api/data.py
+++ b/backend/api/data.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime, timezone
 import hashlib
 from typing import Literal, NamedTuple
@@ -283,7 +282,9 @@ def _document_webdav_materialization_response(
     }
 
 
-def _document_webdav_runner_command(document: Document, intent_result: dict) -> dict[str, object]:
+def _document_webdav_runner_command(
+    document: Document, intent_result: dict
+) -> dict[str, object]:
     return {
         "action": "write_webdav",
         "account": intent_result["source_id"],
@@ -667,6 +668,103 @@ def _embedding_collections(
     ]
 
 
+def _check_thread_id_integrity(
+    email_count: int, missing_thread_count: int
+) -> DataQualityCheck:
+    return DataQualityCheck(
+        check_key="thread_id_integrity",
+        display_name="Thread id integrity",
+        status_code=_quality_status(email_count, missing_thread_count),
+        issue_count=missing_thread_count,
+        total_count=email_count,
+        evidence_source="emails.thread_id",
+        detail_text=_quality_detail(
+            total_count=email_count,
+            issue_count=missing_thread_count,
+            ready_text="All scoped emails have canonical thread ids.",
+            empty_text="No scoped emails are available yet.",
+            issue_text="Some scoped emails need canonical thread ids.",
+        ),
+        provider_write_executed=False,
+    )
+
+
+def _check_dedupe_fingerprint(
+    email_count: int, missing_fingerprint_count: int
+) -> DataQualityCheck:
+    return DataQualityCheck(
+        check_key="dedupe_fingerprint",
+        display_name="Dedupe fingerprint",
+        status_code=_quality_status(email_count, missing_fingerprint_count),
+        issue_count=missing_fingerprint_count,
+        total_count=email_count,
+        evidence_source="emails.fingerprint",
+        detail_text=_quality_detail(
+            total_count=email_count,
+            issue_count=missing_fingerprint_count,
+            ready_text="All scoped emails have duplicate-detection fingerprints.",
+            empty_text="No scoped emails are available yet.",
+            issue_text="Some scoped emails need duplicate-detection fingerprints.",
+        ),
+        provider_write_executed=False,
+    )
+
+
+def _check_attachment_content(
+    attachment_count: int, blank_attachment_count: int
+) -> DataQualityCheck:
+    return DataQualityCheck(
+        check_key="attachment_content",
+        display_name="Attachment content",
+        status_code=_quality_status(attachment_count, blank_attachment_count),
+        issue_count=blank_attachment_count,
+        total_count=attachment_count,
+        evidence_source="attachments.content",
+        detail_text=_quality_detail(
+            total_count=attachment_count,
+            issue_count=blank_attachment_count,
+            ready_text="All scoped attachments have extracted content.",
+            empty_text="No scoped attachments are available yet.",
+            issue_text="Some scoped attachments need extracted content.",
+        ),
+        provider_write_executed=False,
+    )
+
+
+def _check_source_registry_coverage(source_count: int) -> DataQualityCheck:
+    return DataQualityCheck(
+        check_key="source_registry",
+        display_name="Source registry coverage",
+        status_code="pass" if source_count > 0 else "pending",
+        issue_count=0 if source_count > 0 else 1,
+        total_count=max(1, source_count),
+        evidence_source="webdav_accounts, project_folders",
+        detail_text=(
+            "Customer-owned repositories are visible."
+            if source_count > 0
+            else "No customer-owned repositories are visible yet."
+        ),
+        provider_write_executed=False,
+    )
+
+
+def _check_connector_signal_coverage(connector_event_count: int) -> DataQualityCheck:
+    return DataQualityCheck(
+        check_key="connector_signal",
+        display_name="Connector signal coverage",
+        status_code="pass" if connector_event_count > 0 else "pending",
+        issue_count=0 if connector_event_count > 0 else 1,
+        total_count=max(1, connector_event_count),
+        evidence_source="connector_signal_events",
+        detail_text=(
+            "Connector evidence is visible for this workspace."
+            if connector_event_count > 0
+            else "Connector jobs have not emitted workspace evidence yet."
+        ),
+        provider_write_executed=False,
+    )
+
+
 def _quality_checks(
     *,
     email_count: int,
@@ -678,82 +776,20 @@ def _quality_checks(
     connector_event_count: int,
 ) -> list[DataQualityCheck]:
     return [
-        DataQualityCheck(
-            check_key="thread_id_integrity",
-            display_name="Thread id integrity",
-            status_code=_quality_status(email_count, missing_thread_count),
-            issue_count=missing_thread_count,
-            total_count=email_count,
-            evidence_source="emails.thread_id",
-            detail_text=_quality_detail(
-                total_count=email_count,
-                issue_count=missing_thread_count,
-                ready_text="All scoped emails have canonical thread ids.",
-                empty_text="No scoped emails are available yet.",
-                issue_text="Some scoped emails need canonical thread ids.",
-            ),
-            provider_write_executed=False,
+        _check_thread_id_integrity(
+            email_count=email_count,
+            missing_thread_count=missing_thread_count,
         ),
-        DataQualityCheck(
-            check_key="dedupe_fingerprint",
-            display_name="Dedupe fingerprint",
-            status_code=_quality_status(email_count, missing_fingerprint_count),
-            issue_count=missing_fingerprint_count,
-            total_count=email_count,
-            evidence_source="emails.fingerprint",
-            detail_text=_quality_detail(
-                total_count=email_count,
-                issue_count=missing_fingerprint_count,
-                ready_text="All scoped emails have duplicate-detection fingerprints.",
-                empty_text="No scoped emails are available yet.",
-                issue_text="Some scoped emails need duplicate-detection fingerprints.",
-            ),
-            provider_write_executed=False,
+        _check_dedupe_fingerprint(
+            email_count=email_count,
+            missing_fingerprint_count=missing_fingerprint_count,
         ),
-        DataQualityCheck(
-            check_key="attachment_content",
-            display_name="Attachment content",
-            status_code=_quality_status(attachment_count, blank_attachment_count),
-            issue_count=blank_attachment_count,
-            total_count=attachment_count,
-            evidence_source="attachments.content",
-            detail_text=_quality_detail(
-                total_count=attachment_count,
-                issue_count=blank_attachment_count,
-                ready_text="All scoped attachments have extracted content.",
-                empty_text="No scoped attachments are available yet.",
-                issue_text="Some scoped attachments need extracted content.",
-            ),
-            provider_write_executed=False,
+        _check_attachment_content(
+            attachment_count=attachment_count,
+            blank_attachment_count=blank_attachment_count,
         ),
-        DataQualityCheck(
-            check_key="source_registry",
-            display_name="Source registry coverage",
-            status_code="pass" if source_count > 0 else "pending",
-            issue_count=0 if source_count > 0 else 1,
-            total_count=max(1, source_count),
-            evidence_source="webdav_accounts, project_folders",
-            detail_text=(
-                "Customer-owned repositories are visible."
-                if source_count > 0
-                else "No customer-owned repositories are visible yet."
-            ),
-            provider_write_executed=False,
-        ),
-        DataQualityCheck(
-            check_key="connector_signal",
-            display_name="Connector signal coverage",
-            status_code="pass" if connector_event_count > 0 else "pending",
-            issue_count=0 if connector_event_count > 0 else 1,
-            total_count=max(1, connector_event_count),
-            evidence_source="connector_signal_events",
-            detail_text=(
-                "Connector evidence is visible for this workspace."
-                if connector_event_count > 0
-                else "Connector jobs have not emitted workspace evidence yet."
-            ),
-            provider_write_executed=False,
-        ),
+        _check_source_registry_coverage(source_count),
+        _check_connector_signal_coverage(connector_event_count),
     ]
 
 
@@ -780,7 +816,9 @@ async def upload_data_document(
     )
 
 
-@router.post("/documents/{document_id}/reparse", response_model=DataDocumentActionResponse)
+@router.post(
+    "/documents/{document_id}/reparse", response_model=DataDocumentActionResponse
+)
 async def reparse_data_document(
     document_id: str,
     auth_context: AuthContext = Depends(get_auth_context),
@@ -866,7 +904,9 @@ async def create_document_webdav_materialization_intent(
             str(source_result.get("error_code") or ""),
             422,
         )
-        raise HTTPException(status_code=status_code, detail=source_result.get("message"))
+        raise HTTPException(
+            status_code=status_code, detail=source_result.get("message")
+        )
 
     result = _document_webdav_materialization_response(document, source_result)
     if request.execute_provider:


### PR DESCRIPTION
🧹 [코드 헬스] `data.py`의 `_quality_checks` 리팩토링 수행

🎯 **What (작업 내용):**
`backend/api/data.py` 내부의 `_quality_checks` 함수에 존재했던 긴 리스트 표현식을 5개의 전용 헬퍼 함수(`_check_thread_id_integrity` 등)로 분리 추출했습니다.

💡 **Why (작업 이유):**
단일 함수의 크기가 커짐에 따라 발생하는 인지 부하를 줄이기 위해서입니다. 인수들과 기본값들을 잘 명명된 프라이빗 헬퍼 함수로 묶어 관리하게 함으로써 가독성과 유지보수성이 향상되었습니다.

✅ **Verification (검증 내용):**
수정 후 API 데이터 관련 단위 테스트 (`cd backend && python3 -m pytest tests/test_data_api.py -v`)를 수행하여 기존 기능의 회귀나 파손 없이 100% 통과하는 것을 확인했습니다. 또한 `ruff format` 및 `ruff check`를 통해 문법/형식 점검을 완료했습니다.

✨ **Result (결과):**
로직이나 기존 동작 변경 없이 유지보수성과 코드 가독성이 안전하게 향상되었습니다.

---
*PR created automatically by Jules for task [9827308677023986](https://jules.google.com/task/9827308677023986) started by @seonghobae*