### PR TITLE
🔒 배포 워크플로우 secret inheritance 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy to AKS
 
 on:
   workflow_call:
+    secrets:
+      AKS_KUBECONFIG:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -344,4 +344,5 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       needs.deploy_preflight.outputs.aks_kubeconfig_configured == 'true'
     uses: ./.github/workflows/deploy.yml
-    secrets: inherit
+    secrets:
+      AKS_KUBECONFIG: ${{ secrets.AKS_KUBECONFIG }}


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` in `docker-publish.yml` with an explicit `AKS_KUBECONFIG` mapping.
- Declare `AKS_KUBECONFIG` as the only reusable-workflow secret in `deploy.yml`.

## Verification
- `actionlint .github/workflows/deploy.yml .github/workflows/docker-publish.yml`
- `git diff --check`

## Context
Strix reported `.github/workflows/docker-publish.yml:347` as a critical GitHub Actions secret inheritance finding while reviewing #868. This keeps the deploy path least-privilege and unblocks downstream PR checks without broadening unrelated product changes.
