### PR TITLE
🎨 Palette: [UX improvement] Add missing focus states to calendar buttons

### DIFF
--- a/frontend/src/components/calendar/CalendarSidebarRight.tsx
+++ b/frontend/src/components/calendar/CalendarSidebarRight.tsx
@@ -82,7 +82,7 @@ export function CalendarSidebarRight({ selectedDetailEvent }: Props) {
       <div className="mt-8 flex gap-3">
         <button type="button" aria-label="출시 회의 일정 삭제" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">삭제</button>
         <button type="button" aria-label="출시 회의 일정 복사" className="flex-1 rounded-lg border border-border bg-background py-2 text-sm font-bold shadow-sm hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">복사</button>
-        <button type="button" aria-label="출시 회의 일정 수정" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90">수정</button>
+        <button type="button" aria-label="출시 회의 일정 수정" className="flex-1 rounded-lg bg-primary py-2 text-sm font-bold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">수정</button>
       </div>
     </aside>
   );

--- a/frontend/src/components/calendar/CalendarWritebackSection.tsx
+++ b/frontend/src/components/calendar/CalendarWritebackSection.tsx
@@ -45,7 +45,7 @@ export function CalendarWritebackSection({
             onClick={() => void requestWritebackIntent('create')}
             disabled={isWritebackActionDisabled}
             aria-busy={isWritebackLoading}
-            className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60"
+            className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           >
             새 일정 intent 점검
           </button>


### PR DESCRIPTION
💡 What: Added missing `focus-visible` styles to calendar action buttons (`CalendarSidebarRight` and `CalendarWritebackSection`).
🎯 Why: Improves keyboard accessibility by providing a clear visual indicator when the button is focused.
📸 Before/After: Interactive buttons previously lacked a focus ring; now they have a clear outline when focused via keyboard navigation.
♿ Accessibility: Ensures keyboard users can easily see which element has focus.

---
*PR created automatically by Jules for task [2665236050190142270](https://jules.google.com/task/2665236050190142270) started by @seonghobae*