### PR TITLE
⚡ Bolt: Optimize calendar render loop with O(1) event lookup

### DIFF
--- a/frontend/src/components/calendar/CalendarMonthView.tsx
+++ b/frontend/src/components/calendar/CalendarMonthView.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import type { CalendarMonthEvent } from './types';
 
 type Props = {
@@ -5,6 +7,19 @@ type Props = {
 };
 
 export function CalendarMonthView({ visibleMonthEvents }: Props) {
+  const monthEventsByDay = useMemo(() => {
+    const grouped = new Map<number, CalendarMonthEvent[]>();
+    for (const event of visibleMonthEvents) {
+      const dayEvents = grouped.get(event.dayIndex);
+      if (dayEvents) {
+        dayEvents.push(event);
+      } else {
+        grouped.set(event.dayIndex, [event]);
+      }
+    }
+    return grouped;
+  }, [visibleMonthEvents]);
+
   return (
     <div className="h-full rounded-2xl border border-border bg-card shadow-sm flex flex-col overflow-hidden">
       <div className="grid grid-cols-7 border-b border-border bg-secondary/50 text-center text-sm font-semibold py-3">
@@ -13,7 +28,7 @@ export function CalendarMonthView({ visibleMonthEvents }: Props) {
       <div className="grid grid-cols-7 grid-rows-5 flex-1 divide-x divide-y divide-border">
         {/* Simulated Grid Cells */}
         {Array.from({ length: 35 }).map((_, i) => {
-          const dayEvents = visibleMonthEvents.filter((event) => event.dayIndex === i);
+          const dayEvents = monthEventsByDay.get(i) ?? [];
           return (
             <div key={i} className="min-h-[84px] p-2 sm:min-h-[100px]">
               <span className={`text-sm font-semibold ${i % 7 === 0 ? 'text-red-500' : i % 7 === 6 ? 'text-blue-500' : 'text-muted-foreground'}`}>{i < 31 ? i + 1 : ''}</span>


### PR DESCRIPTION
💡 **What**: The calendar component previously filtered the `visibleMonthEvents` array inside a 35-iteration `Array.from` loop to find events for each day cell. This has been replaced by pre-grouping the events into a `Map<number, typeof visibleMonthEvents>` using `useMemo` and performing an O(1) lookup inside the grid loop.

🎯 **Why**: Filtering an array of N items 35 times results in an O(N * 35) algorithmic complexity on every component render. By grouping them beforehand, we reduce this to O(N) for grouping and O(1) for lookup, significantly lowering CPU overhead during state updates and re-renders of the calendar.

📊 **Impact**: Reduces grid rendering computational complexity from O(N * 35) to O(N) + O(1), ensuring smoother render cycles when dealing with large volumes of calendar events.

🔬 **Measurement**: Verified with existing vitest suite (`pnpm run typecheck && pnpm lint && pnpm test`). No regressions detected in frontend tests.

---
*PR created automatically by Jules for task [15749592061267058224](https://jules.google.com/task/15749592061267058224) started by @seonghobae*