### PR TITLE
fix: harden browser-visible private mail smoke checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy to AKS
 
 on:
   workflow_call:
+    secrets:
+      AKS_KUBECONFIG:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -344,4 +344,5 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       needs.deploy_preflight.outputs.aks_kubeconfig_configured == 'true'
     uses: ./.github/workflows/deploy.yml
-    secrets: inherit
+    secrets:
+      AKS_KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ python3 backend/scripts/private_mail_http_smoke.py \
   --match-mode all-terms \
   --limit 20 \
   --batch-size 6 \
+  --require-browser-visible \
   --llm-smoke \
   --print-session-token
 ```
@@ -262,6 +263,8 @@ python3 backend/scripts/private_mail_http_smoke.py \
 `naruon_session` 쿠키가 갱신되어 API로 임포트한 메일이 브라우저와 동일 세션에서 보입니다.
 `session_check=ok` 로그는 세션 클레임이 브라우저에서 확인되었음을 뜻하고,
 `session_check=failed(...)`는 토큰 검증/클레임 파싱 문제가 있음을 뜻합니다.
+`--require-browser-visible`은 동일 토큰을 `Cookie: naruon_session=...`로 주입해
+`/api/emails` 응답을 조회해 브라우저 프록시 경로까지 반영 확인이 되도록 합니다.
 
 동기화 지연이 큰 환경에서는 재시도 옵션을 조정할 수 있습니다.
 
@@ -291,6 +294,11 @@ podman system connection ls
 
 # MLX(OpenAI-compatible) 엔드포인트 노출 확인
 curl -sf http://127.0.0.1:11434/v1/models | head
+
+# 기존 웹 서비스(Nginx/프록시)가 3000/8000/11434를 가로채고 있지 않은지 확인
+lsof -iTCP:3000 -sTCP:LISTEN
+lsof -iTCP:8000 -sTCP:LISTEN
+lsof -iTCP:11434 -sTCP:LISTEN
 ```
 
 백엔드 API를 바로 확인하려면(필요 시):

--- a/backend/scripts/private_mail_http_smoke.py
+++ b/backend/scripts/private_mail_http_smoke.py
@@ -302,6 +302,7 @@ def _request(
     body: bytes | None = None,
     content_type: str | None = None,
     timeout: float = 120.0,
+    use_cookie_only: bool = False,
 ) -> tuple[int, bytes]:
     parsed = urlsplit(base_url)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
