### PR TITLE
🎨 Palette: 비활성화 버튼 설명 툴팁 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### UI/UX 개선
+- `EmailDetail`, `CalendarLayout`, `DataLayout`의 비활성화된 버튼에 상태를 설명하는 `title` 툴팁을 추가했습니다.
 - `CalendarLayout`, `DataLayout`, `ProjectsLayout`, `SettingsLayout`의 기본 버튼에 `focus-visible` 링을 추가해 키보드 포커스 가시성을 높였습니다.
 - 메일/검색/작업 검색 입력을 `type="search"`로 전환하고 WebKit 기본 clear 버튼을 숨겨 모바일 키보드와 커스텀 clear 버튼 동작을 일관화했습니다.
 - `CalendarLayout`의 성공 상태에서 기술적 세부 정보 대신 사용자 친화적인 메시지를 표시하도록 개선하여 불필요한 정보 노출을 방지했습니다.

--- a/frontend/src/components/CalendarLayout.tsx
+++ b/frontend/src/components/CalendarLayout.tsx
@@ -389,6 +389,7 @@ export function CalendarLayout() {
                     type="button"
                     aria-label={`${sourceLabel} ${sourceWritable ? '일정 반영 가능' : '읽기 전용'} 선택`}
                     disabled={!sourceWritable}
+                    title={!sourceWritable ? '읽기 전용 캘린더입니다' : undefined}
                     aria-pressed={sourceSelected}
                     onClick={() => setSelectedSourceId(source.source_id)}
                     className={`rounded-xl border p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-70 ${

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -676,6 +676,7 @@ export function DataLayout() {
                           key={account.source_id}
                           type="button"
                           disabled={!account.writeback_enabled}
+                          title={!account.writeback_enabled ? '쓰기 권한이 없는 계정입니다' : undefined}
                           aria-pressed={accountSelected}
                           onClick={() => setSelectedWebdavSourceId(account.source_id)}
                           className={`flex min-w-0 items-start gap-2 rounded-lg border p-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-70 ${

--- a/frontend/src/components/EmailDetail.tsx
+++ b/frontend/src/components/EmailDetail.tsx
@@ -509,6 +509,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
               <Button 
                 onClick={handleDraftReply} 
                 disabled={isDrafting || !instruction}
+                title={!instruction ? '답장 지시를 입력해주세요' : undefined}
                 aria-busy={isDrafting}
                 variant="outline"
                 size="sm"
@@ -553,6 +554,7 @@ export function EmailDetail({ emailId, actionCommand = null }: { emailId: number
                 <Button 
                   onClick={handleSendReply} 
                   disabled={isSending || !draft}
+                  title={!draft ? '작성된 초안이 없습니다' : undefined}
                   aria-busy={isSending}
                   size="sm"
                   className="h-9 rounded-xl px-4"


### PR DESCRIPTION
💡 **What:** CalendarLayout, DataLayout, EmailDetail의 비활성화된(disabled) 버튼에 이유를 설명하는 `title` 툴팁을 추가했습니다.
🎯 **Why:** 사용자가 버튼이 왜 비활성화되어 있는지(예: 읽기 전용 캘린더, 쓰기 권한 없는 계정, 초안 없음 등) 명확하게 인지할 수 있도록 UX를 개선하기 위함입니다.
♿ **Accessibility:** `title` 속성을 통해 스크린 리더 사용자나 마우스 호버 시 추가적인 상태 문맥을 제공합니다.

---
*PR created automatically by Jules for task [13761417651563809494](https://jules.google.com/task/13761417651563809494) started by @seonghobae*