### PR TITLE
⚡ Bolt: dict get에서 빈 리스트 할당 오버헤드 최적화

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-02-20 - Deduplication Optimization
 **Learning:** Python's `dict.fromkeys()` leverages the underlying C implementation and insertion-order preservation (in Python 3.7+) to deduplicate elements while maintaining order. It can be faster in some workloads (particularly when list size isn't massive) than manually tracking a `set` and appending to a `list` inside a `for` loop, especially for list preparations before database queries or API calls.
 **Action:** Use `list(dict.fromkeys(iterable))` instead of `seen = set(); result = []` for order-preserving deduplication loops to improve CPU performance.
+
+## 2025-02-21 - Optimize list comprehensions over dictionary defaults
+**Learning:** Using `.get(key, [])` inside a frequently called function forces Python to allocate a new empty list object in memory every time the key is missing, increasing garbage collection overhead.
+**Action:** When iterating over a dictionary value in performance-sensitive code, use `if key in my_dict:` to avoid instantiating default objects like `[]` or `set()` when the key is absent.

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -61,11 +61,14 @@ def _enforce_send_email_rate_limit(auth_context: AuthContext) -> None:
 
     # ponytail: process-local throttle; move to Redis when multi-worker send volume matters.
     with _email_send_rate_limit_lock:
-        attempts = [
-            attempt
-            for attempt in _email_send_attempts_by_scope.get(key, [])
-            if attempt > cutoff
-        ]
+        if key in _email_send_attempts_by_scope:
+            attempts = [
+                attempt
+                for attempt in _email_send_attempts_by_scope[key]
+                if attempt > cutoff
+            ]
+        else:
+            attempts = []
         if len(attempts) >= _SEND_EMAIL_RATE_LIMIT_MAX_ATTEMPTS:
             _email_send_attempts_by_scope[key] = attempts
             raise HTTPException(
@@ -281,7 +284,6 @@ async def get_emails(
         .limit(candidate_window)
     )
     emails = list(result.scalars().all())
-
 
     grouped = {}
 


### PR DESCRIPTION
- 💡 What: `backend/api/emails.py`의 이메일 전송 속도 제한 로직에서 `.get(key, [])`를 `in` 연산자 확인 및 딕셔너리 직접 접근으로 변경했습니다.
- 🎯 Why: 리스트 컴프리헨션 내부에서 `.get(key, [])`를 사용하면 키가 없을 때마다 불필요한 빈 리스트가 메모리에 할당됩니다. `in` 연산자로 확인하면 메모리 할당 및 가비지 컬렉션 오버헤드를 줄일 수 있습니다.
- 📊 Impact: 키가 없는 경우 딕셔너리 조회 성능이 향상되고 메모리 할당이 감소합니다.
- 🔬 Measurement: 백엔드 테스트를 통해 이메일 속도 제한 로직에 문제가 없는지 확인했습니다.

---
*PR created automatically by Jules for task [3009866364787244910](https://jules.google.com/task/3009866364787244910) started by @seonghobae*