### PR TITLE
fix(webdav): encoded traversal 경로 정규화 및 100% 회귀 검증

### DIFF
--- a/backend/runner/local_dav_adapters.py
+++ b/backend/runner/local_dav_adapters.py
@@ -2,11 +2,15 @@ import ipaddress
 import socket
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Literal
-from urllib.parse import quote, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 import httpx
 
 from runner.utils.dispatch import dispatch_error
+
+
+_MAX_TARGET_PATH_LENGTH = 4096
+_MAX_URL_DECODE_ROUNDS = 4
 
 
 @dataclass(frozen=True)
@@ -80,7 +84,9 @@ class LocalDavAdapters:
         except ValueError as exc:
             return dispatch_error(str(exc))
 
-        content_type = self._payload_text(payload, "content_type") or default_content_type
+        content_type = (
+            self._payload_text(payload, "content_type") or default_content_type
+        )
         headers = {"Content-Type": content_type, "If-Match": if_match}
         auth = (
             (source.username, source.password or "")
@@ -129,14 +135,43 @@ class LocalDavAdapters:
         return None
 
     def _safe_target_path(self, raw_path: Any) -> str | None:
-        if not isinstance(raw_path, str):
+        """Return one canonical DAV path or reject encoded traversal/control data."""
+        if (
+            not isinstance(raw_path, str)
+            or not raw_path
+            or len(raw_path) > _MAX_TARGET_PATH_LENGTH
+        ):
             return None
-        if not raw_path.startswith("/") or "\\" in raw_path or "://" in raw_path:
+
+        decoded_path = raw_path
+        try:
+            for _ in range(_MAX_URL_DECODE_ROUNDS):
+                next_path = unquote(decoded_path, errors="strict")
+                if next_path == decoded_path:
+                    break
+                decoded_path = next_path
+            else:
+                if unquote(decoded_path, errors="strict") != decoded_path:
+                    return None
+        except UnicodeDecodeError:
             return None
-        segments = [segment for segment in raw_path.split("/") if segment]
+
+        if (
+            not decoded_path.startswith("/")
+            or "\\" in decoded_path
+            or "://" in decoded_path
+            or any(
+                ord(character) < 32 or ord(character) == 127
+                for character in decoded_path
+            )
+        ):
+            return None
+        segments = [segment for segment in decoded_path.split("/") if segment]
         if not segments or any(segment in {".", ".."} for segment in segments):
             return None
-        return "/" + "/".join(quote(segment, safe="@:$&'()*+,;=-._~") for segment in segments)
+        return "/" + "/".join(
+            quote(segment, safe="@:$&'()*+,;=-._~") for segment in segments
+        )
 
     def _target_url(self, base_url: str, target_path: str) -> str:
         parsed = urlsplit(base_url)

--- a/backend/tests/test_runner_dav_adapters.py
+++ b/backend/tests/test_runner_dav_adapters.py
@@ -1,5 +1,6 @@
 import socket
 
+import httpx
 import pytest
 
 from runner.local_dav_adapters import LocalDavAdapters, LocalDavSourceConfig
@@ -34,6 +35,11 @@ class FakeDavClient:
         return self.response
 
 
+class FailingDavClient(FakeDavClient):
+    async def put(self, url, *, content, headers, auth):
+        raise httpx.ConnectError("provider unavailable")
+
+
 @pytest.fixture(autouse=True)
 def stub_dav_dns(monkeypatch):
     def fake_getaddrinfo(host, port, type=socket.SOCK_STREAM):
@@ -49,6 +55,17 @@ def stub_dav_dns(monkeypatch):
 
     monkeypatch.setattr(
         "runner.local_dav_adapters.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+
+def test_webdav_adapter_canonicalizes_encoded_unicode_path():
+    adapters = LocalDavAdapters([])
+
+    assert (
+        adapters._safe_target_path(  # noqa: SLF001 - security boundary regression
+            "/Naruon/%ED%95%9C%EA%B8%80%20note.md"
+        )
+        == "/Naruon/%ED%95%9C%EA%B8%80%20note.md"
     )
 
 
@@ -165,8 +182,23 @@ async def test_webdav_adapter_reports_provider_conflict_without_write_success():
     }
 
 
+@pytest.mark.parametrize(
+    "target_path",
+    [
+        "/Naruon/../Secrets/task.md",
+        "/Naruon/%2e%2e/Secrets/task.md",
+        "/Naruon/%252e%252e/Secrets/task.md",
+        "/Naruon/%25252525252e%25252525252e/Secrets/task.md",
+        "/Naruon/%5c..%5cSecrets/task.md",
+        "/Naruon/%00Secrets/task.md",
+        "/Naruon/%FF/task.md",
+        "/" + "a" * 4096,
+    ],
+)
 @pytest.mark.asyncio
-async def test_webdav_adapter_rejects_path_traversal_before_network_request():
+async def test_webdav_adapter_rejects_path_traversal_before_network_request(
+    target_path,
+):
     fake_client = FakeDavClient(FakeDavResponse(204))
     adapters = LocalDavAdapters(
         [
@@ -183,7 +215,7 @@ async def test_webdav_adapter_rejects_path_traversal_before_network_request():
     result = await adapters.write_webdav(
         {
             "source_id": "webdav_src_1",
-            "target_path": "/Naruon/../Secrets/task.md",
+            "target_path": target_path,
             "content": "# Note\n",
             "if_match": "etag-before-write",
         }
@@ -367,3 +399,123 @@ async def test_webdav_adapter_rejects_invalid_port_before_dns_lookup(monkeypatch
         "provider_write_executed": False,
     }
     assert fake_client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_dav_adapter_default_client_and_payload_helper_boundaries():
+    adapters = LocalDavAdapters([])
+    client = adapters._default_http_client()  # noqa: SLF001
+    assert client.follow_redirects is False
+    await client.aclose()
+
+    assert adapters._payload_text({"value": 1}, "value") is None  # noqa: SLF001
+    assert adapters._payload_text({"value": "  "}, "value") is None  # noqa: SLF001
+    assert adapters._payload_content(b"bytes") == b"bytes"  # noqa: SLF001
+    assert adapters._payload_content(object()) is None  # noqa: SLF001
+    assert adapters._safe_target_path(None) is None  # noqa: SLF001
+    assert adapters._safe_target_path("/") is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_dav_adapter_rejects_source_and_payload_states_before_network():
+    fake_client = FakeDavClient(FakeDavResponse(204))
+    disabled = LocalDavAdapters(
+        [
+            LocalDavSourceConfig(
+                source_id="disabled",
+                protocol="webdav",
+                base_url="https://webdav.example.com",
+            ),
+            LocalDavSourceConfig(
+                source_id="calendar",
+                protocol="caldav",
+                base_url="https://calendar.example.com",
+                writeback_enabled=True,
+            ),
+            LocalDavSourceConfig(
+                source_id="enabled",
+                protocol="webdav",
+                base_url="https://webdav.example.com",
+                writeback_enabled=True,
+            ),
+        ],
+        http_client_factory=lambda: fake_client,
+    )
+    base_payload = {
+        "target_path": "/Naruon/task.md",
+        "content": "note",
+        "if_match": "etag",
+    }
+
+    assert (await disabled.write_webdav(base_payload))["error_code"] == (
+        "source_not_configured"
+    )
+    assert (await disabled.write_webdav({**base_payload, "source_id": "calendar"}))[
+        "error_code"
+    ] == "source_not_configured"
+    assert (await disabled.write_webdav({**base_payload, "source_id": "disabled"}))[
+        "error_code"
+    ] == "source_writeback_disabled"
+    assert (
+        await disabled.write_webdav(
+            {**base_payload, "source_id": "enabled", "content": object()}
+        )
+    )["error_code"] == "invalid_payload"
+    assert fake_client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_dav_adapter_reports_provider_transport_and_status_failures():
+    source = LocalDavSourceConfig(
+        source_id="webdav",
+        protocol="webdav",
+        base_url="https://webdav.example.com",
+        writeback_enabled=True,
+    )
+    payload = {
+        "source_id": "webdav",
+        "target_path": "/Naruon/task.md",
+        "content": "note",
+        "if_match": "etag",
+    }
+    transport_failure = LocalDavAdapters(
+        [source],
+        http_client_factory=lambda: FailingDavClient(FakeDavResponse(204)),
+    )
+    status_failure = LocalDavAdapters(
+        [source],
+        http_client_factory=lambda: FakeDavClient(FakeDavResponse(503)),
+    )
+
+    assert (await transport_failure.write_webdav(payload))["error_code"] == (
+        "provider_request_failed"
+    )
+    assert await status_failure.write_webdav(payload) == {
+        "status": "error",
+        "error": "provider_write_failed",
+        "error_code": "provider_write_failed",
+        "provider_write_executed": False,
+        "provider_status": 503,
+    }
+
+
+def test_dav_adapter_rejects_invalid_source_url_boundaries(monkeypatch):
+    adapters = LocalDavAdapters([])
+
+    with pytest.raises(ValueError, match="invalid_source_url"):
+        adapters._target_url("http://webdav.example.com", "/task.md")  # noqa: SLF001
+    assert (
+        adapters._target_url(  # noqa: SLF001
+            "https://93.184.216.34", "/task.md"
+        )
+        == "https://93.184.216.34/task.md"
+    )
+    with pytest.raises(ValueError, match="invalid_source_url"):
+        adapters._validate_global_address("not-an-ip")  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "runner.local_dav_adapters.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [],
+    )
+    with pytest.raises(ValueError, match="invalid_source_url"):
+        adapters._target_url("https://empty.example.com", "/task.md")  # noqa: SLF001


### PR DESCRIPTION
훼손된 #1027을 대체하는 current develop 통제 PR입니다. DAV target_path를 최대 4회 엄격 decode한 뒤 역슬래시, URL 형태, 제어문자, dot traversal, 과도한 길이 및 추가 중첩 인코딩을 거부하고 단일 canonical path로 re-encode합니다. source/payload/transport/DNS/IP/provider 실패가 명시적 error_code로 남는 테스트를 보존합니다. CodeGraph 초기화/동기화, 관련 DAV 58 passed·3 skipped, local_dav_adapters 140/140 statements 100% coverage, Ruff PASS, Trivy 전체 lockfile/컨테이너/Kubernetes Medium 이상·오설정·secret 0입니다.