### PR TITLE
🧹 [코드 헬스] seed_live_data.py의 복잡한 함수 리팩토링

### DIFF
--- a/backend/tests/live/seed_live_data.py
+++ b/backend/tests/live/seed_live_data.py
@@ -7,8 +7,8 @@ import datetime as dt
 import sys
 from pathlib import Path
 
-from sqlalchemy import delete
-from sqlalchemy import select
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 if str(BACKEND_ROOT) not in sys.path:
@@ -25,7 +25,6 @@ from db.models import (  # noqa: E402
 )
 from db.session import AsyncSessionLocal  # noqa: E402
 
-
 THREAD_ID = "<live-e2e-root@example.test>"
 LIVE_E2E_USER_ID = "testuser"
 LIVE_E2E_ORGANIZATION_ID = "org-acme"
@@ -41,127 +40,147 @@ MESSAGE_IDS = [
 LIVE_E2E_OPENAI_API_KEY = "ollama"
 
 
+async def _cleanup_existing_data(session: AsyncSession) -> None:
+    await session.execute(
+        delete(ConnectorSignalEvent).where(
+            ConnectorSignalEvent.event_uid == LIVE_E2E_CONNECTOR_EVENT_UID
+        )
+    )
+    await session.execute(
+        delete(Document).where(Document.document_id == LIVE_E2E_DOCUMENT_ID)
+    )
+    await session.execute(
+        delete(ProjectFolder).where(
+            ProjectFolder.folder_uid == LIVE_E2E_PROJECT_FOLDER_UID
+        )
+    )
+    await session.execute(
+        delete(WebdavAccount).where(
+            WebdavAccount.source_uid == LIVE_E2E_WEBDAV_SOURCE_UID
+        )
+    )
+    await session.execute(delete(Email).where(Email.message_id.in_(MESSAGE_IDS)))
+
+
+async def _setup_workspace(session: AsyncSession) -> None:
+    workspace_result = await session.execute(
+        select(Workspace).where(Workspace.workspace_id == LIVE_E2E_WORKSPACE_ID)
+    )
+    workspace = workspace_result.scalar_one_or_none()
+    if workspace is None:
+        workspace = Workspace(
+            workspace_id=LIVE_E2E_WORKSPACE_ID,
+            workspace_name="Live E2E Workspace",
+            workspace_domain="example.test",
+        )
+        session.add(workspace)
+
+
+async def _setup_tenant_config(session: AsyncSession) -> None:
+    result = await session.execute(
+        select(TenantConfig).where(
+            TenantConfig.user_id == LIVE_E2E_USER_ID,
+            TenantConfig.organization_id == LIVE_E2E_ORGANIZATION_ID,
+        )
+    )
+    tenant_config = result.scalar_one_or_none()
+    if tenant_config is None:
+        tenant_config = TenantConfig(
+            user_id=LIVE_E2E_USER_ID,
+            organization_id=LIVE_E2E_ORGANIZATION_ID,
+        )
+        session.add(tenant_config)
+    tenant_config.openai_api_key = LIVE_E2E_OPENAI_API_KEY
+
+
+def _seed_emails(session: AsyncSession) -> None:
+    session.add_all(
+        [
+            Email(
+                user_id=LIVE_E2E_USER_ID,
+                organization_id=LIVE_E2E_ORGANIZATION_ID,
+                message_id=MESSAGE_IDS[0],
+                thread_id=THREAD_ID,
+                fingerprint="sha256:live-e2e-root",
+                sender="ops@example.test",
+                recipients="swe@example.test",
+                subject="Live E2E Release",
+                date=dt.datetime(2026, 5, 11, 12, 0, tzinfo=dt.timezone.utc),
+                body="Root live release evidence message.",
+                embedding=[0.0] * 1536,
+            ),
+            Email(
+                user_id=LIVE_E2E_USER_ID,
+                organization_id=LIVE_E2E_ORGANIZATION_ID,
+                message_id=MESSAGE_IDS[1],
+                thread_id=THREAD_ID,
+                fingerprint="sha256:live-e2e-reply",
+                sender="swe@example.test",
+                recipients="ops@example.test",
+                subject="Live E2E Release",
+                in_reply_to=MESSAGE_IDS[0],
+                references=MESSAGE_IDS[0],
+                date=dt.datetime(2026, 5, 11, 12, 1, tzinfo=dt.timezone.utc),
+                body="Reply live release evidence message.",
+                embedding=[0.0] * 1536,
+            ),
+        ]
+    )
+
+
+def _seed_other_entities(session: AsyncSession) -> None:
+    session.add(
+        WebdavAccount(
+            source_uid=LIVE_E2E_WEBDAV_SOURCE_UID,
+            user_id=LIVE_E2E_USER_ID,
+            organization_id=LIVE_E2E_ORGANIZATION_ID,
+            workspace_id=LIVE_E2E_WORKSPACE_ID,
+            server_url="https://files.example.test/dav",
+            username="live-e2e@example.test",
+            credentials_encrypted="live-e2e-webdav-secret",
+            writeback_enabled=True,
+            etag_value="etag-live-data",
+        )
+    )
+    session.add(
+        ProjectFolder(
+            folder_uid=LIVE_E2E_PROJECT_FOLDER_UID,
+            user_id=LIVE_E2E_USER_ID,
+            organization_id=LIVE_E2E_ORGANIZATION_ID,
+            project_name="Live Data Project",
+            webdav_path="/Projects/Live_Data",
+        )
+    )
+    session.add(
+        Document(
+            document_id=LIVE_E2E_DOCUMENT_ID,
+            workspace_id=LIVE_E2E_WORKSPACE_ID,
+            document_name="roadmap.md",
+            document_type="text/markdown",
+            document_content="# Live roadmap\n\nSeeded document for full-stack E2E.",
+            document_status="uploaded",
+        )
+    )
+    session.add(
+        ConnectorSignalEvent(
+            event_uid=LIVE_E2E_CONNECTOR_EVENT_UID,
+            organization_id=LIVE_E2E_ORGANIZATION_ID,
+            workspace_id=LIVE_E2E_WORKSPACE_ID,
+            signal_key="connector_heartbeat",
+            state_code="heartbeat",
+            detail_text="outbound connector heartbeat received",
+            observed_at=dt.datetime(2026, 5, 11, 12, 2, tzinfo=dt.timezone.utc),
+        )
+    )
+
+
 async def seed_live_data() -> None:
     async with AsyncSessionLocal() as session:
-        await session.execute(
-            delete(ConnectorSignalEvent).where(
-                ConnectorSignalEvent.event_uid == LIVE_E2E_CONNECTOR_EVENT_UID
-            )
-        )
-        await session.execute(
-            delete(Document).where(Document.document_id == LIVE_E2E_DOCUMENT_ID)
-        )
-        await session.execute(
-            delete(ProjectFolder).where(
-                ProjectFolder.folder_uid == LIVE_E2E_PROJECT_FOLDER_UID
-            )
-        )
-        await session.execute(
-            delete(WebdavAccount).where(
-                WebdavAccount.source_uid == LIVE_E2E_WEBDAV_SOURCE_UID
-            )
-        )
-        await session.execute(delete(Email).where(Email.message_id.in_(MESSAGE_IDS)))
-        workspace_result = await session.execute(
-            select(Workspace).where(Workspace.workspace_id == LIVE_E2E_WORKSPACE_ID)
-        )
-        workspace = workspace_result.scalar_one_or_none()
-        if workspace is None:
-            workspace = Workspace(
-                workspace_id=LIVE_E2E_WORKSPACE_ID,
-                workspace_name="Live E2E Workspace",
-                workspace_domain="example.test",
-            )
-            session.add(workspace)
-        result = await session.execute(
-            select(TenantConfig).where(
-                TenantConfig.user_id == LIVE_E2E_USER_ID,
-                TenantConfig.organization_id == LIVE_E2E_ORGANIZATION_ID,
-            )
-        )
-        tenant_config = result.scalar_one_or_none()
-        if tenant_config is None:
-            tenant_config = TenantConfig(
-                user_id=LIVE_E2E_USER_ID,
-                organization_id=LIVE_E2E_ORGANIZATION_ID,
-            )
-            session.add(tenant_config)
-        tenant_config.openai_api_key = LIVE_E2E_OPENAI_API_KEY
-        session.add_all(
-            [
-                Email(
-                    user_id=LIVE_E2E_USER_ID,
-                    organization_id=LIVE_E2E_ORGANIZATION_ID,
-                    message_id=MESSAGE_IDS[0],
-                    thread_id=THREAD_ID,
-                    fingerprint="sha256:live-e2e-root",
-                    sender="ops@example.test",
-                    recipients="swe@example.test",
-                    subject="Live E2E Release",
-                    date=dt.datetime(2026, 5, 11, 12, 0, tzinfo=dt.timezone.utc),
-                    body="Root live release evidence message.",
-                    embedding=[0.0] * 1536,
-                ),
-                Email(
-                    user_id=LIVE_E2E_USER_ID,
-                    organization_id=LIVE_E2E_ORGANIZATION_ID,
-                    message_id=MESSAGE_IDS[1],
-                    thread_id=THREAD_ID,
-                    fingerprint="sha256:live-e2e-reply",
-                    sender="swe@example.test",
-                    recipients="ops@example.test",
-                    subject="Live E2E Release",
-                    in_reply_to=MESSAGE_IDS[0],
-                    references=MESSAGE_IDS[0],
-                    date=dt.datetime(2026, 5, 11, 12, 1, tzinfo=dt.timezone.utc),
-                    body="Reply live release evidence message.",
-                    embedding=[0.0] * 1536,
-                ),
-            ]
-        )
-        session.add(
-            WebdavAccount(
-                source_uid=LIVE_E2E_WEBDAV_SOURCE_UID,
-                user_id=LIVE_E2E_USER_ID,
-                organization_id=LIVE_E2E_ORGANIZATION_ID,
-                workspace_id=LIVE_E2E_WORKSPACE_ID,
-                server_url="https://files.example.test/dav",
-                username="live-e2e@example.test",
-                credentials_encrypted="live-e2e-webdav-secret",
-                writeback_enabled=True,
-                etag_value="etag-live-data",
-            )
-        )
-        session.add(
-            ProjectFolder(
-                folder_uid=LIVE_E2E_PROJECT_FOLDER_UID,
-                user_id=LIVE_E2E_USER_ID,
-                organization_id=LIVE_E2E_ORGANIZATION_ID,
-                project_name="Live Data Project",
-                webdav_path="/Projects/Live_Data",
-            )
-        )
-        session.add(
-            Document(
-                document_id=LIVE_E2E_DOCUMENT_ID,
-                workspace_id=LIVE_E2E_WORKSPACE_ID,
-                document_name="roadmap.md",
-                document_type="text/markdown",
-                document_content="# Live roadmap\n\nSeeded document for full-stack E2E.",
-                document_status="uploaded",
-            )
-        )
-        session.add(
-            ConnectorSignalEvent(
-                event_uid=LIVE_E2E_CONNECTOR_EVENT_UID,
-                organization_id=LIVE_E2E_ORGANIZATION_ID,
-                workspace_id=LIVE_E2E_WORKSPACE_ID,
-                signal_key="connector_heartbeat",
-                state_code="heartbeat",
-                detail_text="outbound connector heartbeat received",
-                observed_at=dt.datetime(2026, 5, 11, 12, 2, tzinfo=dt.timezone.utc),
-            )
-        )
+        await _cleanup_existing_data(session)
+        await _setup_workspace(session)
+        await _setup_tenant_config(session)
+        _seed_emails(session)
+        _seed_other_entities(session)
         await session.commit()
 
 


### PR DESCRIPTION
🎯 **무엇을:** \`backend/tests/live/seed_live_data.py\` 파일 내에 있던 단일의 거대한 \`seed_live_data\` 함수를 여러 개의 작은 헬퍼 함수(\`_cleanup_existing_data\`, \`_setup_workspace\`, \`_setup_tenant_config\`, \`_seed_emails\`, \`_seed_other_entities\`)로 분리하였습니다.
💡 **왜:** 이 함수는 많은 로직을 포함하고 있어 유지보수성과 가독성이 크게 떨어졌습니다. 기능별로 분리함으로써 각 로직의 목적을 분명히 하고 유지보수를 용이하게 합니다.
✅ **검증:** ruff format, ruff check 및 pytest 전체 백엔드 테스트를 성공적으로 통과했으며, 수정된 스크립트 실행에도 문제가 없음을 확인했습니다.
✨ **결과:** 코드 가독성과 유지보수성이 크게 향상되었으며, 기존의 데이터 초기화 기능도 완벽히 보존됩니다.

---
*PR created automatically by Jules for task [920075908863104829](https://jules.google.com/task/920075908863104829) started by @seonghobae*