### PR TITLE
테스트: 도구 API(test_tools_api.py) 테스트 커버리지 100% 달성

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 테스트 개선 (Testing)
 
+- `backend/api/tools.py`의 미테스트 코드(핸들러 누락, 파라미터 타입 불일치 등)에 대한 단위 테스트를 추가하여 테스트 커버리지 100%를 달성했습니다.
 - `is_llm_provider_configured`가 `provider_type=None`, 공백-only `base_url`, 공백-only `model_identifier` 입력을 처리하는 엣지 케이스 테스트를 추가했습니다.
 - `thread_group_key`가 `thread_id`와 `message_id`를 trim한 뒤 `coalesce`하는 SQL 표현식을 생성하는지 직접 검증하는 단위 테스트를 추가했습니다.
 - `process_search_results`가 중복 제거, limit, snippet truncation, `None` fallback을 안정적으로 처리하는지 검증하는 단위 테스트를 추가했습니다.

--- a/backend/tests/test_tools_api.py
+++ b/backend/tests/test_tools_api.py
@@ -241,3 +241,71 @@ def test_execute_tool_sync_handler_success():
     data = response.json()
     assert data["status"] == "success"
     assert data["result"] == {"received": "ok"}
+
+@pytest.mark.asyncio
+async def test_execute_tool_no_handler_registered():
+    from api.tools import ToolInfo
+    try:
+        # Register a tool but deliberately remove its handler to trigger line 53
+        registry._tools["no_handler_tool"] = ToolInfo(
+            code="no_handler_tool",
+            name="No Handler",
+            description="Test tool with no handler",
+            category="Test"
+        )
+        with pytest.raises(ValueError, match="No handler registered for tool no_handler_tool"):
+            await registry.execute("no_handler_tool", {})
+    finally:
+        registry.unregister("no_handler_tool")
+
+
+def test_validate_parameters_not_a_dict():
+    # Trigger line 61
+    with pytest.raises(ValueError, match="Tool parameters must be an object"):
+        registry._validate_parameters("thread_summarizer", ["not", "a", "dict"])
+
+
+def test_validate_parameters_does_not_accept_parameters():
+    from api.tools import ToolInfo
+    try:
+        # Register a tool with no parameters schema
+        registry.register(
+            ToolInfo(
+                code="no_params_tool",
+                name="No Params",
+                description="Takes no params",
+                category="Test",
+                parameters=None
+            ),
+            lambda p: "ok"
+        )
+        # Trigger line 67 by providing parameters to a tool that doesn't accept them
+        with pytest.raises(ValueError, match="Tool does not accept parameters"):
+            registry._validate_parameters("no_params_tool", {"unexpected": "value"})
+
+        # Test line 68 (returns empty dict when params are empty and schema is None)
+        assert registry._validate_parameters("no_params_tool", {}) == {}
+    finally:
+        registry.unregister("no_params_tool")
+
+
+def test_validate_parameters_missing_required_parameter():
+    # Trigger line 77
+    with pytest.raises(ValueError, match="Missing required tool parameter"):
+        # thread_summarizer requires thread_id
+        registry._validate_parameters("thread_summarizer", {})
+
+
+def test_parameter_type_name_dict_descriptor():
+    from api.tools import _parameter_type_name
+    # Trigger line 96, 97
+    assert _parameter_type_name({"type": "integer"}) == "integer"
+    assert _parameter_type_name({"type": "ARRAY"}) == "array"
+    assert _parameter_type_name({}) == "string" # Default to string if type is missing
+
+
+def test_parameter_type_name_fallback():
+    from api.tools import _parameter_type_name
+    # Trigger line 98
+    assert _parameter_type_name(123) == "string"
+    assert _parameter_type_name(None) == "string"

--- a/backend/tests/test_tools_api.py
+++ b/backend/tests/test_tools_api.py
@@ -244,15 +244,17 @@ def test_execute_tool_sync_handler_success():
 
 @pytest.mark.asyncio
 async def test_execute_tool_no_handler_registered():
-    from api.tools import ToolInfo
     try:
-        # Register a tool but deliberately remove its handler to trigger line 53
-        registry._tools["no_handler_tool"] = ToolInfo(
-            code="no_handler_tool",
-            name="No Handler",
-            description="Test tool with no handler",
-            category="Test"
+        registry.register(
+            ToolInfo(
+                code="no_handler_tool",
+                name="No Handler",
+                description="Test tool with no handler",
+                category="Test",
+            ),
+            lambda params: "ok",
         )
+        registry._handlers.pop("no_handler_tool", None)
         with pytest.raises(ValueError, match="No handler registered for tool no_handler_tool"):
             await registry.execute("no_handler_tool", {})
     finally:


### PR DESCRIPTION
도구 API (`backend/api/tools.py`)의 미테스트 코드(lines 53, 61, 67, 77, 96-98)에 대한 유닛 테스트를 추가하여 테스트 커버리지 100%를 달성했습니다.

---
*PR created automatically by Jules for task [15684912056423065351](https://jules.google.com/task/15684912056423065351) started by @seonghobae*