### PR TITLE
🔒 OIDC JWKS issuer host 검증 강화

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -7,7 +7,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from core.runtime_secrets import (
     validate_auth_session_hmac_secret_value,
 )
-from core.url_validation import parse_allowed_hosts, validate_https_url_host
+from core.url_validation import (
+    parse_allowed_hosts,
+    validate_https_url_host_details,
+    validate_same_or_subdomain_host,
+)
 
 DEFAULT_ORIGIN_PORTS = {
     "http": 80,
@@ -139,17 +143,23 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "ALLOWED_OIDC_HOSTS must list trusted OIDC issuer and JWKS hosts"
                 )
-            validate_https_url_host(
+            issuer_url = validate_https_url_host_details(
                 "OIDC_ISSUER_URL",
                 self.OIDC_ISSUER_URL or "",
                 allowed_oidc_hosts,
                 "ALLOWED_OIDC_HOSTS",
             )
-            validate_https_url_host(
+            jwks_url = validate_https_url_host_details(
                 "OIDC_JWKS_URL",
                 self.OIDC_JWKS_URL or "",
                 allowed_oidc_hosts,
                 "ALLOWED_OIDC_HOSTS",
+            )
+            validate_same_or_subdomain_host(
+                "OIDC_JWKS_URL",
+                jwks_url.hostname,
+                "OIDC_ISSUER_URL",
+                issuer_url.hostname,
             )
         return self
 

--- a/backend/core/url_validation.py
+++ b/backend/core/url_validation.py
@@ -37,6 +37,19 @@ def validate_https_url_host(
     )
 
 
+def validate_same_or_subdomain_host(
+    setting_name: str,
+    host: str,
+    base_setting_name: str,
+    base_host: str,
+) -> None:
+    if host == base_host or host.endswith(f".{base_host}"):
+        return
+    raise ValueError(
+        f"{setting_name} host must match or be a subdomain of {base_setting_name} host"
+    )
+
+
 def validate_https_url_host_details(
     setting_name: str,
     url_value: str,

--- a/backend/scripts/start_backend.py
+++ b/backend/scripts/start_backend.py
@@ -11,7 +11,11 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from core.runtime_secrets import validate_auth_session_hmac_secret_value  # noqa: E402
-from core.url_validation import parse_allowed_hosts, validate_https_url_host  # noqa: E402
+from core.url_validation import (  # noqa: E402
+    parse_allowed_hosts,
+    validate_https_url_host_details,
+    validate_same_or_subdomain_host,
+)
 
 DEFAULT_SERVER_HOST = "127.0.0.1"
 DEFAULT_SERVER_PORT = 8000
@@ -95,13 +99,33 @@ def validate_runtime_settings() -> list[str]:
                 "ALLOWED_OIDC_HOSTS must list trusted OIDC issuer and JWKS hosts"
             )
         else:
-            for setting_name in ("OIDC_ISSUER_URL", "OIDC_JWKS_URL"):
+            issuer_url = None
+            jwks_url = None
+            try:
+                issuer_url = validate_https_url_host_details(
+                    "OIDC_ISSUER_URL",
+                    values["OIDC_ISSUER_URL"],
+                    allowed_oidc_hosts,
+                    "ALLOWED_OIDC_HOSTS",
+                )
+            except ValueError as exc:
+                messages.append(str(exc))
+            try:
+                jwks_url = validate_https_url_host_details(
+                    "OIDC_JWKS_URL",
+                    values["OIDC_JWKS_URL"],
+                    allowed_oidc_hosts,
+                    "ALLOWED_OIDC_HOSTS",
+                )
+            except ValueError as exc:
+                messages.append(str(exc))
+            if issuer_url is not None and jwks_url is not None:
                 try:
-                    validate_https_url_host(
-                        setting_name,
-                        values[setting_name],
-                        allowed_oidc_hosts,
-                        "ALLOWED_OIDC_HOSTS",
+                    validate_same_or_subdomain_host(
+                        "OIDC_JWKS_URL",
+                        jwks_url.hostname,
+                        "OIDC_ISSUER_URL",
+                        issuer_url.hostname,
                     )
                 except ValueError as exc:
                     messages.append(str(exc))

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -348,6 +348,30 @@ def test_oidc_settings_accept_complete_configuration(monkeypatch):
     assert loaded_settings.OIDC_CLIENT_ID == "naruon-api"
 
 
+def test_oidc_settings_reject_jwks_host_outside_issuer_domain(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"
+    )
+    monkeypatch.setenv("AUTH_SESSION_HMAC_SECRET", TEST_AUTH_SESSION_HMAC_SECRET)
+    monkeypatch.setenv("OIDC_ISSUER_URL", "https://login.example.com/realms/naruon")
+    monkeypatch.setenv("OIDC_CLIENT_ID", "naruon-api")
+    monkeypatch.setenv("OIDC_JWKS_URL", "https://jwks.example.com/realms/naruon/jwks")
+    monkeypatch.setenv("ALLOWED_OIDC_HOSTS", "login.example.com,jwks.example.com")
+    _patch_oidc_dns(
+        monkeypatch,
+        {
+            "login.example.com": ["93.184.216.34"],
+            "jwks.example.com": ["93.184.216.34"],
+        },
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="OIDC_JWKS_URL host must match or be a subdomain of OIDC_ISSUER_URL host",
+    ):
+        _settings_without_env_file()
+
+
 def test_oidc_settings_reject_hostname_resolving_private_address(monkeypatch):
     monkeypatch.setenv(
         "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"

--- a/backend/tests/test_start_backend.py
+++ b/backend/tests/test_start_backend.py
@@ -18,11 +18,19 @@ def _clear_runtime_settings(monkeypatch) -> None:
         monkeypatch.delenv(setting_name, raising=False)
 
 
-def _patch_oidc_dns(monkeypatch, address: str) -> None:
+def _patch_oidc_dns(monkeypatch, address: str | dict[str, list[str]]) -> None:
+    addresses_by_host = (
+        {"login.example.test": [address]} if isinstance(address, str) else address
+    )
+
     def fake_getaddrinfo(host: str, port: int, *args, **kwargs):
-        if host != "login.example.test":
+        addresses = addresses_by_host.get(host)
+        if addresses is None:
             raise socket.gaierror(f"test DNS blocked for {host}")
-        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (resolved_address, port))
+            for resolved_address in addresses
+        ]
 
     monkeypatch.setattr("core.url_validation.socket.getaddrinfo", fake_getaddrinfo)
 
@@ -123,6 +131,33 @@ def test_start_backend_rejects_untrusted_oidc_jwks_host(monkeypatch, tmp_path):
 
     assert start_backend.validate_runtime_settings() == [
         "OIDC_JWKS_URL host must be listed in ALLOWED_OIDC_HOSTS"
+    ]
+
+
+def test_start_backend_rejects_oidc_jwks_host_outside_issuer_domain(
+    monkeypatch, tmp_path
+):
+    _clear_runtime_settings(monkeypatch)
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_db"
+    )
+    monkeypatch.setenv("AUTH_SESSION_HMAC_SECRET", secrets.token_urlsafe(48))
+    monkeypatch.setenv("OIDC_ISSUER_URL", "https://login.example.test/realms/naruon")
+    monkeypatch.setenv("OIDC_CLIENT_ID", "naruon-api")
+    monkeypatch.setenv("OIDC_JWKS_URL", "https://jwks.example.test/realms/naruon/jwks")
+    monkeypatch.setenv("ALLOWED_OIDC_HOSTS", "login.example.test,jwks.example.test")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path)
+    _patch_oidc_dns(
+        monkeypatch,
+        {
+            "login.example.test": ["93.184.216.34"],
+            "jwks.example.test": ["93.184.216.34"],
+        },
+    )
+
+    assert start_backend.validate_runtime_settings() == [
+        "OIDC_JWKS_URL host must match or be a subdomain of OIDC_ISSUER_URL host"
     ]
 
 


### PR DESCRIPTION
## Summary
- Validate `OIDC_JWKS_URL` host against `OIDC_ISSUER_URL` after the existing HTTPS/allowlist checks.
- Apply the same validation in startup preflight so invalid runtime config is reported before boot.
- Add regression tests for config loading and startup preflight.

## Verification
- `/tmp/naruoncs/oidc-venv/bin/python -m pytest -q backend/tests/test_config.py backend/tests/test_start_backend.py backend/tests/test_url_validation.py` (`60 passed`)
- `/tmp/naruoncs/oidc-venv/bin/ruff check backend/core/config.py backend/core/url_validation.py backend/scripts/start_backend.py backend/tests/test_config.py backend/tests/test_start_backend.py`
- `git diff --check`

## Context
Strix reported `backend/core/config.py:120` as a critical OIDC configuration validation gap while reviewing #868. This fixes the root validation path instead of suppressing the scanner finding.
