### PR TITLE
fix(ci): restore PR-head CodeQL SARIF for ruleset merge gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,10 +90,6 @@ jobs:
           persist-credentials: false
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
 
-      - name: Resolve merge preview SHA
-        id: merge_preview
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
@@ -105,5 +101,3 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}-merge"
           upload: always
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-          sha: ${{ steps.merge_preview.outputs.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,7 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"
@@ -59,3 +60,12 @@ jobs:
           upload: always
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Upload CodeQL SARIF (merge preview)
+        if: github.event_name == 'pull_request'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: ${{ steps.analyze.outputs.sarif-output }}
+          category: "/language:${{ matrix.language }}-merge"
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
+  analyze-head:
     name: CodeQL compatibility analysis (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
@@ -51,7 +51,6 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        id: analyze
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"
@@ -61,11 +60,46 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
-      - name: Upload CodeQL SARIF (merge preview)
-        if: github.event_name == 'pull_request'
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+  analyze-merge:
+    name: CodeQL merge preview (${{ matrix.language }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          sarif_file: ${{ steps.analyze.outputs.sarif-output }}
+          egress-policy: audit
+
+      - name: Checkout merge preview
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
           category: "/language:${{ matrix.language }}-merge"
+          upload: always
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
           sha: ${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+
+      - name: Resolve merge preview SHA
+        id: merge_preview
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -102,4 +106,4 @@ jobs:
           category: "/language:${{ matrix.language }}-merge"
           upload: always
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-          sha: ${{ github.sha }}
+          sha: ${{ steps.merge_preview.outputs.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  security-events: read
 
 jobs:
   analyze:
@@ -22,7 +21,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +42,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -54,8 +54,8 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"
-          # This repository uses GitHub CodeQL default setup for code scanning
-          # uploads. Keep this workflow as CI/Scorecard SAST evidence without
-          # uploading duplicate CodeQL SARIF, which GitHub rejects while
-          # default setup is enabled.
-          upload: never
+          # Upload PR-head CodeQL SARIF so ruleset code_scanning (CodeQL) can
+          # evaluate mergeability. Default setup is not configured on this repo.
+          upload: always
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,3 +101,7 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}-merge"
           upload: always
+          # Ruleset code_scanning evaluates merge_commit_sha, which can differ
+          # from the ephemeral SHA refs/pull/<n>/merge resolves to at upload time.
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+          sha: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -81,10 +81,6 @@ jobs:
           persist-credentials: false
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
 
-      - name: Resolve merge preview SHA
-        id: merge_preview
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
@@ -110,4 +106,3 @@ jobs:
           sarif_file: scorecard-results.sarif
           category: scorecard-merge
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-          sha: ${{ steps.merge_preview.outputs.sha }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,8 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  scorecard-head:
-    name: scorecard
+  scorecard:
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -60,49 +59,3 @@ jobs:
           category: scorecard
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-  scorecard-merge:
-    name: scorecard-merge
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      security-events: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          results_file: scorecard-results.sarif
-          results_format: sarif
-          publish_results: false
-
-      - name: Restore Scorecard SARIF ownership
-        run: |
-          if [ -e scorecard-results.sarif ]; then
-            sudo chown "$(id -u):$(id -g)" scorecard-results.sarif
-            chmod u+rw scorecard-results.sarif
-          fi
-
-      - name: Preserve Scorecard SARIF categories
-        run: python scripts/ci/ensure_scorecard_sarif_categories.py scorecard-results.sarif
-
-      - name: Upload Scorecard SARIF (merge preview)
-        if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: scorecard-results.sarif
-          category: scorecard-merge
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -79,7 +79,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+
+      - name: Resolve merge preview SHA
+        id: merge_preview
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
@@ -106,4 +110,4 @@ jobs:
           sarif_file: scorecard-results.sarif
           category: scorecard-merge
           ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-          sha: ${{ github.sha }}
+          sha: ${{ steps.merge_preview.outputs.sha }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,3 +59,12 @@ jobs:
           category: scorecard
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Upload Scorecard SARIF (merge preview)
+        if: ${{ github.event_name == 'pull_request' && always() }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: scorecard-results.sarif
+          category: scorecard-merge
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,7 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  scorecard:
+  scorecard-head:
+    name: scorecard
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -60,8 +61,46 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+  scorecard-merge:
+    name: scorecard-merge
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Restore Scorecard SARIF ownership
+        run: |
+          if [ -e scorecard-results.sarif ]; then
+            sudo chown "$(id -u):$(id -g)" scorecard-results.sarif
+            chmod u+rw scorecard-results.sarif
+          fi
+
+      - name: Preserve Scorecard SARIF categories
+        run: python scripts/ci/ensure_scorecard_sarif_categories.py scorecard-results.sarif
+
       - name: Upload Scorecard SARIF (merge preview)
-        if: ${{ github.event_name == 'pull_request' && always() }}
+        if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: scorecard-results.sarif

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -341,7 +341,8 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
         "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in workflow
     )
-    assert "Upload CodeQL SARIF (merge preview)" in workflow
+    assert "analyze-merge:" in workflow
+    assert "CodeQL merge preview" in workflow
     assert "refs/pull/{0}/merge" in workflow
     assert (
         "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
@@ -407,7 +408,7 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
         "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in scorecard_workflow
     )
-    assert "Upload Scorecard SARIF (merge preview)" in scorecard_workflow
+    assert "scorecard-merge:" in scorecard_workflow
     assert "category: scorecard-merge" in scorecard_workflow
     assert "refs/pull/{0}/merge" in scorecard_workflow
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -341,6 +341,8 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
         "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in workflow
     )
+    assert "Upload CodeQL SARIF (merge preview)" in workflow
+    assert "refs/pull/{0}/merge" in workflow
     assert (
         "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in workflow
@@ -405,6 +407,9 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
         "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in scorecard_workflow
     )
+    assert "Upload Scorecard SARIF (merge preview)" in scorecard_workflow
+    assert "category: scorecard-merge" in scorecard_workflow
+    assert "refs/pull/{0}/merge" in scorecard_workflow
 
     assert (
         "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0"

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -344,6 +344,7 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
     assert "analyze-merge:" in workflow
     assert "CodeQL merge preview" in workflow
     assert "refs/pull/{0}/merge" in workflow
+    assert "github.event.pull_request.merge_commit_sha" in workflow
     assert (
         "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in workflow

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -323,16 +323,28 @@ def test_bandit_security_scan_does_not_continue_on_error() -> None:
     assert "continue-on-error: true" not in workflow
 
 
-def test_codeql_workflow_can_read_security_events_without_uploading_sarif() -> None:
+def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
     workflow = read_repo_text(".github/workflows/codeql.yml")
 
-    assert "permissions:\n  contents: read\n  security-events: read" in workflow
+    assert "permissions:\n  contents: read\n\njobs:" in workflow
     assert (
-        "    permissions:\n      actions: read\n      contents: read\n      security-events: read"
+        "    permissions:\n      actions: read\n      contents: read\n      security-events: write"
         in workflow
     )
-    assert "upload: never" in workflow
-    assert "security-events: write" not in workflow
+    assert "upload: always" in workflow
+    assert "upload: never" not in workflow
+    assert (
+        "ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}"
+        in workflow
+    )
+    assert (
+        "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+        in workflow
+    )
+    assert (
+        "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+        in workflow
+    )
 
 
 def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> None:
@@ -883,6 +895,8 @@ def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge
     assert "/issues/${PR_NUMBER}/comments" in gate_script
     assert "COMMENT_MARKER" in gate_script
     assert "Waiting for" in gate_script
+    assert "no required checks reported" in gate_script
+    assert "ruleset workflows and code-scanning gates" in gate_script
     assert "reviewThreads" in gate_script
     assert "CHANGES_REQUESTED" in gate_script
     assert "gh pr merge" not in gate_script

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -343,7 +343,6 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
     )
     assert "analyze-merge:" in workflow
     assert "CodeQL merge preview" in workflow
-    assert "Resolve merge preview SHA" in workflow
     assert "refs/pull/{0}/merge" in workflow
     assert (
         "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
@@ -410,7 +409,6 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
         in scorecard_workflow
     )
     assert "scorecard-merge:" in scorecard_workflow
-    assert "Resolve merge preview SHA" in scorecard_workflow
     assert "category: scorecard-merge" in scorecard_workflow
     assert "refs/pull/{0}/merge" in scorecard_workflow
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -343,6 +343,7 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
     )
     assert "analyze-merge:" in workflow
     assert "CodeQL merge preview" in workflow
+    assert "Resolve merge preview SHA" in workflow
     assert "refs/pull/{0}/merge" in workflow
     assert (
         "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
@@ -409,6 +410,7 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
         in scorecard_workflow
     )
     assert "scorecard-merge:" in scorecard_workflow
+    assert "Resolve merge preview SHA" in scorecard_workflow
     assert "category: scorecard-merge" in scorecard_workflow
     assert "refs/pull/{0}/merge" in scorecard_workflow
 

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -408,9 +408,7 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
         "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
         in scorecard_workflow
     )
-    assert "scorecard-merge:" in scorecard_workflow
-    assert "category: scorecard-merge" in scorecard_workflow
-    assert "refs/pull/{0}/merge" in scorecard_workflow
+
 
     assert (
         "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0"

--- a/scripts/ci/pr_governance_gate.sh
+++ b/scripts/ci/pr_governance_gate.sh
@@ -91,7 +91,12 @@ if [ "$UNRESOLVED_THREADS" != "0" ]; then
 fi
 
 if ! REQUIRED_CHECKS="$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --required --json name,state,link 2>"$PR_CHECKS_ERROR_FILE")"; then
-  add_blocker "Required check metadata could not be read: $(<"$PR_CHECKS_ERROR_FILE")."
+  PR_CHECKS_ERROR="$(<"$PR_CHECKS_ERROR_FILE")"
+  if printf '%s' "$PR_CHECKS_ERROR" | grep -qi 'no required checks reported'; then
+    add_waiting "Ruleset-governed branch: no legacy required status contexts reported for ${HEAD_REF_OID}; relying on ruleset workflows and code-scanning gates."
+  else
+    add_blocker "Required check metadata could not be read: ${PR_CHECKS_ERROR}."
+  fi
 else
   while IFS= read -r item; do
     [ -n "$item" ] && add_blocker "$item"

--- a/scripts/ci/test_pr_governance_gate.sh
+++ b/scripts/ci/test_pr_governance_gate.sh
@@ -47,6 +47,10 @@ if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+  if [ "${GH_SCENARIO:-pass}" = "no_required_checks" ]; then
+    printf 'no required checks reported on the test branch\n' >&2
+    exit 1
+  fi
   case "${GH_SCENARIO:-pass}" in
     pending)
       printf '[{"name":"Application CI","state":"IN_PROGRESS","link":"https://checks/app-ci"}]'
@@ -330,6 +334,16 @@ assert_passing_gate_is_metadata_only_without_merge() {
   assert_not_in_file 'continue-on-error' "$temp_dir/gh.log"
 }
 
+assert_no_required_checks_waits_without_hard_comment() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  run_gate no_required_checks "$temp_dir"
+
+  assert_in_file 'no legacy required status contexts reported' "$temp_dir/output.txt"
+  assert_not_in_file 'issues/42/comments -f body' "$temp_dir/gh.log"
+  assert_not_in_file '^pr merge' "$temp_dir/gh.log"
+}
+
 assert_no_comment_or_merge_for_pending_checks
 assert_startup_failure_creates_marker_comment
 assert_failed_checks_create_marker_comment
@@ -345,5 +359,6 @@ assert_coderabbit_current_review_comment_blocks
 assert_coderabbit_stale_review_comment_does_not_block
 assert_changes_requested_creates_marker_comment
 assert_passing_gate_is_metadata_only_without_merge
+assert_no_required_checks_waits_without_hard_comment
 
 printf 'test_pr_governance_gate: PASS\n'


### PR DESCRIPTION
## Root cause
Approved PRs (#892, #897, #898, #901, #911) are blocked with:
`Code scanning is waiting for results from CodeQL`.

The local `codeql.yml` used `upload: never` while GitHub default setup is **not configured**, so no CodeQL analyses exist on PR heads despite the ruleset requiring CodeQL.

## Fix
- Enable `upload: always` with explicit PR-head `ref`/`sha` on CodeQL analyze.
- Treat `gh pr checks --required` "no required checks reported" as a ruleset wait state in `pr_governance_gate.sh`.

## Verification
- `bash scripts/ci/test_pr_governance_gate.sh`
- `pytest tests/test_release_governance.py -k "codeql or code_scanning or pr_governance"`