### PR TITLE
feat(project-graph): admit decision-centric relations into the LLM extractor vocabulary

### DIFF
--- a/backend/services/project_graph/llm_extractor.py
+++ b/backend/services/project_graph/llm_extractor.py
@@ -8,14 +8,19 @@ the model cannot introduce uncited (fabricated) domain claims into the graph.
 
 Beyond objects, this extractor also densifies the project knowledge graph with
 typed **object-to-object relations** (a feature *implements* a requirement, an
-issue *blocks* a milestone, …). Relations are held to the same grounding
-discipline: they may only connect two objects that survived object grounding,
-their ``relation_type`` must come from a controlled vocabulary
-(:data:`ALLOWED_RELATION_TYPES`), self-loops and duplicates are dropped, and
-each relation edge is evidenced by the union of its endpoints' cited segments —
-so a relation can never smuggle in an uncited segment reference. The
-deterministic keyword extractor stays the reference/fallback stopgap and is left
-unchanged; the dense inter-object graph is a capability of the real LLM
+issue *blocks* a milestone, a decision *supersedes* a prior decision, …).
+Relations are held to the same grounding discipline: they may only connect two
+objects that survived object grounding, their ``relation_type`` must come from a
+controlled vocabulary (:data:`ALLOWED_RELATION_TYPES`), self-loops and duplicates
+are dropped, and each relation edge is evidenced by the union of its endpoints'
+cited segments — so a relation can never smuggle in an uncited segment reference.
+The vocabulary carries decision-centric relations (``resolves``, ``decided_by``,
+``supersedes``) so the DECISION entity introduced in #1058 — and the decision
+read model that surfaces it (#1061) — can express *how* a decision connects to
+the issues it settles, the requirements it settles, and the prior decisions it
+replaces, instead of collapsing every such link into the generic ``relates_to``.
+The deterministic keyword extractor stays the reference/fallback stopgap and is
+left unchanged; the dense inter-object graph is a capability of the real LLM
 extractor behind the extractor seam.
 """
 
@@ -42,7 +47,7 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 LLM_EXTRACTOR_NAME = "llm_grounded_project_graph"
-LLM_EXTRACTOR_VERSION = "2026.07.12.1"
+LLM_EXTRACTOR_VERSION = "2026.07.13.1"
 
 _MAX_SEGMENTS_PER_REQUEST = 40
 _MAX_SEGMENT_TEXT_CHARS = 2000
@@ -63,6 +68,12 @@ ALLOWED_RELATION_TYPES: frozenset[str] = frozenset(
         "delivers",
         "owns",
         "relates_to",
+        # Decision-centric relations (see module docstring): a decision resolves
+        # an issue, a requirement/feature is decided_by a decision, and a newer
+        # decision supersedes the prior one it replaces.
+        "resolves",
+        "decided_by",
+        "supersedes",
     }
 )
 
@@ -105,6 +116,12 @@ def _system_instruction() -> str:
         "Optionally return relations that connect two objects you extracted, "
         "using their local_key values in source_local_key and target_local_key. "
         f"Allowed relation_type values: {allowed_relations}. "
+        "Orient decision relations by their direction: use resolves from a "
+        "decision to the issue it settles, decided_by from a requirement or "
+        "feature to the decision that settled it, and supersedes from a newer "
+        "decision to the prior decision it replaces. Only assert these when the "
+        "cited segment text explicitly states the settlement or replacement; "
+        "never infer them from mere ordering or co-mention. "
         "A relation must connect two distinct objects both grounded in the "
         "segments; do not relate an object to itself. "
         "Do not invent segment uids, facts, names, dates, or policies that "

--- a/backend/tests/test_project_graph_llm_extractor.py
+++ b/backend/tests/test_project_graph_llm_extractor.py
@@ -416,6 +416,236 @@ async def test_self_loop_and_duplicate_relations_are_dropped(monkeypatch):
     assert relation_edges[0].edge_type == "implements"
 
 
+def _two_grounded_decisions() -> list["llm_extractor.ExtractedObjectPayload"]:
+    # A superseding decision (seg1) and the prior decision it replaces (seg2),
+    # each grounded in its own cited segment so a supersedes relation between
+    # them is evidenced by the union of both citations.
+    return [
+        _object(
+            object_type="decision",
+            title="Adopt Stripe as the payment gateway",
+            summary="The committee now standardizes on Stripe.",
+            segment_uids=["seg1"],
+            confidence=0.86,
+            local_key="dec-new",
+        ),
+        _object(
+            object_type="decision",
+            title="Adopt PayPal as the payment gateway",
+            summary="The earlier decision had chosen PayPal.",
+            segment_uids=["seg2"],
+            confidence=0.71,
+            local_key="dec-old",
+        ),
+    ]
+
+
+def _two_decision_segments() -> list[ProjectSourceSegment]:
+    return [
+        _segment("seg1", "We now standardize on Stripe, replacing the prior choice."),
+        _segment("seg2", "The earlier decision had chosen PayPal as the gateway."),
+    ]
+
+
+def test_decision_centric_relations_are_in_controlled_vocabulary():
+    # The DECISION entity (#1058) and the decision read model (#1061) speak in
+    # terms of a decision resolving an issue, a requirement being decided by a
+    # decision, and a decision superseding a prior one. Those relation tokens
+    # must live in the controlled vocabulary or the grounded LLM extractor would
+    # silently drop every decision-centric relation at the vocabulary gate,
+    # leaving decisions connectable only through the generic ``relates_to``.
+    assert {"resolves", "decided_by", "supersedes"} <= (
+        llm_extractor.ALLOWED_RELATION_TYPES
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolves_relation_links_decision_to_issue(monkeypatch):
+    objects = [
+        _object(
+            object_type="decision",
+            title="Waive the staging gate for the hotfix",
+            summary="The lead approved shipping the hotfix without staging.",
+            segment_uids=["seg1"],
+            confidence=0.83,
+            local_key="dec-a",
+        ),
+        _object(
+            object_type="issue",
+            title="Staging environment is down",
+            summary="Staging outage blocks the release.",
+            segment_uids=["seg2"],
+            confidence=0.9,
+            local_key="iss-b",
+        ),
+    ]
+    monkeypatch.setattr(
+        llm_extractor,
+        "_call_llm",
+        AsyncMock(
+            return_value=llm_extractor.ExtractionPayload(
+                objects=objects,
+                relations=[
+                    _relation(
+                        source_local_key="dec-a",
+                        target_local_key="iss-b",
+                        relation_type="resolves",
+                        confidence=0.68,
+                    )
+                ],
+            )
+        ),
+    )
+
+    result = await llm_extractor.extract_project_semantics_llm(
+        [
+            _segment("seg1", "The lead approved shipping the hotfix without staging."),
+            _segment("seg2", "Staging outage blocks the release."),
+        ],
+        api_key="key",
+        model="gpt-test",
+    )
+
+    decision = next(o for o in result.objects if o.object_type.value == "decision")
+    issue = next(o for o in result.objects if o.object_type.value == "issue")
+    resolves_edges = [edge for edge in result.edges if edge.edge_type == "resolves"]
+    assert len(resolves_edges) == 1
+    edge = resolves_edges[0]
+    # Directionality is preserved: the decision resolves the issue, not vice
+    # versa.
+    assert edge.source_uid == decision.uid
+    assert edge.target_uid == issue.uid
+    # Grounded in the union of both endpoints' cited segments — never an uncited
+    # reference.
+    assert set(edge.source_segment_uids) == {"seg1", "seg2"}
+
+
+@pytest.mark.asyncio
+async def test_decided_by_relation_preserves_direction(monkeypatch):
+    objects = [
+        _object(
+            object_type="requirement",
+            title="Payments must use a single gateway",
+            summary="One gateway is required for reconciliation.",
+            segment_uids=["seg2"],
+            confidence=0.88,
+            local_key="req-a",
+        ),
+        _object(
+            object_type="decision",
+            title="Adopt Stripe as the payment gateway",
+            summary="The committee standardizes on Stripe.",
+            segment_uids=["seg1"],
+            confidence=0.86,
+            local_key="dec-b",
+        ),
+    ]
+    monkeypatch.setattr(
+        llm_extractor,
+        "_call_llm",
+        AsyncMock(
+            return_value=llm_extractor.ExtractionPayload(
+                objects=objects,
+                relations=[
+                    _relation(
+                        source_local_key="req-a",
+                        target_local_key="dec-b",
+                        relation_type="decided_by",
+                        confidence=0.7,
+                    )
+                ],
+            )
+        ),
+    )
+
+    result = await llm_extractor.extract_project_semantics_llm(
+        [
+            _segment("seg1", "The committee standardizes on Stripe."),
+            _segment("seg2", "One gateway is required for reconciliation."),
+        ],
+        api_key="key",
+        model="gpt-test",
+    )
+
+    requirement = next(
+        o for o in result.objects if o.object_type.value == "requirement"
+    )
+    decision = next(o for o in result.objects if o.object_type.value == "decision")
+    decided_by_edges = [
+        edge for edge in result.edges if edge.edge_type == "decided_by"
+    ]
+    assert len(decided_by_edges) == 1
+    edge = decided_by_edges[0]
+    assert edge.source_uid == requirement.uid
+    assert edge.target_uid == decision.uid
+
+
+@pytest.mark.asyncio
+async def test_supersedes_relation_links_two_decisions(monkeypatch):
+    monkeypatch.setattr(
+        llm_extractor,
+        "_call_llm",
+        AsyncMock(
+            return_value=llm_extractor.ExtractionPayload(
+                objects=_two_grounded_decisions(),
+                relations=[
+                    _relation(
+                        source_local_key="dec-new",
+                        target_local_key="dec-old",
+                        relation_type="supersedes",
+                        confidence=0.74,
+                    )
+                ],
+            )
+        ),
+    )
+
+    result = await llm_extractor.extract_project_semantics_llm(
+        _two_decision_segments(), api_key="key", model="gpt-test"
+    )
+
+    supersedes_edges = [
+        edge for edge in result.edges if edge.edge_type == "supersedes"
+    ]
+    assert len(supersedes_edges) == 1
+    edge = supersedes_edges[0]
+    assert set(edge.source_segment_uids) == {"seg1", "seg2"}
+
+
+@pytest.mark.asyncio
+async def test_decision_relation_synonym_outside_vocabulary_is_dropped(monkeypatch):
+    # Disambiguation: "overrides" is a natural-language synonym of the controlled
+    # ``supersedes`` token, but the vocabulary is a closed set of exact tokens,
+    # not a fuzzy match. A relation labelled with the synonym is dropped so the
+    # inter-object graph never accretes free-text edge labels.
+    monkeypatch.setattr(
+        llm_extractor,
+        "_call_llm",
+        AsyncMock(
+            return_value=llm_extractor.ExtractionPayload(
+                objects=_two_grounded_decisions(),
+                relations=[
+                    _relation(
+                        source_local_key="dec-new",
+                        target_local_key="dec-old",
+                        relation_type="overrides",
+                        confidence=0.9,
+                    )
+                ],
+            )
+        ),
+    )
+
+    result = await llm_extractor.extract_project_semantics_llm(
+        _two_decision_segments(), api_key="key", model="gpt-test"
+    )
+
+    assert all(
+        edge.edge_type == "segment_evidences_project_object"
+        for edge in result.edges
+    )
+
+
 # The import selector resolves through the KG extractor registry, so these
 # tests patch the extraction cores where the registry imports them.
 def _patch_extractor_cores(monkeypatch, *, llm, keyword):


### PR DESCRIPTION
## Description

Capability-deepening increment for the dense KG — **not** another read-model/surfacing slice. It closes a real seam between the extractor and the decision read model rather than adding a new view.

**The gap.** The DECISION entity (#1058) and the decision read model (#1061) already speak in terms of a decision *resolving* an issue, a requirement/feature being *decided_by* a decision, and a newer decision *superseding* the one it replaces — the decision-view read model even renders `edge_type="resolves"` and `edge_type="decided_by"` in its own tests (`backend/tests/test_project_graph_decision_view.py`). But none of `resolves` / `decided_by` / `supersedes` lived in the LLM extractor's controlled relation vocabulary (`ALLOWED_RELATION_TYPES`). The vocabulary gate in `_relation_edges` therefore **dropped every decision-centric relation**, so the grounded extractor could never actually emit one — decisions could only connect to the rest of the graph through the generic `relates_to` edge. The read model surfaced relation types the extractor was structurally incapable of producing.

**The change.** Admit the three decision-centric relations into the controlled vocabulary, with prompt guidance that orients each relation's direction (`resolves`: decision→issue; `decided_by`: requirement/feature→decision; `supersedes`: newer decision→prior decision) and holds them to the same grounding discipline (only assert on explicit settlement/replacement in the cited text; never infer from ordering or co-mention). Grounding, self-loop/duplicate dropping, and union-of-endpoint citation all reuse the existing machinery, so the change is **purely additive and backward-compatible** — existing relation types and read-model behavior are unchanged. Provenance version bumped (`LLM_EXTRACTOR_VERSION` → `2026.07.13.1`).

**Why LLM-extractor-only (honesty over "emitted by both").** Directed decision relations cannot be honestly grounded by the deterministic keyword extractor: it produces at most one decision per segment, so a directed decision→X edge from single-segment co-occurrence would *overstate* grounding — which the hard "never overstate grounding" rule forbids. This also matches the extractor seam's documented design (the module docstring already states the dense inter-object graph is a capability of the LLM extractor; the deterministic extractor stays relation-free by design).

Refs `docs/CWL-MASTER-CONTEXT.md` §8 P0 (make the dense KG real behind a stable extractor seam **and** surface it). Follows #1051 (persist relations) → #1053 (traceability) → #1055 (per-object evidence) → #1057 (relation summary) → #1058 (DECISION entity) → #1061 (decisions read model).

## Collision check (git-based)
- Candidate files diffed 3-way (`origin/develop...<branch>`) against every open branch. `llm_extractor.py` is "touched" only by **stale** branches (`fix-open-redirect-bypass`, `palette-*`, `sentinel-*`) whose diffs *revert* the relations feature and carry the older `LLM_EXTRACTOR_VERSION 2026.07.06.1` — full-file-deletion/stale, ignored per protocol.
- Did **not** touch the hot `extractor_registry.py` (churned by `feature/naruon-tools-expansion`, `fix-open-redirect-bypass`), any `frontend/**` decision/projects component, or `hybrid_retrieval` (project-graph objects are already in the retrieval path — no change needed there).
- No prompt-string or vocabulary contract test pins the exact `ALLOWED_RELATION_TYPES` set; nothing pins the old version string. Read models fold **any** inter-object `edge_type` generically, so admitting new types does not change their contract.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Test evidence
From `backend/`, matching CI (`PYTHONWARNINGS=error DISABLE_BACKGROUND_WORKERS=1`), no `Timeout`/`Fatal`/`Warn`/`Denied` in output:

```
python -m pytest tests/test_project_graph_llm_extractor.py -q          # 19 passed
python -m pytest tests/test_project_graph_extractors.py \
  tests/test_project_graph_extractor_registry.py \
  tests/test_project_graph_traceability_relations.py \
  tests/test_project_graph_decision_view.py \
  tests/test_project_graph_relation_summary.py \
  tests/test_project_graph_projection.py \
  tests/test_project_graph_api.py \
  tests/test_project_graph_import_wiring.py -q                          # 63 passed, 12 skipped (PG)
python -m ruff check .                                                  # All checks passed!
```

New tests (TDD — added and confirmed RED before the vocabulary change):
- decision-centric tokens are in the controlled vocabulary
- `resolves` links decision→issue with preserved direction, grounded in the union of both endpoints' citations
- `decided_by` preserves requirement→decision direction
- `supersedes` links two decisions grounded across both segments
- **disambiguation**: the natural-language synonym `overrides` is dropped, because the vocabulary is a closed set of exact tokens, not a fuzzy match

Pre-existing `test_bootstrap_db` / `test_data_api` raw-SQL `email_records`/`is_read` smoke seeds are unrelated (they need a real PG cluster; they pass/skip here) and do not touch the changed files.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (module docstring + prompt)
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Fxd76REwJfmQcXCJjLi6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_018Fxd76REwJfmQcXCJjLi6Z)_