### PR TITLE
chore(ci): delegate PR CodeQL to org central codeql-pr.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,17 +5,13 @@ on:
     branches:
       - develop
       - master
-  pull_request:
-    branches:
-      - develop
-      - master
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  analyze-head:
+  analyze:
     name: CodeQL compatibility analysis (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
@@ -42,7 +38,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -54,54 +49,4 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"
-          # Upload PR-head CodeQL SARIF so ruleset code_scanning (CodeQL) can
-          # evaluate mergeability. Default setup is not configured on this repo.
           upload: always
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
-          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-  analyze-merge:
-    name: CodeQL merge preview (${{ matrix.language }})
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
-          - language: python
-            build-mode: none
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout merge preview
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-        with:
-          persist-credentials: false
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          category: "/language:${{ matrix.language }}-merge"
-          upload: always
-          # Ruleset code_scanning evaluates merge_commit_sha, which can differ
-          # from the ephemeral SHA refs/pull/<n>/merge resolves to at upload time.
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-          sha: ${{ github.event.pull_request.merge_commit_sha }}

--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -323,7 +323,7 @@ def test_bandit_security_scan_does_not_continue_on_error() -> None:
     assert "continue-on-error: true" not in workflow
 
 
-def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
+def test_codeql_workflow_uploads_default_branch_sarif_only() -> None:
     workflow = read_repo_text(".github/workflows/codeql.yml")
 
     assert "permissions:\n  contents: read\n\njobs:" in workflow
@@ -333,22 +333,21 @@ def test_codeql_workflow_uploads_pr_head_sarif_for_ruleset_gate() -> None:
     )
     assert "upload: always" in workflow
     assert "upload: never" not in workflow
-    assert (
-        "ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}"
-        in workflow
-    )
-    assert (
-        "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
-        in workflow
-    )
-    assert "analyze-merge:" in workflow
-    assert "CodeQL merge preview" in workflow
-    assert "refs/pull/{0}/merge" in workflow
-    assert "github.event.pull_request.merge_commit_sha" in workflow
-    assert (
-        "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
-        in workflow
-    )
+    assert "pull_request:" not in workflow
+    assert "analyze-merge:" not in workflow
+    assert "- develop" in workflow
+    assert "- master" in workflow
+
+
+def test_central_required_workflows_include_codeql_pr_for_ruleset_gate() -> None:
+    readme = read_repo_text("README.md")
+    architecture = read_repo_text("ARCHITECTURE.md")
+
+    for document in (readme, architecture):
+        assert "ContextualWisdomLab/.github" in document
+        assert "central required workflows" in document.lower() or "central required workflow" in document
+
+    assert not (REPO_ROOT / ".github/workflows/codeql-pr.yml").exists()
 
 
 def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> None:
@@ -489,6 +488,7 @@ def test_review_automation_uses_central_required_workflows_without_local_copies(
     normalized_security = " ".join(security.split())
 
     central_workflow_paths = [
+        ".github/workflows/codeql-pr.yml",
         ".github/workflows/opencode-review.yml",
         ".github/workflows/pr-review-merge-scheduler.yml",
         ".github/workflows/strix-selftest.yml",


### PR DESCRIPTION
## Summary
- Simplify repository `codeql.yml` to default-branch push scans only (`develop`/`master`).
- Rely on org ruleset `18156473` central `ContextualWisdomLab/.github` workflow `codeql-pr.yml` for PR-head and merge-preview CodeQL SARIF (same posture as `osv-scanner-pr.yml` and `scorecard-pr.yml`).
- Update release governance tests to assert the central workflow contract.

## Depends on
- ContextualWisdomLab/.github PR #304 merging to `main`
- Org ruleset `18156473` adding `.github/workflows/codeql-pr.yml` as a required workflow

## Test plan
- [x] `pytest backend/tests/test_release_governance.py::test_codeql_workflow_uploads_default_branch_sarif_only`
- [x] `pytest backend/tests/test_release_governance.py::test_central_required_workflows_include_codeql_pr_for_ruleset_gate`
- [x] `pytest backend/tests/test_release_governance.py::test_review_automation_uses_central_required_workflows_without_local_copies`