### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in OIDC Login

### DIFF
--- a/frontend/src/app/auth/oidc/shared.test.ts
+++ b/frontend/src/app/auth/oidc/shared.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { safeReturnTo } from "./shared";
+
+describe("safeReturnTo", () => {
+  it("allows local paths with query strings and fragments", () => {
+    expect(safeReturnTo("/settings?tab=security#oidc")).toBe(
+      "/settings?tab=security#oidc",
+    );
+  });
+
+  it.each([
+    "https://evil.example/phish",
+    "//evil.example/phish",
+    "/%2f%2fevil.example/phish",
+    "/%5c%5cevil.example/phish",
+    "/%09/evil.example/phish",
+    "/\\evil.example/phish",
+    "settings",
+  ])("rejects unsafe return target %s", (target) => {
+    expect(safeReturnTo(target)).toBe("/");
+  });
+});

--- a/frontend/src/app/auth/oidc/shared.ts
+++ b/frontend/src/app/auth/oidc/shared.ts
@@ -55,16 +55,39 @@ export function serverOidcConfig(origin: string): ServerOidcConfig | null {
 
 export function safeReturnTo(value: unknown) {
   const candidate = typeof value === "string" ? value.trim() : "";
-  if (
-    !candidate ||
-    !candidate.startsWith("/") ||
-    candidate.startsWith("//") ||
-    candidate.includes("\\") ||
-    CONTROL_CHARACTER_PATTERN.test(candidate)
-  ) {
+  if (!candidate) return "/";
+
+  try {
+    const decodedCandidate = decodeURIComponent(candidate);
+    if (
+      !candidate.startsWith("/") ||
+      candidate.startsWith("//") ||
+      decodedCandidate.startsWith("//") ||
+      /[\u0000-\u001f\u007f\\]/.test(candidate) ||
+      /[\u0000-\u001f\u007f\\]/.test(decodedCandidate)
+    ) {
+      return "/";
+    }
+
+    const url = new URL(candidate, "http://localhost");
+    if (url.origin !== "http://localhost") return "/";
+
+    const safePath = url.pathname + url.search + url.hash;
+    const decodedSafePath = decodeURIComponent(safePath);
+
+    if (
+      !safePath.startsWith("/") ||
+      safePath.startsWith("//") ||
+      decodedSafePath.startsWith("//") ||
+      /[\u0000-\u001f\u007f\\]/.test(decodedSafePath)
+    ) {
+      return "/";
+    }
+
+    return safePath;
+  } catch {
     return "/";
   }
-  return candidate;
 }
 
 export function randomUrlSafeString(byteLength: number) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `frontend/src/app/auth/oidc/shared.ts`의 `safeReturnTo` 함수에 존재하는 오픈 리다이렉트(Open Redirect) 취약점입니다. 단순히 문자열 검증에만 의존하여 `/%5c%5cevil.com` 또는 `/%09/evil.com`과 같이 URL 인코딩 및 제어 문자를 활용한 우회가 가능했습니다.
🎯 Impact: 공격자가 조작된 URL을 통해 사용자를 악의적인 외부 사이트로 리다이렉트하여 피싱 등 2차 공격에 활용할 수 있습니다.
🔧 Fix: `URL` 객체 생성자를 사용하여 더미 `http://localhost` 주소를 기준으로 URL을 먼저 디코딩 및 정규화(Normalization)하고, `origin` 값이 임의로 변경되지 않았는지 검증하도록 개선했습니다.
✅ Verification: `pnpm test --run`을 실행하여 모든 인증 경로 콜백의 리다이렉트가 내부 경로로만 제한됨을 확인했습니다.

---
*PR created automatically by Jules for task [12473387638251536961](https://jules.google.com/task/12473387638251536961) started by @seonghobae*