### PR TITLE
test(ci): align release governance tests with central Security Scan (#926)

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -224,11 +224,14 @@ def test_stepsecurity_remediation_adds_pinned_audit_hardening() -> None:
     harden_runner_ref = (
         "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4"
     )
+    # dependency-review.yml was intentionally removed in #926: the org-wide
+    # central Security Scan already runs dependency-review on every PR, so the
+    # per-repo PR-only workflow was a duplicate. Only workflows that still exist
+    # in this repository are asserted here.
     hardened_workflows = [
         ".github/workflows/app-ci.yml",
         ".github/workflows/bandit.yml",
         ".github/workflows/codeql.yml",
-        ".github/workflows/dependency-review.yml",
         ".github/workflows/docker-publish.yml",
         ".github/workflows/mail-smoke.yml",
         ".github/workflows/pr-governance.yml",
@@ -240,14 +243,6 @@ def test_stepsecurity_remediation_adds_pinned_audit_hardening() -> None:
         workflow = read_repo_text(workflow_path)
         assert harden_runner_ref in workflow
         assert "egress-policy: audit" in workflow
-
-    dependency_review_workflow = read_repo_text(
-        ".github/workflows/dependency-review.yml"
-    )
-    assert (
-        "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0"
-        in dependency_review_workflow
-    )
 
     pre_commit = read_repo_text(".pre-commit-config.yaml")
     assert "https://github.com/gitleaks/gitleaks" in pre_commit
@@ -355,8 +350,12 @@ def test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif() -> 
     scorecard_workflow = read_repo_text(".github/workflows/scorecard.yml")
     trivy_workflow = read_repo_text(".github/workflows/trivy.yml")
 
+    # PR-triggered scorecard/trivy runs were removed in #926 because the org-wide
+    # central Security Scan already runs scorecard and trivy-fs on every PR. These
+    # per-repo workflows now cover the default branch only (push/schedule), so the
+    # PR trigger is intentionally absent and must NOT be asserted here.
     for workflow in (scorecard_workflow, trivy_workflow):
-        assert "pull_request:" in workflow
+        assert "pull_request:" not in workflow
         assert "push:" in workflow
         assert "- develop" in workflow
         assert "- master" in workflow


### PR DESCRIPTION
## Problem

The `backend (Python 3.14)` CI job fails on `develop` (and therefore on every feature PR that inherits it — #964/#965/#970/#971/#972) with two failures in `backend/tests/test_release_governance.py`:

```
FAILED test_stepsecurity_remediation_adds_pinned_audit_hardening
  AssertionError: required governance artifact is missing: .github/workflows/dependency-review.yml
FAILED test_required_code_scanning_workflows_upload_scorecard_and_trivy_sarif
  assert 'pull_request:' in "<scorecard.yml contents>"
```

## Root cause

This is stale test drift, not a Python 3.14 incompatibility (the same assertions fail on any interpreter). Commit `9db32d04` (#926, "stop duplicating central Security Scan on PRs") **intentionally**:

- deleted `.github/workflows/dependency-review.yml`, and
- removed the `pull_request:` trigger from `scorecard.yml` and `trivy.yml`,

because the org-wide **central Security Scan** already runs dependency-review, scorecard, and trivy-fs on every PR. The per-repo workflows now provide default-branch coverage via `push`/`schedule` only. The governance suite was not updated in that PR, so two assertions still expect the pre-#926 state.

## Fix

Realign the governance tests with the intended architecture:

- Drop the deleted `dependency-review.yml` from the hardened-workflow list and remove its `dependency-review-action` assertion.
- Assert `pull_request:` is **absent** (not present) for scorecard/trivy, while keeping the `push:` / `- develop` / `- master` default-branch coverage checks.

No governance coverage is lost — the central Security Scan remains the PR gate. Full backend suite verified locally with the CI env (`PYTHONWARNINGS=error`, `DISABLE_BACKGROUND_WORKERS=1`): **1139 passed, 22 skipped** (previously 1137 passed, 2 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)