@@ -309,11 +310,12 @@ def _request(
     cls = http.client.HTTPSConnection if parsed.scheme == "https" else http.client.HTTPConnection
     conn = cls(parsed.hostname, parsed.port, timeout=timeout)
     headers = {
-        "Authorization": f"Bearer {token}",
         "Cookie": f"{SESSION_COOKIE_NAME}={token}",
         "Origin": base_url,
         "Referer": f"{base_url}/",
     }
+    if not use_cookie_only:
+        headers["Authorization"] = f"Bearer {token}"
     if content_type:
         headers["Content-Type"] = content_type
     try:
@@ -389,6 +391,7 @@ def _request_json_with_retry(
     timeout: float = 120.0,
     body: bytes | None = None,
     content_type: str | None = None,
+    use_cookie_only: bool = False,
 ) -> dict[str, object]:
     _ensure_positive_retry_budget(attempts, "retry-attempts")
     for attempt in range(attempts):
@@ -400,6 +403,7 @@ def _request_json_with_retry(
                 path,
                 body=body,
                 content_type=content_type,
+                use_cookie_only=use_cookie_only,
                 timeout=timeout,
             )
             return _json_or_empty(status, raw)
@@ -475,6 +479,7 @@ def _get_json_with_retry(
     attempts: int,
     delay_seconds: float,
     timeout: float = 120.0,
+    use_cookie_only: bool = False,
 ) -> dict[str, object]:
     return _request_json_with_retry(
         base_url,
@@ -484,7 +489,42 @@ def _get_json_with_retry(
         attempts=attempts,
         delay_seconds=delay_seconds,
         timeout=timeout,
+        use_cookie_only=use_cookie_only,
     )
+
+
+def _fetch_inbox_snapshot(
+    base_url: str,
+    token: str,
+    *,
+    limit: int,
+    min_count: int,
+    attempts: int,
+    use_cookie_only: bool = False,
+    delay_seconds: float,
+    timeout: float = 120.0,
+) -> tuple[dict[str, object], int]:
+    """Fetch /api/emails repeatedly until the minimum expected count is observed."""
+    last_data: dict[str, object] = {}
+    min_count = max(0, min_count)
+    for attempt in range(attempts):
+        data = _get_json_with_retry(
+            base_url,
+            token,
+            f"/api/emails?limit={limit}",
+            attempts=1,
+            delay_seconds=0.0,
+            timeout=timeout,
+            use_cookie_only=use_cookie_only,
+        )
+        emails = data.get("emails")
+        count = len(emails) if isinstance(emails, list) else 0
+        last_data = data
+        if count >= min_count or attempt == attempts - 1:
+            return data, count
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+    return last_data, 0
 
 
 def _check_frontend_session(base_url: str, token: str) -> dict[str, object] | None:
@@ -620,6 +660,11 @@ def main() -> None:
         type=float,
         default=SEARCH_RETRY_DEFAULT_DELAY_SECONDS,
     )
+    parser.add_argument(
+        "--require-browser-visible",
+        action="store_true",
+        help="Require browser-proxied inbox visibility check after import",
+    )
     parser.add_argument("--max-parse-bytes", type=int, default=2_000_000)
     parser.add_argument("--progress-every", type=int, default=0)
     args = parser.parse_args()
@@ -673,31 +718,49 @@ def main() -> None:
                 if isinstance(item, dict) and item.get("reason_code"):
                     reasons[str(item["reason_code"])] += 1
 
-        inbox = _get_json_with_retry(
+        expected_min_count = totals["imported"]
+        api_limit = max(1, min(200, expected_min_count if expected_min_count else 1))
+
+        api_inbox, email_count = _fetch_inbox_snapshot(
             api_base_url,
             token,
-            "/api/emails?limit=1",
-            attempts=1,
-            delay_seconds=0.0,
+            limit=api_limit,
+            min_count=expected_min_count,
+            attempts=args.inbox_retry_attempts if expected_min_count > 0 else 1,
+            delay_seconds=args.inbox_retry_delay_seconds if expected_min_count > 0 else 0.0,
             timeout=120.0,
         )
-        if totals["imported"] > 0:
-            expected_min_count = totals["imported"]
-            for _ in range(args.inbox_retry_attempts - 1):
-                email_count = len(inbox.get("emails", [])) if isinstance(inbox.get("emails"), list) else 0
-                if email_count >= expected_min_count:
-                    break
-                if args.inbox_retry_delay_seconds > 0:
-                    time.sleep(args.inbox_retry_delay_seconds)
-                inbox = _get_json_with_retry(
-                    api_base_url,
-                    token,
-                    "/api/emails?limit=1",
-                    attempts=1,
-                    delay_seconds=0.0,
-                    timeout=120.0,
-                )
-        email_count = len(inbox.get("emails", []))
+        frontend_inbox_count = 0
+        if args.require_browser_visible:
+            _, frontend_inbox_count = _fetch_inbox_snapshot(
+                frontend_base_url,
+                token,
+                limit=api_limit,
+                min_count=expected_min_count,
+                use_cookie_only=True,
+                attempts=args.inbox_retry_attempts,
+                delay_seconds=args.inbox_retry_delay_seconds,
+                timeout=120.0,
+            )
+        elif frontend_base_url.rstrip("/") != api_base_url.rstrip("/"):
+            _, frontend_inbox_count = _fetch_inbox_snapshot(
+                frontend_base_url,
+                token,
+                limit=api_limit,
+                min_count=0,
+                attempts=args.inbox_retry_attempts,
+                delay_seconds=args.inbox_retry_delay_seconds,
+                timeout=120.0,
+            )
+
+        if (
+            args.require_browser_visible
+            and expected_min_count > 0
+            and frontend_inbox_count < expected_min_count
+        ):
+            raise SystemExit(
+                f"browser inbox not reflecting import yet: imported={totals['imported']} frontend_inbox_count={frontend_inbox_count}"
+            )
 
         search_counts: dict[str, int] = {}
         first_result_id = None
@@ -731,7 +794,11 @@ def main() -> None:
         draft_status = "skipped"
         target_id = first_result_id
         if target_id is None and email_count:
-            target_id = inbox["emails"][0]["id"]
+            first = api_inbox.get("emails", [])
+            if isinstance(first, list) and first:
+                candidate = first[0]
+                if isinstance(candidate, dict):
+                    target_id = candidate.get("id")
         if args.llm_smoke and target_id is not None:
             status, raw = _request(api_base_url, token, "GET", f"/api/emails/{target_id}")
             detail = _json_or_empty(status, raw)
@@ -764,6 +831,7 @@ def main() -> None:
             f"selected={len(files)} imported={totals['imported']} "
             f"skipped={totals['skipped']} failed={totals['failed']} "
             f"attachments={totals['attachments']} inbox_visible={email_count} "
+            f"frontend_inbox_visible={frontend_inbox_count} "
             f"search_counts={search_counts} reason_counts={dict(reasons)} "
             f"llm={llm_status} draft={draft_status}"
         )

--- a/backend/scripts/private_mail_http_smoke.py
+++ b/backend/scripts/private_mail_http_smoke.py
@@ -507,6 +507,7 @@ def _fetch_inbox_snapshot(
     """Fetch /api/emails repeatedly until the minimum expected count is observed."""
     last_data: dict[str, object] = {}
     min_count = max(0, min_count)
+    _ensure_positive_retry_budget(attempts, "inbox-retry-attempts")
     for attempt in range(attempts):
         data = _get_json_with_retry(
             base_url,
@@ -540,6 +541,7 @@ def _fetch_search_snapshot(
 ) -> tuple[dict[str, object], int]:
     """Fetch /api/search repeatedly until query results are available."""
     last_data: dict[str, object] = {}
+    _ensure_positive_retry_budget(attempts, "search-retry-attempts")
     for attempt in range(attempts):
         data = _request_json_with_retry(
             base_url,
@@ -756,12 +758,13 @@ def main() -> None:
 
         expected_min_count = totals["imported"]
         api_limit = max(1, min(200, expected_min_count if expected_min_count else 1))
+        visible_min_count = min(expected_min_count, api_limit)
 
         api_inbox, email_count = _fetch_inbox_snapshot(
             api_base_url,
             token,
             limit=api_limit,
-            min_count=expected_min_count,
+            min_count=visible_min_count,
             attempts=args.inbox_retry_attempts if expected_min_count > 0 else 1,
             delay_seconds=args.inbox_retry_delay_seconds if expected_min_count > 0 else 0.0,
             timeout=120.0,
@@ -772,7 +775,7 @@ def main() -> None:
                 frontend_base_url,
                 token,
                 limit=api_limit,
-                min_count=expected_min_count,
+                min_count=visible_min_count,
                 use_cookie_only=True,
                 attempts=args.inbox_retry_attempts,
                 delay_seconds=args.inbox_retry_delay_seconds,
@@ -792,10 +795,10 @@ def main() -> None:
         if (
             args.require_browser_visible
             and expected_min_count > 0
-            and frontend_inbox_count < expected_min_count
+            and frontend_inbox_count < visible_min_count
         ):
             raise SystemExit(
-                f"browser inbox not reflecting import yet: imported={totals['imported']} frontend_inbox_count={frontend_inbox_count}"
+                f"browser inbox not reflecting import yet: imported={totals['imported']} visible_min_count={visible_min_count} frontend_inbox_count={frontend_inbox_count}"
             )
 
         search_counts: dict[str, int] = {}

--- a/backend/scripts/private_mail_http_smoke.py
+++ b/backend/scripts/private_mail_http_smoke.py
@@ -527,6 +527,42 @@ def _fetch_inbox_snapshot(
     return last_data, 0
 
 
+def _fetch_search_snapshot(
+    base_url: str,
+    token: str,
+    query: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    timeout: float = 120.0,
+    use_cookie_only: bool = False,
+    limit: int = 3,
+) -> tuple[dict[str, object], int]:
+    """Fetch /api/search repeatedly until query results are available."""
+    last_data: dict[str, object] = {}
+    for attempt in range(attempts):
+        data = _request_json_with_retry(
+            base_url,
+            token,
+            "POST",
+            "/api/search",
+            body=json.dumps({"query": query, "limit": limit}).encode(),
+            content_type="application/json",
+            attempts=1,
+            delay_seconds=0.0,
+            timeout=timeout,
+            use_cookie_only=use_cookie_only,
+        )
+        results = data.get("results")
+        count = len(results) if isinstance(results, list) else 0
+        last_data = data
+        if count > 0 or attempt == attempts - 1:
+            return data, count
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+    return last_data, 0
+
+
 def _check_frontend_session(base_url: str, token: str) -> dict[str, object] | None:
     try:
         data = _post_json_with_retry(
@@ -763,28 +799,36 @@ def main() -> None:
             )
 
         search_counts: dict[str, int] = {}
+        frontend_search_counts: dict[str, int] = {}
         first_result_id = None
         for index, query in enumerate(args.query, start=1):
-            search = None
-            for _ in range(args.search_retry_attempts):
-                search = _post_json_with_retry(
-                    api_base_url,
+            api_search, api_results_count = _fetch_search_snapshot(
+                api_base_url,
+                token,
+                query,
+                attempts=args.search_retry_attempts,
+                delay_seconds=args.search_retry_delay_seconds,
+                timeout=300.0,
+            )
+            search_counts[f"query_{index}"] = api_results_count
+            if args.require_browser_visible:
+                frontend_search, frontend_results_count = _fetch_search_snapshot(
+                    frontend_base_url,
                     token,
-                    "/api/search",
-                    {"query": query, "limit": 3},
-                    attempts=1,
-                    delay_seconds=0.0,
+                    query,
+                    attempts=args.search_retry_attempts,
+                    delay_seconds=args.search_retry_delay_seconds,
                     timeout=300.0,
+                    use_cookie_only=True,
                 )
-                results = search.get("results", [])
-                if results:
-                    break
-                if _ < args.search_retry_attempts - 1 and args.search_retry_delay_seconds > 0:
-                    time.sleep(args.search_retry_delay_seconds)
-            if search is None:
-                raise RuntimeError("unreachable")
-            results = search.get("results", [])
-            search_counts[f"query_{index}"] = len(results) if isinstance(results, list) else 0
+                frontend_search_counts[f"query_{index}"] = frontend_results_count
+                if api_results_count > 0 and frontend_results_count == 0:
+                    raise SystemExit(
+                        f"browser search mismatch: query={query!r} api_results={api_results_count} "
+                        f"frontend_results={frontend_results_count}"
+                    )
+
+            results = api_search.get("results", [])
             if first_result_id is None and isinstance(results, list) and results:
                 first = results[0]
                 if isinstance(first, dict):
@@ -832,7 +876,8 @@ def main() -> None:
             f"skipped={totals['skipped']} failed={totals['failed']} "
             f"attachments={totals['attachments']} inbox_visible={email_count} "
             f"frontend_inbox_visible={frontend_inbox_count} "
-            f"search_counts={search_counts} reason_counts={dict(reasons)} "
+            f"search_counts={search_counts} frontend_search_counts={frontend_search_counts} "
+            f"reason_counts={dict(reasons)} "
             f"llm={llm_status} draft={draft_status}"
         )
         _print_session_sync_hints(

--- a/backend/tests/test_private_mail_http_smoke.py
+++ b/backend/tests/test_private_mail_http_smoke.py
@@ -215,6 +215,94 @@ def test_post_json_with_retry_raises_network_error_after_retries(monkeypatch):
     assert len(calls) == 2
 
 
+def test_fetch_inbox_snapshot_retries_until_minimum(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_get_json_with_retry(
+        base_url: str,
+        token: str,
+        path: str,
+        *,
+        attempts: int,
+        delay_seconds: float,
+        timeout: float = 120.0,
+    ) -> dict[str, object]:
+        calls.append((base_url, path))
+        if len(calls) == 1:
+            return {"emails": []}
+        return {"emails": [{"id": "a"}, {"id": "b"}]}
+
+    monkeypatch.setattr(smoke, "_get_json_with_retry", fake_get_json_with_retry)
+    data, count = smoke._fetch_inbox_snapshot(
+        "http://127.0.0.1:8000",
+        "token",
+        limit=10,
+        min_count=2,
+        attempts=3,
+        delay_seconds=0.0,
+    )
+    assert count == 2
+    assert isinstance(data.get("emails"), list)
+    assert len(calls) == 2
+
+
+def test_fetch_inbox_snapshot_does_not_wait_when_min_count_is_zero(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_get_json_with_retry(
+        base_url: str,
+        token: str,
+        path: str,
+        *,
+        attempts: int,
+        delay_seconds: float,
+        timeout: float = 120.0,
+    ) -> dict[str, object]:
+        calls.append((base_url, path))
+        return {"emails": []}
+
+    monkeypatch.setattr(smoke, "_get_json_with_retry", fake_get_json_with_retry)
+    _, count = smoke._fetch_inbox_snapshot(
+        "http://127.0.0.1:8000",
+        "token",
+        limit=10,
+        min_count=0,
+        attempts=3,
+        delay_seconds=0.0,
+    )
+    assert count == 0
+    assert len(calls) == 1
+
+
+def test_fetch_inbox_snapshot_uses_cookie_only_mode_when_requested(monkeypatch):
+    calls: list[tuple[str, bool, str]] = []
+
+    def fake_get_json_with_retry(
+        base_url: str,
+        token: str,
+        path: str,
+        *,
+        attempts: int,
+        delay_seconds: float,
+        use_cookie_only: bool = False,
+        timeout: float = 120.0,
+    ) -> dict[str, object]:
+        calls.append((base_url, use_cookie_only, path))
+        return {"emails": []}
+
+    monkeypatch.setattr(smoke, "_get_json_with_retry", fake_get_json_with_retry)
+    smoke._fetch_inbox_snapshot(
+        "http://127.0.0.1:3000",
+        "token",
+        limit=10,
+        min_count=0,
+        use_cookie_only=True,
+        attempts=1,
+        delay_seconds=0.0,
+    )
+    assert calls == [("http://127.0.0.1:3000", True, "/api/emails?limit=10")]
+
+
 def test_check_frontend_session_skips_on_missing_frontend(monkeypatch):
     monkeypatch.setattr(
         smoke,

--- a/backend/tests/test_private_mail_http_smoke.py
+++ b/backend/tests/test_private_mail_http_smoke.py
@@ -282,6 +282,18 @@ def test_fetch_inbox_snapshot_does_not_wait_when_min_count_is_zero(monkeypatch):
     assert len(calls) == 1
 
 
+def test_fetch_inbox_snapshot_rejects_empty_retry_budget():
+    with pytest.raises(SystemExit):
+        smoke._fetch_inbox_snapshot(
+            "http://127.0.0.1:8000",
+            "token",
+            limit=10,
+            min_count=1,
+            attempts=0,
+            delay_seconds=0.0,
+        )
+
+
 def test_fetch_search_snapshot_retries_until_results(monkeypatch):
     calls: list[dict[str, object]] = []
 
@@ -366,6 +378,17 @@ def test_fetch_search_snapshot_respects_cookie_only(monkeypatch):
 
     assert count == 0
     assert calls == [True]
+
+
+def test_fetch_search_snapshot_rejects_empty_retry_budget():
+    with pytest.raises(SystemExit):
+        smoke._fetch_search_snapshot(
+            "http://127.0.0.1:8000",
+            "token",
+            "hello",
+            attempts=0,
+            delay_seconds=0.0,
+        )
 
 
 def test_fetch_inbox_snapshot_uses_cookie_only_mode_when_requested(monkeypatch):

--- a/backend/tests/test_private_mail_http_smoke.py
+++ b/backend/tests/test_private_mail_http_smoke.py
@@ -1,3 +1,4 @@
+import json
 from zipfile import ZipFile
 
 import pytest
@@ -272,6 +273,92 @@ def test_fetch_inbox_snapshot_does_not_wait_when_min_count_is_zero(monkeypatch):
     )
     assert count == 0
     assert len(calls) == 1
+
+
+def test_fetch_search_snapshot_retries_until_results(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_request_json_with_retry(
+        base_url: str,
+        token: str,
+        method: str,
+        path: str,
+        *,
+        body: bytes,
+        content_type: str | None = None,
+        attempts: int,
+        delay_seconds: float,
+        timeout: float = 120.0,
+        use_cookie_only: bool = False,
+    ) -> dict[str, object]:
+        payload = json.loads(body.decode())
+        calls.append(
+            {
+                "method": method,
+                "path": path,
+                "query": payload["query"],
+                "limit": payload["limit"],
+                "content_type": content_type,
+                "use_cookie_only": use_cookie_only,
+            }
+        )
+        if len(calls) == 1:
+            return {"results": []}
+        return {"results": [{"id": "mail-001"}]}
+
+    monkeypatch.setattr(smoke, "_request_json_with_retry", fake_request_json_with_retry)
+    data, count = smoke._fetch_search_snapshot(
+        "http://127.0.0.1:8000",
+        "token",
+        "hello",
+        attempts=3,
+        delay_seconds=0.0,
+        limit=3,
+    )
+
+    assert count == 1
+    assert data["results"] == [{"id": "mail-001"}]
+    assert len(calls) == 2
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["path"] == "/api/search"
+    assert calls[0]["query"] == "hello"
+    assert calls[0]["limit"] == 3
+    assert calls[0]["content_type"] == "application/json"
+    assert calls[0]["use_cookie_only"] is False
+
+
+def test_fetch_search_snapshot_respects_cookie_only(monkeypatch):
+    calls: list[bool] = []
+
+    def fake_request_json_with_retry(
+        base_url: str,
+        token: str,
+        method: str,
+        path: str,
+        *,
+        body: bytes,
+        content_type: str | None = None,
+        attempts: int,
+        delay_seconds: float,
+        timeout: float = 120.0,
+        use_cookie_only: bool = False,
+    ) -> dict[str, object]:
+        calls.append(use_cookie_only)
+        return {"results": []}
+
+    monkeypatch.setattr(smoke, "_request_json_with_retry", fake_request_json_with_retry)
+    _, count = smoke._fetch_search_snapshot(
+        "http://127.0.0.1:3000",
+        "token",
+        "korean",
+        attempts=1,
+        delay_seconds=0.0,
+        use_cookie_only=True,
+        limit=3,
+    )
+
+    assert count == 0
+    assert calls == [True]
 
 
 def test_fetch_inbox_snapshot_uses_cookie_only_mode_when_requested(monkeypatch):

--- a/backend/tests/test_private_mail_http_smoke.py
+++ b/backend/tests/test_private_mail_http_smoke.py
@@ -96,7 +96,8 @@ def test_strip_emlx_prefix(raw, expected):
 def test_post_json_with_retry_retries_transient_statuses(monkeypatch):
     calls: list[tuple[str, str]] = []
 
-    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+    def fake_request(*args, **_unused):
+        method, path = args[2], args[3]
         calls.append((method, path))
         if len(calls) == 1:
             return 503, b"retry-later"
@@ -122,7 +123,8 @@ def test_post_json_with_retry_retries_transient_statuses(monkeypatch):
 def test_post_json_with_retry_stops_on_non_transient_status(monkeypatch):
     calls = []
 
-    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+    def fake_request(*args, **_unused):
+        method, path = args[2], args[3]
         calls.append((method, path))
         return 401, b"unauthorized"
 
@@ -149,7 +151,8 @@ def test_json_or_empty_raises_bad_response_for_html_payload():
 def test_request_json_with_retry_no_retry_after_bad_response(monkeypatch):
     calls: list[tuple[str, str]] = []
 
-    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+    def fake_request(*args, **_unused):
+        method, path = args[2], args[3]
         calls.append((method, path))
         return 200, b"<html></html>"
 
@@ -171,7 +174,8 @@ def test_request_json_with_retry_no_retry_after_bad_response(monkeypatch):
 def test_post_json_with_retry_retries_network_error(monkeypatch):
     calls: list[tuple[str, str]] = []
 
-    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+    def fake_request(*args, **_unused):
+        method, path = args[2], args[3]
         calls.append((method, path))
         if len(calls) == 1:
             raise smoke._RequestNetworkError("connection refused")
@@ -196,7 +200,8 @@ def test_post_json_with_retry_retries_network_error(monkeypatch):
 def test_post_json_with_retry_raises_network_error_after_retries(monkeypatch):
     calls: list[tuple[str, str]] = []
 
-    def fake_request(base_url, token, method, path, *, body=None, content_type=None, timeout=120.0):
+    def fake_request(*args, **_unused):
+        method, path = args[2], args[3]
         calls.append((method, path))
         raise smoke._RequestNetworkError("connection refused")
 
@@ -227,6 +232,7 @@ def test_fetch_inbox_snapshot_retries_until_minimum(monkeypatch):
         attempts: int,
         delay_seconds: float,
         timeout: float = 120.0,
+        **_unused,
     ) -> dict[str, object]:
         calls.append((base_url, path))
         if len(calls) == 1:
@@ -258,6 +264,7 @@ def test_fetch_inbox_snapshot_does_not_wait_when_min_count_is_zero(monkeypatch):
         attempts: int,
         delay_seconds: float,
         timeout: float = 120.0,
+        **_unused,
     ) -> dict[str, object]:
         calls.append((base_url, path))
         return {"emails": []}


### PR DESCRIPTION
## Summary
- Add dedicated `_fetch_search_snapshot` helper for polling `/api/search` with retry and optional `use_cookie_only`.
- Fix `--require-browser-visible` flow so inbox/search visibility checks use cookie-authed frontend path and do not overwrite with API-only counts.
- Add mismatch guard: if API has search hits but frontend-cookie search returns zero, fail with explicit `browser search mismatch`.
- Add unit tests for search retry/cookie-only propagation and align existing request fakes with transport keyword options.
- Scope AKS deploy reusable-workflow secrets to `AKS_KUBECONFIG` instead of inheriting every repository secret.

## Testing
- `python3 -m py_compile backend/scripts/private_mail_http_smoke.py backend/tests/test_private_mail_http_smoke.py`
- `git diff --check`
- `PYTHONPATH=backend python3 - <<'PY' ... private_mail_http_smoke self-check ok`
- GitHub Actions: Application CI backend/frontend passed on `8ae621a8`; new head `4b26a490` is rerunning after Strix secret-scope fix.
