### PR TITLE
🎨 Palette: 탭 버튼 키보드 포커스 시각적 피드백(A11y) 추가

### DIFF
--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -333,7 +333,7 @@ export function DataLayout() {
             <button type="button"
               key={tab}
               onClick={() => setActiveTab(tab as '문서 저장소' | '수집 파이프라인' | '임베딩' | '품질 점검')}
-              className={`whitespace-nowrap px-3 md:px-4 py-2 text-sm font-bold rounded-lg transition-colors shrink-0 ${activeTab === tab ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+              className={`whitespace-nowrap px-3 md:px-4 py-2 text-sm font-bold rounded-lg transition-colors shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${activeTab === tab ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
             >
               {tab}
             </button>

--- a/frontend/src/components/DataLayout.tsx
+++ b/frontend/src/components/DataLayout.tsx
@@ -333,6 +333,7 @@ export function DataLayout() {
             <button type="button"
               key={tab}
               onClick={() => setActiveTab(tab as '문서 저장소' | '수집 파이프라인' | '임베딩' | '품질 점검')}
+              aria-current={activeTab === tab ? 'page' : undefined}
               className={`whitespace-nowrap px-3 md:px-4 py-2 text-sm font-bold rounded-lg transition-colors shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${activeTab === tab ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
             >
               {tab}

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -856,7 +856,7 @@ export function SettingsLayout() {
               <button type="button"
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-bold transition-colors ${activeTab === tab.id ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}`}
+                className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${activeTab === tab.id ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}`}
               >
                 <tab.icon className="size-4" /> {tab.id}
               </button>

--- a/frontend/src/components/SettingsLayout.tsx
+++ b/frontend/src/components/SettingsLayout.tsx
@@ -836,6 +836,7 @@ export function SettingsLayout() {
               key={tab.id}
               type="button"
               onClick={() => setActiveTab(tab.id)}
+              aria-current={activeTab === tab.id ? 'page' : undefined}
               className={`min-h-10 shrink-0 rounded-xl px-4 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${
                 activeTab === tab.id
                   ? 'bg-primary text-primary-foreground shadow-sm'
@@ -856,6 +857,7 @@ export function SettingsLayout() {
               <button type="button"
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
+                aria-current={activeTab === tab.id ? 'page' : undefined}
                 className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${activeTab === tab.id ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:bg-secondary hover:text-foreground'}`}
               >
                 <tab.icon className="size-4" /> {tab.id}


### PR DESCRIPTION
🎨 Palette: 키보드 탐색을 위한 포커스 링 추가

💡 **What**: `DataLayout.tsx`와 `SettingsLayout.tsx` 내 탭 버튼들에 키보드 포커스 시각적 피드백(`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40`)을 추가했습니다.
🎯 **Why**: 기존 탭 버튼들(예: 데이터 레이아웃의 '문서 저장소' 등, 설정 레이아웃의 사이드바 탭)이 키보드로 탐색할 때 활성화 상태를 명확히 보여주지 않아, 스크린 리더 및 키보드 사용자의 접근성(accessibility)이 떨어지는 문제가 있었습니다. 이를 해결하기 위해 포커스 링을 추가하여 마이크로 UX를 개선했습니다.
♿ **Accessibility**: 키보드 탐색 지원을 위한 `focus-visible` 상태 추가

---
*PR created automatically by Jules for task [13516834713830101385](https://jules.google.com/task/13516834713830101385) started by @seonghobae*