### PR TITLE
Phase 6: 프로젝트 자동화 브리프

### DIFF
--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -165,7 +165,7 @@ describe("ProjectsPage", () => {
       title: "Project: Alpha Checkout",
       status_code: "needs_review",
       score: 0.87,
-      object_count: 6,
+      object_count: 10,
       requirement_count: 1,
       issue_count: 1,
       milestone_count: 1,
@@ -216,6 +216,94 @@ describe("ProjectsPage", () => {
               summary: "PG 응답 지연 시 결제 재시도 UX가 필요합니다.",
               status_code: "open",
               confidence: 0.81,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "milestone:alpha-beta-freeze",
+              object_type: "milestone",
+              title: "7월 결제 UX 베타 동결",
+              summary: "결제 재시도 안내는 베타 동결 전에 검증되어야 합니다.",
+              status_code: "open",
+              confidence: 0.84,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "wbs:alpha-retry-work-package",
+              object_type: "wbs_item",
+              title: "결제 재시도 UX 작업 패키지",
+              summary: "프론트엔드 상태, PG timeout 처리, QA 검증을 하나의 WBS 항목으로 묶습니다.",
+              status_code: "open",
+              confidence: 0.8,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "deliverable:alpha-qa-report",
+              object_type: "deliverable",
+              title: "결제 재시도 QA 산출물",
+              summary: "카드 승인 실패 재시도 안내의 검증 결과가 산출물로 관리됩니다.",
+              status_code: "open",
+              confidence: 0.79,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "report:alpha-weekly",
+              object_type: "report_delta",
+              title: "주간 보고: 결제 재시도 리스크",
+              summary: "승인 실패 UX와 PG timeout 리스크가 이번 주 보고 항목입니다.",
+              status_code: "open",
+              confidence: 0.78,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "wiki:alpha-checkout",
+              object_type: "wiki_projection",
+              title: "Alpha Checkout 위키 초안",
+              summary: "결제 재시도 요구사항과 근거 문단을 위키 페이지로 투영합니다.",
+              status_code: "open",
+              confidence: 0.76,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "data:alpha-failure-reason",
+              object_type: "data_requirement",
+              title: "결제 실패 사유 데이터 요건",
+              summary: "승인 실패와 재시도 안내를 연결할 실패 사유 필드가 필요합니다.",
+              status_code: "open",
+              confidence: 0.75,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "erd:alpha-payment-attempt",
+              object_type: "erd_candidate",
+              title: "PaymentAttempt ERD 후보",
+              summary: "결제 시도, 승인 실패, 재시도 안내 상태를 ERD 후보로 관리합니다.",
+              status_code: "open",
+              confidence: 0.74,
+              source_segment_uids: ["segment-alpha-1"],
+              citation_bundle: [citation],
+              attributes: {},
+            },
+            {
+              object_uid: "infra:alpha-pg-timeout-observability",
+              object_type: "infra_requirement",
+              title: "PG timeout 관측 인프라",
+              summary: "PG 응답 지연을 감지해 재시도 UX 품질을 추적합니다.",
+              status_code: "open",
+              confidence: 0.73,
               source_segment_uids: ["segment-alpha-1"],
               citation_bundle: [citation],
               attributes: {},
@@ -299,6 +387,18 @@ describe("ProjectsPage", () => {
     expect(container.textContent).toContain("1 citations");
     expect(container.textContent).toContain("Full evidence 확인됨");
     expect(container.textContent).toContain("Source coverage: 1 문단");
+    expect(container.textContent).toContain("자동화 브리프");
+    expect(container.textContent).toContain("Automation coverage");
+    expect(container.textContent).toContain("5 / 5 domains ready");
+    expect(container.textContent).toContain("Buyer KPI: source-backed delivery automation");
+    expect(container.textContent).toContain("WBS / 일정");
+    expect(container.textContent).toContain("보고 자동 생성");
+    expect(container.textContent).toContain("프로젝트 위키");
+    expect(container.textContent).toContain("데이터·ERD·인프라");
+    expect(container.textContent).toContain("산출물 준비도");
+    expect(container.textContent).toContain("주간 보고: 결제 재시도 리스크");
+    expect(container.textContent).toContain("Alpha Checkout 위키 초안");
+    expect(container.textContent).toContain("PaymentAttempt ERD 후보");
 
     const reviewButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("문단 근거 검토 저장"));
     expect(reviewButton).toBeDefined();

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -129,6 +129,29 @@ interface ProjectAccessScope {
   organizationId: string | null;
 }
 
+interface AutomationBriefMetric {
+  key: string;
+  label: string;
+  value: number;
+}
+
+interface AutomationBriefDomain {
+  key: string;
+  label: string;
+  description: string;
+  objectTypes: string[];
+  count: number;
+  citationCount: number;
+  primaryTitle: string;
+}
+
+interface AutomationBrief {
+  domains: AutomationBriefDomain[];
+  metrics: AutomationBriefMetric[];
+  readyDomainCount: number;
+  totalDomainCount: number;
+}
+
 const projectStatusClass = {
   '완료': 'bg-emerald-100 text-emerald-700',
   '진행 중': 'bg-blue-100 text-blue-700',
@@ -315,6 +338,62 @@ function citationSourceLabel(citation: ProjectCitation) {
   return citation.source_kind;
 }
 
+function buildAutomationBrief(objects: ProjectTraceObject[]): AutomationBrief {
+  const domains = [
+    {
+      key: 'wbs',
+      label: 'WBS / 일정',
+      description: 'Waterfall·Agile 실행 단위를 일정과 WBS로 묶습니다.',
+      objectTypes: ['wbs_item', 'milestone'],
+    },
+    {
+      key: 'report',
+      label: '보고 자동 생성',
+      description: '주간·일일 보고 초안에 들어갈 변화와 리스크를 모읍니다.',
+      objectTypes: ['report_delta'],
+    },
+    {
+      key: 'wiki',
+      label: '프로젝트 위키',
+      description: 'LLM Wiki 스타일 프로젝트 지식 페이지 후보를 표시합니다.',
+      objectTypes: ['wiki_projection'],
+    },
+    {
+      key: 'data',
+      label: '데이터·ERD·인프라',
+      description: '데이터 요건, ERD 후보, 인프라 요건을 같은 근거 체인으로 묶습니다.',
+      objectTypes: ['data_requirement', 'erd_candidate', 'infra_requirement'],
+    },
+    {
+      key: 'deliverable',
+      label: '산출물 준비도',
+      description: '요구사항에서 산출물까지 추적 가능한 납품 후보를 계산합니다.',
+      objectTypes: ['requirement', 'feature', 'deliverable'],
+    },
+  ].map((domain) => {
+    const matchingObjects = objects.filter((projectObject) => domain.objectTypes.includes(projectObject.object_type));
+    return {
+      ...domain,
+      count: matchingObjects.length,
+      citationCount: matchingObjects.reduce((total, projectObject) => total + projectObject.citation_bundle.length, 0),
+      primaryTitle: safeText(matchingObjects[0]?.title, '근거 객체 대기'),
+    };
+  });
+  const readyDomainCount = domains.filter((domain) => domain.count > 0).length;
+  const reportReadyCount = domains.find((domain) => domain.key === 'report')?.count ?? 0;
+  const wikiReadyCount = domains.find((domain) => domain.key === 'wiki')?.count ?? 0;
+  return {
+    domains,
+    readyDomainCount,
+    totalDomainCount: domains.length,
+    metrics: [
+      { key: 'coverage', label: 'Automation coverage', value: readyDomainCount },
+      { key: 'report', label: 'Report ready signals', value: reportReadyCount },
+      { key: 'wiki', label: 'Wiki ready signals', value: wikiReadyCount },
+    ],
+  };
+}
+
 export function ProjectsLayout() {
   const [folders, setFolders] = useState<ProjectFolder[]>([]);
   const [tasks, setTasks] = useState<TicketTask[]>([]);
@@ -395,6 +474,7 @@ export function ProjectsLayout() {
   const projectBoundaryLabel = getProjectBoundaryLabel(activeProject);
   const workspaceScopeLabel = getWorkspaceScopeLabel(projectScope);
   const currentTraceability = traceability?.project_uid === activeSemanticCandidate?.project_uid ? traceability : null;
+  const automationBrief = useMemo(() => buildAutomationBrief(currentTraceability?.objects ?? []), [currentTraceability]);
   const traceLoading = Boolean(activeSemanticCandidate && !currentTraceability && traceFailureProjectUid !== activeSemanticCandidate.project_uid);
   const selectedTraceObject = currentTraceability?.objects.find((item) => item.object_uid === selectedObjectUid) ?? currentTraceability?.objects[0] ?? null;
   const selectedEvidenceProjectUid = activeSemanticCandidate?.project_uid ?? null;
@@ -684,6 +764,67 @@ export function ProjectsLayout() {
                     <span className="font-mono text-xs font-black">{graphHealthPercent}%</span>
                   </div>
                 </div>
+              </section>
+            ) : null}
+
+            {activeSemanticCandidate ? (
+              <section aria-label="프로젝트 자동화 브리프" className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
+                <div className="flex flex-col gap-3 border-b border-border p-5 md:flex-row md:items-center md:justify-between">
+                  <div className="min-w-0">
+                    <h2 className="flex items-center gap-2 font-bold text-lg"><ListChecks className="size-5 text-primary" /> 자동화 브리프</h2>
+                    <p className="mt-1 text-sm font-semibold text-muted-foreground">Traceability 객체를 WBS, 보고, 위키, 데이터 산출물로 접어 보여줍니다.</p>
+                  </div>
+                  <div className="grid min-w-52 grid-cols-3 gap-2 text-center">
+                    {automationBrief.metrics.map((metric) => (
+                      <div key={metric.key} className="rounded-lg border border-border bg-background px-3 py-2">
+                        <p className="text-[11px] font-bold text-muted-foreground">{metric.label}</p>
+                        <p className="mt-1 font-mono text-lg font-black">{metric.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                {currentTraceability ? (
+                  <div className="p-5">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+                        {automationBrief.readyDomainCount} / {automationBrief.totalDomainCount} domains ready
+                      </span>
+                      <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-bold text-muted-foreground">Buyer KPI: source-backed delivery automation</span>
+                    </div>
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      {automationBrief.domains.map((domain) => (
+                        <article key={domain.key} className="rounded-lg border border-border bg-background p-4">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <h3 className="break-keep text-sm font-black">{domain.label}</h3>
+                              <p className="mt-1 text-xs leading-5 text-muted-foreground">{domain.description}</p>
+                            </div>
+                            <span className={`shrink-0 rounded px-2 py-1 text-xs font-bold ${domain.count > 0 ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600'}`}>
+                              {domain.count > 0 ? '근거 있음' : '대기'}
+                            </span>
+                          </div>
+                          <dl className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                            <div className="rounded-md border border-border bg-card p-2">
+                              <dt className="font-bold text-muted-foreground">객체</dt>
+                              <dd className="mt-1 font-mono text-base font-black">{domain.count}</dd>
+                            </div>
+                            <div className="rounded-md border border-border bg-card p-2">
+                              <dt className="font-bold text-muted-foreground">문단 근거</dt>
+                              <dd className="mt-1 font-mono text-base font-black">{domain.citationCount}</dd>
+                            </div>
+                          </dl>
+                          <p className="mt-3 line-clamp-2 text-xs font-semibold text-foreground">{domain.primaryTitle}</p>
+                        </article>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="p-5">
+                    <p className="rounded-xl border border-dashed border-border p-4 text-sm font-semibold text-muted-foreground">
+                      {traceLoading ? '자동화 브리프를 구성하는 중입니다.' : '자동화 브리프를 구성할 traceability 근거가 없습니다.'}
+                    </p>
+                  </div>
+                )}
               </section>
             ) : null}
 


### PR DESCRIPTION
## Summary
- Adds a Project Automation Brief layer to `/projects` using the existing project traceability response only.
- Groups traceability objects into WBS/schedule, weekly/daily report signals, project wiki projection, data/ERD/infra requirements, and deliverable readiness.
- Extends the Projects page test fixture to cover WBS, report, wiki, data, ERD, infra, and deliverable readiness while keeping raw content segment IDs, source email IDs, and correction IDs out of the UI.

## Design / plugin notes
- Figma FigJam planning board: https://www.figma.com/board/I9tbBoUCgMh96E0SyU7RQA
- Product Design: stays inside the existing Projects command center pattern.
- Data Analytics: buyer-facing KPI is limited to automation coverage and source-backed report/wiki readiness.
- Ponytail: no new backend endpoint, library split, dependency, or submodule; this is a narrow frontend derivation from existing traceability objects.
- Figma Code Connect was not used.

## Verification
- `cd frontend && corepack pnpm test --run src/app/projects/page.test.tsx`
- `cd frontend && corepack pnpm lint`
- `cd frontend && corepack pnpm typecheck`
- `cd frontend && corepack pnpm test --run`
- `cd backend && python3 -m pytest -q tests/test_project_graph_api.py`
- `cd backend && ruff check .`
- `cd backend && python3 -m pytest -q`
- `git diff --check`
- `codegraph sync`
- `codegraph status`
- Playwright desktop/mobile render smoke for `/projects` with mocked signed APIs and raw identifier leak checks

Review process and queued GitHub checks are not treated as blockers per project direction.
