### PR TITLE
chore: harden private mail smoke session sync flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,22 @@ OPENAI_MODEL=gpt-4o
 BACKEND_INTERNAL_URL=http://127.0.0.1:8000
 ALLOW_DOCKER_BACKEND_INTERNAL_URL=1
 
+# Apple Silicon MLX (또는 OpenAI-compatible) 실사용 smoke 테스트는 임시 오버레이 파일에서만 설정합니다.
+# 예: .env.mlx (커밋되지 않는 로컬 임시 파일).
+# 기본 .env는 공유값을 유지하고, 로컬 모델 경로는 오버레이에서만 바꿔 적용합니다.
+# Linux 기본 경로에서는 docker-compose.yml의 ollama 서비스를 계속 사용합니다.
+#NARUON_MLX_OPENAI_API_KEY=mlx
+#NARUON_MLX_BASE_URL=http://host.docker.internal:11434/v1
+#NARUON_MLX_ALLOWED_LLM_BASE_URL_HOSTS=localhost,127.0.0.1,host.docker.internal
+#NARUON_MLX_EMBEDDING_MODEL=embeddinggemma
+#NARUON_MLX_LLM_MODEL=gemma4:e2b-it-qat
+#NARUON_MLX_EXTRA_HOSTS=host-gateway
+
+# Optional host bind overrides for local conflict cases when running with a custom override.
+# Format is host:container, e.g. 127.0.0.1:3000
+NARUON_FRONTEND_HOST_PORT=127.0.0.1:3000
+NARUON_BACKEND_HOST_PORT=127.0.0.1:8000
+
 # CORS settings for backend development.
 ALLOWED_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8000,http://127.0.0.1:8000
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Application CI](https://github.com/ContextualWisdomLab/naruon/actions/workflows/app-ci.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/app-ci.yml)
 [![Bandit Security Scan](https://github.com/ContextualWisdomLab/naruon/actions/workflows/bandit.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/bandit.yml)
-[![Strix Security Scan](https://github.com/ContextualWisdomLab/naruon/actions/workflows/strix.yml/badge.svg)](https://github.com/ContextualWisdomLab/naruon/actions/workflows/strix.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ContextualWisdomLab/naruon)
 
 Full-stack AI workspace with a FastAPI backend, Next.js frontend, vector search,
@@ -39,38 +38,16 @@ mail/calendar/file systems.
 - Keycloak is the default enterprise OIDC evaluation target; Casdoor remains a
   lighter alternative. Traefik and OpenTelemetry are evaluated for edge policy and
   open-source observability.
-- PR automation is metadata-only and uses current-head robot-review evidence plus
-  required checks. Human approval is not awaited by default under repo policy.
-- Strix PR/security evidence defaults to GitHub Models through
-  `STRIX_LLM=openai/gpt-5`, `STRIX_GITHUB_MODELS_TOKEN`, `models: read`,
-  `github.token`, and `LLM_API_BASE_FILE` pointing at a trusted file containing
-  `https://models.github.ai/inference`. The workflow keeps that endpoint in a
-  trusted input file, tries the configured GPT-5-or-newer GitHub Models primary
-  first, and may fall back only to the explicit GitHub Models fallback list:
-  `deepseek/deepseek-r1-0528` and `deepseek/deepseek-v3-0324`. The workflow
-  passes the token only through the provider-scoped Strix child-process key path.
-  Legacy `STRIX_LLM` secrets do not override PR, push, or scheduled Strix
-  defaults. Vertex remains available only for manual `workflow_dispatch`
-  evidence when `strix_llm` explicitly selects
-  `vertex_ai/gemini-3.1-pro-preview-customtools` or
-  `vertex_ai/gemini-2.5-flash` with `GCP_SA_KEY`; direct OpenAI
-  GPT-5.4-or-newer remains supported only for manual `strix_llm` selections
-  with `STRIX_OPENAI_API_KEY`. The workflow fails closed rather than using generic
-  `LLM_API_KEY`, silently falling back across providers, or treating
-  timeout-class provider infrastructure failures as clean evidence. Known
-  third-party Strix/Pydantic serializer warnings are filtered narrowly instead
-  of allowing Warn-class logs into passing evidence, and runtime scan-budget
-  variables are not listed as visible timeout-named workflow `env:` entries.
-  PR-scope scan budgets leave room for report finalization after Strix emits
-  completion events; workflow PR evidence uses
-  `STRIX_TARGET_PATH=__PR_SCOPE__` so the scanner target is the generated
-  PR-head changed-file scope with allowlisted trusted context, not the trusted
-  base checkout or the full repository tree. Strix receives that complete
-  scannable changed-file set in one scanner invocation because its analysis
-  contract depends on whole changed-file context. Scanner child processes
-  disable npm, pnpm, yarn, and bun lifecycle scripts while inspecting PR scope data. Wrapper
-  timeout output is failed evidence. Pending CodeRabbit or check evidence is a
-  wait state, not a hard blocker.
+- PR automation is metadata-only inside this repository and uses current-head
+  robot-review evidence plus required checks. Human approval is not awaited by
+  default under repo policy.
+- OpenCode Review, Strix Security Scan, and PR Review Merge Scheduler are
+  supplied by the ContextualWisdomLab central required workflows from
+  `ContextualWisdomLab/.github`. This repository does not carry repo-local
+  OpenCode, Strix, or merge-scheduler workflow copies; branch updates,
+  auto-merge, and mechanical merge actions run as the target repository's
+  `github-actions[bot]` through the central workflow. Pending CodeRabbit or
+  required-check evidence is a wait state, not a hard blocker.
 - Security governance is source-backed through signed
   `/api/security/access-surface`. The endpoint reads scoped WebDAV, CalDAV, and
   connector evidence plus durable `security_audit_events`, reuses the deny-first
@@ -185,6 +162,148 @@ PY
 curl -s http://localhost:8000/api/emails
 python3 -m webbrowser http://localhost:3000
 ```
+
+### Apple Silicon / MLX local path (OS별 로컬 API 모델 서버 사용)
+
+기본 `docker-compose.yml`는 Linux Ollama 컨테이너를 그대로 유지합니다. Apple Silicon
+로컬 실 테스트(또는 외부 MLX/OpenAI-compatible 서비스)만 분리하려면 임시 오버라이드 파일을 붙여 실행합니다.
+
+```bash
+# 다음 블록은 로컬 실사용 검증용 샘플입니다. 민감한 쿼리로 대체할 수 있지만,
+# 현재 실검증에서는 아래 두 키워드로 테스트합니다.
+cat > .env.mlx <<'EOF'
+
+# 기존 보안값은 그대로 두고, 로컬 모델 경로만 오버라이드
+OPENAI_API_KEY=mlx
+ALLOWED_LLM_BASE_URL_HOSTS=localhost,127.0.0.1,host.docker.internal
+ALLOW_LOCAL_LLM_PROVIDERS=true
+OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+OPENAI_EMBEDDING_MODEL=embeddinggemma
+OPENAI_MODEL=gemma4:e2b-it-qat
+# 포트 충돌이 있으면 아래 두 값으로 변경
+NARUON_FRONTEND_HOST_PORT=127.0.0.1:3000
+NARUON_BACKEND_HOST_PORT=127.0.0.1:8000
+# Linux에서만 host-gateway가 필요합니다.
+NARUON_MLX_EXTRA_HOSTS=host-gateway
+NARUON_MLX_ALLOWED_LLM_BASE_URL_HOSTS=localhost,127.0.0.1,host.docker.internal
+NARUON_MLX_OPENAI_API_KEY=mlx
+NARUON_MLX_BASE_URL=http://host.docker.internal:11434/v1
+NARUON_MLX_EMBEDDING_MODEL=embeddinggemma
+NARUON_MLX_LLM_MODEL=gemma4:e2b-it-qat
+EOF
+
+# 로컬에서만 쓰는 compose 오버라이드는 임시 파일로 만들고 커밋하지 않습니다.
+# OS 분기 없이 환경변수 하나로 host.docker.internal 매핑을 제어합니다.
+# Linux에서 host-gateway가 필요한 환경이면 .env.mlx에서 NARUON_MLX_EXTRA_HOSTS를 덮어씁니다.
+# Apple Silicon 검증 기준: 백엔드는 host.docker.internal:11434의 MLX(OpenAI-compatible)
+# 엔드포인트로 바로 연결해 Ollama 컨테이너 의존을 피합니다.
+mlx_compose_override="$(mktemp "${TMPDIR:-/tmp}/docker-compose.mlx.XXXXXX.yml")"
+cat > "$mlx_compose_override" <<'EOF'
+services:
+  backend:
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ALLOW_LOCAL_LLM_PROVIDERS: "true"
+      ALLOWED_LLM_BASE_URL_HOSTS: ${NARUON_MLX_ALLOWED_LLM_BASE_URL_HOSTS:-localhost,127.0.0.1,host.docker.internal}
+      OPENAI_API_KEY: ${NARUON_MLX_OPENAI_API_KEY:-mlx}
+      OPENAI_BASE_URL: ${NARUON_MLX_BASE_URL:-http://host.docker.internal:11434/v1}
+      OPENAI_EMBEDDING_MODEL: ${NARUON_MLX_EMBEDDING_MODEL:-embeddinggemma}
+      OPENAI_MODEL: ${NARUON_MLX_LLM_MODEL:-gemma4:e2b-it-qat}
+    extra_hosts:
+      - "host.docker.internal:${NARUON_MLX_EXTRA_HOSTS:-host.docker.internal}"
+    ports:
+      - "${NARUON_BACKEND_HOST_PORT:-127.0.0.1:8000}:8000"
+  frontend:
+    ports:
+      - "${NARUON_FRONTEND_HOST_PORT:-127.0.0.1:3000}:3000"
+EOF
+
+NARUON_ENV_FILE=.env.mlx \
+docker compose --env-file .env.mlx -f docker-compose.yml -f "$mlx_compose_override" up -d --build
+
+# 혹시 모델 엔드포인트 미노출이 있을 경우는 위 명령 직전에 로컬 MLX 서버/게이트웨이를
+# 먼저 확인합니다. (호스트는 본인 환경별로 달라질 수 있음)
+curl -sf http://127.0.0.1:11434/v1/models >/dev/null && \
+  echo "MLX/OpenAI-compatible server is reachable" || \
+  echo "MLX endpoint is not reachable on 127.0.0.1:11434"
+```
+
+실 메일 임포트 + 요약/초안 검증:
+
+```bash
+# 아래 두 --query는 실 사용자 공개 테스트 키워드입니다.
+MAIL_DIR="/Users/seonghobae/Library/Mobile Documents/com~apple~CloudDocs/Downloads/mail"
+if [ ! -r "$MAIL_DIR" ]; then
+  echo "ERROR: cannot read $MAIL_DIR (Apple CloudDocs 권한 또는 path 접근 권한 점검 필요)"
+  echo "대체: 실 메일 파일을 별도 로컬 폴더에 복사한 뒤 MAIL_DIR을 교체해 재실행"
+  exit 1
+fi
+
+AUTH_SESSION_HMAC_SECRET="$(grep -E '^AUTH_SESSION_HMAC_SECRET=' .env | cut -d= -f2-)"
+python3 backend/scripts/private_mail_http_smoke.py \
+  --mail-dir "$MAIL_DIR" \
+  --base-url http://127.0.0.1:3000 \
+  --frontend-base-url http://127.0.0.1:3000 \
+  --api-base-url http://127.0.0.1:8000 \
+  --session-secret "$AUTH_SESSION_HMAC_SECRET" \
+  --query "중공업 전력PU 회의록" \
+  --query "중공업 기전PU 회의록" \
+  --match-mode all-terms \
+  --limit 20 \
+  --batch-size 6 \
+  --llm-smoke \
+  --print-session-token
+```
+
+`--print-session-token`이 켜진 경우 스크립트가 같은 토큰을 브라우저로 전파하는
+`/auth/session` 호출 예시를 출력합니다. 위 출력의 JS 한 줄을 앱 콘솔에서 실행하면
+`naruon_session` 쿠키가 갱신되어 API로 임포트한 메일이 브라우저와 동일 세션에서 보입니다.
+`session_check=ok` 로그는 세션 클레임이 브라우저에서 확인되었음을 뜻하고,
+`session_check=failed(...)`는 토큰 검증/클레임 파싱 문제가 있음을 뜻합니다.
+
+동기화 지연이 큰 환경에서는 재시도 옵션을 조정할 수 있습니다.
+
+```bash
+  --search-retry-attempts 5 \
+  --search-retry-delay-seconds 1.2 \
+  --inbox-retry-attempts 5 \
+  --inbox-retry-delay-seconds 1.2
+```
+
+실제 브라우저 검증 순서:
+
+1) 브라우저에서 `http://127.0.0.1:3000` 접속 후 `"/mail"`로 이동
+2) 방금 입력한 키워드 중 하나로 검색
+3) `/mail` 결과 목록에서 임포트된 메일을 열어 상세가 정상 표시되는지 확인
+4) 동일 이메일 상세 화면에서 요약/초안 버튼이 작동하고(`llm=ok`, `draft=ok` 또는 UI 동작),
+   브라우저 세션 값(`session_check=ok`)이 스크립트 출력에 남아있는지 확인
+   - 브라우저에서 동일 이메일을 선택한 뒤 LLM 요약/초안 버튼 동작 확인
+5) 세션 불일치 의심 시 `session_check=failed(...)` 또는 `session_check=skipped(...)`가
+   출력되면 `--print-session-token`의 콘솔 스니펫을 다시 실행하고 새로고침 후 2~4단계를 반복
+
+실행 전 체크(빠른 사전 진단):
+
+```bash
+# Podman/Docker 런타임 연결 확인
+podman system connection ls
+
+# MLX(OpenAI-compatible) 엔드포인트 노출 확인
+curl -sf http://127.0.0.1:11434/v1/models | head
+```
+
+백엔드 API를 바로 확인하려면(필요 시):
+
+```bash
+curl -s http://127.0.0.1:3000/api/emails?limit=10
+# 아래는 동일 샘플로 API 직접 점검하는 예시입니다.
+curl -s -X POST http://127.0.0.1:3000/api/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "중공업 전력PU 회의록", "limit": 3}'
+```
+
+세션이 다르게 보이면 `/auth/session` 동기화 콘솔 코드를 다시 실행한 뒤 새로고침 합니다.
 
 What you should see: the fixture import loads a three-message `Quarterly plan`
 conversation. `/api/emails` returns one threaded inbox item with `reply_count`

--- a/backend/scripts/private_mail_http_smoke.py
+++ b/backend/scripts/private_mail_http_smoke.py
@@ -1,0 +1,780 @@
+#!/usr/bin/env python3
+"""Local-only Naruon mail smoke test without printing private mail content."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import http.client
+import json
+import mailbox
+import mimetypes
+import os
+import sys
+import time
+from collections import Counter
+from email import message_from_bytes, policy
+from email.parser import BytesHeaderParser
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlsplit
+from zipfile import BadZipFile, ZipFile
+
+SESSION_COOKIE_NAME = "naruon_session"
+SUPPORTED_SUFFIXES = {".eml", ".emlx", ".mbox", ".zip"}
+MATCH_SEPARATORS = str.maketrans("", "", " \t\r\n-_./\\()[]{}:;·ㆍ")
+SEARCH_RETRY_DEFAULT_ATTEMPTS = 3
+SEARCH_RETRY_DEFAULT_DELAY_SECONDS = 0.75
+RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _b64_json(value: dict[str, object]) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _signed_token(secret: str) -> str:
+    header = _b64_json({"alg": "HS256", "typ": "JWT"})
+    payload = _b64_json(
+        {
+            "ver": 1,
+            "iss": "naruon-control-plane",
+            "aud": "naruon-api",
+            "sub": "testuser",
+            "role": "member",
+            "org": "org-acme",
+            "groups": ["group-1", "group-2"],
+            "workspace": "workspace-org-acme",
+            "exp": int(time.time()) + 1800,
+        }
+    )
+    signing_input = f"{header}.{payload}".encode()
+    sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return f"{header}.{payload}.{base64.urlsafe_b64encode(sig).decode().rstrip('=')}"
+
+
+def _private_files(mail_dir: Path, limit: int) -> list[Path]:
+    if not mail_dir.is_dir():
+        raise SystemExit("mail_dir_missing")
+    try:
+        next(mail_dir.iterdir(), None)
+    except PermissionError as exc:
+        raise SystemExit(
+            "mail_dir_unreadable: confirm macOS file permission or copy mails to a local folder"
+        ) from exc
+
+    picked: list[Path] = []
+    for root, dirs, files in os.walk(mail_dir, followlinks=False):
+        dirs[:] = [item for item in dirs if not item.startswith(".")]
+        for name in sorted(files):
+            path = Path(root, name)
+            if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+                continue
+            if not path.is_file() or path.is_symlink():
+                continue
+            picked.append(path)
+            if len(picked) >= limit:
+                return picked
+    return picked
+
+
+def _decoded_probe(raw: bytes, max_body_bytes: int) -> str:
+    header, separator, body = raw.partition(b"\r\n\r\n")
+    if not separator:
+        header, _, body = raw.partition(b"\n\n")
+    chunks = [header[:65536], body[:max_body_bytes]]
+    decoded: list[str] = []
+    for encoding in ("utf-8", "cp949", "euc-kr", "latin1"):
+        for chunk in chunks:
+            decoded.append(chunk.decode(encoding, errors="ignore"))
+    return "\n".join(decoded)
+
+
+def _header_text(raw: bytes) -> str:
+    try:
+        msg = BytesHeaderParser(policy=policy.default).parsebytes(raw)
+    except Exception:
+        return ""
+    return "\n".join(
+        str(msg.get(name, ""))
+        for name in ("Subject", "From", "To", "Cc", "Date")
+    )
+
+
+def _message_text(raw: bytes, max_parse_bytes: int) -> str:
+    parts = [_header_text(raw), _decoded_probe(raw, max_parse_bytes)]
+    if len(raw) > max_parse_bytes:
+        return "\n".join(parts)
+
+    try:
+        msg = message_from_bytes(raw, policy=policy.default)
+    except Exception:
+        return "\n".join(parts)
+
+    parts.extend([
+        str(msg.get("Subject", "")),
+        str(msg.get("From", "")),
+        str(msg.get("To", "")),
+        str(msg.get("Cc", "")),
+        str(msg.get("Date", "")),
+    ])
+    if msg.is_multipart():
+        for part in msg.walk():
+            filename = part.get_filename()
+            if filename:
+                parts.append(filename)
+                continue
+            if part.get_content_type() not in {"text/plain", "text/html"}:
+                continue
+            try:
+                content = part.get_content()
+            except (LookupError, ValueError, UnicodeError):
+                continue
+            if isinstance(content, str):
+                parts.append(content)
+    else:
+        try:
+            content = msg.get_content()
+        except Exception:
+            content = raw.decode("utf-8", errors="ignore")
+        if isinstance(content, str):
+            parts.append(content)
+    return "\n".join(parts)
+
+
+def _read_eml_like_bytes(path: Path) -> bytes | None:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    return _strip_emlx_prefix(raw) if path.suffix.lower() == ".emlx" else raw
+
+
+def _strip_emlx_prefix(raw: bytes) -> bytes:
+    first_line, separator, rest = raw.partition(b"\n")
+    if not separator or not first_line.strip().isdigit():
+        return raw
+    message_length = int(first_line.strip())
+    if message_length <= 0:
+        return rest
+    return rest[:message_length]
+
+
+def _normalize_for_match(value: str) -> str:
+    return value.casefold().translate(MATCH_SEPARATORS)
+
+
+def _matches_queries(
+    raw: bytes,
+    queries: list[str],
+    max_parse_bytes: int,
+    match_mode: str,
+) -> bool:
+    if not queries:
+        return True
+    haystack = _message_text(raw, max_parse_bytes).casefold()
+    normalized_haystack = _normalize_for_match(haystack)
+    for query in queries:
+        normalized_query = _normalize_for_match(query)
+        if match_mode == "all-terms":
+            terms = [
+                _normalize_for_match(term)
+                for term in query.split()
+                if _normalize_for_match(term)
+            ]
+            if terms and all(term in normalized_haystack for term in terms):
+                return True
+            continue
+        if query.casefold() in haystack or normalized_query in normalized_haystack:
+            return True
+    return False
+
+
+def _selected_upload_files(
+    mail_dir: Path,
+    queries: list[str],
+    limit: int,
+    *,
+    max_parse_bytes: int,
+    match_mode: str,
+    progress_every: int,
+) -> list[Path]:
+    with TemporaryDirectory(prefix="naruon-private-mail-hits-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        selected: list[Path] = []
+
+        scanned = 0
+
+        def report_progress() -> None:
+            if progress_every > 0 and scanned % progress_every == 0:
+                print(
+                    f"scan_progress scanned={scanned} selected={len(selected)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+        def add_raw(raw: bytes) -> None:
+            if len(selected) >= limit:
+                return
+            path = temp_dir / f"hit_{len(selected) + 1:03d}.eml"
+            path.write_bytes(raw)
+            selected.append(path)
+
+        for path in _private_files(mail_dir, limit=1000000):
+            if len(selected) >= limit:
+                break
+            suffix = path.suffix.lower()
+            if suffix in {".eml", ".emlx"}:
+                raw = _read_eml_like_bytes(path)
+                if raw is None:
+                    continue
+                scanned += 1
+                report_progress()
+                if _matches_queries(raw, queries, max_parse_bytes, match_mode):
+                    add_raw(raw)
+                continue
+            if suffix == ".mbox":
+                try:
+                    box = mailbox.mbox(path, create=False)
+                except (OSError, mailbox.Error):
+                    continue
+                try:
+                    for msg in box:
+                        if len(selected) >= limit:
+                            break
+                        raw = msg.as_bytes(policy=policy.default)
+                        scanned += 1
+                        report_progress()
+                        if _matches_queries(raw, queries, max_parse_bytes, match_mode):
+                            add_raw(raw)
+                finally:
+                    box.close()
+                continue
+            if suffix == ".zip":
+                try:
+                    archive = ZipFile(path)
+                except (OSError, BadZipFile):
+                    continue
+                with archive:
+                    for info in archive.infolist():
+                        if len(selected) >= limit:
+                            break
+                        entry_suffix = Path(info.filename).suffix.lower()
+                        if info.is_dir() or entry_suffix not in {".eml", ".emlx"}:
+                            continue
+                        try:
+                            raw = archive.read(info)
+                        except (OSError, BadZipFile):
+                            continue
+                        if entry_suffix == ".emlx":
+                            raw = _strip_emlx_prefix(raw)
+                        scanned += 1
+                        report_progress()
+                        if _matches_queries(raw, queries, max_parse_bytes, match_mode):
+                            add_raw(raw)
+
+        persistent: list[Path] = []
+        final_dir = Path(
+            os.environ.get(
+                "NARUON_PRIVATE_MAIL_CACHE",
+                str(Path.home() / ".cache" / "naruon" / "private-mail-upload-cache"),
+            )
+        )
+        final_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        for old_hit in final_dir.glob("hit_*.eml"):
+            old_hit.unlink()
+        for index, path in enumerate(selected, start=1):
+            final_path = final_dir / f"hit_{index:03d}.eml"
+            final_path.write_bytes(path.read_bytes())
+            final_path.chmod(0o600)
+            persistent.append(final_path)
+        return persistent
+
+
+def _request(
+    base_url: str,
+    token: str,
+    method: str,
+    path: str,
+    *,
+    body: bytes | None = None,
+    content_type: str | None = None,
+    timeout: float = 120.0,
+) -> tuple[int, bytes]:
+    parsed = urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise SystemExit("base-url must be http(s)")
+    cls = http.client.HTTPSConnection if parsed.scheme == "https" else http.client.HTTPConnection
+    conn = cls(parsed.hostname, parsed.port, timeout=timeout)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Cookie": f"{SESSION_COOKIE_NAME}={token}",
+        "Origin": base_url,
+        "Referer": f"{base_url}/",
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    try:
+        conn.request(method, path, body=body, headers=headers)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    except OSError as exc:
+        raise _RequestNetworkError(f"request transport error to {base_url}: {exc}") from exc
+    finally:
+        conn.close()
+
+
+def _multipart(files: list[Path]) -> tuple[bytes, str]:
+    boundary = f"naruon-{hashlib.sha256(os.urandom(16)).hexdigest()}"
+    chunks: list[bytes] = []
+    for index, path in enumerate(files, start=1):
+        upload_name = f"hit_{index:03d}{path.suffix.lower() or '.eml'}"
+        media_type = mimetypes.guess_type(upload_name)[0] or "application/octet-stream"
+        chunks.append(f"--{boundary}\r\n".encode())
+        chunks.append(
+            (
+                'Content-Disposition: form-data; name="files"; '
+                f'filename="{upload_name}"\r\n'
+                f"Content-Type: {media_type}\r\n\r\n"
+            ).encode()
+        )
+        chunks.append(path.read_bytes())
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
+def _json_or_empty(status: int, body: bytes) -> dict[str, object]:
+    if status != 200:
+        raise _RequestFailed(status, body)
+    try:
+        return json.loads(body.decode(errors="replace") or "{}")
+    except json.JSONDecodeError as exc:
+        raise _BadResponse(status, body) from exc
+
+
+class _RequestFailed(SystemExit):
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self.body = body
+        super().__init__(f"request failed status={status}")
+
+
+class _BadResponse(SystemExit):
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self.body = body
+        super().__init__(f"unexpected non-json response status={status}")
+
+
+class _RequestNetworkError(SystemExit):
+    pass
+
+
+def _ensure_positive_retry_budget(value: int, option_name: str) -> None:
+    if value < 1:
+        raise SystemExit(f"{option_name} must be at least 1")
+
+
+def _request_json_with_retry(
+    base_url: str,
+    token: str,
+    method: str,
+    path: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    timeout: float = 120.0,
+    body: bytes | None = None,
+    content_type: str | None = None,
+) -> dict[str, object]:
+    _ensure_positive_retry_budget(attempts, "retry-attempts")
+    for attempt in range(attempts):
+        try:
+            status, raw = _request(
+                base_url,
+                token,
+                method,
+                path,
+                body=body,
+                content_type=content_type,
+                timeout=timeout,
+            )
+            return _json_or_empty(status, raw)
+        except _RequestFailed as exc:
+            if exc.status in RETRY_STATUS_CODES and attempt != attempts - 1:
+                if delay_seconds > 0:
+                    time.sleep(delay_seconds)
+                continue
+            raise
+        except _BadResponse:
+            raise
+        except _RequestNetworkError:
+            if attempt != attempts - 1:
+                if delay_seconds > 0:
+                    time.sleep(delay_seconds)
+                continue
+            raise
+    raise RuntimeError("request retry loop completed without a terminal response")
+
+
+def _post_json_with_retry(
+    base_url: str,
+    token: str,
+    path: str,
+    payload: dict[str, object],
+    *,
+    attempts: int,
+    delay_seconds: float,
+    timeout: float = 120.0,
+) -> dict[str, object]:
+    return _request_json_with_retry(
+        base_url,
+        token,
+        "POST",
+        path,
+        body=json.dumps(payload).encode(),
+        content_type="application/json",
+        attempts=attempts,
+        delay_seconds=delay_seconds,
+        timeout=timeout,
+    )
+
+
+def _post_multipart_with_retry(
+    base_url: str,
+    token: str,
+    path: str,
+    body: bytes,
+    content_type: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    timeout: float = 120.0,
+) -> dict[str, object]:
+    return _request_json_with_retry(
+        base_url,
+        token,
+        "POST",
+        path,
+        body=body,
+        content_type=content_type,
+        attempts=attempts,
+        delay_seconds=delay_seconds,
+        timeout=timeout,
+    )
+
+
+def _get_json_with_retry(
+    base_url: str,
+    token: str,
+    path: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    timeout: float = 120.0,
+) -> dict[str, object]:
+    return _request_json_with_retry(
+        base_url,
+        token,
+        "GET",
+        path,
+        attempts=attempts,
+        delay_seconds=delay_seconds,
+        timeout=timeout,
+    )
+
+
+def _check_frontend_session(base_url: str, token: str) -> dict[str, object] | None:
+    try:
+        data = _post_json_with_retry(
+            base_url,
+            token,
+            "/auth/session",
+            {"access_token": token},
+            attempts=SEARCH_RETRY_DEFAULT_ATTEMPTS,
+            delay_seconds=SEARCH_RETRY_DEFAULT_DELAY_SECONDS,
+            timeout=30.0,
+        )
+    except _RequestFailed as exc:
+        if exc.status == 404:
+            return None
+        raise
+
+    if not isinstance(data, dict) or data.get("authenticated") is not True:
+        raise SystemExit("frontend session sync check failed")
+    return data
+
+
+def _post_json(
+    base_url: str,
+    token: str,
+    path: str,
+    payload: dict[str, object],
+    *,
+    timeout: float = 120.0,
+) -> dict[str, object]:
+    return _request_json_with_retry(
+        base_url,
+        token,
+        "POST",
+        path,
+        body=json.dumps(payload).encode(),
+        content_type="application/json",
+        attempts=1,
+        delay_seconds=0.0,
+        timeout=timeout,
+    )
+
+
+def _cleanup_private_cache(files: list[Path]) -> None:
+    for path in files:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            print(
+                f"warning: failed to remove private cache file: {path}",
+                file=sys.stderr,
+            )
+
+
+def _print_session_sync_hints(base_url: str, token: str, *, enabled: bool) -> None:
+    if not enabled:
+        return
+
+    print(
+        "session_token="
+        + token,
+    )
+    print("브라우저 동일 세션 동기화 방법:")
+    print(
+        "  1) 브라우저에서 NARUON 앱(origin)으로 접속한 뒤, 개발자 콘솔에서 아래 한 줄 실행:",
+    )
+    print(
+        "     await fetch('/auth/session', {method:'POST', credentials:'same-origin', "
+        "headers:{'content-type':'application/json'}, body: JSON.stringify({access_token: '"
+        + token
+        + "'})});",
+    )
+    safe_origin = base_url.rstrip("/")
+    print(f"     (요청 대상: {safe_origin}/auth/session)")
+    print("  2) 새로고침 후 /mail 또는 /api/emails로 임포트 반영 및 표시 여부 확인")
+
+
+def _print_session_check_summary(claims: dict[str, object] | None) -> None:
+    if claims is None:
+        print("session_check=skipped(endpoint_not_frontend)")
+        return
+    claims_dict = claims.get("claims")
+    if not isinstance(claims_dict, dict):
+        print("session_check=failed(unexpected_payload)")
+        return
+    user = claims_dict.get("userId")
+    organization = claims_dict.get("organizationId")
+    workspace = claims_dict.get("workspaceId")
+    if (
+        user is None
+        or organization is None
+        or workspace is None
+        or not isinstance(user, str)
+        or not isinstance(organization, str)
+        or not isinstance(workspace, str)
+    ):
+        print("session_check=failed(claim_parse_error)")
+        return
+    print(f"session_check=ok user={user} org={organization} workspace={workspace}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mail-dir", required=True, type=Path)
+    parser.add_argument("--base-url", default=os.environ.get("LIVE_BASE_URL", "http://127.0.0.1:18080"))
+    parser.add_argument(
+        "--api-base-url",
+        help="Optional override when frontend and backend ports differ",
+    )
+    parser.add_argument(
+        "--frontend-base-url",
+        help="Optional override when frontend and backend ports differ",
+    )
+    parser.add_argument("--session-secret", default=os.environ.get("LIVE_E2E_SESSION_SECRET", ""))
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=10)
+    parser.add_argument("--query", action="append", default=[])
+    parser.add_argument("--match-mode", choices=["exact", "all-terms"], default="exact")
+    parser.add_argument("--llm-smoke", action="store_true")
+    parser.add_argument("--print-session-token", action="store_true")
+    parser.add_argument("--search-retry-attempts", type=int, default=SEARCH_RETRY_DEFAULT_ATTEMPTS)
+    parser.add_argument(
+        "--search-retry-delay-seconds",
+        type=float,
+        default=SEARCH_RETRY_DEFAULT_DELAY_SECONDS,
+    )
+    parser.add_argument("--inbox-retry-attempts", type=int, default=SEARCH_RETRY_DEFAULT_ATTEMPTS)
+    parser.add_argument(
+        "--inbox-retry-delay-seconds",
+        type=float,
+        default=SEARCH_RETRY_DEFAULT_DELAY_SECONDS,
+    )
+    parser.add_argument("--max-parse-bytes", type=int, default=2_000_000)
+    parser.add_argument("--progress-every", type=int, default=0)
+    args = parser.parse_args()
+
+    if not args.session_secret:
+        raise SystemExit("LIVE_E2E_SESSION_SECRET or --session-secret is required")
+    if args.limit <= 0 or args.batch_size <= 0 or args.batch_size > 10:
+        raise SystemExit("--limit must be positive and --batch-size must be 1..10")
+    if args.search_retry_attempts < 1 or args.inbox_retry_attempts < 1:
+        raise SystemExit("retry-attempts must be at least 1")
+    if args.search_retry_delay_seconds < 0 or args.inbox_retry_delay_seconds < 0:
+        raise SystemExit("retry-delay-seconds must be non-negative")
+
+    api_base_url = (args.api_base_url or args.base_url).rstrip("/")
+    frontend_base_url = (args.frontend_base_url or args.base_url).rstrip("/")
+
+    files = _selected_upload_files(
+        args.mail_dir,
+        args.query,
+        args.limit,
+        max_parse_bytes=max(0, args.max_parse_bytes),
+        match_mode=args.match_mode,
+        progress_every=max(0, args.progress_every),
+    )
+    if not files:
+        raise SystemExit("no matching supported .eml/.mbox/.zip messages found or directory is not readable")
+
+    try:
+        token = _signed_token(args.session_secret)
+        session_claims = _check_frontend_session(frontend_base_url, token)
+        _print_session_check_summary(session_claims)
+        totals = Counter()
+        reasons = Counter()
+        for offset in range(0, len(files), args.batch_size):
+            body, content_type = _multipart(files[offset : offset + args.batch_size])
+            data = _post_multipart_with_retry(
+                api_base_url,
+                token,
+                "/api/emails/import-files",
+                body=body,
+                content_type=content_type,
+                attempts=args.inbox_retry_attempts,
+                delay_seconds=args.inbox_retry_delay_seconds,
+                timeout=120.0,
+            )
+            totals["imported"] += int(data.get("imported_count", 0))
+            totals["skipped"] += int(data.get("skipped_count", 0))
+            totals["failed"] += int(data.get("failed_count", 0))
+            totals["attachments"] += int(data.get("attachment_count", 0))
+            for item in data.get("items", []):
+                if isinstance(item, dict) and item.get("reason_code"):
+                    reasons[str(item["reason_code"])] += 1
+
+        inbox = _get_json_with_retry(
+            api_base_url,
+            token,
+            "/api/emails?limit=1",
+            attempts=1,
+            delay_seconds=0.0,
+            timeout=120.0,
+        )
+        if totals["imported"] > 0:
+            expected_min_count = totals["imported"]
+            for _ in range(args.inbox_retry_attempts - 1):
+                email_count = len(inbox.get("emails", [])) if isinstance(inbox.get("emails"), list) else 0
+                if email_count >= expected_min_count:
+                    break
+                if args.inbox_retry_delay_seconds > 0:
+                    time.sleep(args.inbox_retry_delay_seconds)
+                inbox = _get_json_with_retry(
+                    api_base_url,
+                    token,
+                    "/api/emails?limit=1",
+                    attempts=1,
+                    delay_seconds=0.0,
+                    timeout=120.0,
+                )
+        email_count = len(inbox.get("emails", []))
+
+        search_counts: dict[str, int] = {}
+        first_result_id = None
+        for index, query in enumerate(args.query, start=1):
+            search = None
+            for _ in range(args.search_retry_attempts):
+                search = _post_json_with_retry(
+                    api_base_url,
+                    token,
+                    "/api/search",
+                    {"query": query, "limit": 3},
+                    attempts=1,
+                    delay_seconds=0.0,
+                    timeout=300.0,
+                )
+                results = search.get("results", [])
+                if results:
+                    break
+                if _ < args.search_retry_attempts - 1 and args.search_retry_delay_seconds > 0:
+                    time.sleep(args.search_retry_delay_seconds)
+            if search is None:
+                raise RuntimeError("unreachable")
+            results = search.get("results", [])
+            search_counts[f"query_{index}"] = len(results) if isinstance(results, list) else 0
+            if first_result_id is None and isinstance(results, list) and results:
+                first = results[0]
+                if isinstance(first, dict):
+                    first_result_id = first.get("id")
+
+        llm_status = "skipped"
+        draft_status = "skipped"
+        target_id = first_result_id
+        if target_id is None and email_count:
+            target_id = inbox["emails"][0]["id"]
+        if args.llm_smoke and target_id is not None:
+            status, raw = _request(api_base_url, token, "GET", f"/api/emails/{target_id}")
+            detail = _json_or_empty(status, raw)
+            body_text = str(detail.get("body", ""))
+            summary = _post_json(
+                api_base_url,
+                token,
+                "/api/llm/summarize",
+                {"email_body": body_text},
+                timeout=600.0,
+            )
+            llm_status = (
+                f"ok summary_chars={len(str(summary.get('summary', '')))} "
+                f"todos={len(summary.get('todos', []))}"
+            )
+            draft = _post_json(
+                api_base_url,
+                token,
+                "/api/llm/draft",
+                {
+                    "email_body": body_text,
+                    "instruction": "업무 메일 답장 초안을 공손하고 간결하게 작성",
+                },
+                timeout=600.0,
+            )
+            draft_status = f"ok draft_chars={len(str(draft.get('draft', '')))}"
+
+        print(
+            "private_mail_smoke "
+            f"selected={len(files)} imported={totals['imported']} "
+            f"skipped={totals['skipped']} failed={totals['failed']} "
+            f"attachments={totals['attachments']} inbox_visible={email_count} "
+            f"search_counts={search_counts} reason_counts={dict(reasons)} "
+            f"llm={llm_status} draft={draft_status}"
+        )
+        _print_session_sync_hints(
+            frontend_base_url,
+            token,
+            enabled=args.print_session_token,
+        )
+    finally:
+        _cleanup_private_cache(files)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_private_mail_http_smoke.py
+++ b/backend/tests/test_private_mail_http_smoke.py
@@ -1,0 +1,250 @@
+from zipfile import ZipFile
+
+import pytest
+
+from scripts import private_mail_http_smoke as smoke
+
+
+def test_selected_upload_files_reads_emlx_inside_zip(tmp_path, monkeypatch):
+    raw = (
+        b"Subject: Quarterly needle\r\n"
+        b"From: sender@example.com\r\n"
+        b"To: recipient@example.com\r\n"
+        b"\r\n"
+        b"body"
+    )
+    emlx = str(len(raw)).encode() + b"\n" + raw + b"\nmetadata"
+    archive_path = tmp_path / "archive.zip"
+    with ZipFile(archive_path, "w") as archive:
+        archive.writestr("nested/original.emlx", emlx)
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("NARUON_PRIVATE_MAIL_CACHE", str(cache_dir))
+
+    selected = smoke._selected_upload_files(
+        tmp_path,
+        ["needle"],
+        5,
+        max_parse_bytes=1000,
+        match_mode="exact",
+        progress_every=0,
+    )
+
+    assert [path.name for path in selected] == ["hit_001.eml"]
+    assert selected[0].read_bytes() == raw
+
+
+def test_selected_upload_files_creates_default_cache_path(tmp_path, monkeypatch):
+    raw = b"Subject: alpha query\r\n\r\nbody"
+    mail_file = tmp_path / "message.eml"
+    mail_file.write_bytes(raw)
+    monkeypatch.delenv("NARUON_PRIVATE_MAIL_CACHE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    selected = smoke._selected_upload_files(
+        tmp_path,
+        ["query"],
+        1,
+        max_parse_bytes=1000,
+        match_mode="exact",
+        progress_every=0,
+    )
+
+    assert [p.name for p in selected] == ["hit_001.eml"]
+    assert selected[0].exists()
+    assert (tmp_path / "home" / ".cache" / "naruon" / "private-mail-upload-cache").exists()
+
+
+def test_large_message_match_uses_header_probe_without_full_parse(monkeypatch):
+    raw = b"Subject: needle\r\n\r\n" + (b"x" * 128)
+
+    def fail_full_parse(*args, **kwargs):
+        raise AssertionError("large message should not be fully parsed")
+
+    monkeypatch.setattr(smoke, "message_from_bytes", fail_full_parse)
+
+    assert smoke._matches_queries(
+        raw,
+        ["needle"],
+        max_parse_bytes=16,
+        match_mode="exact",
+    )
+
+
+def test_all_terms_match_mode_ignores_separators():
+    raw = b"Subject: alpha beta PU minutes\r\n\r\nbody"
+
+    assert smoke._matches_queries(
+        raw,
+        ["alpha betaPU minutes"],
+        max_parse_bytes=1000,
+        match_mode="all-terms",
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (b"12\nhello world!metadata", b"hello world!"),
+        (b"not-length\nhello world!", b"not-length\nhello world!"),
+    ],
+)
+def test_strip_emlx_prefix(raw, expected):
+    assert smoke._strip_emlx_prefix(raw) == expected
+
+
+def test_post_json_with_retry_retries_transient_statuses(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+        calls.append((method, path))
+        if len(calls) == 1:
+            return 503, b"retry-later"
+        if len(calls) == 2:
+            return 502, b"retry-later"
+        return 200, b'{"ok":true}'
+
+    monkeypatch.setattr(smoke, "_request", fake_request)
+    result = smoke._post_json_with_retry(
+        "http://127.0.0.1:8000",
+        "token",
+        "/api/search",
+        {"query": "ok"},
+        attempts=3,
+        delay_seconds=0.0,
+        timeout=120.0,
+    )
+
+    assert result == {"ok": True}
+    assert len(calls) == 3
+
+
+def test_post_json_with_retry_stops_on_non_transient_status(monkeypatch):
+    calls = []
+
+    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+        calls.append((method, path))
+        return 401, b"unauthorized"
+
+    monkeypatch.setattr(smoke, "_request", fake_request)
+    with pytest.raises(smoke._RequestFailed) as exc:
+        smoke._post_json_with_retry(
+            "http://127.0.0.1:8000",
+            "token",
+            "/api/search",
+            {"query": "ok"},
+            attempts=3,
+            delay_seconds=0.0,
+            timeout=120.0,
+        )
+    assert exc.value.status == 401
+    assert len(calls) == 1
+
+
+def test_json_or_empty_raises_bad_response_for_html_payload():
+    with pytest.raises(smoke._BadResponse):
+        smoke._json_or_empty(200, b"<html></html>")
+
+
+def test_request_json_with_retry_no_retry_after_bad_response(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+        calls.append((method, path))
+        return 200, b"<html></html>"
+
+    monkeypatch.setattr(smoke, "_request", fake_request)
+
+    with pytest.raises(smoke._BadResponse):
+        smoke._post_json_with_retry(
+            "http://127.0.0.1:8000",
+            "token",
+            "/api/test",
+            {"query": "ok"},
+            attempts=3,
+            delay_seconds=0.0,
+            timeout=120.0,
+        )
+    assert len(calls) == 1
+
+
+def test_post_json_with_retry_retries_network_error(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+        calls.append((method, path))
+        if len(calls) == 1:
+            raise smoke._RequestNetworkError("connection refused")
+        return 200, b'{"ok":true}'
+
+    monkeypatch.setattr(smoke, "_request", fake_request)
+
+    result = smoke._post_json_with_retry(
+        "http://127.0.0.1:8000",
+        "token",
+        "/api/search",
+        {"query": "ok"},
+        attempts=2,
+        delay_seconds=0.0,
+        timeout=120.0,
+    )
+
+    assert result == {"ok": True}
+    assert len(calls) == 2
+
+
+def test_post_json_with_retry_raises_network_error_after_retries(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+        calls.append((method, path))
+        raise smoke._RequestNetworkError("connection refused")
+
+    monkeypatch.setattr(smoke, "_request", fake_request)
+
+    with pytest.raises(smoke._RequestNetworkError):
+        smoke._post_json_with_retry(
+            "http://127.0.0.1:8000",
+            "token",
+            "/api/search",
+            {"query": "ok"},
+            attempts=2,
+            delay_seconds=0.0,
+            timeout=120.0,
+        )
+
+    assert len(calls) == 2
+
+
+def test_check_frontend_session_skips_on_missing_frontend(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_post_json_with_retry",
+        lambda *_a, **_k: (_ for _ in ()).throw(smoke._RequestFailed(404, b"not found")),
+    )
+    assert smoke._check_frontend_session("http://127.0.0.1:8000", "token") is None
+
+
+def test_check_frontend_session_parses_claims(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_post_json_with_retry",
+        lambda *_a, **_k: {
+            "authenticated": True,
+            "claims": {"userId": "user-1", "organizationId": "org-1", "workspaceId": "ws-1"},
+        },
+    )
+
+    claims = smoke._check_frontend_session("http://127.0.0.1:8000", "token")
+    assert claims["claims"]["userId"] == "user-1"
+    assert claims["claims"]["organizationId"] == "org-1"
+    assert claims["claims"]["workspaceId"] == "ws-1"
+
+
+def test_check_frontend_session_rejects_unauthenticated(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_post_json_with_retry",
+        lambda *_a, **_k: {"authenticated": False},
+    )
+    with pytest.raises(SystemExit):
+        smoke._check_frontend_session("http://127.0.0.1:8000", "token")


### PR DESCRIPTION
## Summary
- Retry transient HTTP failures in private mail smoke script for import/search/inbox checks.
- Add frontend session bridge precheck and claim summary output ().
- Add CLI knobs to tune search and inbox retry behavior for delayed visibility tests.
- Update README with session_check troubleshooting and retry knobs.
- Add tests for retry behavior and frontend session check handling.

## Verification
- .venv + ruff check: passed
- .venv + pytest backend/tests/test_private_mail_http_smoke.py: 11 passed