### PR TITLE
fix: harden k8s securityContext (Trivy KSV-0014 / KSV-0118 HIGH)

### DIFF
--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -16,10 +16,28 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: backend
         image: ghcr.io/seongho-bae/ai_email_client-backend:REPLACE_ME_VERSION
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 8000
         env:
@@ -33,3 +51,9 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: auth-session-hmac-secret
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/k8s/db-statefulset.yaml
+++ b/k8s/db-statefulset.yaml
@@ -15,9 +15,27 @@ spec:
       labels:
         app: postgres-db
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: pgvector/pgvector:pg16
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         env:
         - name: POSTGRES_USER
           value: postgres
@@ -28,6 +46,34 @@ spec:
               key: password
         - name: POSTGRES_DB
           value: ai_email
+        # Point PGDATA at a subdirectory of the mounted volume so the data
+        # directory is on writable persistent storage (rootfs is read-only).
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         ports:
         - containerPort: 5432
           name: postgres
+        volumeMounts:
+        # Persistent, writable data directory (rootfs is read-only).
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+        # Unix socket directory needs to be writable.
+        - name: postgres-run
+          mountPath: /var/run/postgresql
+        # Scratch space.
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: postgres-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -16,10 +16,28 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-registry
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: ghcr.io/seongho-bae/ai_email_client-frontend:REPLACE_ME_VERSION
         imagePullPolicy: Always
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 3000
         env:
@@ -27,3 +45,13 @@ spec:
             value: "http://backend:8000"
           - name: ALLOW_DOCKER_BACKEND_INTERNAL_URL
             value: "1"
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: next-cache
+          mountPath: /app/.next/cache
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: next-cache
+        emptyDir: {}


### PR DESCRIPTION
## Finding

Trivy (`fs --scanners vuln,secret,misconfig --severity CRITICAL,HIGH --ignore-unfixed`) reported **HIGH** Kubernetes misconfigurations on all three workload manifests — `k8s/backend-deployment.yaml`, `k8s/frontend-deployment.yaml`, and `k8s/db-statefulset.yaml` (3 HIGH each, 9 total):

- **KSV-0118** — container/pod is using the default security context, which allows root privileges (`runAsNonRoot` not set).
- **KSV-0014** — container should set `securityContext.readOnlyRootFilesystem` to `true`.

## Fix

Added a hardened **pod-level and container-level** `securityContext` to every workload:

- `runAsNonRoot: true`, `runAsUser: 10001`, `runAsGroup: 10001`, `fsGroup: 10001`
- `allowPrivilegeEscalation: false`
- `readOnlyRootFilesystem: true`
- `capabilities.drop: [ALL]`
- `seccompProfile.type: RuntimeDefault`

Because `readOnlyRootFilesystem: true` breaks any container that writes to its rootfs, writable volumes were added for exactly the paths each app needs, so the workloads still run:

- **backend** — `emptyDir` at `/tmp`.
- **frontend** — `emptyDir` at `/tmp` and `/app/.next/cache` (Next.js runtime cache).
- **postgres** — a persistent `volumeClaimTemplate` (`postgres-data`, 10Gi RWO) mounted at `/var/lib/postgresql/data`, with `PGDATA` pointed at the `pgdata` subdirectory; plus `emptyDir` for `/var/run/postgresql` (Unix socket) and `/tmp`. `fsGroup: 10001` makes the mounts writable by the non-root process. The StatefulSet previously had **no** persistent storage at all, so this also fixes an ephemeral-data bug.

## Local verification

Same command before and after, with a freshly updated Trivy DB:

| | Result |
|---|---|
| Before | `k8s/backend-deployment.yaml`, `k8s/frontend-deployment.yaml`, `k8s/db-statefulset.yaml` — 3 HIGH each (KSV-0014, KSV-0118 ×2) |
| After | **0 findings across the entire repo**, `--exit-code 1` returns `0`. No new CRITICAL/HIGH introduced. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)