### PR TITLE
[codex] Stabilize jsdom browser storage tests

### DIFF
--- a/frontend/src/test/setup-contract.test.ts
+++ b/frontend/src/test/setup-contract.test.ts
@@ -1,7 +1,14 @@
+/* @vitest-environment jsdom */
 import { describe, expect, it } from "vitest";
 
 describe("Vitest React setup", () => {
   it("enables the React act environment globally", () => {
     expect(globalThis.IS_REACT_ACT_ENVIRONMENT).toBe(true);
+  });
+
+  it("provides browser storage in jsdom tests", () => {
+    expect(window.localStorage).toBeDefined();
+    window.localStorage.setItem("naruon_test_storage", "ready");
+    expect(window.localStorage.getItem("naruon_test_storage")).toBe("ready");
   });
 });

--- a/frontend/src/test/setup-contract.test.ts
+++ b/frontend/src/test/setup-contract.test.ts
@@ -7,8 +7,13 @@ describe("Vitest React setup", () => {
   });
 
   it("provides browser storage in jsdom tests", () => {
+    const key = "naruon_test_storage";
     expect(window.localStorage).toBeDefined();
-    window.localStorage.setItem("naruon_test_storage", "ready");
-    expect(window.localStorage.getItem("naruon_test_storage")).toBe("ready");
+    try {
+      window.localStorage.setItem(key, "ready");
+      expect(window.localStorage.getItem(key)).toBe("ready");
+    } finally {
+      window.localStorage.removeItem(key);
+    }
   });
 });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,34 +1,53 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 if (typeof window !== "undefined") {
-  const entries = new Map<string, string>();
-  const storage = {
-    get length() {
-      return entries.size;
-    },
-    clear() {
-      entries.clear();
-    },
-    getItem(key: string) {
-      return entries.get(key) ?? null;
-    },
-    key(index: number) {
-      return Array.from(entries.keys())[index] ?? null;
-    },
-    removeItem(key: string) {
-      entries.delete(key);
-    },
-    setItem(key: string, value: string) {
-      entries.set(key, String(value));
-    },
-  } satisfies Storage;
+  const createMemoryStorage = () => {
+    const entries = new Map<string, string>();
+    return {
+      get length() {
+        return entries.size;
+      },
+      clear() {
+        entries.clear();
+      },
+      getItem(key: string) {
+        return entries.get(key) ?? null;
+      },
+      key(index: number) {
+        return Array.from(entries.keys())[index] ?? null;
+      },
+      removeItem(key: string) {
+        entries.delete(key);
+      },
+      setItem(key: string, value: string) {
+        entries.set(key, String(value));
+      },
+    } satisfies Storage;
+  };
 
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
+  const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+  const storage =
+    descriptor && "value" in descriptor && descriptor.value
+      ? (descriptor.value as Storage)
+      : createMemoryStorage();
+
+  if (!descriptor || descriptor.configurable) {
+    try {
+      Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: storage,
+      });
+    } catch {
+      // Some jsdom/browser implementations expose a non-configurable localStorage.
+    }
+  }
+
+  try {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+  } catch {
+    // Keep tests running even if the host provides a locked global storage.
+  }
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,34 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (typeof window !== "undefined") {
+  const entries = new Map<string, string>();
+  const storage = {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, String(value));
+    },
+  } satisfies Storage;
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a jsdom setup contract test that asserts browser storage is available in UI tests.
- Provides a test-only in-memory `localStorage` shim from `src/test/setup.ts` for jsdom runs where storage is absent.
- Keeps the fix scoped to test infrastructure so product code and AI Hub UI behavior stay unchanged.

## Root cause
Fresh AI Hub verification exposed that Vitest/jsdom was running with `window.localStorage` undefined in this environment. The same issue affected other UI tests that rely on browser storage.

## Validation
- `pnpm exec vitest run src/test/setup-contract.test.ts src/app/ai-hub/page.test.tsx src/components/DashboardLayout.test.tsx src/app/projects/page.test.tsx --reporter=dot`
- `pnpm exec vitest run --reporter=dot` (301 passed; existing stderr logs remain in Calendar/EmailDetail tests)
- `pnpm exec eslint src/test/setup.ts src/test/setup-contract.test.ts src/components/AIHubLayout.tsx src/app/ai-hub/page.tsx src/app/ai-hub/page.test.tsx`
- `pnpm exec tsc --noEmit`
- `py -3.12 -m pytest tests/test_ai_hub_api.py -q` (10 passed, 1 skipped)

## Figma audit context
This PR accompanies the 4th-pass Figma repair for `Implementation Proof / AI Hub`, where the page was upgraded from gap/component notes to desktop, mobile, API contract, state matrix, and publisher QA proof.