### PR TITLE
🛡️ Sentinel: [MEDIUM] 민감한 비밀번호 입력 필드에 autoComplete="new-password" 속성 추가

### DIFF
--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -1041,7 +1041,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="commercial-api-key" className="text-sm font-bold text-muted-foreground">API Key</label>
-                        <input id="commercial-api-key" ref={commercialApiKeyInputRef} type="password" onChange={() => setModelProviderStatus(null)} placeholder="저장 시에만 전송" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="commercial-api-key" ref={commercialApiKeyInputRef} type="password" autoComplete="new-password" onChange={() => setModelProviderStatus(null)} placeholder="저장 시에만 전송" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                       <button type="submit" disabled={commercialModelSaving || modelProvidersLoading} aria-busy={commercialModelSaving || modelProvidersLoading} className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-bold text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60">
                         {commercialModelSaving ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : <Plus className="size-4" aria-hidden="true" />}
@@ -1090,7 +1090,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="local-api-key" className="text-sm font-bold text-muted-foreground">로컬 API 키 대체값</label>
-                        <input id="local-api-key" ref={localApiKeyInputRef} type="password" onChange={() => setModelProviderStatus(null)} placeholder="필요한 경우에만 입력" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="local-api-key" ref={localApiKeyInputRef} type="password" autoComplete="new-password" onChange={() => setModelProviderStatus(null)} placeholder="필요한 경우에만 입력" className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                       <button type="submit" disabled={localModelSaving || modelProvidersLoading} aria-busy={localModelSaving || modelProvidersLoading} className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-60">
                         {localModelSaving ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : <Cpu className="size-4" aria-hidden="true" />}
@@ -1328,7 +1328,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="smtp-password" className="text-sm font-bold text-muted-foreground">SMTP secret</label>
-                        <input id="smtp-password" ref={smtpPasswordInputRef} name="smtp_password" type="password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_smtp_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="smtp-password" ref={smtpPasswordInputRef} name="smtp_password" type="password" autoComplete="new-password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_smtp_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                     </section>
 
@@ -1347,7 +1347,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="imap-password" className="text-sm font-bold text-muted-foreground">IMAP secret</label>
-                        <input id="imap-password" ref={imapPasswordInputRef} name="imap_password" type="password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_imap_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="imap-password" ref={imapPasswordInputRef} name="imap_password" type="password" autoComplete="new-password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_imap_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                     </section>
 
@@ -1366,7 +1366,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="pop3-password" className="text-sm font-bold text-muted-foreground">POP3 secret</label>
-                        <input id="pop3-password" ref={pop3PasswordInputRef} name="pop3_password" type="password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_pop3_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="pop3-password" ref={pop3PasswordInputRef} name="pop3_password" type="password" autoComplete="new-password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_pop3_password ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                     </section>
 
@@ -1377,7 +1377,7 @@ export function SettingsLayout() {
                       </div>
                       <div className="space-y-2">
                         <label htmlFor="oauth-client-secret" className="text-sm font-bold text-muted-foreground">OAuth client secret</label>
-                        <input id="oauth-client-secret" ref={oauthClientSecretInputRef} name="oauth_client_secret" type="password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_oauth_client_secret ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
+                        <input id="oauth-client-secret" ref={oauthClientSecretInputRef} name="oauth_client_secret" type="password" autoComplete="new-password" onChange={() => setAccountStatus(null)} placeholder={accountConfig?.has_oauth_client_secret ? '저장된 secret 유지' : '새 secret 입력'} className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary" />
                       </div>
                       <div className="space-y-2 sm:col-span-2">
                         <label htmlFor="oauth-redirect-uri" className="text-sm font-bold text-muted-foreground">OAuth redirect URI</label>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: 여러 설정 페이지 내 민감한 입력 필드(API 키, 메일 서버 비밀번호 등)가 `type="password"`로 설정되어 있으나 `autoComplete="new-password"` 속성이 누락되어 있어 브라우저 비밀번호 관리자가 이를 기본 애플리케이션 비밀번호로 오인하여 자동 완성하거나 저장하려 할 수 있습니다.
🎯 Impact: 사용자가 실수로 외부 서비스의 인증 정보를 주 계정 로그인 정보로 덮어쓰거나 원치 않는 자동 완성이 발생할 수 있습니다.
🔧 Fix: `frontend/src/components/SettingsLayout.tsx`의 관련된 모든 `<input type="password">`에 `autoComplete="new-password"` 속성을 추가하여 의도하지 않은 자동 완성을 방지했습니다.
✅ Verification: `pnpm test` 및 `pnpm lint`를 실행하여 렌더링에 문제가 없음을 확인했습니다.

---
*PR created automatically by Jules for task [10967377563162285043](https://jules.google.com/task/10967377563162285043) started by @seonghobae*