### PR TITLE
🎨 Palette: DataLayout 문서 액션 버튼 로딩 피드백 추가

### DIFF
--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -813,27 +813,42 @@ export function DataLayout() {
                         type="button"
                         onClick={() => void requestDocumentAction('reparse')}
                         disabled={isDocumentActionLoading}
+                        aria-busy={isDocumentActionLoading}
                         className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs font-bold text-foreground hover:bg-secondary disabled:cursor-wait disabled:opacity-60"
                       >
-                        <RefreshCw className="size-4" />
+                        {isDocumentActionLoading ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <RefreshCw className="size-4" />
+                        )}
                         재파싱 실행
                       </button>
                       <button
                         type="button"
                         onClick={() => void requestDocumentAction('embedding-regeneration-intent')}
                         disabled={isDocumentActionLoading}
+                        aria-busy={isDocumentActionLoading}
                         className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs font-bold text-foreground hover:bg-secondary disabled:cursor-wait disabled:opacity-60"
                       >
-                        <Database className="size-4" />
+                        {isDocumentActionLoading ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Database className="size-4" />
+                        )}
                         임베딩 재생성 의도
                       </button>
                       <button
                         type="button"
                         onClick={() => void requestDocumentAction('hwp-conversion-intent')}
                         disabled={isDocumentActionLoading}
+                        aria-busy={isDocumentActionLoading}
                         className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs font-bold text-foreground hover:bg-secondary disabled:cursor-wait disabled:opacity-60"
                       >
-                        <FileText className="size-4" />
+                        {isDocumentActionLoading ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <FileText className="size-4" />
+                        )}
                         HWP 변환 의도
                       </button>
                       <button
@@ -843,7 +858,11 @@ export function DataLayout() {
                         aria-busy={isDocumentActionLoading}
                         className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-primary px-3 py-2 text-xs font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        <Server className="size-4" />
+                        {isDocumentActionLoading ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Server className="size-4" />
+                        )}
                         WebDAV 문서 실행 요청
                       </button>
                     </div>


### PR DESCRIPTION
💡 What: DataLayout의 문서 액션 버튼('재파싱 실행', '임베딩 재생성 의도', 'HWP 변환 의도', 'WebDAV 문서 실행 요청')에 작업 처리 중임을 나타내는 로딩 스피너 아이콘(Loader2)과 `aria-busy={loading}` 속성을 추가했습니다.
🎯 Why: 기존에는 문서 액션이 진행 중일 때 버튼이 비활성화되긴 했으나 시각적인 로딩 피드백이 없어 작업 상태를 파악하기 어려웠습니다. 로딩 애니메이션을 통해 시스템 상태를 명확히 인지할 수 있도록 합니다.
♿ Accessibility: `aria-busy` 속성을 지원하여 스크린 리더 등 보조 기기 사용자가 현재 컨트롤이 작동 중임을 파악할 수 있도록 보장합니다.

---
*PR created automatically by Jules for task [4942984180828817911](https://jules.google.com/task/4942984180828817911) started by @seonghobae*