### PR TITLE
🎨 Palette: 검색 필드에 type="search" 적용하여 모바일 UX 및 시맨틱 접근성 개선

### DIFF
--- a/frontend/src/app/search/page.test.tsx
+++ b/frontend/src/app/search/page.test.tsx
@@ -439,7 +439,7 @@ describe("SearchPage", () => {
 
     const input = container.querySelector("#search-input") as HTMLInputElement | null;
     expect(input).not.toBeNull();
-    expect(input?.type).toBe("text");
+    expect(input?.type).toBe("search");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
     expect(

--- a/frontend/src/app/tasks/page.test.tsx
+++ b/frontend/src/app/tasks/page.test.tsx
@@ -137,7 +137,7 @@ describe("TasksPage", () => {
 
     const taskSearchInput = container.querySelector<HTMLInputElement>('input[aria-label="작업 맥락 검색"]');
     expect(taskSearchInput).not.toBeNull();
-    expect(taskSearchInput?.type).toBe("text");
+    expect(taskSearchInput?.type).toBe("search");
     expect(taskSearchInput?.inputMode).toBe("search");
     expect(taskSearchInput?.getAttribute("role")).toBe("searchbox");
     await act(async () => {

--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -92,7 +92,7 @@ describe("DashboardLayout", () => {
     expect(main).not.toBeNull();
     expect(skipLink).not.toBeNull();
     expect(logo?.getAttribute("src")).toBe("/brand/naruon-symbol.svg");
-    expect(globalSearchInput?.getAttribute("type")).toBe("text");
+    expect(globalSearchInput?.getAttribute("type")).toBe("search");
     expect(globalSearchInput?.getAttribute("inputmode")).toBe("search");
     expect(globalSearchInput?.getAttribute("role")).toBe("searchbox");
     expect(headerActionButtons).toEqual(["일정 반영", "답장 초안", "실행 항목 생성"]);
@@ -222,7 +222,7 @@ describe("DashboardLayout", () => {
 
     const input = container.querySelector<HTMLInputElement>("#global-search-input");
     expect(input).not.toBeNull();
-    expect(input?.getAttribute("type")).toBe("text");
+    expect(input?.getAttribute("type")).toBe("search");
     expect(input?.getAttribute("inputmode")).toBe("search");
     expect(input?.getAttribute("role")).toBe("searchbox");
 

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -364,13 +364,13 @@ export function DashboardLayout({
             <input
               id="global-search-input"
               ref={globalSearchInputRef}
-              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground"
+              className="min-w-0 flex-1 bg-transparent pr-8 outline-none placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:hidden"
               inputMode="search"
               role="searchbox"
               value={globalSearchQuery}
               onChange={(event) => setGlobalSearchQuery(event.target.value)}
               placeholder="맥락, 사람, 파일, 판단 포인트 맥락 검색..."
-              type="text"
+              type="search"
             />
             {globalSearchQuery ? (
               <button

--- a/frontend/src/components/EmailList.tsx
+++ b/frontend/src/components/EmailList.tsx
@@ -220,10 +220,10 @@ export function EmailList({
               placeholder="메일, 사람, 키워드 맥락 검색..."
               value={searchQuery}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
-              type="text"
+              type="search"
               inputMode="search"
               role="searchbox"
-              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02]"
+              className="h-10 rounded-xl border-input bg-background/80 pl-9 pr-9 shadow-inner shadow-slate-950/[0.02] [&::-webkit-search-cancel-button]:hidden"
             />
             {searchQuery && (
               <button

--- a/frontend/src/components/SearchLayout.tsx
+++ b/frontend/src/components/SearchLayout.tsx
@@ -511,14 +511,14 @@ export function SearchLayout() {
             <input
               id="search-input"
               ref={searchInputRef}
-              type="text"
+              type="search"
               inputMode="search"
               role="searchbox"
               aria-label="맥락 검색어 입력"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="메일, 일정, 파일, 사람, 의사결정 로그 맥락 검색..."
-              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10"
+              className="h-12 w-full rounded-full border-2 border-primary/20 bg-background pl-12 pr-12 text-base shadow-sm transition-all focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/10 [&::-webkit-search-cancel-button]:hidden"
             />
             {query && (
               <button

--- a/frontend/src/components/TasksLayout.tsx
+++ b/frontend/src/components/TasksLayout.tsx
@@ -326,14 +326,14 @@ export function TasksLayout() {
             <input
               ref={taskSearchInputRef}
               id="task-search-input"
-              type="text"
+              type="search"
               inputMode="search"
               role="searchbox"
               value={taskSearch}
               onChange={(event) => setTaskSearch(event.target.value)}
               placeholder="작업 맥락 검색..."
               aria-label="작업 맥락 검색"
-              className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64"
+              className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-9 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary sm:w-64 [&::-webkit-search-cancel-button]:hidden"
             />
             {taskSearch.length > 0 && (
               <button


### PR DESCRIPTION
💡 **What**: 검색 관련 `<input>` 필드의 타입을 `text`에서 `search`로 변경하고 WebKit 브라우저(크롬, 사파리 등)의 기본 검색 취소 버튼을 숨겼습니다.
🎯 **Why**: 모바일 디바이스에서 시맨틱 키보드(엔터 키 대신 '검색'/'이동' 버튼 렌더링)를 띄워 모바일 UX를 개선하고, 기존에 구현되어 있던 커스텀 검색어 지우기 버튼('X')과 네이티브 취소 버튼이 겹쳐 보이는 시각적 문제를 방지하기 위함입니다.
📸 **Before/After**: 시각적인 겹침 문제를 방지하고 모바일 환경에서 더 나은 키보드 레이아웃을 제공합니다.
♿ **Accessibility**: `type="search"`를 통해 스크린 리더 및 브라우저에서 해당 필드가 검색 용도임을 명확히 인지하게 하여 시맨틱 마크업을 강화했습니다.

---
*PR created automatically by Jules for task [16964276235791327210](https://jules.google.com/task/16964276235791327210) started by @seonghobae*