### PR TITLE
fix(tests): postgres smoke fails on develop — seed tenant config missing org scope

### DIFF
--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1374,6 +1374,10 @@ async def _seed_reply_tracking_smoke_data(Session, user_id, organization_id, now
         session.add(
             TenantConfig(
                 user_id=user_id,
+                # Tenant configs are (user, organization) scoped; the endpoint
+                # looks the config up with the request's X-Organization-Id, so
+                # the seed must carry the same organization.
+                organization_id=organization_id,
                 smtp_username="Smoke User <reply-smoke@example.com>",
                 imap_username=None,
             )


### PR DESCRIPTION
## Bug (pre-existing on develop, found while validating #936)
`test_get_emails_reply_tracking_real_postgres_smoke` fails on `origin/develop` when run against a real PostgreSQL: the request sends `X-Organization-Id`, so `get_scoped_tenant_config` filters on `(user_id, organization_id)` — but the seeded `TenantConfig` had **no `organization_id`**. Lookup → `None` → `user_addresses` empty → `requires_reply`/`is_self_sent` computed against no addresses → assertions fail. The seed predates tenant-config organization scoping.

## Fix
One seed line: `organization_id=organization_id` (+ comment). No production code changes.

## Verification
- Fresh `pgvector:pg16`: smoke test **passes** (baseline on `origin/develop`: fails).
- Full email API suite: **48 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)