### PR TITLE
Build Prompt Studio visual handoff surface

### DIFF
--- a/frontend/src/app/prompt-studio/page.test.tsx
+++ b/frontend/src/app/prompt-studio/page.test.tsx
@@ -4,11 +4,17 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("lucide-react", () => ({
+  AlertCircle: () => <svg aria-hidden="true" />,
   CheckIcon: () => <svg aria-hidden="true" />,
+  CheckCircle2: () => <svg aria-hidden="true" />,
   Code: () => <svg aria-hidden="true" />,
+  FileText: () => <svg aria-hidden="true" />,
   Loader2: () => <svg aria-hidden="true" data-testid="loader" />,
   Play: () => <svg aria-hidden="true" />,
   Save: () => <svg aria-hidden="true" />,
+  Share2: () => <svg aria-hidden="true" />,
+  Sparkles: () => <svg aria-hidden="true" />,
+  Variable: () => <svg aria-hidden="true" />,
 }));
 
 import PromptStudioPage from "./page";
@@ -43,6 +49,17 @@ function getButton(container: HTMLElement, label: string) {
   );
   expect(button).toBeInstanceOf(HTMLButtonElement);
   return button as HTMLButtonElement;
+}
+
+function setControlValue(control: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = control instanceof HTMLTextAreaElement
+    ? window.HTMLTextAreaElement.prototype
+    : window.HTMLInputElement.prototype;
+  const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+  act(() => {
+    valueSetter?.call(control, value);
+    control.dispatchEvent(new Event("input", { bubbles: true }));
+  });
 }
 
 function lowerCaseHeaders(headers: HeadersInit | undefined) {
@@ -111,7 +128,7 @@ describe("PromptStudioPage", () => {
       "prompt-title",
       "prompt-description",
       "prompt-content",
-      "test-variable",
+      "prompt-variable-email",
       "is_shared",
     ]) {
       expect(page.querySelector(`#${fieldId}`)).not.toBeNull();
@@ -158,8 +175,8 @@ describe("PromptStudioPage", () => {
     const promptSave = deferred<Response>();
     const fetchMock = vi.fn(() => promptSave.promise);
     vi.stubGlobal("fetch", fetchMock);
-    vi.stubGlobal("alert", vi.fn());
     const page = await renderPage();
+    setControlValue(page.querySelector<HTMLInputElement>("#prompt-title")!, "맥락 종합 프롬프트");
 
     act(() => {
       getButton(page, "프롬프트 저장 (Save)").click();
@@ -179,8 +196,8 @@ describe("PromptStudioPage", () => {
       "/api/prompts",
       expect.objectContaining({
         body: JSON.stringify({
-          title: "",
-          description: "",
+          title: "맥락 종합 프롬프트",
+          description: null,
           content: "핵심 맥락을 종합해주세요: {{email}}",
           is_shared: false,
         }),
@@ -189,5 +206,19 @@ describe("PromptStudioPage", () => {
       }),
     );
     expectNoPublicIdentityHeaders((fetchMock.mock.calls[0] as unknown as [RequestInfo, RequestInit?])?.[1]?.headers);
+    expect(page.textContent).toContain("AI 허브에서 실행 후보와 평가 근거로 연결됩니다.");
+  });
+
+  it("blocks save before required prompt metadata is present", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const page = await renderPage();
+
+    act(() => {
+      getButton(page, "프롬프트 저장 (Save)").click();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(page.querySelector("[role='alert']")?.textContent).toContain("프롬프트 이름을 입력하세요.");
   });
 });

--- a/frontend/src/app/prompt-studio/page.test.tsx
+++ b/frontend/src/app/prompt-studio/page.test.tsx
@@ -209,6 +209,29 @@ describe("PromptStudioPage", () => {
     expect(page.textContent).toContain("AI 허브에서 실행 후보와 평가 근거로 연결됩니다.");
   });
 
+  it("keeps prototype-like variable names as own payload fields", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ result: "안전한 실행 결과" })));
+    vi.stubGlobal("fetch", fetchMock);
+    const page = await renderPage();
+
+    setControlValue(page.querySelector<HTMLTextAreaElement>("#prompt-content")!, "검토: {{__proto__}}");
+    const variableInput = page.querySelector<HTMLTextAreaElement>("#prompt-variable-__proto__");
+    expect(variableInput).toBeInstanceOf(HTMLTextAreaElement);
+    expect(variableInput?.value).toBe("");
+
+    setControlValue(variableInput!, "프로토타입 안전 값");
+    act(() => {
+      getButton(page, "실행 (Test)").click();
+    });
+    await flushAsyncWork();
+
+    const requestInit = (fetchMock.mock.calls[0] as unknown as [RequestInfo, RequestInit])?.[1];
+    const payload = JSON.parse(String(requestInit.body));
+    expect(Object.prototype.hasOwnProperty.call(payload.variables, "__proto__")).toBe(true);
+    expect(payload.variables["__proto__"]).toBe("프로토타입 안전 값");
+    expectNoPublicIdentityHeaders(requestInit.headers);
+  });
+
   it("blocks save before required prompt metadata is present", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -1,132 +1,395 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { apiClient } from '@/lib/api-client';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Play, Save, Code, Loader2 } from 'lucide-react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Code,
+  FileText,
+  Loader2,
+  Play,
+  Save,
+  Share2,
+  Sparkles,
+  Variable,
+} from 'lucide-react';
+
+type PromptFormData = {
+  title: string;
+  description: string;
+  content: string;
+  is_shared: boolean;
+};
+
+const DEFAULT_CONTENT = '핵심 맥락을 종합해주세요: {{email}}';
+const DEFAULT_VARIABLE_VALUES: Record<string, string> = {
+  email: '메일 내용 예시입니다.',
+};
+const PLACEHOLDER_PATTERN = /\{\{([A-Za-z_][A-Za-z0-9_]{0,63})\}\}/g;
+
+function extractPromptVariables(content: string) {
+  const variables = new Set<string>();
+  for (const match of content.matchAll(PLACEHOLDER_PATTERN)) {
+    variables.add(match[1]);
+  }
+  return Array.from(variables);
+}
+
+function renderPromptPreview(content: string, variables: Record<string, string>) {
+  return content.replace(PLACEHOLDER_PATTERN, (placeholder, name: string) => {
+    const value = variables[name];
+    return value?.trim() ? value : placeholder;
+  });
+}
+
+function syncVariableValues(variableNames: string[], currentValues: Record<string, string>) {
+  const nextValues: Record<string, string> = {};
+  for (const variableName of variableNames) {
+    nextValues[variableName] = currentValues[variableName] ?? DEFAULT_VARIABLE_VALUES[variableName] ?? '';
+  }
+  return nextValues;
+}
+
+function getSafeErrorSummary(error: unknown, fallback: string) {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
 
 export default function PromptStudioPage() {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<PromptFormData>({
     title: '',
     description: '',
-    content: '핵심 맥락을 종합해주세요: {{email}}',
-    is_shared: false
+    content: DEFAULT_CONTENT,
+    is_shared: false,
   });
-  
-  const [testVariable, setTestVariable] = useState('메일 내용 예시입니다.');
+  const promptVariables = useMemo(() => extractPromptVariables(formData.content), [formData.content]);
+  const [variableValues, setVariableValues] = useState<Record<string, string>>(DEFAULT_VARIABLE_VALUES);
   const [testResult, setTestResult] = useState('');
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
+  const previewText = useMemo(
+    () => renderPromptPreview(formData.content, variableValues),
+    [formData.content, variableValues],
+  );
+
+  const setFormField = <Key extends keyof PromptFormData>(field: Key, value: PromptFormData[Key]) => {
+    setError(null);
+    setSaveStatus(null);
+    setFormData((current) => ({ ...current, [field]: value }));
+  };
+
+  const setPromptContent = (content: string) => {
+    setError(null);
+    setSaveStatus(null);
+    setFormData((current) => ({ ...current, content }));
+    setVariableValues((currentValues) => syncVariableValues(extractPromptVariables(content), currentValues));
+  };
+
+  const buildVariablesPayload = () =>
+    Object.fromEntries(promptVariables.map((variableName) => [variableName, variableValues[variableName] ?? '']));
+
+  const validateForSave = () => {
+    if (!formData.title.trim()) {
+      setError('프롬프트 이름을 입력하세요.');
+      return false;
+    }
+    if (!formData.content.trim()) {
+      setError('프롬프트 내용을 입력하세요.');
+      return false;
+    }
+    return true;
+  };
 
   const handleTest = async () => {
     setTesting(true);
     setError(null);
+    setSaveStatus(null);
     try {
       const data = await apiClient.post<{ result?: string }>('/api/prompts/test', {
         content: formData.content,
-        variables: { email: testVariable }
+        variables: buildVariablesPayload(),
       });
       setTestResult(data.result || '응답이 없습니다.');
     } catch (err: unknown) {
-      setError(((err as Error).message || '') || '테스트 실패');
+      setError(getSafeErrorSummary(err, '테스트 실패'));
     } finally {
       setTesting(false);
     }
   };
 
   const handleSave = async () => {
+    if (!validateForSave()) return;
     setSaving(true);
     setError(null);
+    setSaveStatus(null);
     try {
-      await apiClient.post<{ result?: string }>('/api/prompts', formData);
-      alert("성공적으로 저장되었습니다.");
+      await apiClient.post<{ result?: string }>('/api/prompts', {
+        title: formData.title.trim(),
+        description: formData.description.trim() || null,
+        content: formData.content,
+        is_shared: formData.is_shared,
+      });
+      setSaveStatus('프롬프트가 저장되었습니다. AI 허브에서 실행 후보와 평가 근거로 연결됩니다.');
     } catch (err: unknown) {
-      setError(((err as Error).message || '') || '저장 실패');
+      setError(getSafeErrorSummary(err, '저장 실패'));
     } finally {
       setSaving(false);
     }
   };
 
   return (
-    <div className="p-8 max-w-4xl mx-auto space-y-8">
-      <div>
-        <h1 className="text-2xl font-black text-foreground flex items-center gap-2 mb-2">
-          <Code className="w-6 h-6 text-primary" aria-hidden="true" />
-          Prompt Studio
-        </h1>
-        <p className="text-muted-foreground text-sm">프롬프트를 작성, 테스트, 저장하세요.</p>
-      </div>
-
-      <div className="space-y-4">
-        {error && <div className="text-red-500 text-sm bg-red-50 p-3 rounded-lg border border-red-100">{error}</div>}
-        
-        <div className="space-y-1.5">
-          <label htmlFor="prompt-title" className="text-sm font-medium">프롬프트 이름</label>
-          <Input
-            id="prompt-title"
-            placeholder="프롬프트 이름"
-            value={formData.title}
-            onChange={e => setFormData({ ...formData, title: e.target.value })}
-          />
-        </div>
-        <div className="space-y-1.5">
-          <label htmlFor="prompt-description" className="text-sm font-medium">설명</label>
-          <Input
-            id="prompt-description"
-            placeholder="설명"
-            value={formData.description}
-            onChange={e => setFormData({ ...formData, description: e.target.value })}
-          />
-        </div>
-        <div className="space-y-1.5">
-          <label htmlFor="prompt-content" className="text-sm font-medium">프롬프트 내용</label>
-          <Textarea
-            id="prompt-content"
-            className="min-h-[200px] font-mono text-sm"
-            value={formData.content}
-            onChange={e => setFormData({ ...formData, content: e.target.value })}
-          />
-        </div>
-        <div className="flex items-center space-x-2">
-          <Checkbox 
-            id="is_shared" 
-            checked={formData.is_shared} 
-            onCheckedChange={(checked) => setFormData({ ...formData, is_shared: !!checked })}
-          />
-          <label htmlFor="is_shared" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-            워크스페이스에 공유하기
-          </label>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 border-t border-border pt-6">
-        <div className="space-y-3">
-          <label htmlFor="test-variable" className="font-bold text-sm block">테스트 변수 입력</label>
-          <Textarea 
-            id="test-variable"
-            placeholder="{{email}} 변수 값" 
-            value={testVariable} 
-            onChange={e => setTestVariable(e.target.value)} 
-          />
-          <Button onClick={handleTest} disabled={testing} className="w-full">
-            {testing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" /> : <Play className="w-4 h-4 mr-2" aria-hidden="true" />}
-            {testing ? '테스트 중...' : '실행 (Test)'}
-          </Button>
-        </div>
-        <div className="space-y-3">
-          <h3 className="font-bold text-sm">실행 결과</h3>
-          <div className="p-4 bg-secondary/30 rounded-lg min-h-[100px] text-sm whitespace-pre-wrap border border-border">
-            {testResult || '실행 결과가 여기에 표시됩니다.'}
+    <div className="h-full min-h-0 overflow-y-auto bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-8">
+        <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="gap-1 border-primary/20 bg-primary/10 font-black text-primary">
+                <Sparkles className="size-3" aria-hidden="true" />
+                AI Hub source
+              </Badge>
+              <Badge variant={formData.is_shared ? 'default' : 'secondary'} className="font-black">
+                {formData.is_shared ? '워크스페이스 공유' : '개인 초안'}
+              </Badge>
+            </div>
+            <h1 className="mt-3 flex items-center gap-3 text-2xl font-black md:text-3xl">
+              <Code className="size-7 text-primary" aria-hidden="true" />
+              Prompt Studio
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+              원본 변수, 실행 미리보기, 저장 범위를 한 화면에서 확인한 뒤 AI 허브 실행 후보로 넘깁니다.
+            </p>
           </div>
-          <Button onClick={handleSave} disabled={saving} variant="secondary" className="w-full">
-            {saving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" /> : <Save className="w-4 h-4 mr-2" aria-hidden="true" />}
-            {saving ? '저장 중...' : '프롬프트 저장 (Save)'}
-          </Button>
-        </div>
+
+          <Card size="sm" className="bg-card/90">
+            <CardHeader>
+              <CardTitle className="text-sm font-black">개발 계약 상태</CardTitle>
+              <CardDescription>Figma와 코드가 함께 보장해야 하는 필수 상태</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid gap-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="font-bold text-muted-foreground">변수</dt>
+                  <dd className="font-black text-primary">{promptVariables.length}개</dd>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="font-bold text-muted-foreground">저장 범위</dt>
+                  <dd className="font-black">{formData.is_shared ? '공유' : '개인'}</dd>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="font-bold text-muted-foreground">결과</dt>
+                  <dd className="font-black">{testResult ? '실행됨' : '대기'}</dd>
+                </div>
+              </dl>
+            </CardContent>
+          </Card>
+        </section>
+
+        {error && (
+          <Card role="alert" className="border-red-200 bg-red-50 text-red-700 dark:border-red-500/30 dark:bg-red-500/15 dark:text-red-200">
+            <CardContent className="flex items-center gap-3 py-4">
+              <AlertCircle className="size-5 shrink-0" aria-hidden="true" />
+              <p className="font-bold">{error}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {saveStatus && (
+          <Card role="status" aria-live="polite" className="border-green-200 bg-green-50 text-green-700 dark:border-green-500/30 dark:bg-green-500/15 dark:text-green-200">
+            <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+              <div className="flex items-center gap-3">
+                <CheckCircle2 className="size-5 shrink-0" aria-hidden="true" />
+                <p className="font-bold">{saveStatus}</p>
+              </div>
+              <a href="/ai-hub" className="text-sm font-black text-current underline underline-offset-4">
+                AI 허브 열기
+              </a>
+            </CardContent>
+          </Card>
+        )}
+
+        <section className="grid min-h-0 gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(20rem,0.9fr)]">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle className="font-black">템플릿 작성</CardTitle>
+                  <CardDescription className="mt-1">저장 전 제목, 설명, 원본 변수, 공유 범위를 확정합니다.</CardDescription>
+                </div>
+                <Button onClick={handleSave} disabled={saving || testing} className="font-black">
+                  {saving ? <Loader2 className="size-4 animate-spin" aria-hidden="true" data-testid="loader" /> : <Save className="size-4" aria-hidden="true" />}
+                  {saving ? '저장 중...' : '프롬프트 저장 (Save)'}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="grid gap-4">
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_16rem]">
+                <div className="space-y-1.5">
+                  <label htmlFor="prompt-title" className="text-sm font-bold">프롬프트 이름</label>
+                  <Input
+                    id="prompt-title"
+                    aria-invalid={!formData.title.trim() && Boolean(error)}
+                    placeholder="프롬프트 이름"
+                    value={formData.title}
+                    onChange={e => setFormField('title', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label htmlFor="prompt-scope" className="text-sm font-bold">저장 범위</label>
+                  <div id="prompt-scope" className="flex min-h-10 items-center gap-2 rounded-xl border border-border bg-background px-3">
+                    <Checkbox
+                      id="is_shared"
+                      checked={formData.is_shared}
+                      onCheckedChange={(checked) => setFormField('is_shared', Boolean(checked))}
+                    />
+                    <label htmlFor="is_shared" className="text-sm font-bold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                      워크스페이스에 공유하기
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <label htmlFor="prompt-description" className="text-sm font-bold">설명</label>
+                <Input
+                  id="prompt-description"
+                  placeholder="설명"
+                  value={formData.description}
+                  onChange={e => setFormField('description', e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label htmlFor="prompt-content" className="text-sm font-bold">프롬프트 내용</label>
+                <Textarea
+                  id="prompt-content"
+                  aria-describedby="prompt-content-help"
+                  className="min-h-[17rem] font-mono text-sm"
+                  value={formData.content}
+                  onChange={e => setPromptContent(e.target.value)}
+                />
+                <p id="prompt-content-help" className="text-xs font-semibold text-muted-foreground">
+                  변수는 <code className="rounded bg-secondary px-1 py-0.5">{'{{email}}'}</code> 형식으로 작성합니다.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-6">
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <CardTitle className="flex items-center gap-2 font-black">
+                      <Variable className="size-4 text-primary" aria-hidden="true" />
+                      변수 입력
+                    </CardTitle>
+                    <CardDescription className="mt-1">실행 테스트에 전달되는 원본 값을 확인합니다.</CardDescription>
+                  </div>
+                  <Badge variant="outline" className="font-black">{promptVariables.length}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="grid gap-3">
+                {promptVariables.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-border bg-secondary/30 p-4 text-sm font-semibold text-muted-foreground">
+                    등록된 변수가 없습니다. 프롬프트 내용에 변수를 추가하면 입력 필드가 생성됩니다.
+                  </div>
+                ) : (
+                  promptVariables.map((variableName) => (
+                    <div key={variableName} className="space-y-1.5">
+                      <label htmlFor={`prompt-variable-${variableName}`} className="text-sm font-bold">
+                        {`{{${variableName}}}`}
+                      </label>
+                      <Textarea
+                        id={`prompt-variable-${variableName}`}
+                        className="min-h-24"
+                        placeholder={`${variableName} 변수 값`}
+                        value={variableValues[variableName] ?? ''}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setVariableValues((current) => ({ ...current, [variableName]: value }));
+                          setError(null);
+                        }}
+                      />
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 font-black">
+                  <FileText className="size-4 text-primary" aria-hidden="true" />
+                  실행 미리보기
+                </CardTitle>
+                <CardDescription>변수 값이 반영된 요청 본문입니다.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-border bg-secondary/30 p-4 font-mono text-xs leading-5 text-foreground">
+                  {previewText || '프롬프트 내용이 비어 있습니다.'}
+                </pre>
+              </CardContent>
+              <CardFooter className="justify-end">
+                <Button onClick={handleTest} disabled={testing || saving || !formData.content.trim()} className="font-black">
+                  {testing ? <Loader2 className="size-4 animate-spin" aria-hidden="true" data-testid="loader" /> : <Play className="size-4" aria-hidden="true" />}
+                  {testing ? '테스트 중...' : '실행 (Test)'}
+                </Button>
+              </CardFooter>
+            </Card>
+          </div>
+        </section>
+
+        <Card>
+          <CardHeader>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <CardTitle className="font-black">실행 결과</CardTitle>
+                <CardDescription className="mt-1">테스트 결과는 저장 전 품질 검토와 Publisher 확인에 사용됩니다.</CardDescription>
+              </div>
+              <a
+                href="/ai-hub"
+                className="inline-flex h-10 items-center gap-2 rounded-xl border border-border bg-background px-4 text-sm font-black text-foreground transition-colors hover:border-primary/30 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              >
+                <Share2 className="size-4" aria-hidden="true" />
+                AI 허브에서 보기
+              </a>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div
+              role={testResult ? 'status' : undefined}
+              aria-live="polite"
+              className="min-h-36 rounded-xl border border-border bg-card p-4 text-sm leading-6"
+            >
+              {testResult ? (
+                <p className="whitespace-pre-wrap">{testResult}</p>
+              ) : (
+                <div className="flex h-full min-h-28 flex-col items-center justify-center text-center text-muted-foreground">
+                  <Sparkles className="mb-3 size-6 text-primary" aria-hidden="true" />
+                  <p className="font-black text-foreground">아직 실행 전입니다.</p>
+                  <p className="mt-1 max-w-md text-sm">
+                    변수 값을 확인하고 실행하면 결과가 이 영역에 표시됩니다.
+                  </p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -35,11 +35,26 @@ type PromptFormData = {
   is_shared: boolean;
 };
 
+type VariableValues = Record<string, string>;
+
 const DEFAULT_CONTENT = '핵심 맥락을 종합해주세요: {{email}}';
-const DEFAULT_VARIABLE_VALUES: Record<string, string> = {
-  email: '메일 내용 예시입니다.',
-};
 const PLACEHOLDER_PATTERN = /\{\{([A-Za-z_][A-Za-z0-9_]{0,63})\}\}/g;
+
+function createVariableValueMap(entries: Iterable<readonly [string, string]> = []): VariableValues {
+  const values = Object.create(null) as VariableValues;
+  for (const [key, value] of entries) {
+    values[key] = value;
+  }
+  return values;
+}
+
+const DEFAULT_VARIABLE_VALUES = createVariableValueMap([
+  ['email', '메일 내용 예시입니다.'],
+]);
+
+function getOwnVariableValue(values: VariableValues, key: string) {
+  return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : undefined;
+}
 
 function extractPromptVariables(content: string) {
   const variables = new Set<string>();
@@ -49,17 +64,20 @@ function extractPromptVariables(content: string) {
   return Array.from(variables);
 }
 
-function renderPromptPreview(content: string, variables: Record<string, string>) {
+function renderPromptPreview(content: string, variables: VariableValues) {
   return content.replace(PLACEHOLDER_PATTERN, (placeholder, name: string) => {
-    const value = variables[name];
+    const value = getOwnVariableValue(variables, name);
     return value?.trim() ? value : placeholder;
   });
 }
 
-function syncVariableValues(variableNames: string[], currentValues: Record<string, string>) {
-  const nextValues: Record<string, string> = {};
+function syncVariableValues(variableNames: string[], currentValues: VariableValues) {
+  const nextValues = createVariableValueMap();
   for (const variableName of variableNames) {
-    nextValues[variableName] = currentValues[variableName] ?? DEFAULT_VARIABLE_VALUES[variableName] ?? '';
+    nextValues[variableName] =
+      getOwnVariableValue(currentValues, variableName) ??
+      getOwnVariableValue(DEFAULT_VARIABLE_VALUES, variableName) ??
+      '';
   }
   return nextValues;
 }
@@ -76,7 +94,9 @@ export default function PromptStudioPage() {
     is_shared: false,
   });
   const promptVariables = useMemo(() => extractPromptVariables(formData.content), [formData.content]);
-  const [variableValues, setVariableValues] = useState<Record<string, string>>(DEFAULT_VARIABLE_VALUES);
+  const [variableValues, setVariableValues] = useState<VariableValues>(() =>
+    createVariableValueMap(Object.entries(DEFAULT_VARIABLE_VALUES)),
+  );
   const [testResult, setTestResult] = useState('');
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -100,8 +120,13 @@ export default function PromptStudioPage() {
     setVariableValues((currentValues) => syncVariableValues(extractPromptVariables(content), currentValues));
   };
 
-  const buildVariablesPayload = () =>
-    Object.fromEntries(promptVariables.map((variableName) => [variableName, variableValues[variableName] ?? '']));
+  const buildVariablesPayload = () => {
+    const payload = createVariableValueMap();
+    for (const variableName of promptVariables) {
+      payload[variableName] = getOwnVariableValue(variableValues, variableName) ?? '';
+    }
+    return payload;
+  };
 
   const validateForSave = () => {
     if (!formData.title.trim()) {
@@ -318,10 +343,14 @@ export default function PromptStudioPage() {
                         id={`prompt-variable-${variableName}`}
                         className="min-h-24"
                         placeholder={`${variableName} 변수 값`}
-                        value={variableValues[variableName] ?? ''}
+                        value={getOwnVariableValue(variableValues, variableName) ?? ''}
                         onChange={(event) => {
                           const value = event.target.value;
-                          setVariableValues((current) => ({ ...current, [variableName]: value }));
+                          setVariableValues((current) => {
+                            const nextValues = createVariableValueMap(Object.entries(current));
+                            nextValues[variableName] = value;
+                            return nextValues;
+                          });
                           setError(null);
                         }}
                       />


### PR DESCRIPTION
## What changed
- Rebuilt `/prompt-studio` from a thin form into an executable visual handoff surface: metadata, variable extraction, dynamic variable fields, rendered preview, test result state, save validation, and AI Hub handoff.
- Updated Prompt Studio tests for label associations, loading states, sanitized signed-session requests, inline save success, and required metadata validation.
- Updated Figma `oopEGL22sKEA9j8q3FsFNZ`: filled the empty `--- Components` page with a component-library index and added `Implementation Proof / Prompt Studio` with desktop, mobile-first, mobile-scrolled, state matrix, API contract, and Publisher QA frames.

## Review lenses
- Ponytail: fixed the visual thinness by aligning Prompt Studio to existing card/button/input/badge tokens and adding mobile scrolled evidence.
- Superpowers: converted hidden assumptions into executable code/test/Figma contracts.
- Product Design: removed a real empty Figma page, preserved current product patterns, and verified desktop/mobile rendering.

## Verification
- `npx --yes pnpm@11.5.3 --dir C:\naruon-vf\frontend exec eslint src/app/prompt-studio/page.tsx src/app/prompt-studio/page.test.tsx`
- `npx --yes pnpm@11.5.3 --dir C:\naruon-vf\frontend exec tsc --noEmit --pretty false`
- `npx --yes pnpm@11.5.3 --dir C:\naruon-vf\frontend exec vitest run src/app/prompt-studio/page.test.tsx` (4 passed)
- Edge/Playwright visual QA for `/prompt-studio`: desktop 1440x1100, mobile 390x900 first view, mobile scrolled result; no console errors and no horizontal overflow.
- Full frontend Vitest with `NODE_OPTIONS=--localstorage-file=...`: 289/294 passed. Remaining 5 failures are existing `DashboardLayout`/home action bridge localStorage and viewport interaction tests outside this PR scope.

## Figma evidence
- File: https://www.figma.com/design/oopEGL22sKEA9j8q3FsFNZ
- Empty pages after update: 0
- New page: `Implementation Proof / Prompt Studio` (`45:33`)
- Key frames: `Guide / Prompt Studio Visual Handoff`, `Desktop Screen / Prompt Studio / Default 1440x1100`, `Mobile Screen / Prompt Studio / First View 390x900`, `Mobile Screen / Prompt Studio / Scrolled Result 390x900`, `Table / Prompt Studio Implementation Contract`, `State Matrix / Prompt Studio`, `Publisher QA Checklist / Prompt Studio`