### PR TITLE
feat: persist project graph projections

### DIFF
--- a/backend/alembic/versions/0009_project_graph_projection.py
+++ b/backend/alembic/versions/0009_project_graph_projection.py
@@ -1,0 +1,171 @@
+"""add project graph projection records
+
+Revision ID: 0009_project_graph_projection
+Revises: 0008_attachment_parser_audit_metadata
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009_project_graph_projection"
+down_revision = "0008_attachment_parser_audit_metadata"
+
+_OBJECT_TABLE = "project_graph_objects"
+_EDGE_TABLE = "project_graph_edges"
+_CORRECTION_TABLE = "project_graph_corrections"
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if not inspector.has_table(_OBJECT_TABLE):
+        op.create_table(
+            _OBJECT_TABLE,
+            sa.Column("project_graph_object_id", sa.Integer(), nullable=False),
+            sa.Column("object_uid", sa.String(length=96), nullable=False),
+            sa.Column("user_id", sa.String(), nullable=False),
+            sa.Column("organization_id", sa.String(), nullable=True),
+            sa.Column("workspace_id", sa.String(), nullable=False),
+            sa.Column("email_id", sa.Integer(), nullable=False),
+            sa.Column("attachment_id", sa.Integer(), nullable=True),
+            sa.Column("primary_content_segment_id", sa.Integer(), nullable=False),
+            sa.Column("object_type", sa.String(length=64), nullable=False),
+            sa.Column("title", sa.String(length=240), nullable=False),
+            sa.Column("summary", sa.Text(), nullable=False),
+            sa.Column("status_code", sa.String(length=64), nullable=False),
+            sa.Column("confidence", sa.Float(), nullable=False),
+            sa.Column("source_segment_uids", sa.JSON(), nullable=False),
+            sa.Column("attributes_json", sa.JSON(), nullable=False),
+            sa.Column("extractor_name", sa.String(length=120), nullable=False),
+            sa.Column("extractor_version", sa.String(length=64), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["attachment_id"], ["email_attachments.id"]),
+            sa.ForeignKeyConstraint(["email_id"], ["email_records.id"]),
+            sa.ForeignKeyConstraint(
+                ["primary_content_segment_id"],
+                ["content_segments.content_segment_id"],
+            ),
+            sa.PrimaryKeyConstraint("project_graph_object_id"),
+            sa.UniqueConstraint("object_uid", name="uq_project_graph_objects_uid"),
+        )
+
+    if not inspector.has_table(_EDGE_TABLE):
+        op.create_table(
+            _EDGE_TABLE,
+            sa.Column("project_graph_edge_id", sa.Integer(), nullable=False),
+            sa.Column("edge_uid", sa.String(length=96), nullable=False),
+            sa.Column("user_id", sa.String(), nullable=False),
+            sa.Column("organization_id", sa.String(), nullable=True),
+            sa.Column("workspace_id", sa.String(), nullable=False),
+            sa.Column("source_uid", sa.String(length=160), nullable=False),
+            sa.Column("target_uid", sa.String(length=160), nullable=False),
+            sa.Column("edge_type", sa.String(length=80), nullable=False),
+            sa.Column("confidence", sa.Float(), nullable=False),
+            sa.Column("source_segment_uids", sa.JSON(), nullable=False),
+            sa.Column("source_object_id", sa.Integer(), nullable=True),
+            sa.Column("target_object_id", sa.Integer(), nullable=True),
+            sa.Column("primary_content_segment_id", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["primary_content_segment_id"],
+                ["content_segments.content_segment_id"],
+            ),
+            sa.ForeignKeyConstraint(
+                ["source_object_id"],
+                ["project_graph_objects.project_graph_object_id"],
+            ),
+            sa.ForeignKeyConstraint(
+                ["target_object_id"],
+                ["project_graph_objects.project_graph_object_id"],
+            ),
+            sa.PrimaryKeyConstraint("project_graph_edge_id"),
+            sa.UniqueConstraint("edge_uid", name="uq_project_graph_edges_uid"),
+        )
+
+    if not inspector.has_table(_CORRECTION_TABLE):
+        op.create_table(
+            _CORRECTION_TABLE,
+            sa.Column("project_graph_correction_id", sa.Integer(), nullable=False),
+            sa.Column("correction_uid", sa.String(length=96), nullable=False),
+            sa.Column("project_graph_object_id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.String(), nullable=False),
+            sa.Column("organization_id", sa.String(), nullable=True),
+            sa.Column("workspace_id", sa.String(), nullable=False),
+            sa.Column("actor_user_id", sa.String(), nullable=False),
+            sa.Column("correction_action", sa.String(length=64), nullable=False),
+            sa.Column("before_json", sa.JSON(), nullable=False),
+            sa.Column("after_json", sa.JSON(), nullable=False),
+            sa.Column("rationale", sa.Text(), nullable=True),
+            sa.Column("source_segment_uids", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["project_graph_object_id"],
+                ["project_graph_objects.project_graph_object_id"],
+            ),
+            sa.PrimaryKeyConstraint("project_graph_correction_id"),
+            sa.UniqueConstraint(
+                "correction_uid",
+                name="uq_project_graph_corrections_uid",
+            ),
+        )
+
+    for table_name, indexes in _project_graph_indexes().items():
+        for index_name, column_names in indexes:
+            op.create_index(
+                index_name,
+                table_name,
+                column_names,
+                if_not_exists=True,
+            )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    for table_name in (_CORRECTION_TABLE, _EDGE_TABLE, _OBJECT_TABLE):
+        if inspector.has_table(table_name):
+            for index_name, _column_names in reversed(
+                _project_graph_indexes()[table_name]
+            ):
+                op.drop_index(index_name, table_name=table_name, if_exists=True)
+            op.drop_table(table_name)
+
+
+def _project_graph_indexes() -> dict[str, list[tuple[str, list[str]]]]:
+    return {
+        _OBJECT_TABLE: [
+            (
+                "ix_project_graph_objects_scope_type_status",
+                [
+                    "user_id",
+                    "organization_id",
+                    "workspace_id",
+                    "object_type",
+                    "status_code",
+                ],
+            ),
+            ("ix_project_graph_objects_email", ["email_id"]),
+            ("ix_project_graph_objects_primary_segment", ["primary_content_segment_id"]),
+            ("ix_project_graph_objects_extractor", ["extractor_name", "extractor_version"]),
+        ],
+        _EDGE_TABLE: [
+            (
+                "ix_project_graph_edges_scope_type",
+                ["user_id", "organization_id", "workspace_id", "edge_type"],
+            ),
+            ("ix_project_graph_edges_source_object", ["source_object_id"]),
+            ("ix_project_graph_edges_target_object", ["target_object_id"]),
+            ("ix_project_graph_edges_primary_segment", ["primary_content_segment_id"]),
+        ],
+        _CORRECTION_TABLE: [
+            (
+                "ix_project_graph_corrections_scope_time",
+                ["user_id", "organization_id", "workspace_id", "created_at"],
+            ),
+            ("ix_project_graph_corrections_object", ["project_graph_object_id"]),
+        ],
+    }

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
+    Float,
     Index,
     Integer,
     JSON,
@@ -809,6 +810,197 @@ class KnowledgeGraphEdgeRecord(Base):
         "ContentSegmentRecord",
         back_populates="incoming_edges",
         foreign_keys=[target_segment_id],
+    )
+
+
+class ProjectGraphObjectRecord(Base):
+    __tablename__ = "project_graph_objects"
+    __table_args__ = (
+        UniqueConstraint("object_uid", name="uq_project_graph_objects_uid"),
+        Index(
+            "ix_project_graph_objects_scope_type_status",
+            "user_id",
+            "organization_id",
+            "workspace_id",
+            "object_type",
+            "status_code",
+        ),
+        Index("ix_project_graph_objects_email", "email_id"),
+        Index("ix_project_graph_objects_primary_segment", "primary_content_segment_id"),
+        Index("ix_project_graph_objects_extractor", "extractor_name", "extractor_version"),
+    )
+
+    project_graph_object_id: Mapped[int] = mapped_column(primary_key=True)
+    object_uid: Mapped[str] = mapped_column(String(96), nullable=False)
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    email_id: Mapped[int] = mapped_column(
+        ForeignKey("email_records.id"), nullable=False
+    )
+    attachment_id: Mapped[int | None] = mapped_column(
+        ForeignKey("email_attachments.id"), nullable=True
+    )
+    primary_content_segment_id: Mapped[int] = mapped_column(
+        ForeignKey("content_segments.content_segment_id"), nullable=False
+    )
+    object_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(240), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    status_code: Mapped[str] = mapped_column(
+        String(64), default="candidate", nullable=False
+    )
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    source_segment_uids: Mapped[list[str]] = mapped_column(
+        JSON, default=list, nullable=False
+    )
+    attributes_json: Mapped[dict[str, object]] = mapped_column(
+        JSON, default=dict, nullable=False
+    )
+    extractor_name: Mapped[str] = mapped_column(String(120), nullable=False)
+    extractor_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
+        nullable=False,
+    )
+
+    email: Mapped["Email"] = relationship("Email")
+    attachment: Mapped["Attachment | None"] = relationship("Attachment")
+    primary_content_segment: Mapped["ContentSegmentRecord"] = relationship(
+        "ContentSegmentRecord"
+    )
+    outgoing_edges: Mapped[list["ProjectGraphEdgeRecord"]] = relationship(
+        "ProjectGraphEdgeRecord",
+        back_populates="source_object",
+        foreign_keys="ProjectGraphEdgeRecord.source_object_id",
+    )
+    incoming_edges: Mapped[list["ProjectGraphEdgeRecord"]] = relationship(
+        "ProjectGraphEdgeRecord",
+        back_populates="target_object",
+        foreign_keys="ProjectGraphEdgeRecord.target_object_id",
+    )
+    corrections: Mapped[list["ProjectGraphCorrectionRecord"]] = relationship(
+        "ProjectGraphCorrectionRecord",
+        back_populates="project_object",
+        cascade="all, delete-orphan",
+    )
+
+
+class ProjectGraphEdgeRecord(Base):
+    __tablename__ = "project_graph_edges"
+    __table_args__ = (
+        UniqueConstraint("edge_uid", name="uq_project_graph_edges_uid"),
+        Index(
+            "ix_project_graph_edges_scope_type",
+            "user_id",
+            "organization_id",
+            "workspace_id",
+            "edge_type",
+        ),
+        Index("ix_project_graph_edges_source_object", "source_object_id"),
+        Index("ix_project_graph_edges_target_object", "target_object_id"),
+        Index("ix_project_graph_edges_primary_segment", "primary_content_segment_id"),
+    )
+
+    project_graph_edge_id: Mapped[int] = mapped_column(primary_key=True)
+    edge_uid: Mapped[str] = mapped_column(String(96), nullable=False)
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    source_uid: Mapped[str] = mapped_column(String(160), nullable=False)
+    target_uid: Mapped[str] = mapped_column(String(160), nullable=False)
+    edge_type: Mapped[str] = mapped_column(String(80), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    source_segment_uids: Mapped[list[str]] = mapped_column(
+        JSON, default=list, nullable=False
+    )
+    source_object_id: Mapped[int | None] = mapped_column(
+        ForeignKey("project_graph_objects.project_graph_object_id"),
+        nullable=True,
+    )
+    target_object_id: Mapped[int | None] = mapped_column(
+        ForeignKey("project_graph_objects.project_graph_object_id"),
+        nullable=True,
+    )
+    primary_content_segment_id: Mapped[int] = mapped_column(
+        ForeignKey("content_segments.content_segment_id"), nullable=False
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        nullable=False,
+    )
+
+    source_object: Mapped["ProjectGraphObjectRecord | None"] = relationship(
+        "ProjectGraphObjectRecord",
+        back_populates="outgoing_edges",
+        foreign_keys=[source_object_id],
+    )
+    target_object: Mapped["ProjectGraphObjectRecord | None"] = relationship(
+        "ProjectGraphObjectRecord",
+        back_populates="incoming_edges",
+        foreign_keys=[target_object_id],
+    )
+    primary_content_segment: Mapped["ContentSegmentRecord"] = relationship(
+        "ContentSegmentRecord"
+    )
+
+
+class ProjectGraphCorrectionRecord(Base):
+    __tablename__ = "project_graph_corrections"
+    __table_args__ = (
+        UniqueConstraint("correction_uid", name="uq_project_graph_corrections_uid"),
+        Index(
+            "ix_project_graph_corrections_scope_time",
+            "user_id",
+            "organization_id",
+            "workspace_id",
+            "created_at",
+        ),
+        Index("ix_project_graph_corrections_object", "project_graph_object_id"),
+    )
+
+    project_graph_correction_id: Mapped[int] = mapped_column(primary_key=True)
+    correction_uid: Mapped[str] = mapped_column(
+        String(96),
+        default=lambda: f"project_correction_{uuid.uuid4().hex}",
+        nullable=False,
+    )
+    project_graph_object_id: Mapped[int] = mapped_column(
+        ForeignKey("project_graph_objects.project_graph_object_id"),
+        nullable=False,
+    )
+    user_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    organization_id: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    workspace_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    actor_user_id: Mapped[str] = mapped_column(String, nullable=False)
+    correction_action: Mapped[str] = mapped_column(String(64), nullable=False)
+    before_json: Mapped[dict[str, object]] = mapped_column(
+        JSON, default=dict, nullable=False
+    )
+    after_json: Mapped[dict[str, object]] = mapped_column(
+        JSON, default=dict, nullable=False
+    )
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_segment_uids: Mapped[list[str]] = mapped_column(
+        JSON, default=list, nullable=False
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        nullable=False,
+    )
+
+    project_object: Mapped["ProjectGraphObjectRecord"] = relationship(
+        "ProjectGraphObjectRecord",
+        back_populates="corrections",
     )
 
 

--- a/backend/services/project_graph/__init__.py
+++ b/backend/services/project_graph/__init__.py
@@ -10,14 +10,23 @@ from .models import (
     ProjectSemanticObject,
     ProjectSourceSegment,
 )
+from .projection import (
+    apply_project_graph_correction,
+    persist_project_graph_projection,
+)
+from .repository import ProjectGraphPersistResult, ProjectGraphRepository
 
 __all__ = [
     "EXTRACTOR_NAME",
     "EXTRACTOR_VERSION",
+    "ProjectGraphPersistResult",
+    "ProjectGraphRepository",
     "ProjectObjectType",
     "ProjectSemanticEdge",
     "ProjectSemanticExtractionResult",
     "ProjectSemanticObject",
     "ProjectSourceSegment",
+    "apply_project_graph_correction",
     "extract_project_semantics",
+    "persist_project_graph_projection",
 ]

--- a/backend/services/project_graph/projection.py
+++ b/backend/services/project_graph/projection.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import ProjectSemanticExtractionResult
+from .repository import ProjectGraphPersistResult, ProjectGraphRepository
+
+
+async def persist_project_graph_projection(
+    session: AsyncSession,
+    *,
+    extraction: ProjectSemanticExtractionResult,
+    user_id: str,
+    organization_id: str | None,
+    workspace_id: str,
+    status_code: str = "candidate",
+) -> ProjectGraphPersistResult:
+    repository = ProjectGraphRepository(session)
+    return await repository.persist_extraction(
+        extraction=extraction,
+        user_id=user_id,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        status_code=status_code,
+    )
+
+
+async def apply_project_graph_correction(
+    session: AsyncSession,
+    *,
+    object_uid: str,
+    user_id: str,
+    organization_id: str | None,
+    workspace_id: str,
+    actor_user_id: str,
+    correction_action: str,
+    after_json: Mapping[str, Any],
+    rationale: str | None = None,
+    source_segment_uids: tuple[str, ...] | None = None,
+):
+    repository = ProjectGraphRepository(session)
+    return await repository.apply_correction(
+        object_uid=object_uid,
+        user_id=user_id,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        actor_user_id=actor_user_id,
+        correction_action=correction_action,
+        after_json=after_json,
+        rationale=rationale,
+        source_segment_uids=source_segment_uids,
+    )

--- a/backend/services/project_graph/repository.py
+++ b/backend/services/project_graph/repository.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from db.models import (
+    ContentSegmentRecord,
+    ProjectGraphCorrectionRecord,
+    ProjectGraphEdgeRecord,
+    ProjectGraphObjectRecord,
+)
+
+from .models import ProjectSemanticEdge, ProjectSemanticExtractionResult
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectGraphPersistResult:
+    objects: tuple[ProjectGraphObjectRecord, ...]
+    edges: tuple[ProjectGraphEdgeRecord, ...]
+
+
+class ProjectGraphRepository:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def persist_extraction(
+        self,
+        *,
+        extraction: ProjectSemanticExtractionResult,
+        user_id: str,
+        organization_id: str | None,
+        workspace_id: str,
+        status_code: str = "candidate",
+    ) -> ProjectGraphPersistResult:
+        segment_uids = _unique_source_segment_uids(
+            semantic_object.source_segment_uids
+            for semantic_object in extraction.objects
+        )
+        segment_map = await self._load_segment_map(segment_uids)
+        _validate_segment_scope(
+            segment_map.values(),
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+
+        object_records = await self._upsert_objects(
+            extraction=extraction,
+            segment_map=segment_map,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            status_code=status_code,
+        )
+        await self._session.flush()
+        object_map = {record.object_uid: record for record in object_records}
+        edge_records = await self._upsert_edges(
+            edges=extraction.edges,
+            object_map=object_map,
+            segment_map=segment_map,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+        await self._session.flush()
+
+        return ProjectGraphPersistResult(
+            objects=tuple(object_records),
+            edges=tuple(edge_records),
+        )
+
+    async def apply_correction(
+        self,
+        *,
+        object_uid: str,
+        user_id: str,
+        organization_id: str | None,
+        workspace_id: str,
+        actor_user_id: str,
+        correction_action: str,
+        after_json: Mapping[str, Any],
+        rationale: str | None = None,
+        source_segment_uids: tuple[str, ...] | None = None,
+    ) -> ProjectGraphCorrectionRecord:
+        project_object = await self._get_scoped_object(
+            object_uid=object_uid,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+        before_json = _object_snapshot(project_object)
+        _apply_projection_updates(project_object, after_json)
+        correction = ProjectGraphCorrectionRecord(
+            project_object=project_object,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            correction_action=correction_action,
+            before_json=before_json,
+            after_json=_json_ready(dict(after_json)),
+            rationale=rationale,
+            source_segment_uids=list(
+                source_segment_uids or tuple(project_object.source_segment_uids)
+            ),
+            created_at=_utcnow(),
+        )
+        self._session.add(correction)
+        await self._session.flush()
+        return correction
+
+    async def _load_segment_map(
+        self,
+        segment_uids: tuple[str, ...],
+    ) -> dict[str, ContentSegmentRecord]:
+        if not segment_uids:
+            raise ValueError("Project graph projection requires source segments")
+        result = await self._session.execute(
+            select(ContentSegmentRecord)
+            .options(selectinload(ContentSegmentRecord.email))
+            .where(ContentSegmentRecord.content_segment_uid.in_(segment_uids))
+        )
+        records = result.scalars().all()
+        segment_map = {record.content_segment_uid: record for record in records}
+        missing = sorted(set(segment_uids) - set(segment_map))
+        if missing:
+            raise ValueError(f"Missing project graph source segments: {missing}")
+        return segment_map
+
+    async def _upsert_objects(
+        self,
+        *,
+        extraction: ProjectSemanticExtractionResult,
+        segment_map: dict[str, ContentSegmentRecord],
+        user_id: str,
+        organization_id: str | None,
+        workspace_id: str,
+        status_code: str,
+    ) -> list[ProjectGraphObjectRecord]:
+        object_uids = tuple(semantic_object.uid for semantic_object in extraction.objects)
+        existing = await self._load_object_map(object_uids)
+        records: list[ProjectGraphObjectRecord] = []
+        for semantic_object in extraction.objects:
+            primary_segment = segment_map[semantic_object.source_segment_uids[0]]
+            record = existing.get(semantic_object.uid)
+            if record is None:
+                record = ProjectGraphObjectRecord(
+                    object_uid=semantic_object.uid,
+                    user_id=user_id,
+                    organization_id=organization_id,
+                    workspace_id=workspace_id,
+                    email_id=primary_segment.email_id,
+                    attachment_id=primary_segment.attachment_id,
+                    primary_content_segment_id=primary_segment.content_segment_id,
+                    object_type=semantic_object.object_type.value,
+                    title=semantic_object.title,
+                    summary=semantic_object.summary,
+                    status_code=status_code,
+                    confidence=semantic_object.confidence,
+                    source_segment_uids=list(semantic_object.source_segment_uids),
+                    attributes_json=_json_ready(dict(semantic_object.attributes)),
+                    extractor_name=semantic_object.extractor_name,
+                    extractor_version=semantic_object.extractor_version,
+                    created_at=_utcnow(),
+                    updated_at=_utcnow(),
+                )
+                self._session.add(record)
+            else:
+                record.user_id = user_id
+                record.organization_id = organization_id
+                record.workspace_id = workspace_id
+                record.email_id = primary_segment.email_id
+                record.attachment_id = primary_segment.attachment_id
+                record.primary_content_segment_id = primary_segment.content_segment_id
+                record.object_type = semantic_object.object_type.value
+                record.title = semantic_object.title
+                record.summary = semantic_object.summary
+                record.status_code = status_code
+                record.confidence = semantic_object.confidence
+                record.source_segment_uids = list(semantic_object.source_segment_uids)
+                record.attributes_json = _json_ready(dict(semantic_object.attributes))
+                record.extractor_name = semantic_object.extractor_name
+                record.extractor_version = semantic_object.extractor_version
+                record.updated_at = _utcnow()
+            records.append(record)
+        return records
+
+    async def _upsert_edges(
+        self,
+        *,
+        edges: tuple[ProjectSemanticEdge, ...],
+        object_map: dict[str, ProjectGraphObjectRecord],
+        segment_map: dict[str, ContentSegmentRecord],
+        user_id: str,
+        organization_id: str | None,
+        workspace_id: str,
+    ) -> list[ProjectGraphEdgeRecord]:
+        edge_uids = tuple(_edge_uid(edge) for edge in edges)
+        existing = await self._load_edge_map(edge_uids)
+        records: list[ProjectGraphEdgeRecord] = []
+        for semantic_edge in edges:
+            primary_segment = segment_map[semantic_edge.source_segment_uids[0]]
+            record = existing.get(_edge_uid(semantic_edge))
+            source_object = object_map.get(semantic_edge.source_uid)
+            target_object = object_map.get(semantic_edge.target_uid)
+            if record is None:
+                record = ProjectGraphEdgeRecord(
+                    edge_uid=_edge_uid(semantic_edge),
+                    user_id=user_id,
+                    organization_id=organization_id,
+                    workspace_id=workspace_id,
+                    source_uid=semantic_edge.source_uid,
+                    target_uid=semantic_edge.target_uid,
+                    edge_type=semantic_edge.edge_type,
+                    confidence=semantic_edge.confidence,
+                    source_segment_uids=list(semantic_edge.source_segment_uids),
+                    source_object=source_object,
+                    target_object=target_object,
+                    primary_content_segment_id=primary_segment.content_segment_id,
+                    created_at=_utcnow(),
+                )
+                self._session.add(record)
+            else:
+                record.user_id = user_id
+                record.organization_id = organization_id
+                record.workspace_id = workspace_id
+                record.source_uid = semantic_edge.source_uid
+                record.target_uid = semantic_edge.target_uid
+                record.edge_type = semantic_edge.edge_type
+                record.confidence = semantic_edge.confidence
+                record.source_segment_uids = list(semantic_edge.source_segment_uids)
+                record.source_object = source_object
+                record.target_object = target_object
+                record.primary_content_segment_id = primary_segment.content_segment_id
+            records.append(record)
+        return records
+
+    async def _load_object_map(
+        self,
+        object_uids: tuple[str, ...],
+    ) -> dict[str, ProjectGraphObjectRecord]:
+        if not object_uids:
+            return {}
+        result = await self._session.execute(
+            select(ProjectGraphObjectRecord).where(
+                ProjectGraphObjectRecord.object_uid.in_(object_uids)
+            )
+        )
+        return {record.object_uid: record for record in result.scalars().all()}
+
+    async def _load_edge_map(
+        self,
+        edge_uids: tuple[str, ...],
+    ) -> dict[str, ProjectGraphEdgeRecord]:
+        if not edge_uids:
+            return {}
+        result = await self._session.execute(
+            select(ProjectGraphEdgeRecord).where(
+                ProjectGraphEdgeRecord.edge_uid.in_(edge_uids)
+            )
+        )
+        return {record.edge_uid: record for record in result.scalars().all()}
+
+    async def _get_scoped_object(
+        self,
+        *,
+        object_uid: str,
+        user_id: str,
+        organization_id: str | None,
+        workspace_id: str,
+    ) -> ProjectGraphObjectRecord:
+        result = await self._session.execute(
+            select(ProjectGraphObjectRecord)
+            .where(ProjectGraphObjectRecord.object_uid == object_uid)
+            .where(ProjectGraphObjectRecord.user_id == user_id)
+            .where(ProjectGraphObjectRecord.organization_id == organization_id)
+            .where(ProjectGraphObjectRecord.workspace_id == workspace_id)
+        )
+        record = result.scalar_one_or_none()
+        if record is None:
+            raise ValueError("Project graph object is outside the requested scope")
+        return record
+
+
+def _unique_source_segment_uids(
+    source_uid_groups: Iterable[tuple[str, ...]],
+) -> tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for source_uids in source_uid_groups:
+        if not source_uids:
+            raise ValueError("Project graph projection requires cited objects")
+        for source_uid in source_uids:
+            seen.setdefault(source_uid, None)
+    return tuple(seen)
+
+
+def _validate_segment_scope(
+    segments: Iterable[ContentSegmentRecord],
+    *,
+    user_id: str,
+    organization_id: str | None,
+    workspace_id: str,
+) -> None:
+    for segment in segments:
+        email = segment.email
+        expected_workspace_id = (
+            f"workspace-{organization_id}" if organization_id else f"workspace-{user_id}"
+        )
+        if (
+            email.user_id != user_id
+            or email.organization_id != organization_id
+            or expected_workspace_id != workspace_id
+        ):
+            raise ValueError("Project graph source segment belongs to a different scope")
+
+
+def _edge_uid(edge: ProjectSemanticEdge) -> str:
+    payload = "|".join(
+        (
+            edge.source_uid,
+            edge.target_uid,
+            edge.edge_type,
+            ",".join(edge.source_segment_uids),
+        )
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+    return f"project_edge:{digest}"
+
+
+def _object_snapshot(record: ProjectGraphObjectRecord) -> dict[str, object]:
+    return {
+        "title": record.title,
+        "summary": record.summary,
+        "status_code": record.status_code,
+        "confidence": record.confidence,
+        "attributes_json": record.attributes_json,
+        "source_segment_uids": record.source_segment_uids,
+    }
+
+
+def _apply_projection_updates(
+    record: ProjectGraphObjectRecord,
+    after_json: Mapping[str, Any],
+) -> None:
+    if "title" in after_json:
+        record.title = str(after_json["title"])
+    if "summary" in after_json:
+        record.summary = str(after_json["summary"])
+    if "status_code" in after_json:
+        record.status_code = str(after_json["status_code"])
+    if "confidence" in after_json:
+        confidence = float(after_json["confidence"])
+        if not 0.0 <= confidence <= 1.0:
+            raise ValueError("Project graph correction confidence must be 0..1")
+        record.confidence = confidence
+    if "attributes_json" in after_json:
+        attributes = after_json["attributes_json"]
+        if not isinstance(attributes, Mapping):
+            raise ValueError("Project graph correction attributes_json must be a mapping")
+        record.attributes_json = _json_ready(dict(attributes))
+    record.updated_at = _utcnow()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -186,6 +186,37 @@ def test_attachment_parse_metadata_has_incremental_revision():
     assert "op.drop_column(" in revision_text
 
 
+def test_project_graph_projection_has_incremental_revision():
+    versions_dir = BACKEND_ROOT / "alembic" / "versions"
+    revision_path = versions_dir / "0009_project_graph_projection.py"
+    assert revision_path.exists()
+    revision_text = revision_path.read_text()
+
+    assert 'revision = "0009_project_graph_projection"' in revision_text
+    assert 'down_revision = "0008_attachment_parser_audit_metadata"' in revision_text
+    assert '"project_graph_objects"' in revision_text
+    assert '"project_graph_edges"' in revision_text
+    assert '"project_graph_corrections"' in revision_text
+    assert '"object_uid"' in revision_text
+    assert '"edge_uid"' in revision_text
+    assert '"correction_uid"' in revision_text
+    assert '"workspace_id"' in revision_text
+    assert '"source_segment_uids"' in revision_text
+    assert '"attributes_json"' in revision_text
+    assert '"before_json"' in revision_text
+    assert '"after_json"' in revision_text
+    assert '"content_segments.content_segment_id"' in revision_text
+    assert "ix_project_graph_objects_scope_type_status" in revision_text
+    assert "ix_project_graph_edges_scope_type" in revision_text
+    assert "ix_project_graph_corrections_scope_time" in revision_text
+    assert "has_table" in revision_text
+    assert "op.create_table(" in revision_text
+    assert "op.create_index(" in revision_text
+    assert "if_not_exists=True" in revision_text
+    assert "op.drop_index(" in revision_text
+    assert "if_exists=True" in revision_text
+
+
 def test_migration_runner_uses_alembic_upgrade_head_not_bootstrap_create_all():
     migration_runner = BACKEND_ROOT / "scripts" / "migrate_db.py"
 

--- a/backend/tests/test_project_graph_projection.py
+++ b/backend/tests/test_project_graph_projection.py
@@ -1,0 +1,314 @@
+import datetime
+import uuid
+
+import pytest
+import pytest_asyncio
+from asyncpg.exceptions import (
+    InvalidAuthorizationSpecificationError,
+    InvalidPasswordError,
+)
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from core.config import settings
+from db.models import (
+    Base,
+    ContentNodeRecord,
+    ContentSegmentRecord,
+    Email,
+    ProjectGraphCorrectionRecord,
+    ProjectGraphEdgeRecord,
+    ProjectGraphObjectRecord,
+)
+from services.project_graph import (
+    ProjectSourceSegment,
+    apply_project_graph_correction,
+    extract_project_semantics,
+    persist_project_graph_projection,
+)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def project_graph_sessionmaker():
+    engine = create_async_engine(settings.DATABASE_URL)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            await conn.run_sync(Base.metadata.create_all)
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    except (
+        InvalidAuthorizationSpecificationError,
+        InvalidPasswordError,
+        OperationalError,
+        OSError,
+    ) as exc:
+        pytest.skip(f"PostgreSQL smoke database unavailable: {exc}")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_project_graph_projection_persists_source_cited_objects_and_edges(
+    project_graph_sessionmaker,
+):
+    user_id = f"project-user-{uuid.uuid4().hex}"
+    organization_id = "org-acme"
+    workspace_id = "workspace-org-acme"
+    async with project_graph_sessionmaker() as session:
+        segment = await _seed_source_segment(
+            session,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        extraction = extract_project_semantics([_source_segment(segment)])
+
+        result = await persist_project_graph_projection(
+            session,
+            extraction=extraction,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+        await session.commit()
+
+        assert len(result.objects) == 1
+        assert len(result.edges) == 1
+        persisted_object = result.objects[0]
+        persisted_edge = result.edges[0]
+        assert persisted_object.user_id == user_id
+        assert persisted_object.organization_id == organization_id
+        assert persisted_object.workspace_id == workspace_id
+        assert persisted_object.primary_content_segment_id == segment.content_segment_id
+        assert persisted_object.source_segment_uids == [segment.content_segment_uid]
+        assert persisted_object.attributes_json["source_record_uid"] == (
+            segment.source_record_uid
+        )
+        assert persisted_edge.target_object_id == persisted_object.project_graph_object_id
+        assert persisted_edge.source_uid == f"segment:{segment.content_segment_uid}"
+        assert persisted_edge.source_segment_uids == [segment.content_segment_uid]
+
+
+@pytest.mark.asyncio
+async def test_project_graph_projection_upserts_existing_records(
+    project_graph_sessionmaker,
+):
+    user_id = f"project-user-{uuid.uuid4().hex}"
+    organization_id = "org-acme"
+    workspace_id = "workspace-org-acme"
+    async with project_graph_sessionmaker() as session:
+        segment = await _seed_source_segment(
+            session,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        extraction = extract_project_semantics([_source_segment(segment)])
+
+        await persist_project_graph_projection(
+            session,
+            extraction=extraction,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+        await persist_project_graph_projection(
+            session,
+            extraction=extraction,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            status_code="confirmed",
+        )
+        await session.commit()
+
+        object_count = await session.scalar(
+            select(func.count()).select_from(ProjectGraphObjectRecord).where(
+                ProjectGraphObjectRecord.user_id == user_id
+            )
+        )
+        edge_count = await session.scalar(
+            select(func.count()).select_from(ProjectGraphEdgeRecord).where(
+                ProjectGraphEdgeRecord.user_id == user_id
+            )
+        )
+        persisted_object = await session.scalar(
+            select(ProjectGraphObjectRecord).where(
+                ProjectGraphObjectRecord.user_id == user_id
+            )
+        )
+
+        assert object_count == 1
+        assert edge_count == 1
+        assert persisted_object is not None
+        assert persisted_object.status_code == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_project_graph_correction_records_before_after_and_updates_projection(
+    project_graph_sessionmaker,
+):
+    user_id = f"project-user-{uuid.uuid4().hex}"
+    organization_id = "org-acme"
+    workspace_id = "workspace-org-acme"
+    async with project_graph_sessionmaker() as session:
+        segment = await _seed_source_segment(
+            session,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        extraction = extract_project_semantics([_source_segment(segment)])
+        result = await persist_project_graph_projection(
+            session,
+            extraction=extraction,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+        )
+
+        correction = await apply_project_graph_correction(
+            session,
+            object_uid=result.objects[0].object_uid,
+            user_id=user_id,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            actor_user_id="reviewer",
+            correction_action="confirm_requirement",
+            after_json={
+                "status_code": "approved",
+                "title": "Requirement: confirmed checkout retry guidance",
+            },
+            rationale="Reviewed against the source segment.",
+        )
+        await session.commit()
+
+        persisted_object = await session.get(
+            ProjectGraphObjectRecord,
+            result.objects[0].project_graph_object_id,
+        )
+        persisted_correction = await session.get(
+            ProjectGraphCorrectionRecord,
+            correction.project_graph_correction_id,
+        )
+
+        assert persisted_object is not None
+        assert persisted_object.status_code == "approved"
+        assert persisted_object.title == "Requirement: confirmed checkout retry guidance"
+        assert persisted_correction is not None
+        assert persisted_correction.before_json["status_code"] == "candidate"
+        assert persisted_correction.after_json["status_code"] == "approved"
+        assert persisted_correction.source_segment_uids == [segment.content_segment_uid]
+
+
+@pytest.mark.asyncio
+async def test_project_graph_projection_rejects_cross_scope_source_segments(
+    project_graph_sessionmaker,
+):
+    async with project_graph_sessionmaker() as session:
+        segment = await _seed_source_segment(
+            session,
+            user_id=f"project-user-{uuid.uuid4().hex}",
+            organization_id="org-acme",
+        )
+        extraction = extract_project_semantics([_source_segment(segment)])
+
+        with pytest.raises(ValueError, match="different scope"):
+            await persist_project_graph_projection(
+                session,
+                extraction=extraction,
+                user_id="different-user",
+                organization_id="org-acme",
+                workspace_id="workspace-org-acme",
+            )
+
+
+async def _seed_source_segment(
+    session,
+    *,
+    user_id: str,
+    organization_id: str,
+) -> ContentSegmentRecord:
+    await _cleanup_user(session, user_id)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    email = Email(
+        user_id=user_id,
+        organization_id=organization_id,
+        message_id=f"<{uuid.uuid4().hex}@example.com>",
+        thread_id=f"thread-{uuid.uuid4().hex}",
+        fingerprint=f"sha256:{uuid.uuid4().hex}",
+        sender="partner@example.com",
+        recipients="owner@example.com",
+        subject="Project Alpha requirements",
+        date=now,
+        body="요구사항 본문",
+    )
+    session.add(email)
+    await session.flush()
+    node = ContentNodeRecord(
+        content_node_uid=f"node-{uuid.uuid4().hex[:16]}",
+        email_id=email.id,
+        attachment_id=None,
+        source_kind="email_body",
+        source_record_uid=email.message_id,
+        parent_node_uid=None,
+        node_kind="document",
+        node_path="/document[1]",
+        ordinal_index=1,
+        display_label="body",
+        safe_text_content="요구사항 문단",
+        content_hash=uuid.uuid4().hex,
+        created_at=now,
+    )
+    session.add(node)
+    await session.flush()
+    segment = ContentSegmentRecord(
+        content_segment_uid=f"seg-{uuid.uuid4().hex[:16]}",
+        email_id=email.id,
+        attachment_id=None,
+        content_node_id=node.content_node_id,
+        source_kind="email_body",
+        source_record_uid=email.message_id,
+        segment_kind="paragraph",
+        segment_path="/document[1]/paragraph[1]",
+        ordinal_index=1,
+        heading_path="Requirements",
+        safe_text_content=(
+            "요구사항: 결제 화면은 카드 승인 실패 시 재시도 안내를 반드시 보여줘야 합니다."
+        ),
+        content_hash=uuid.uuid4().hex,
+        word_count=9,
+        created_at=now,
+    )
+    session.add(segment)
+    await session.flush()
+    return segment
+
+
+def _source_segment(segment: ContentSegmentRecord) -> ProjectSourceSegment:
+    return ProjectSourceSegment(
+        content_segment_uid=segment.content_segment_uid,
+        source_kind=segment.source_kind,
+        source_record_uid=segment.source_record_uid,
+        safe_text_content=segment.safe_text_content,
+        heading_path=segment.heading_path,
+        segment_path=segment.segment_path,
+        ordinal_index=segment.ordinal_index,
+    )
+
+
+async def _cleanup_user(session, user_id: str) -> None:
+    await session.execute(
+        delete(ProjectGraphCorrectionRecord).where(
+            ProjectGraphCorrectionRecord.user_id == user_id
+        )
+    )
+    await session.execute(
+        delete(ProjectGraphEdgeRecord).where(ProjectGraphEdgeRecord.user_id == user_id)
+    )
+    await session.execute(
+        delete(ProjectGraphObjectRecord).where(
+            ProjectGraphObjectRecord.user_id == user_id
+        )
+    )
+    await session.execute(delete(Email).where(Email.user_id == user_id))
+    await session.flush()


### PR DESCRIPTION
요약
- PR #902의 Project Semantic KG extractor foundation 위에 Phase 2 projection persistence와 correction trail을 추가합니다.
- project_graph_objects, project_graph_edges, project_graph_corrections 테이블과 Alembic 0009 migration을 추가했습니다.
- source segment citation, workspace/user/organization scope 검증, deterministic upsert, correction before/after trail을 담당하는 repository/projection service를 추가했습니다.
- projection persistence, correction update, cross-scope rejection, Alembic revision guard 테스트를 추가했습니다.

검증
- cd backend && ruff check .
- cd backend && python3 -m pytest -q
- git diff --check
- codegraph sync

메모
- Figma Code Connect는 사용하지 않았습니다.
- GitHub checks queued와 review process는 blocker로 취급하지 않습니다.