### PR TITLE
🧹 [코드 건강성 개선] test_get_emails_reply_tracking_real_postgres_smoke 함수 복잡도 완화

### DIFF
--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1327,15 +1327,12 @@ async def test_unique_email_thread_intent_query_is_scoped_to_current_user(
     assert_query_is_owner_scoped(session.queries[-1])
 
 
-@pytest.mark.postgres
-@pytest.mark.asyncio
-async def test_get_emails_reply_tracking_real_postgres_smoke():
+async def _setup_postgres_smoke_session():
     from core.config import settings
     from asyncpg.exceptions import InvalidAuthorizationSpecificationError
     from asyncpg.exceptions import InvalidPasswordError
-    from db.models import Base, TenantConfig
-    from db.session import get_db
-    from sqlalchemy import delete, text
+    from db.models import Base
+    from sqlalchemy import text
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -1352,12 +1349,17 @@ async def test_get_emails_reply_tracking_real_postgres_smoke():
         OSError,
     ) as exc:
         await engine.dispose()
+        import pytest
+
         pytest.skip(f"PostgreSQL smoke database unavailable: {exc}")
 
     Session = async_sessionmaker(engine, expire_on_commit=False)
-    user_id = "reply-smoke-user"
-    organization_id = "reply-smoke-org"
-    now = datetime.datetime.now(datetime.timezone.utc)
+    return engine, Session
+
+
+async def _seed_reply_tracking_smoke_data(Session, user_id, organization_id, now):
+    from db.models import Email, TenantConfig
+    from sqlalchemy import delete
 
     async def cleanup_seed_rows():
         async with Session() as session:
@@ -1425,6 +1427,24 @@ async def test_get_emails_reply_tracking_real_postgres_smoke():
             ]
         )
         await session.commit()
+
+    return cleanup_seed_rows
+
+
+@pytest.mark.postgres
+@pytest.mark.asyncio
+async def test_get_emails_reply_tracking_real_postgres_smoke():
+    from db.session import get_db
+
+    engine, Session = await _setup_postgres_smoke_session()
+
+    user_id = "reply-smoke-user"
+    organization_id = "reply-smoke-org"
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    cleanup_seed_rows = await _seed_reply_tracking_smoke_data(
+        Session, user_id, organization_id, now
+    )
 
     async def real_db_override():
         async with Session() as session:


### PR DESCRIPTION
🎯 **What:** `backend/tests/test_emails_api.py`의 `test_get_emails_reply_tracking_real_postgres_smoke` 함수 복잡도를 개선했습니다.
💡 **Why:** 데이터베이스 초기 설정 및 데이터 시딩과 테스트 검증 로직이 한 함수에 결합되어 있었습니다. `_setup_postgres_smoke_session`와 `_seed_reply_tracking_smoke_data` 두 개의 헬퍼 함수로 분리하여 유지보수성과 가독성을 높였습니다.
✅ **Verification:** 테스트(`cd backend && python3 -m pytest tests/test_emails_api.py -k test_get_emails_reply_tracking_real_postgres_smoke`)와 전체 테스트 셋이 오류 없이 수행되는 것을 검증했고 ruff linter/formatter 를 모두 통과했습니다.
✨ **Result:** 20줄 이상의 긴 함수가 관심사별로 분리되어 코드 품질 및 유지보수성이 크게 향상되었습니다. CHANGELOG 항목도 추가되었습니다.

---
*PR created automatically by Jules for task [1564754662863718326](https://jules.google.com/task/1564754662863718326) started by @seonghobae*