### PR TITLE
fix(k8s): harden securityContext + add postgres PVC (unblocks repo-wide Trivy gate)

### DIFF
--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -16,12 +16,23 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      # Image runs as the non-root `appuser` (Dockerfile `USER appuser`).
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: backend
         image: ghcr.io/seongho-bae/ai_email_client-backend:REPLACE_ME_VERSION
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         env:
         - name: DATABASE_URL
           valueFrom:
@@ -33,3 +44,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: auth-session-hmac-secret
+        volumeMounts:
+        # readOnlyRootFilesystem needs a writable temp dir: email import
+        # extracts uploaded .zip/.mbox archives via tempfile (TMPDIR=/tmp).
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/k8s/db-statefulset.yaml
+++ b/k8s/db-statefulset.yaml
@@ -15,9 +15,24 @@ spec:
       labels:
         app: postgres-db
     spec:
+      # pgvector/postgres runs the server as the `postgres` user (uid/gid 999).
+      # fsGroup makes the persistent volume writable by that group.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: pgvector/pgvector:pg16
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         env:
         - name: POSTGRES_USER
           value: postgres
@@ -28,6 +43,34 @@ spec:
               key: password
         - name: POSTGRES_DB
           value: ai_email
+        # Keep data in a subdirectory of the mounted volume so the PVC root
+        # (which may carry lost+found) is not used as PGDATA directly.
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         ports:
         - containerPort: 5432
           name: postgres
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+        # readOnlyRootFilesystem needs writable socket + temp dirs.
+        - name: run
+          mountPath: /var/run/postgresql
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+  # Persistent storage: without this the database is stored on the pod's
+  # ephemeral filesystem and is lost on every restart/reschedule.
+  volumeClaimTemplates:
+  - metadata:
+      name: pgdata
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -16,14 +16,38 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      # Image runs as the non-root `node` user (frontend/Dockerfile `USER node`).
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: ghcr.io/seongho-bae/ai_email_client-frontend:REPLACE_ME_VERSION
         imagePullPolicy: Always
         ports:
         - containerPort: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         env:
           - name: BACKEND_INTERNAL_URL
             value: "http://backend:8000"
           - name: ALLOW_DOCKER_BACKEND_INTERNAL_URL
             value: "1"
+        volumeMounts:
+        # readOnlyRootFilesystem needs writable paths for `next start`:
+        # Next.js writes runtime caches under .next/cache (fetch/image cache),
+        # and libraries may use /tmp. WORKDIR is /app (frontend/Dockerfile).
+        - name: next-cache
+          mountPath: /app/.next/cache
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: next-cache
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
## Root cause
`trivy-fs` fails on **every** open PR (verified on #919, #920, and my own #921/#922) — not because of any PR's diff, but because the k8s manifests trip Trivy misconfig rules on all three workloads:

- **KSV-0014 (HIGH)** — containers should set `readOnlyRootFilesystem: true`
- **KSV-0118 (HIGH ×2)** — container/workload using the default security context (allows root privileges)

`opencode-review` then fails only *downstream* of this (it REQUEST_CHANGES when another check fails, then can't diagnose it). So this one baseline is what blocks the security gate across the repo.

## Fix
Harden `backend-deployment`, `frontend-deployment`, and `db-statefulset`:
- **securityContext** (pod + container): `runAsNonRoot`, `capabilities.drop: [ALL]`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`. App images already run non-root (`Dockerfile` `USER appuser`, `frontend/Dockerfile` `USER node`); postgres runs as uid/gid `999` with `fsGroup: 999`.
- **Writable mounts** required by `readOnlyRootFilesystem`: `/tmp` for backend (email import extracts `.zip`/`.mbox` via `tempfile`), `/app/.next/cache` + `/tmp` for the frontend (`next start` runtime caches), postgres socket dir + `/tmp`.
- **Postgres PVC**: added `volumeClaimTemplates`. Without it the DB lived on the pod's **ephemeral** filesystem and was lost on every restart/reschedule (separately flagged **P0** in `docs/assessment/cloud-native-deployability-assessment.md`). `PGDATA` moved to a subdir of the mounted volume.

## Verification (same scanners CI uses, run locally)
```
trivy config --severity HIGH,CRITICAL k8s/                            -> 0 findings
trivy fs --scanners vuln,secret,misconfig --severity HIGH,CRITICAL .  -> exit 0
```
(Before: 3 HIGH per workload = 9 findings, exit 1.)

## Deployer note (please smoke-test before rollout)
These are deploy **templates** (`REPLACE_ME_VERSION` image placeholders), not live manifests, so there's no running infra to break. Two things warrant a cluster smoke-test before production rollout: (1) postgres non-root + PVC ownership via `fsGroup`, and (2) the frontend `readOnlyRootFilesystem` with the `.next/cache` emptyDir mount. Everything is Trivy-green and reasoned for runtime-safety, but a live `kubectl rollout status` is the right final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)