### PR TITLE
fix(ai-hub): show evaluation empty state

### DIFF
--- a/frontend/src/app/ai-hub/page.test.tsx
+++ b/frontend/src/app/ai-hub/page.test.tsx
@@ -337,4 +337,30 @@ describe('AIHubPage', () => {
     expect(container.textContent).toContain('다시 시도');
     expect(consoleError).toHaveBeenCalled();
   });
+
+  it('renders an accessible evaluation empty state when no metrics exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({
+          ...aiHubSurface,
+          evaluation_metrics: [],
+        }),
+      ),
+    );
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<AIHubPage />);
+    });
+    await flushAsyncWork();
+
+    clickButton(container, '평가');
+
+    expect(container.textContent).toContain('평가 근거가 없습니다.');
+    expect(container.textContent).toContain('정확성, 관련성, 안전성 지표');
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('평가 근거가 없습니다.');
+  });
 });

--- a/frontend/src/components/AIHubLayout.tsx
+++ b/frontend/src/components/AIHubLayout.tsx
@@ -154,7 +154,7 @@ function StatusBadge({ stateCode }: { stateCode: string }) {
 
 function EmptyState({ title, detail }: { title: string; detail: string }) {
   return (
-    <Card className="border-dashed text-center">
+    <Card role="status" aria-live="polite" className="border-dashed text-center">
       <CardContent className="py-8">
         <p className="font-bold text-foreground">{title}</p>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">{detail}</p>
@@ -328,6 +328,9 @@ function AgentsPanel({ agents }: { agents: AgentCard[] }) {
 }
 
 function EvaluationPanel({ metrics, onOpenRuns }: { metrics: EvaluationMetric[]; onOpenRuns: () => void }) {
+  if (metrics.length === 0) {
+    return <EmptyState title="평가 근거가 없습니다." detail="실행 이력과 모델 평가 점수가 기록되면 정확성, 관련성, 안전성 지표로 표시됩니다." />;
+  }
   return (
     <div className="grid gap-4 lg:grid-cols-2">
       {metrics.map((metric) => (


### PR DESCRIPTION
## Summary
- render an accessible AI Hub evaluation empty state when `/api/ai-hub/surface` has no metrics
- reuse the existing AI Hub empty-state component and add `role="status"`/`aria-live="polite"`
- cover sparse evaluation data so the ?? tab does not render as blank visual space

## Verification
- `npx -y pnpm@11.5.3 --dir frontend test src/app/ai-hub/page.test.tsx`
- `npx -y pnpm@11.5.3 --dir frontend lint src/components/AIHubLayout.tsx src/app/ai-hub/page.test.tsx`
- `npx -y pnpm@11.5.3 --dir frontend typecheck`
- Playwright browser check against `http://127.0.0.1:3002/ai-hub` with mocked sparse `/api/ai-hub/surface`