### PR TITLE
Phase 8: 프로젝트 컨트롤 준비도 레이어

### DIFF
--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -410,6 +410,20 @@ describe("ProjectsPage", () => {
     expect(container.textContent).toContain("상태 자동 업데이트: PG timeout risk 검토 필요");
     expect(container.textContent).toContain("다음 액션: PG timeout risk 확인");
     expect(container.textContent).toContain("검토자 액션: 2개 보고 초안 근거 확인");
+    expect(container.textContent).toContain("컨트롤 준비도");
+    expect(container.textContent).toContain("Control readiness score");
+    expect(container.textContent).toContain("Missing evidence count");
+    expect(container.textContent).toContain("Acceptance-to-action coverage");
+    expect(container.textContent).toContain("Scope-risk balance");
+    expect(container.textContent).toContain("5 / 5 controls ready");
+    expect(container.textContent).toContain("Diligence KPI: source-backed control readiness");
+    expect(container.textContent).toContain("Acceptance coverage");
+    expect(container.textContent).toContain("Schedule confidence");
+    expect(container.textContent).toContain("Scope clarity");
+    expect(container.textContent).toContain("Data/infra readiness");
+    expect(container.textContent).toContain("Owner/action readiness");
+    expect(container.textContent).toContain("실행 준비 요약: 5개 컨트롤이 문단 근거로 준비됨");
+    expect(container.textContent).toContain("검토자 액션: 누락 근거 없음, 인수 검토 가능");
 
     const reviewButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("문단 근거 검토 저장"));
     expect(reviewButton).toBeDefined();

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -171,6 +171,26 @@ interface ProjectReportDraftLayer {
   reviewerAction: string;
 }
 
+interface ProjectControlReadinessItem {
+  key: string;
+  label: string;
+  description: string;
+  objectTypes: string[];
+  count: number;
+  citationCount: number;
+  primaryTitle: string;
+}
+
+interface ProjectControlReadinessLayer {
+  items: ProjectControlReadinessItem[];
+  metrics: AutomationBriefMetric[];
+  readyItemCount: number;
+  totalItemCount: number;
+  missingEvidenceCount: number;
+  summary: string;
+  reviewerAction: string;
+}
+
 const projectStatusClass = {
   '완료': 'bg-emerald-100 text-emerald-700',
   '진행 중': 'bg-blue-100 text-blue-700',
@@ -475,6 +495,71 @@ function buildProjectReportDraftLayer(objects: ProjectTraceObject[]): ProjectRep
   };
 }
 
