### PR TITLE
🎨 Palette: 검색 필터 버튼에 ARIA 레이블 추가

### DIFF
--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -559,7 +559,7 @@ export function SearchLayout() {
               <button
                 key={filter.key}
                 type="button"
-                aria-label={`${filter.label} 필터`}
+                aria-label={`${filter.label} filter`}
                 aria-pressed={activeFilter === filter.key}
                 onClick={() => setActiveFilter(filter.key)}
                 className={`shrink-0 rounded-full px-3 py-1 text-xs font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background ${

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -559,7 +559,7 @@ export function SearchLayout() {
               <button
                 key={filter.key}
                 type="button"
-                aria-label={`${filter.label} filter`}
+                aria-label={`${filter.label} 필터`}
                 aria-pressed={activeFilter === filter.key}
                 onClick={() => setActiveFilter(filter.key)}
                 className={`shrink-0 rounded-full px-3 py-1 text-xs font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background ${

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -559,6 +559,7 @@ export function SearchLayout() {
               <button
                 key={filter.key}
                 type="button"
+                aria-label={`${filter.label} filter`}
                 aria-pressed={activeFilter === filter.key}
                 onClick={() => setActiveFilter(filter.key)}
                 className={`shrink-0 rounded-full px-3 py-1 text-xs font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background ${


### PR DESCRIPTION
💡 What: `SearchLayout.tsx` 컴포넌트의 검색 결과 필터 버튼 목록에 화면 판독기(Screen Reader) 사용자를 위한 `aria-label` 속성을 추가했습니다.
🎯 Why: 기존 필터 버튼들은 텍스트 내용(`filter.label`)만 가지고 있어 화면 판독기가 해당 버튼의 구체적인 목적(예: "결과 필터")을 명확히 전달하지 못하는 문제가 있었습니다. 이번 수정으로 스크린 리더 사용자들이 버튼이 '필터' 역할을 수행한다는 것을 명확하게 인지할 수 있게 되어 접근성이 향상되었습니다.
♿ Accessibility: WCAG 2.5.3 (Label in Name) 표준을 준수하며, 버튼에 `aria-label="${filter.label} filter"` 속성을 추가하여 접근성 컨텍스트를 제공합니다.

---
*PR created automatically by Jules for task [8645812125502831568](https://jules.google.com/task/8645812125502831568) started by @seonghobae*