### PR TITLE
fix(tests): develop is red — align governance tests with #926's central delegation

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -228,7 +228,6 @@ def test_stepsecurity_remediation_adds_pinned_audit_hardening() -> None:
         ".github/workflows/app-ci.yml",
         ".github/workflows/bandit.yml",
         ".github/workflows/codeql.yml",
-        ".github/workflows/dependency-review.yml",
         ".github/workflows/docker-publish.yml",
         ".github/workflows/mail-smoke.yml",
         ".github/workflows/pr-governance.yml",
@@ -241,13 +240,9 @@ def test_stepsecurity_remediation_adds_pinned_audit_hardening() -> None:
         assert harden_runner_ref in workflow
         assert "egress-policy: audit" in workflow
 
-    dependency_review_workflow = read_repo_text(
-        ".github/workflows/dependency-review.yml"
-    )
-    assert (
-        "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0"
-        in dependency_review_workflow
-    )
+    # Dependency review is supplied by the central required Security Scan
+    # (ContextualWisdomLab/.github); this repo must not carry a duplicate.
+    assert not (REPO_ROOT / ".github/workflows/dependency-review.yml").exists()
 
     pre_commit = read_repo_text(".pre-commit-config.yaml")
     assert "https://github.com/gitleaks/gitleaks" in pre_commit
@@ -356,7 +351,10 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
     trivy_workflow = read_repo_text(".github/workflows/trivy.yml")
 
     for workflow in (scorecard_workflow, trivy_workflow):
-        assert "pull_request:" in workflow
+        # PR scanning is owned by the central required Security Scan; these
+        # repo-local workflows keep push-only default-branch coverage and
+        # must not re-add duplicate PR triggers.
+        assert "pull_request:" not in workflow
         assert "push:" in workflow
         assert "- develop" in workflow
         assert "- master" in workflow


### PR DESCRIPTION
## Bug (develop itself is red)
`9db32d04` (#926) removed the repo-local `dependency-review.yml` and the `pull_request` triggers on scorecard/trivy — correctly delegating PR scanning to the org central Security Scan — but didn't update `tests/test_release_governance.py`. Result: **`backend (Python 3.14)` fails on every PR's merge ref** (verified by running the suite directly on `origin/develop`: 2 failed). Combined with the trivy-fs gate issue, this is the second independent cause of the current org-wide PR stall; it went unnoticed because the runner freeze started right after #926 merged.

## Fix (aligns tests with #926's documented intent — no workflow changes)
- `test_stepsecurity_remediation_adds_pinned_audit_hardening`: drop the deleted `dependency-review.yml` from the hardened list; now asserts the duplicate file **stays deleted** (central supplies it).
- `test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif`: scorecard/trivy are push-only default-branch coverage; asserts `pull_request:` triggers **stay absent** — locking the no-duplication intent instead of contradicting it.

## Verification
`pytest tests/test_release_governance.py`: **29 passed** (was 2 failed on `origin/develop`); ruff clean.

## Note
This unblocks the `backend` check for every open PR once merged (it's on the merge ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)