### PR TITLE
fix(k8s): enable readOnlyRootFilesystem on backend, db, frontend (KSV-0014)

### DIFF
--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       - name: backend
         image: ghcr.io/seongho-bae/ai_email_client-backend:REPLACE_ME_VERSION
         imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 8000
         env:
@@ -33,3 +35,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: auth-session-hmac-secret
+        volumeMounts:
+        # readOnlyRootFilesystem is enabled, so provide writable scratch space
+        # for temp files (e.g. multipart upload spooling) that the app needs.
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/k8s/db-statefulset.yaml
+++ b/k8s/db-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
       containers:
       - name: postgres
         image: pgvector/pgvector:pg16
+        securityContext:
+          readOnlyRootFilesystem: true
         env:
         - name: POSTGRES_USER
           value: postgres
@@ -28,6 +30,30 @@ spec:
               key: password
         - name: POSTGRES_DB
           value: ai_email
+        # Keep PGDATA in a subdirectory of the mounted PVC so initdb sees an
+        # empty target even when the volume root contains lost+found.
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         ports:
         - containerPort: 5432
           name: postgres
+        volumeMounts:
+        # readOnlyRootFilesystem is enabled: the database data directory is
+        # persisted through the StatefulSet PVC below, and the Unix socket
+        # directory needs a small writable scratch mount.
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+        - name: postgres-run
+          mountPath: /var/run/postgresql
+      volumes:
+      - name: postgres-run
+        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       - name: frontend
         image: ghcr.io/seongho-bae/ai_email_client-frontend:REPLACE_ME_VERSION
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 3000
         env:
@@ -27,3 +29,15 @@ spec:
             value: "http://backend:8000"
           - name: ALLOW_DOCKER_BACKEND_INTERNAL_URL
             value: "1"
+        volumeMounts:
+        # readOnlyRootFilesystem is enabled, so provide writable scratch space
+        # for temp files and the Next.js runtime cache (ISR / image optimizer).
+        - name: tmp
+          mountPath: /tmp
+        - name: next-cache
+          mountPath: /app/.next/cache
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: next-cache
+        emptyDir: {}


### PR DESCRIPTION
## What

Remediate Trivy **KSV-0014** (container root filesystem is not read-only) on all three Kubernetes workloads by setting `containers[].securityContext.readOnlyRootFilesystem: true`, backed by writable volumes only where each process genuinely writes.

| Workload | readOnlyRootFilesystem | Writable mounts added |
|---|---|---|
| `backend-deployment` | ✅ | `emptyDir` → `/tmp` (temp/upload spooling) |
| `frontend-deployment` | ✅ | `emptyDir` → `/tmp`, `emptyDir` → `/app/.next/cache` (Next.js runtime cache) |
| `db-statefulset` | ✅ | PVC (`volumeClaimTemplates`) → `/var/lib/postgresql/data`, `emptyDir` → `/var/run/postgresql` |

For Postgres, `PGDATA` is pinned to a `/pgdata` subdirectory of the mounted PVC so `initdb` sees an empty target even when the volume root contains `lost+found`. The entrypoint runs as root, chowns the PVC and socket dir, then drops to the `postgres` user — so no `fsGroup` change is required.

## Verification

```
$ trivy config k8s/ --severity HIGH,CRITICAL
# KSV-0014: 0 findings (was 3)
```

Config hardening only — no vulnerable package, **no `# nosec` / ignore entries, no gate weakened**.

## Scope note

This clears **KSV-0014 x3** plus the container-level **KSV-0118** on each workload. The remaining 3 pod-level KSV-0118 (`default security context allows root privileges`) findings are handled by the companion security fix; the two together take `trivy config` / `trivy-fs` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)