### PR TITLE
fix: treat ruleset-only PR checks as waiting governance state

### DIFF
--- a/backend/tests/test_release_governance.py
+++ b/backend/tests/test_release_governance.py
@@ -945,6 +945,9 @@ def test_pr_governance_uses_metadata_only_events_without_checkout_or_admin_merge
     assert "headRefOid" in gate_script
     assert "mergeStateStatus" in gate_script
     assert "gh pr checks" in gate_script and "--required" in gate_script
+    assert "no required checks reported" in gate_script
+    assert "no legacy required status contexts reported" in gate_script
+    assert "add_waiting" in gate_script
     assert "check-runs" in gate_script
     assert "Review skipped" in gate_script
     assert "CodeRabbit" in gate_script or "coderabbit" in gate_script

--- a/scripts/ci/pr_governance_gate.sh
+++ b/scripts/ci/pr_governance_gate.sh
@@ -91,7 +91,12 @@ if [ "$UNRESOLVED_THREADS" != "0" ]; then
 fi
 
 if ! REQUIRED_CHECKS="$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --required --json name,state,link 2>"$PR_CHECKS_ERROR_FILE")"; then
-  add_blocker "Required check metadata could not be read: $(<"$PR_CHECKS_ERROR_FILE")."
+  PR_CHECKS_ERROR="$(<"$PR_CHECKS_ERROR_FILE")"
+  if printf '%s' "$PR_CHECKS_ERROR" | grep -qi 'no required checks reported'; then
+    add_waiting "Ruleset-governed branch: no legacy required status contexts reported for ${HEAD_REF_OID}; relying on ruleset workflows and code-scanning gates."
+  else
+    add_blocker "Required check metadata could not be read: ${PR_CHECKS_ERROR}."
+  fi
 else
   while IFS= read -r item; do
     [ -n "$item" ] && add_blocker "$item"

--- a/scripts/ci/test_pr_governance_gate.sh
+++ b/scripts/ci/test_pr_governance_gate.sh
@@ -47,6 +47,10 @@ if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+  if [ "${GH_SCENARIO:-pass}" = "no_required_checks" ]; then
+    printf 'no required checks reported on the test branch\n' >&2
+    exit 1
+  fi
   case "${GH_SCENARIO:-pass}" in
     pending)
       printf '[{"name":"Application CI","state":"IN_PROGRESS","link":"https://checks/app-ci"}]'
@@ -364,6 +368,17 @@ assert_passing_gate_is_metadata_only_without_merge() {
   assert_not_in_file 'continue-on-error' "$temp_dir/gh.log"
 }
 
+assert_no_required_checks_waits_without_hard_comment() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  run_gate no_required_checks "$temp_dir"
+
+  assert_exit_code 0 "$temp_dir"
+  assert_in_file 'no legacy required status contexts reported' "$temp_dir/output.txt"
+  assert_not_in_file 'issues/42/comments -f body' "$temp_dir/gh.log"
+  assert_not_in_file '^pr merge' "$temp_dir/gh.log"
+}
+
 assert_no_comment_or_merge_for_pending_checks
 assert_startup_failure_creates_marker_comment
 assert_failed_checks_create_marker_comment
@@ -379,5 +394,6 @@ assert_coderabbit_current_review_comment_blocks
 assert_coderabbit_stale_review_comment_does_not_block
 assert_changes_requested_creates_marker_comment
 assert_passing_gate_is_metadata_only_without_merge
+assert_no_required_checks_waits_without_hard_comment
 
 printf 'test_pr_governance_gate: PASS\n'


### PR DESCRIPTION
## Summary
- Restore PR governance handling for ruleset-only branches when gh reports \
o required checks reported\.
- Keep the gate non-blocking in that metadata race: it records a waiting reason instead of posting a hard blocker comment.
- Add release-governance coverage so the behavior is checked even on Windows workstations without jq.

## Verification
- \py -m pytest backend/tests/test_release_governance.py -q\ -> 33 passed
- \py -m ruff check backend/tests/test_release_governance.py\ -> clean
- \C:\\Program Files\\Git\\bin\\bash.exe -n scripts/ci/pr_governance_gate.sh scripts/ci/test_pr_governance_gate.sh\ -> clean
- \git diff --cached --check\ -> clean
- \codegraph sync && codegraph status\ -> up to date

Note: full local \scripts/ci/test_pr_governance_gate.sh\ execution is blocked on this Windows machine because Git Bash does not have \jq\ installed; Linux CI covers the jq-backed shell path.