### PR TITLE
🧪 [testing improvement] search_results_process 함수 단위 테스트 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 테스트 개선 (Testing)
 
 - `thread_group_key`가 `thread_id`와 `message_id`를 trim한 뒤 `coalesce`하는 SQL 표현식을 생성하는지 직접 검증하는 단위 테스트를 추가했습니다.
+- `process_search_results`가 중복 제거, limit, snippet truncation, `None` fallback을 안정적으로 처리하는지 검증하는 단위 테스트를 추가했습니다.
 - `build_reply_counts_subquery`가 `user_id`와 `organization_id` 필터를 SQLAlchemy 쿼리에 올바르게 적용하는지 검증하는 단위 테스트를 추가했습니다.
 
 ### 테스트 개선 (Testing)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -364,3 +364,43 @@ def test_build_reply_counts_subquery_with_user_and_org_id():
         in sql
     )
     assert "group by coalesce" in sql
+
+
+def test_process_search_results_deduplicates_and_applies_limit():
+    from api.search import process_search_results
+
+    rows = [
+        MockRow(1, "First", "sender@example.com", "First body", 1.0),
+        MockRow(1, "Duplicate", "sender@example.com", "Duplicate body", 0.9),
+        MockRow(2, "Second", "sender@example.com", "Second body", 0.8),
+        MockRow(3, "Third", "sender@example.com", "Third body", 0.7),
+    ]
+
+    results = process_search_results(rows, limit=2)
+
+    assert [item.id for item in results] == [1, 2]
+    assert results[0].subject == "First"
+    assert results[0].snippet == "First body"
+
+
+def test_process_search_results_truncates_long_snippets():
+    from api.search import process_search_results
+
+    rows = [MockRow(1, "Long", "sender@example.com", "A" * 300, 1.0)]
+
+    results = process_search_results(rows, limit=10)
+
+    assert results[0].snippet == ("A" * 200) + "..."
+
+
+def test_process_search_results_applies_none_fallbacks():
+    from api.search import process_search_results
+
+    row = MockRow(1, "Fallbacks", "sender@example.com", None, None)
+    row.reply_count = None
+
+    results = process_search_results([row], limit=10)
+
+    assert results[0].snippet == ""
+    assert results[0].score == 0.0
+    assert results[0].reply_count == 1


### PR DESCRIPTION
`process_search_results` 함수에서 누락되었던 단위 테스트를 추가하여 코드 커버리지를 개선했습니다. 중복 제거, 텍스트 생략, None 값 처리 및 limit 제어 등 주요 시나리오를 테스트합니다.

---
*PR created automatically by Jules for task [819547192213214745](https://jules.google.com/task/819547192213214745) started by @seonghobae*