### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible styles to CalendarLayout buttons

### DIFF
--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -550,7 +550,7 @@ export function CalendarLayout() {
                 <h3 className="text-lg font-bold mb-4">회의 조율</h3>
                 <p className="text-sm text-muted-foreground mb-4">참석자들의 캘린더(CalDAV)를 종합 분석하여 최적의 시간을 제안합니다.</p>
                 <div className="grid gap-3 max-w-lg">
-                  <button type="button" className="flex items-center justify-between rounded-xl border border-primary/20 bg-primary/5 p-4 hover:bg-primary/10 transition-colors">
+                  <button type="button" className="flex items-center justify-between rounded-xl border border-primary/20 bg-primary/5 p-4 hover:bg-primary/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
                     <div className="flex items-center gap-3">
                       <span className="grid size-8 place-items-center rounded-lg bg-primary/20 text-primary font-bold">1안</span>
                       <div className="text-left">


### PR DESCRIPTION
💡 What: "회의 조율" 탭의 "1안" 버튼에 키보드 포커스 스타일(`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40`)을 추가하여 다른 버튼들과 일관성을 맞추었습니다.
🎯 Why: 마우스를 사용하지 않고 키보드로 탭 네비게이션을 할 때 "1안" 버튼에 포커스가 갔는지 시각적으로 확인할 수 없는 접근성 문제가 있어, 이를 개선하여 보다 직관적인 UX를 제공하기 위함입니다.
♿ Accessibility: 버튼 컴포넌트의 키보드 접근성(Keyboard Accessibility)을 향상시켰습니다.

---
*PR created automatically by Jules for task [16374101204323549508](https://jules.google.com/task/16374101204323549508) started by @seonghobae*