### PR TITLE
🎨 Palette: AI 핵심 용어 및 UX/UI 텍스트 일관성 업데이트

### DIFF
--- a/frontend/src/app/prompt-studio/page.test.tsx
+++ b/frontend/src/app/prompt-studio/page.test.tsx
@@ -208,7 +208,7 @@ describe("PromptStudioPage", () => {
     expectNoPublicIdentityHeaders((fetchMock.mock.calls[0] as unknown as [RequestInfo, RequestInit?])?.[1]?.headers);
 
     act(() => {
-      getButton(page, "데이터 분석 인사이트").click();
+      getButton(page, "데이터 분석 판단 포인트").click();
     });
     expect(page.textContent).not.toContain("맥락 종합 결과");
   });

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -148,7 +148,7 @@ const MODEL_OPTIONS = [
   { label: 'OpenAI Compatible', value: 'provider-default' },
 ];
 const RESPONSE_STYLES = ['전문적이고 간결하게', '친근하고 상세하게', '실행 항목 중심'];
-const OUTPUT_FORMATS = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 핵심 맥락'];
+const OUTPUT_STYLES = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 핵심 맥락'];
 
 const QUALITY_CHECKS = ['요구사항 충족', '구조 및 가독성', '정확성/사실성', '근거/출처 포함', '톤 & 스타일 일관성'];
 
@@ -203,7 +203,7 @@ export default function PromptStudioPage() {
     model: MODEL_OPTIONS[0].value,
     temperature: '0.3',
     responseStyle: RESPONSE_STYLES[0],
-    outputFormat: OUTPUT_FORMATS[0],
+    outputFormat: OUTPUT_STYLES[0],
   });
   const [showTemplateCounts, setShowTemplateCounts] = useState(true);
   const promptVariables = useMemo(() => extractPromptVariables(formData.content), [formData.content]);
