### PR TITLE
🎨 Palette: 캘린더 연동 버튼 aria-busy 접근성 추가

### DIFF
--- a/frontend/src/app/calendar/page.test.tsx
+++ b/frontend/src/app/calendar/page.test.tsx
@@ -396,6 +396,7 @@ describe("CalendarPage", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(String(fetchMock.mock.calls[1]?.[0])).toBe("/api/calendar/writeback-intent");
+    expect(button?.getAttribute("aria-busy")).toBe("true");
     expect(container.textContent).toContain("일정 반영 의도 요청 중입니다.");
   });
 

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -355,6 +355,7 @@ export function CalendarLayout() {
                   type="button"
                   onClick={() => void requestWritebackIntent('create')}
                   disabled={isWritebackActionDisabled}
+                  aria-busy={isWritebackLoading}
                   className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60"
                 >
                   새 일정 intent 점검
@@ -363,6 +364,7 @@ export function CalendarLayout() {
                   type="button"
                   onClick={() => void requestWritebackIntent('update')}
                   disabled={isWritebackActionDisabled}
+                  aria-busy={isWritebackLoading}
                   className="rounded-xl border border-border bg-background px-4 py-2 text-sm font-bold hover:bg-secondary disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                 >
                   ETag 업데이트 점검
@@ -371,6 +373,7 @@ export function CalendarLayout() {
                   type="button"
                   onClick={() => void requestWritebackIntent('update', true)}
                   disabled={isProviderExecutionDisabled}
+                  aria-busy={isWritebackLoading}
                   className="rounded-xl border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-bold text-primary hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                 >
                   ETag 실행 요청


### PR DESCRIPTION
### 💡 무엇을 수정했나요?
`CalendarLayout.tsx`의 캘린더 연동 검사 버튼들('새 일정 intent 점검', 'ETag 업데이트 점검', 'ETag 실행 요청')이 비동기 통신 중일 때 `aria-busy` 속성을 가지도록 개선했습니다.

### 🎯 왜 수정했나요?
버튼이 클릭되어 네트워크 통신(Loading)이 진행 중일 때, 시각적으로는 투명도나 커서 변경으로 인지할 수 있지만, 스크린 리더 사용자에게는 이 상태가 제대로 전달되지 않는 문제가 있었습니다. `aria-busy`를 명시하여 접근성을 확보했습니다.

### ♿ 접근성 개선 사항
- 캘린더 연동 액션 버튼 3종에 `aria-busy={isWritebackLoading}` 적용

---
*PR created automatically by Jules for task [9027539364369745726](https://jules.google.com/task/9027539364369745726) started by @seonghobae*