### PR TITLE
⚡ Bolt: Memoize SearchLayout resultList

### DIFF
--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -456,7 +456,9 @@ export function SearchLayout() {
       });
   };
 
-  const resultList = (
+  // ⚡ Bolt: Wrap search results in useMemo to prevent O(N) re-renders when other state changes
+  // 🎯 Why: Mapping over long lists of search results blocks the main thread during unrelated state updates.
+  const resultList = useMemo(() => (
     <div className="divide-y divide-border">
       {loading ? (
         <div
@@ -490,7 +492,7 @@ export function SearchLayout() {
         ))
       )}
     </div>
-  );
+  ), [loading, error, filteredResults, activeResult?.id, setActiveResultId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">


### PR DESCRIPTION
💡 What: Wrapped `resultList` JSX in `useMemo` in `SearchLayout.tsx` with exhaustive dependencies.
🎯 Why: Mapping over long lists of search results and reconciling the DOM blocks the main thread during unrelated state updates (e.g. typing in the search input).
📊 Impact: Reduces O(N) re-renders for the results list, making typing and state changes in the layout significantly smoother when many results are present.
🔬 Measurement: Verify by typing in the search input while many results are rendered; there should be no noticeable lag.

---
*PR created automatically by Jules for task [13497889026018422445](https://jules.google.com/task/13497889026018422445) started by @seonghobae*