### PR TITLE
🔒 [보안 패치] llm_provider_urls.py의 SSRF 취약점 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### 보안 패치 (Security)
 
 - (백엔드) 버전 정보를 읽어올 때 `VERSION` 파일이 없는 경우, 에러 메시지에서 애플리케이션의 내부 디렉토리 경로가 노출되는 취약점(Information Disclosure)을 수정했습니다.
+- LLM provider 전용 HTTP transport가 검증된 base URL의 scheme/host/port와 `Host` 헤더를 전송 직전에 고정하도록 보강해 임의 요청 URL 또는 헤더 주입을 통한 SSRF 우회를 차단했습니다.
 - release governance 테스트 계약에서 부분 실행 경로 기반 `subprocess.run` 경로를 제거해 테스트 보안 점검이 절대 경로 기반 실행 계약과 어긋나지 않도록 정리했습니다.
 - **CRLF 인젝션 방지:** 이메일 전송 API(`POST /api/emails/send`)의 `subject`, `to`, `in_reply_to`, `references` 파라미터에서 개행 문자(`\r`, `\n`)를 차단하는 엄격한 Pydantic 검증 로직을 추가하여 SMTP 명령 인젝션 취약점을 해결했습니다.
 - **이중 확장자 검증:** 이메일 파일 업로드 API(`POST /api/emails/import-files`)에서 `.exe.eml` 등 악성 이중 확장자 파일이 업로드되는 것을 방지하도록 확장자 검증 로직을 강화했습니다.

--- a/backend/services/llm_provider_urls.py
+++ b/backend/services/llm_provider_urls.py
@@ -383,6 +383,7 @@ class _PinnedLLMProviderNetworkBackend(httpcore.AsyncNetworkBackend):
 
 class _PinnedLLMProviderAsyncTransport(httpx.AsyncBaseTransport):
     def __init__(self, validated: ValidatedLLMProviderBaseURL):
+        self._validated = validated
         ssl_context = create_ssl_context(verify=True, trust_env=False)
         self._pool = httpcore.AsyncConnectionPool(
             ssl_context=ssl_context,
@@ -399,15 +400,27 @@ class _PinnedLLMProviderAsyncTransport(httpx.AsyncBaseTransport):
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        parsed_url = urlsplit(self._validated.normalized_url)
+        validated_scheme = parsed_url.scheme.encode("ascii")
+        validated_host = self._validated.hostname.encode("ascii")
+        validated_netloc = parsed_url.netloc.encode("ascii")
+
+        safe_headers = [
+            (key, value)
+            for key, value in request.headers.raw
+            if key.lower() != b"host"
+        ]
+        safe_headers.append((b"host", validated_netloc))
+
         req = httpcore.Request(
             method=request.method,
             url=httpcore.URL(
-                scheme=request.url.raw_scheme,
-                host=request.url.raw_host,
-                port=request.url.port,
+                scheme=validated_scheme,
+                host=validated_host,
+                port=self._validated.port,
                 target=request.url.raw_path,
             ),
-            headers=request.headers.raw,
+            headers=safe_headers,
             content=request.stream,
             extensions=request.extensions,
         )

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import httpx
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -190,6 +191,57 @@ async def test_llm_provider_pinned_backend_rejects_host_changes():
 
     with pytest.raises(OSError, match="host changed"):
         await backend.connect_tcp("metadata.google.internal", 443)
+
+
+@pytest.mark.asyncio
+async def test_llm_provider_transport_rewrites_request_origin_and_host_header():
+    validated = provider_urls.ValidatedLLMProviderBaseURL(
+        normalized_url="https://llm-gateway.example.com:8443/v1",
+        hostname="llm-gateway.example.com",
+        port=8443,
+        addresses=("93.184.216.34",),
+    )
+    transport = provider_urls._PinnedLLMProviderAsyncTransport(validated)
+    await transport._pool.aclose()
+
+    captured_request = None
+
+    class FakePool:
+        async def handle_async_request(self, request):
+            nonlocal captured_request
+            captured_request = request
+            raise RuntimeError("captured request")
+
+    transport._pool = FakePool()
+    request = httpx.Request(
+        "POST",
+        "https://metadata.google.internal/v1/chat/completions?stream=false",
+        headers=[
+            ("Host", "metadata.google.internal"),
+            ("HOST", "metadata.google.internal:443"),
+            ("X-Provider", "keep"),
+        ],
+        content=b"{}",
+    )
+
+    with pytest.raises(RuntimeError, match="captured request"):
+        await transport.handle_async_request(request)
+
+    assert captured_request is not None
+    assert captured_request.url.scheme == b"https"
+    assert captured_request.url.host == b"llm-gateway.example.com"
+    assert captured_request.url.port == 8443
+    assert captured_request.url.target == b"/v1/chat/completions?stream=false"
+    host_headers = [
+        (key, value)
+        for key, value in captured_request.headers
+        if key.lower() == b"host"
+    ]
+    assert host_headers == [(b"host", b"llm-gateway.example.com:8443")]
+    assert any(
+        key.lower() == b"x-provider" and value == b"keep"
+        for key, value in captured_request.headers
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🎯 **What:**
`backend/services/llm_provider_urls.py`에 존재하는 서버 측 요청 위조(SSRF) 취약점을 해결했습니다.

⚠️ **Risk:**
기존 코드에서는 `handle_async_request` 메서드에서 클라이언트가 보낸 원본 요청의 `request.url.raw_scheme`와 `request.url.raw_host` 속성을 확인 없이 그대로 사용하여 backend request 객체를 만들고 있었습니다. 이는 만일 검증이 없는 상태에서 악의적인 호스트 정보가 그대로 백엔드로 포워딩 될 경우, 내부 IP 주소나 내부망 서비스에 무단으로 접근(SSRF)하여 민감한 정보가 노출되거나 원격 코드가 실행될 수 있는 위험이 있었습니다. 또한, `Host` 헤더에도 공격자가 제어 가능한 임의의 값이 그대로 사용될 수 있었습니다.

🛡️ **Solution:**
- 요청을 보낼 때 `httpcore.Request` URL의 scheme과 host 정보를 클라이언트의 값에서 가져오는 대신 미리 안전성이 검증된 `self._validated` 객체로부터 직접 주입하도록 하드코딩하여 우회 가능성을 원천 차단했습니다.
- 원본 요청의 헤더에서 `Host` 값을 찾아내어 안전하게 검증된 호스트 값(netloc 기반)으로 덮어쓰도록 수정함으로써 Host 헤더 변조를 통한 서버의 잠재적 우회 공격(Host Header Injection) 가능성도 방지했습니다.

---
*PR created automatically by Jules for task [17447419779035477530](https://jules.google.com/task/17447419779035477530) started by @seonghobae*