### PR TITLE
🧹 [Code Health] Refactor _import_single_eml to reduce complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `backend/api/security.py`에서 사용하지 않는 `from __future__ import annotations` 구문을 제거하고 조건 표현식을 정리했습니다.
 - `backend/alembic/env.py`에서 사용하지 않는 `from __future__ import annotations` 구문을 제거해 Alembic 환경 설정 코드를 간결하게 정리했습니다.
+- `_import_single_eml`의 embedding 생성과 `Email`/attachment 객체 생성을 헬퍼 함수로 분리해 email import 서비스의 복잡도를 낮췄습니다.
 - `backend/tests/test_tenant_config_api.py` 내의 `test_create_read_pop3_postgres_smoke` 함수의 복잡한 설정 로직을 `pytest` fixture로 분리하여 코드 가독성과 유지보수성을 개선했습니다.
 - `backend/tests/test_webdav_api.py`의 복잡한 PostgreSQL smoke 테스트 설정을 재사용 가능한 DB 연결 확인 헬퍼와 인증/DB 클라이언트 컨텍스트 매니저로 분리했습니다.
 - `backend/tests/test_release_governance.py`의 복잡한 Strix 실패 체크 리뷰 테스트를 명확한 작은 테스트 단위로 분리하여 유지보수성을 개선했습니다.

--- a/backend/services/email_import_service.py
+++ b/backend/services/email_import_service.py
@@ -214,6 +214,69 @@ async def _release_owner_import_quota_lock(
     )
 
 
+async def _extract_and_generate_embeddings(
+    parsed: EmailData,
+    embedding_provider: EmailImportEmbeddingProvider | None,
+) -> tuple[list[dict], list[list[float]]]:
+    attachment_payloads = list(parsed.get("attachments", []))
+    embedding_texts = [str(parsed.get("body") or "")]
+    embedding_texts.extend(
+        str(attachment.get("content") or "") for attachment in attachment_payloads
+    )
+    fitted_embeddings = await _generate_import_embeddings(
+        embedding_texts,
+        embedding_provider=embedding_provider,
+    )
+    return attachment_payloads, fitted_embeddings
+
+
+def _build_email_object(
+    *,
+    parsed: EmailData,
+    user_id: str,
+    organization_id: str,
+    message_id: str,
+    thread_id: str | None,
+    fingerprint: str,
+    persisted_date: datetime.datetime,
+    attachment_payloads: list[dict],
+    fitted_embeddings: list[list[float]],
+) -> tuple[Email, int]:
+    email_obj = Email(
+        user_id=user_id,
+        organization_id=organization_id,
+        message_id=message_id,
+        thread_id=thread_id,
+        fingerprint=fingerprint,
+        sender=parsed.get("sender", ""),
+        reply_to=parsed.get("reply_to"),
+        recipients=parsed.get("recipients"),
+        subject=parsed.get("subject"),
+        in_reply_to=parsed.get("in_reply_to"),
+        references=parsed.get("references"),
+        date=persisted_date,
+        body=parsed.get("body", ""),
+        embedding=fitted_embeddings[0] if fitted_embeddings else _zero_embedding(),
+    )
+
+    attachment_count = 0
+    for attachment_index, attachment in enumerate(attachment_payloads, start=1):
+        email_obj.attachments.append(
+            Attachment(
+                filename=str(attachment.get("filename") or "attachment.txt"),
+                content=str(attachment.get("content") or ""),
+                embedding=(
+                    fitted_embeddings[attachment_index]
+                    if attachment_index < len(fitted_embeddings)
+                    else _zero_embedding()
+                ),
+            )
+        )
+        attachment_count += 1
+
+    return email_obj, attachment_count
+
+
 async def _import_single_eml(
     session: AsyncSession,
     *,
@@ -257,46 +320,22 @@ async def _import_single_eml(
         user_id=user_id,
         organization_id=organization_id,
     )
-    attachment_payloads = list(parsed.get("attachments", []))
-    embedding_texts = [str(parsed.get("body") or "")]
-    embedding_texts.extend(
-        str(attachment.get("content") or "") for attachment in attachment_payloads
+
+    attachment_payloads, fitted_embeddings = await _extract_and_generate_embeddings(
+        parsed, embedding_provider
     )
-    fitted_embeddings = await _generate_import_embeddings(
-        embedding_texts,
-        embedding_provider=embedding_provider,
-    )
-    email_obj = Email(
+
+    email_obj, attachment_count = _build_email_object(
+        parsed=parsed,
         user_id=user_id,
         organization_id=organization_id,
         message_id=message_id,
         thread_id=thread_id,
         fingerprint=fingerprint,
-        sender=parsed.get("sender", ""),
-        reply_to=parsed.get("reply_to"),
-        recipients=parsed.get("recipients"),
-        subject=parsed.get("subject"),
-        in_reply_to=parsed.get("in_reply_to"),
-        references=parsed.get("references"),
-        date=persisted_date,
-        body=parsed.get("body", ""),
-        embedding=fitted_embeddings[0] if fitted_embeddings else _zero_embedding(),
+        persisted_date=persisted_date,
+        attachment_payloads=attachment_payloads,
+        fitted_embeddings=fitted_embeddings,
     )
-
-    attachment_count = 0
-    for attachment_index, attachment in enumerate(attachment_payloads, start=1):
-        email_obj.attachments.append(
-            Attachment(
-                filename=str(attachment.get("filename") or "attachment.txt"),
-                content=str(attachment.get("content") or ""),
-                embedding=(
-                    fitted_embeddings[attachment_index]
-                    if attachment_index < len(fitted_embeddings)
-                    else _zero_embedding()
-                ),
-            )
-        )
-        attachment_count += 1
 
     session.add(email_obj)
     try:


### PR DESCRIPTION
🎯 **What:** `backend/services/email_import_service.py` 내부의 거대했던 `_import_single_eml` 함수를 더 작은 헬퍼 함수들로 분리했습니다. `_extract_and_generate_embeddings`와 `_build_email_object`를 새롭게 추가하였습니다.
💡 **Why:** `_import_single_eml` 함수는 너무 많은 역할을 수행하고 있어 복잡도가 높고 가독성이 떨어졌습니다. 데이터 파싱, 임베딩 생성, 모델 인스턴스화 등의 로직을 분리하여 코드의 응집도를 높이고 유지보수성을 향상시켰습니다. 
✅ **Verification:** 기존 동작이 완벽히 유지되는지 확인하기 위해 `ruff check` 및 전체 `pytest` 테스트 스위트를 실행하여 모든 테스트가 통과하는 것을 검증했습니다.
✨ **Result:** 단일 메서드의 길이가 크게 줄어들고 기능별로 함수가 명확하게 분리되어 코드 파악이 훨씬 수월해졌습니다.

---
*PR created automatically by Jules for task [10492646960040071655](https://jules.google.com/task/10492646960040071655) started by @seonghobae*