+function buildProjectControlReadinessLayer(objects: ProjectTraceObject[]): ProjectControlReadinessLayer {
+  const items = [
+    {
+      key: 'acceptance',
+      label: 'Acceptance coverage',
+      description: '요구사항, 기능, 산출물이 인수 기준으로 이어지는지 확인합니다.',
+      objectTypes: ['requirement', 'feature', 'deliverable'],
+    },
+    {
+      key: 'schedule',
+      label: 'Schedule confidence',
+      description: '마일스톤과 WBS 근거가 일정 추적에 충분한지 확인합니다.',
+      objectTypes: ['milestone', 'wbs_item'],
+    },
+    {
+      key: 'scope',
+      label: 'Scope clarity',
+      description: '요구사항과 위키 후보가 프로젝트 범위를 설명하는지 확인합니다.',
+      objectTypes: ['requirement', 'feature', 'wiki_projection'],
+    },
+    {
+      key: 'dataInfra',
+      label: 'Data/infra readiness',
+      description: '데이터 요건, ERD 후보, 인프라 요건이 함께 잡혔는지 확인합니다.',
+      objectTypes: ['data_requirement', 'erd_candidate', 'infra_requirement'],
+    },
+    {
+      key: 'ownerAction',
+      label: 'Owner/action readiness',
+      description: '담당자, 이슈, WBS 근거가 다음 액션으로 이어지는지 확인합니다.',
+      objectTypes: ['participant', 'issue', 'wbs_item'],
+    },
+  ].map((item) => {
+    const matchingObjects = objects.filter((projectObject) => item.objectTypes.includes(projectObject.object_type));
+    return {
+      ...item,
+      count: matchingObjects.length,
+      citationCount: matchingObjects.reduce((total, projectObject) => total + projectObject.citation_bundle.length, 0),
+      primaryTitle: safeText(matchingObjects[0]?.title, '근거 객체 대기'),
+    };
+  });
+  const readyItemCount = items.filter((item) => item.count > 0 && item.citationCount > 0).length;
+  const missingEvidenceCount = items.length - readyItemCount;
+  const acceptanceReady = items.find((item) => item.key === 'acceptance')?.count ? 1 : 0;
+  const actionReady = items.find((item) => item.key === 'ownerAction')?.count ? 1 : 0;
+  const scopeReady = items.find((item) => item.key === 'scope')?.count ? 1 : 0;
+  const riskReady = objects.some((projectObject) => projectObject.object_type === 'issue') ? 1 : 0;
+  return {
+    items,
+    readyItemCount,
+    totalItemCount: items.length,
+    missingEvidenceCount,
+    summary: `실행 준비 요약: ${readyItemCount}개 컨트롤이 문단 근거로 준비됨`,
+    reviewerAction: missingEvidenceCount > 0
+      ? `검토자 액션: ${missingEvidenceCount}개 컨트롤 근거 보강`
+      : '검토자 액션: 누락 근거 없음, 인수 검토 가능',
+    metrics: [
+      { key: 'score', label: 'Control readiness score', value: Math.round((readyItemCount / items.length) * 100) },
+      { key: 'missing', label: 'Missing evidence count', value: missingEvidenceCount },
+      { key: 'acceptanceAction', label: 'Acceptance-to-action coverage', value: acceptanceReady && actionReady ? 1 : 0 },
+      { key: 'scopeRisk', label: 'Scope-risk balance', value: scopeReady && riskReady ? 1 : 0 },
+    ],
+  };
+}
+
 export function ProjectsLayout() {
   const [folders, setFolders] = useState<ProjectFolder[]>([]);
   const [tasks, setTasks] = useState<TicketTask[]>([]);
@@ -557,6 +642,7 @@ export function ProjectsLayout() {
   const currentTraceability = traceability?.project_uid === activeSemanticCandidate?.project_uid ? traceability : null;
   const automationBrief = useMemo(() => buildAutomationBrief(currentTraceability?.objects ?? []), [currentTraceability]);
   const reportDraftLayer = useMemo(() => buildProjectReportDraftLayer(currentTraceability?.objects ?? []), [currentTraceability]);
+  const controlReadinessLayer = useMemo(() => buildProjectControlReadinessLayer(currentTraceability?.objects ?? []), [currentTraceability]);
   const traceLoading = Boolean(activeSemanticCandidate && !currentTraceability && traceFailureProjectUid !== activeSemanticCandidate.project_uid);
   const selectedTraceObject = currentTraceability?.objects.find((item) => item.object_uid === selectedObjectUid) ?? currentTraceability?.objects[0] ?? null;
   const selectedEvidenceProjectUid = activeSemanticCandidate?.project_uid ?? null;
@@ -970,6 +1056,72 @@ export function ProjectsLayout() {
                   <div className="p-5">
                     <p className="rounded-xl border border-dashed border-border p-4 text-sm font-semibold text-muted-foreground">
                       {traceLoading ? '보고 초안을 구성하는 중입니다.' : '보고 초안을 구성할 traceability 근거가 없습니다.'}
+                    </p>
+                  </div>
+                )}
+              </section>
+            ) : null}
+
+            {activeSemanticCandidate ? (
+              <section aria-label="프로젝트 컨트롤 준비도" className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
+                <div className="flex flex-col gap-3 border-b border-border p-5 md:flex-row md:items-center md:justify-between">
+                  <div className="min-w-0">
+                    <h2 className="flex items-center gap-2 font-bold text-lg"><CheckCircle2 className="size-5 text-primary" /> 컨트롤 준비도</h2>
+                    <p className="mt-1 text-sm font-semibold text-muted-foreground">인수·일정·범위·데이터·액션 근거를 실사 가능한 컨트롤로 묶습니다.</p>
+                  </div>
+                  <div className="grid min-w-52 grid-cols-2 gap-2 text-center md:grid-cols-4">
+                    {controlReadinessLayer.metrics.map((metric) => (
+                      <div key={metric.key} className="rounded-lg border border-border bg-background px-3 py-2">
+                        <p className="text-[11px] font-bold text-muted-foreground">{metric.label}</p>
+                        <p className="mt-1 font-mono text-lg font-black">{metric.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                {currentTraceability ? (
+                  <div className="p-5">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+                        {controlReadinessLayer.readyItemCount} / {controlReadinessLayer.totalItemCount} controls ready
+                      </span>
+                      <span className="rounded-full bg-secondary px-2.5 py-1 text-xs font-bold text-muted-foreground">Diligence KPI: source-backed control readiness</span>
+                    </div>
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      {controlReadinessLayer.items.map((item) => (
+                        <article key={item.key} className="rounded-lg border border-border bg-background p-4">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <h3 className="break-keep text-sm font-black">{item.label}</h3>
+                              <p className="mt-1 text-xs leading-5 text-muted-foreground">{item.description}</p>
+                            </div>
+                            <span className={`shrink-0 rounded px-2 py-1 text-xs font-bold ${item.count > 0 && item.citationCount > 0 ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600'}`}>
+                              {item.count > 0 && item.citationCount > 0 ? '준비됨' : '근거 대기'}
+                            </span>
+                          </div>
+                          <dl className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                            <div className="rounded-md border border-border bg-card p-2">
+                              <dt className="font-bold text-muted-foreground">컨트롤 근거</dt>
+                              <dd className="mt-1 font-mono text-base font-black">{item.count}</dd>
+                            </div>
+                            <div className="rounded-md border border-border bg-card p-2">
+                              <dt className="font-bold text-muted-foreground">문단 citation</dt>
+                              <dd className="mt-1 font-mono text-base font-black">{item.citationCount}</dd>
+                            </div>
+                          </dl>
+                          <p className="mt-3 line-clamp-2 text-xs font-semibold text-foreground">{item.primaryTitle}</p>
+                        </article>
+                      ))}
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      {[controlReadinessLayer.summary, controlReadinessLayer.reviewerAction].map((item) => (
+                        <p key={item} className="rounded-lg border border-border bg-background p-3 text-xs font-bold leading-5 text-foreground">{item}</p>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="p-5">
+                    <p className="rounded-xl border border-dashed border-border p-4 text-sm font-semibold text-muted-foreground">
+                      {traceLoading ? '컨트롤 준비도를 구성하는 중입니다.' : '컨트롤 준비도를 구성할 traceability 근거가 없습니다.'}
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Add a `/projects` Project Control Readiness layer on top of the existing traceability response.
- Reuse source-backed KG objects to show acceptance coverage, schedule confidence, scope clarity, data/infra readiness, and owner/action readiness.
- Add diligence-facing KPIs: control readiness score, missing evidence count, acceptance-to-action coverage, and scope-risk balance.

## Plugin coordination
- Figma: added `Phase 8 Control Readiness Layer` to the existing FigJam board: https://www.figma.com/board/I9tbBoUCgMh96E0SyU7RQA
- Product Design: followed the existing Projects command center card/section/mobile pattern.
- Data Analytics: limited metrics to decision-ready readiness and evidence gaps.
- Ponytail: no new backend API, dependency, submodule, or library; minimal helper/test changes only.
- Superpowers: created a concrete Goal, checked related PRs/resources, and verified before handoff.
- Figma Code Connect was not used.

## Related PRs checked
- #900 productization plan axis
- #901 diligence checklist axis
- #902 implementation axis and base branch
- #908 Phase 7 report draft layer, already merged into #902 branch

## Verification
- `corepack pnpm test --run src/app/projects/page.test.tsx`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test --run`
- `uv run --with ruff ruff check .`
- `uv run --with-requirements requirements.txt --with pytest pytest -q`
- `git diff --check`
- `codegraph sync && codegraph status`
- Playwright desktop/mobile render smoke with mocked traceability API

## Screenshots
- `/tmp/naruon-projects-phase8-desktop-control.png`
- `/tmp/naruon-projects-phase8-mobile-control.png`
- `/tmp/naruon-projects-phase8-desktop-control-section.png`
- `/tmp/naruon-projects-phase8-mobile-control-section.png`
