### PR TITLE
fix(k8s): remediate KSV-0118 default security context on all workloads

### DIFF
--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -16,10 +16,26 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: backend
         image: ghcr.io/seongho-bae/ai_email_client-backend:REPLACE_ME_VERSION
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 8000
         env:

--- a/k8s/db-statefulset.yaml
+++ b/k8s/db-statefulset.yaml
@@ -15,9 +15,25 @@ spec:
       labels:
         app: postgres-db
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: pgvector/pgvector:pg16
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         env:
         - name: POSTGRES_USER
           value: postgres

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -16,10 +16,26 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: ghcr.io/seongho-bae/ai_email_client-frontend:REPLACE_ME_VERSION
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
## What

Adds an explicit non-default `securityContext` at **both pod and container level** to all three Kubernetes workloads:

- `k8s/backend-deployment.yaml`
- `k8s/frontend-deployment.yaml`
- `k8s/db-statefulset.yaml`

**Pod-level** (`spec.template.spec.securityContext`): `runAsNonRoot: true`, `runAsUser/runAsGroup/fsGroup: 10001`, `seccompProfile.type: RuntimeDefault`.

**Container-level**: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `seccompProfile.type: RuntimeDefault`.

## Why

Trivy flagged **KSV-0118** (default security context, allows root privileges) as HIGH on the pod and container of every workload. This is root-cause manifest hardening — no `.trivyignore` entry, no severity/CVE filtering. `readOnlyRootFilesystem: true` additionally clears the pre-existing KSV-0014 HIGH so the gate is fully green.

## Verify

```
trivy config k8s/ --severity HIGH,CRITICAL --exit-code 1 && echo PASS
```

Result: **PASS** — zero HIGH/CRITICAL findings, KSV-0118 no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)