### PR TITLE
🎨 Palette: [UX improvement] Update AI terminology in prompt-studio and ProjectsLayout

### DIFF
--- a/frontend/src/app/projects/page.test.tsx
+++ b/frontend/src/app/projects/page.test.tsx
@@ -422,7 +422,7 @@ describe("ProjectsPage", () => {
     expect(container.textContent).toContain("Scope clarity");
     expect(container.textContent).toContain("Data/infra readiness");
     expect(container.textContent).toContain("Owner/action readiness");
-    expect(container.textContent).toContain("실행 준비 요약: 5개 컨트롤이 문단 근거로 준비됨");
+    expect(container.textContent).toContain("실행 준비 핵심 맥락: 5개 컨트롤이 문단 근거로 준비됨");
     expect(container.textContent).toContain("검토자 액션: 누락 근거 없음, 인수 검토 가능");
 
     const reviewButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("문단 근거 검토 저장"));

--- a/frontend/src/app/prompt-studio/page.test.tsx
+++ b/frontend/src/app/prompt-studio/page.test.tsx
@@ -208,7 +208,7 @@ describe("PromptStudioPage", () => {
     expectNoPublicIdentityHeaders((fetchMock.mock.calls[0] as unknown as [RequestInfo, RequestInit?])?.[1]?.headers);
 
     act(() => {
-      getButton(page, "데이터 분석 인사이트").click();
+      getButton(page, "데이터 분석 판단 포인트").click();
     });
     expect(page.textContent).not.toContain("맥락 종합 결과");
   });

--- a/frontend/src/app/prompt-studio/page.tsx
+++ b/frontend/src/app/prompt-studio/page.tsx
@@ -102,10 +102,10 @@ function getSafeErrorSummary(error: unknown, fallback: string) {
 
 const TEMPLATE_GROUPS = [
   {
-    name: '업무 요약',
+    name: '업무 핵심 맥락',
     items: [
-      { id: 'summary', title: '문서 요약/초안 작성', favorite: true },
-      { id: 'insight', title: '데이터 분석 인사이트' },
+      { id: 'summary', title: '문서 핵심 맥락/초안 작성', favorite: true },
+      { id: 'insight', title: '데이터 분석 판단 포인트' },
       { id: 'mail', title: '이메일 작성' },
       { id: 'automation', title: '업무 자동화 제안' },
     ],
@@ -114,7 +114,7 @@ const TEMPLATE_GROUPS = [
     name: '회의/리포트',
     items: [
       { id: 'meeting', title: '회의록 작성' },
-      { id: 'decision', title: '의사결정 요약' },
+      { id: 'decision', title: '의사결정 핵심 맥락' },
       { id: 'weekly', title: '주간 보고서 작성' },
     ],
   },
@@ -148,7 +148,7 @@ const MODEL_OPTIONS = [
   { label: 'OpenAI Compatible', value: 'provider-default' },
 ];
 const RESPONSE_STYLES = ['전문적이고 간결하게', '친근하고 상세하게', '실행 항목 중심'];
-const OUTPUT_FORMATS = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 요약'];
+const OUTPUT_FORMATS = ['마크다운 (Markdown)', 'JSON 구조화', '짧은 핵심 맥락'];
 
 const QUALITY_CHECKS = ['요구사항 충족', '구조 및 가독성', '정확성/사실성', '근거/출처 포함', '톤 & 스타일 일관성'];
 
@@ -160,10 +160,10 @@ const VERSION_HISTORY = [
 ];
 
 const RECENT_TEST_RESULTS = [
-  { time: '2024.05.25 10:22', case: '분기 성과 보고서 요약', result: '성공', score: 92, tokens: '1,024', duration: '2.8초' },
+  { time: '2024.05.25 10:22', case: '분기 성과 보고서 핵심 맥락', result: '성공', score: 92, tokens: '1,024', duration: '2.8초' },
   { time: '2024.05.25 10:18', case: '고객 피드백 분석', result: '성공', score: 88, tokens: '1,156', duration: '3.1초' },
   { time: '2024.05.25 10:12', case: '경쟁사 분석 리포트', result: '부분 성공', score: 76, tokens: '1,432', duration: '3.6초' },
-  { time: '2024.05.25 10:05', case: '제품 출시 계획 요약', result: '성공', score: 95, tokens: '987', duration: '2.6초' },
+  { time: '2024.05.25 10:05', case: '제품 출시 계획 핵심 맥락', result: '성공', score: 95, tokens: '987', duration: '2.6초' },
 ];
 
 const DEPLOYMENT_HISTORY = [

--- a/frontend/src/components/ProjectsLayout.tsx
+++ b/frontend/src/components/ProjectsLayout.tsx
@@ -547,7 +547,7 @@ function buildProjectControlReadinessLayer(objects: ProjectTraceObject[]): Proje
     readyItemCount,
     totalItemCount: items.length,
     missingEvidenceCount,
-    summary: `실행 준비 요약: ${readyItemCount}개 컨트롤이 문단 근거로 준비됨`,
+    summary: `실행 준비 핵심 맥락: ${readyItemCount}개 컨트롤이 문단 근거로 준비됨`,
     reviewerAction: missingEvidenceCount > 0
       ? `검토자 액션: ${missingEvidenceCount}개 컨트롤 근거 보강`
       : '검토자 액션: 누락 근거 없음, 인수 검토 가능',
@@ -1152,7 +1152,7 @@ export function ProjectsLayout() {
                             <span className="font-mono text-xs font-bold text-muted-foreground">{Math.round(projectObject.confidence * 100)}%</span>
                           </div>
                           <h3 className="line-clamp-2 break-keep text-sm font-bold">{safeText(projectObject.title, '제목 없는 그래프 객체')}</h3>
-                          <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">{safeText(projectObject.summary, '요약 대기')}</p>
+                          <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">{safeText(projectObject.summary, '핵심 맥락 대기')}</p>
                         </button>
                       ))}
                     </div>


### PR DESCRIPTION
💡 What
Updated AI terminology labels in `prompt-studio` and `ProjectsLayout` to match the Naruon UI/UX terminology mapping guidelines. Specifically, updated occurrences of '요약' (Summary) and '인사이트' (Insight) to '핵심 맥락' (Core Context) and '판단 포인트' (Decision Point) respectively.

🎯 Why
To adhere to the UX guidelines which dictate that Naruon is an evidence-based AI Email Workspace that doesn't just summarize but connects context and aids judgment.

📸 Before/After
**Before:**
- '업무 요약', '문서 요약/초안 작성', '의사결정 요약'
- '데이터 분석 인사이트'
- '실행 준비 요약', '요약 대기'

**After:**
- '업무 핵심 맥락', '문서 핵심 맥락/초안 작성', '의사결정 핵심 맥락'
- '데이터 분석 판단 포인트'
- '실행 준비 핵심 맥락', '핵심 맥락 대기'

♿ Accessibility
N/A (No structural changes to interactive elements; only display text was updated).

---
*PR created automatically by Jules for task [5205996897816046518](https://jules.google.com/task/5205996897816046518) started by @seonghobae*