### PR TITLE
🧪 [testing] search API의 thread_group_key 단위 테스트 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 테스트 개선 (Testing)
 
+- `thread_group_key`가 `thread_id`와 `message_id`를 trim한 뒤 `coalesce`하는 SQL 표현식을 생성하는지 직접 검증하는 단위 테스트를 추가했습니다.
 - `build_reply_counts_subquery`가 `user_id`와 `organization_id` 필터를 SQLAlchemy 쿼리에 올바르게 적용하는지 검증하는 단위 테스트를 추가했습니다.
 
 ### 테스트 개선 (Testing)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -175,6 +175,31 @@ def test_search_reply_counts_group_by_coalesced_thread_key():
     assert "group by coalesce(nullif(btrim(btrim(email_records.thread_id)" in sql
 
 
+def test_thread_group_key_uses_trimmed_thread_then_message_id():
+    from sqlalchemy.dialects import postgresql
+
+    from api.search import thread_group_key
+
+    compiled_sql = " ".join(
+        str(
+            thread_group_key().compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        .lower()
+        .split()
+    )
+    expected_sql = (
+        "coalesce("
+        "nullif(btrim(btrim(email_records.thread_id), '<>'), ''), "
+        "nullif(btrim(btrim(email_records.message_id), '<>'), '')"
+        ")"
+    )
+
+    assert expected_sql in compiled_sql
+
+
 @patch("api.search.generate_embeddings", new_callable=AsyncMock)
 def test_search_endpoint_query_is_scoped_to_current_user(mock_generate_embeddings):
     mock_generate_embeddings.return_value = [[0.1] * 1536]


### PR DESCRIPTION
🎯 **무엇을 (What):**
`backend/api/search.py` 파일의 `thread_group_key` 함수에 대한 단위 테스트가 누락되어 있던 것을 해결했습니다.

📊 **테스트 커버리지 (Coverage):**
`thread_group_key` 함수가 예상대로 `thread_id`와 `message_id`를 대상으로 `coalesce`와 `btrim`을 결합한 유효한 SQLAlchemy SQL 표현식을 반환하는지 테스트하는 시나리오를 추가했습니다.

✨ **결과 (Result):**
`test_thread_group_key_behavior` 테스트를 작성하고 파일 형식 정리를 적용하여 코드베이스의 안정성과 테스트 커버리지를 높였습니다.

---
*PR created automatically by Jules for task [17423734744036498395](https://jules.google.com/task/17423734744036498395) started by @seonghobae*