@@ -594,7 +594,7 @@ export default function PromptStudioPage() {
                     onChange={(event) => setPromptSetting('outputFormat', event.target.value)}
                     className="h-10 w-full rounded-xl border border-input bg-background px-3 text-sm font-semibold outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                   >
-                    {OUTPUT_FORMATS.map((format) => <option key={format}>{format}</option>)}
+                    {OUTPUT_STYLES.map((style) => <option key={style}>{style}</option>)}
                   </select>
                 </div>
               </CardContent>

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -102,10 +102,10 @@ function getSafeErrorSummary(error: unknown, fallback: string) {
 
 const TEMPLATE_GROUPS = [
   {
-    name: '업무 요약',
+    name: '업무 맥락 종합',
     items: [
-      { id: 'summary', title: '문서 요약/초안 작성', favorite: true },
-      { id: 'insight', title: '데이터 분석 인사이트' },
+      { id: 'summary', title: '문서 핵심 맥락/초안 작성', favorite: true },
+      { id: 'insight', title: '데이터 분석 판단 포인트' },
       { id: 'mail', title: '이메일 작성' },
       { id: 'automation', title: '업무 자동화 제안' },
     ],
@@ -114,7 +114,7 @@ const TEMPLATE_GROUPS = [
     name: '회의/리포트',
     items: [
       { id: 'meeting', title: '회의록 작성' },
-      { id: 'decision', title: '의사결정 요약' },
+      { id: 'decision', title: '의사결정 핵심 맥락' },
       { id: 'weekly', title: '주간 보고서 작성' },
     ],
   },
@@ -148,7 +148,7 @@ const MODEL_OPTIONS = [
   { label: 'OpenAI Compatible', value: 'provider-default' },
 ];
 const RESPONSE_STYLES = ['전문적이고 간결하게', '친근하고 상세하게', '실행 항목 중심'];
-const OUTPUT_FORMATS = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 요약'];
+const OUTPUT_FORMATS = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 핵심 맥락'];
 
 const QUALITY_CHECKS = ['요구사항 충족', '구조 및 가독성', '정확성/사실성', '근거/출처 포함', '톤 & 스타일 일관성'];
 
@@ -160,10 +160,10 @@ const VERSION_HISTORY = [
 ];
 
 const RECENT_TEST_RESULTS = [
-  { time: '2024.05.25 10:22', case: '분기 성과 보고서 요약', result: '성공', score: 92, tokens: '1,024', duration: '2.8초' },
+  { time: '2024.05.25 10:22', case: '분기 성과 보고서 핵심 맥락', result: '성공', score: 92, tokens: '1,024', duration: '2.8초' },
   { time: '2024.05.25 10:18', case: '고객 피드백 분석', result: '성공', score: 88, tokens: '1,156', duration: '3.1초' },
   { time: '2024.05.25 10:12', case: '경쟁사 분석 리포트', result: '부분 성공', score: 76, tokens: '1,432', duration: '3.6초' },
-  { time: '2024.05.25 10:05', case: '제품 출시 계획 요약', result: '성공', score: 95, tokens: '987', duration: '2.6초' },
+  { time: '2024.05.25 10:05', case: '제품 출시 계획 핵심 맥락', result: '성공', score: 95, tokens: '987', duration: '2.6초' },
 ];
 
 const DEPLOYMENT_HISTORY = [

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -753,7 +753,7 @@ export function SearchLayout() {
                             <div>
                               <p className="text-sm font-black text-purple-900">판단 보조</p>
                               <p className="mt-2 text-sm leading-6 text-purple-900/80">
-                                이 화면의 AI/관계 정보는 검색 점수, 원본 메시지, 스레드 범위를 함께 보여주는 보조 근거입니다. 외부 실행은 사용자가 메일, 일정, 관계 캡처 액션을 명시적으로 선택할 때만 진행됩니다.
+                                이 화면의 AI/관계 정보는 맥락 검색 점수, 원본 메시지, 스레드 범위를 함께 보여주는 보조 근거입니다. 외부 실행은 사용자가 메일, 일정, 관계 캡처 액션을 명시적으로 선택할 때만 진행됩니다.
                               </p>
                             </div>
                           </div>

--- a/frontend/src/components/mobile-workspace-panels.tsx
+++ b/frontend/src/components/mobile-workspace-panels.tsx
@@ -31,7 +31,7 @@ type MobilePanelCopy = {
 
 const mobileSearchCopy: MobilePanelCopy = {
   eyebrow: '맥락 검색',
-  title: '메일, 첨부, 일정, 사람을 한 번에 검색합니다.',
+  title: '메일, 첨부, 일정, 사람을 한 번에 맥락 검색합니다.',
   description: '흩어진 대화와 파일을 하나의 판단 흐름으로 묶어 보여주는 모바일 맥락 검색 진입점입니다.',
   loading: '맥락 검색 결과를 불러오는 중입니다.',
   empty: '맥락 검색 결과가 없습니다.',


### PR DESCRIPTION
💡 What
Naruon UX/UI 기획 가이드라인(docs/ui-ux/naruon-ui-ux-mapping.md)에 명시된 핵심 용어 원칙에 따라, 프론트엔드 내의 AI 관련 용어 표기를 수정했습니다.

🎯 Why
사용자 경험의 일관성을 높이고 제품의 철학(AI 요약 도구가 아닌, 증거 기반의 판단 및 실행을 돕는 이메일 워크스페이스)을 UI에 정확하게 반영하기 위함입니다. 
잘못된 용어(예: 요약 -> 맥락 종합, 인사이트 -> 판단 포인트)를 기획에 맞게 수정했습니다.

📸 Before/After
- Before: 프롬프트 스튜디오 템플릿 이름에 '업무 요약', '데이터 분석 인사이트' 등이 사용됨
- After: '업무 맥락 종합', '데이터 분석 판단 포인트' 등 기획서에 부합하는 용어로 변경됨
- Before: '메일, 첨부, 일정, 사람을 한 번에 검색합니다.'
- After: '메일, 첨부, 일정, 사람을 한 번에 맥락 검색합니다.'

♿ Accessibility
텍스트 라벨 변경 사항으로 접근성에 미치는 부정적 영향은 없으며, 시맨틱 구조나 aria 속성은 동일하게 유지되었습니다. 관련 테스트가 모두 업데이트되어 통과했습니다.

---
*PR created automatically by Jules for task [1846552886083888044](https://jules.google.com/task/1846552886083888044) started by @seonghobae*