### PR TITLE
🎨 Palette: 커스텀 검색창에서 네이티브 WebKit clear 버튼 겹침 방지

### DIFF
--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -439,7 +439,7 @@ describe("SearchPage", () => {
 
     const input = container.querySelector("#search-input") as HTMLInputElement | null;
     expect(input).not.toBeNull();
-    expect(input?.type).toBe("search");
+    expect(input?.type).toBe("text");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
     expect(

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -137,7 +137,7 @@ describe("TasksPage", () => {
 
     const taskSearchInput = container.querySelector<HTMLInputElement>('input[aria-label="작업 맥락 검색"]');
     expect(taskSearchInput).not.toBeNull();
-    expect(taskSearchInput?.type).toBe("search");
+    expect(taskSearchInput?.type).toBe("text");
     expect(taskSearchInput?.inputMode).toBe("search");
     expect(taskSearchInput?.getAttribute("role")).toBe("searchbox");
     await act(async () => {

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -92,7 +92,7 @@ describe("DashboardLayout", () => {
     expect(main).not.toBeNull();
     expect(skipLink).not.toBeNull();
     expect(logo?.getAttribute("src")).toBe("/brand/naruon-symbol.svg");
-    expect(globalSearchInput?.getAttribute("type")).toBe("search");
+    expect(globalSearchInput?.getAttribute("type")).toBe("text");
     expect(globalSearchInput?.getAttribute("inputmode")).toBe("search");
     expect(globalSearchInput?.getAttribute("role")).toBe("searchbox");
     expect(headerActionButtons).toEqual(["일정 반영", "답장 초안", "실행 항목 생성"]);
@@ -222,7 +222,7 @@ describe("DashboardLayout", () => {
 
     const input = container.querySelector<HTMLInputElement>("#global-search-input");
     expect(input).not.toBeNull();
-    expect(input?.getAttribute("type")).toBe("search");
+    expect(input?.getAttribute("type")).toBe("text");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
 

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -364,13 +364,13 @@ export function DashboardLayout({
             <input
               id="global-search-input"
               ref={globalSearchInputRef}
-              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:hidden"
+              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground"
               inputMode="search"
               role="searchbox"
               value={globalSearchQuery}
               onChange={(event) => setGlobalSearchQuery(event.target.value)}
               placeholder="맥락, 사람, 파일, 판단 포인트 맥락 검색..."
-              type="search"
+              type="text"
             />
             {globalSearchQuery ? (
               <button

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -220,10 +220,10 @@ export function EmailList({
               placeholder="메일, 사람, 키워드 맥락 검색..."
               value={searchQuery}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
-              type="search"
+              type="text"
               inputMode="search"
               role="searchbox"
-              className="h-10 rounded-xl [&::-webkit-search-cancel-button]:hidden border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02]"
+              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02]"
             />
             {searchQuery && (
               <button

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -509,14 +509,14 @@ export function SearchLayout() {
             <input
               id="search-input"
               ref={searchInputRef}
-              type="search"
+              type="text"
               inputMode="search"
               role="searchbox"
               aria-label="맥락 검색어 입력"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="메일, 일정, 파일, 사람, 의사결정 로그 맥락 검색..."
-              className="h-12 w-full [&::-webkit-search-cancel-button]:hidden rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
+              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
             />
             {query && (
               <button

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -326,14 +326,14 @@ export function TasksLayout() {
             <input
               ref={taskSearchInputRef}
               id="task-search-input"
-              type="search"
+              type="text"
               inputMode="search"
               role="searchbox"
               value={taskSearch}
               onChange={(event) => setTaskSearch(event.target.value)}
               placeholder="작업 맥락 검색..."
               aria-label="작업 맥락 검색"
-              className="h-9 w-full [&::-webkit-search-cancel-button]:hidden rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64"
+              className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64"
             />
             {taskSearch.length > 0 && (
               <button


### PR DESCRIPTION
💡 **What:** 
전역 맥락 검색, 메일 검색, 작업 검색 등에서 사용되는 커스텀 검색 입력창의 타입을 `type="search"`에서 `type="text"`로 변경하고, `inputMode="search"`와 `role="searchbox"` 속성을 명시적으로 유지했습니다.

🎯 **Why:** 
WebKit 기반 브라우저(Safari, Chrome 등)는 `<input type="search">`에 기본적으로 네이티브 '지우기(cancel)' 버튼을 주입합니다. 이 애플리케이션은 자체적인 커스텀 삭제 버튼 아이콘 컴포넌트를 제공하고 있었기 때문에, 특정 환경에서 네이티브 버튼과 커스텀 버튼이 두 개 겹쳐 보이는 UI 버그가 발생했습니다. 기존에 사용된 CSS WebKit hack (`[&::-webkit-search-cancel-button]:hidden`)은 브라우저 업데이트에 따라 불안정할 수 있으므로, HTML 스펙을 통해 원천적으로 차단했습니다.

📸 **Before/After:**
- Before: `<input type="search" className="[&::-webkit-search-cancel-button]:hidden ..." />`
- After: `<input type="text" inputMode="search" role="searchbox" className="..." />`

♿ **Accessibility:**
- `inputMode="search"`를 통해 모바일 기기에서 '검색' 키보드 레이아웃이 계속해서 정상적으로 호출됩니다.
- `role="searchbox"`를 통해 스크린 리더(VoiceOver, NVDA 등)가 여전히 해당 필드를 "검색 입력란"으로 올바르게 인식하고 읽어줍니다.

---
*PR created automatically by Jules for task [4863486493946799038](https://jules.google.com/task/4863486493946799038) started by @seonghobae*