### PR TITLE
🧪 관측성 Postgres smoke 테스트 bootstrap 보강

### DIFF
--- a/backend/tests/test_observability_api.py
+++ b/backend/tests/test_observability_api.py
@@ -503,6 +503,27 @@ async def test_operational_signals_real_postgres_connector_history_smoke():
             )
             await conn.execute(
                 text(
+                    """
+                    CREATE TABLE IF NOT EXISTS provider_writeback_retry_items (
+                        retry_item_uid VARCHAR PRIMARY KEY,
+                        organization_id VARCHAR NOT NULL,
+                        workspace_id VARCHAR NOT NULL,
+                        source_uid VARCHAR,
+                        command_action VARCHAR NOT NULL,
+                        command_payload_encrypted VARCHAR NOT NULL,
+                        retry_state VARCHAR NOT NULL,
+                        last_error_code VARCHAR NOT NULL,
+                        runner_request_uid VARCHAR,
+                        attempt_count INTEGER NOT NULL DEFAULT 1,
+                        next_retry_at TIMESTAMPTZ NOT NULL,
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
                     "DELETE FROM connector_signal_events "
                     "WHERE organization_id = :organization_id "
                     "AND workspace_id = :workspace_id"


### PR DESCRIPTION
🎯 **What:**
real Postgres 관측성 smoke 테스트의 raw SQL bootstrap에 `provider_writeback_retry_items` 테이블 생성을 추가했습니다.

🎯 **Why:**
현재 develop에는 대용량 vector 컬럼 deferred loading이 이미 반영되어 있습니다. 이 PR에는 중복 모델 변경을 남기지 않고, raw SQL로 필요한 테이블만 만들던 smoke 테스트가 writeback retry queue 조회에서 테이블 부재로 실패하지 않도록 보강만 남겼습니다.

📊 **Validation:**
* `python -m ruff check backend/tests/test_observability_api.py`
* `python -m pytest backend/tests/test_observability_api.py -q`

---
*PR rebuilt from Jules task [1832048302327678089](https://jules.google.com/task/1832048302327678089).*