### PR TITLE
fix(auth): reject non-ID-token OIDC material in API bearer sessions

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -285,8 +285,8 @@ def _reject_non_id_token_payload(payload: dict[str, Any]) -> None:
     token_use/scope/scp claims, and tokens for other clients name that client
     in azp (OIDC Core 3.1.3.7).
     """
-    token_use = payload.get("token_use")
-    if token_use is not None and token_use != "id":
+    usage_claim = payload.get("token_use")
+    if usage_claim is not None and usage_claim != "id":
         raise _authentication_error()
     if "scope" in payload or "scp" in payload:
         raise _authentication_error()

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -232,6 +232,13 @@ def _oidc_unverified_header(token: str) -> dict[str, Any]:
     _reject_unsupported_critical_headers(header)
     if header.get("alg") != "RS256":
         raise _authentication_error()
+    # RFC 9068 access tokens declare "at+jwt"; only ID-token material ("JWT",
+    # or an absent typ from IdPs that omit it) may become an API session.
+    token_type = header.get("typ")
+    if token_type is not None and (
+        not isinstance(token_type, str) or token_type.strip().upper() != "JWT"
+    ):
+        raise _authentication_error()
     key_id = header.get("kid")
     if not isinstance(key_id, str) or not key_id.strip():
         raise _authentication_error()
@@ -263,8 +270,29 @@ def _decode_cached_oidc_session_payload(token: str) -> dict[str, Any]:
             raise _authentication_error()
         if not isinstance(payload, dict):
             raise _authentication_error()
+        _reject_non_id_token_payload(payload)
         return payload
     raise _authentication_error()
+
+
+def _reject_non_id_token_payload(payload: dict[str, Any]) -> None:
+    """Reject same-issuer OIDC material that is not an ID token for this client.
+
+    The enterprise IdP mints naruon session claims directly into the ID token,
+    so the ID token is the intended API bearer credential. Access tokens and
+    tokens minted for other clients can share this issuer and carry this API's
+    client_id in aud; their claim shapes distinguish them: access tokens carry
+    token_use/scope/scp claims, and tokens for other clients name that client
+    in azp (OIDC Core 3.1.3.7).
+    """
+    token_use = payload.get("token_use")
+    if token_use is not None and token_use != "id":
+        raise _authentication_error()
+    if "scope" in payload or "scp" in payload:
+        raise _authentication_error()
+    authorized_party = payload.get("azp")
+    if authorized_party is not None and authorized_party != settings.OIDC_CLIENT_ID:
+        raise _authentication_error()
 
 
 def _reject_unsupported_critical_headers(header: dict[str, Any]) -> None:

--- a/backend/tests/test_auth_real.py
+++ b/backend/tests/test_auth_real.py
@@ -1051,6 +1051,134 @@ async def test_oidc_session_accepts_tuple_audience(monkeypatch):
     assert context.user_id == "alice"
 
 
+def _oidc_test_settings():
+    settings.OIDC_ISSUER_URL = "https://login.example.test/realms/naruon"
+    settings.OIDC_CLIENT_ID = "naruon-api"
+    settings.AUTH_SESSION_HMAC_SECRET = SecretStr(TEST_SESSION_HMAC_SECRET)
+
+
+def _restore_oidc_settings(previous):
+    (
+        settings.OIDC_ISSUER_URL,
+        settings.OIDC_CLIENT_ID,
+        settings.AUTH_SESSION_HMAC_SECRET,
+    ) = previous
+
+
+def _snapshot_oidc_settings():
+    return (
+        settings.OIDC_ISSUER_URL,
+        settings.OIDC_CLIENT_ID,
+        settings.AUTH_SESSION_HMAC_SECRET,
+    )
+
+
+def _oidc_id_token_payload(**overrides):
+    payload = {
+        "iss": "https://login.example.test/realms/naruon",
+        "aud": "naruon-api",
+        "sub": "alice",
+        "role": "member",
+        "org": "org-acme",
+        "groups": ["group-1", "group-2"],
+        "workspace": "workspace-org-acme",
+        "exp": int(time.time()) + 300,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class _OidcMockKey:
+    key_id = "test-key"
+    key = "public_key"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_type", ["at+jwt", 123])
+async def test_oidc_rejects_access_token_typ_header(monkeypatch, token_type):
+    import jwt
+
+    previous = _snapshot_oidc_settings()
+    _oidc_test_settings()
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (_OidcMockKey(),))
+    monkeypatch.setattr(jwt, "decode", lambda *a, **k: _oidc_id_token_payload())
+
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={"alg": "RS256", "typ": token_type, "kid": "test-key"},
+    )
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        _restore_oidc_settings(previous)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload_overrides",
+    [
+        {"token_use": "access"},
+        {"scope": "openid api.read"},
+        {"scp": ["api.read"]},
+        {"azp": "other-client"},
+    ],
+)
+async def test_oidc_rejects_non_id_token_claim_shapes(monkeypatch, payload_overrides):
+    import jwt
+
+    previous = _snapshot_oidc_settings()
+    _oidc_test_settings()
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (_OidcMockKey(),))
+    monkeypatch.setattr(
+        jwt, "decode", lambda *a, **k: _oidc_id_token_payload(**payload_overrides)
+    )
+
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={"alg": "RS256", "typ": "JWT", "kid": "test-key"},
+    )
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        _restore_oidc_settings(previous)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_oidc_accepts_id_token_with_matching_azp_and_token_use(monkeypatch):
+    import jwt
+
+    previous = _snapshot_oidc_settings()
+    _oidc_test_settings()
+    monkeypatch.setattr("api.auth.jwks_client", object())
+    monkeypatch.setattr("api.auth._cached_oidc_signing_keys", (_OidcMockKey(),))
+    monkeypatch.setattr(
+        jwt,
+        "decode",
+        lambda *a, **k: _oidc_id_token_payload(token_use="id", azp="naruon-api"),
+    )
+
+    # No typ header: IdPs that omit typ still mint valid ID tokens.
+    token = _signed_session_token(
+        _valid_session_payload(),
+        header={"alg": "RS256", "kid": "test-key"},
+    )
+    try:
+        context = await get_auth_context(authorization=f"Bearer {token}")
+    finally:
+        _restore_oidc_settings(previous)
+
+    assert context.session_verifier == "oidc"
+    assert context.user_id == "alice"
+
+
 @pytest.mark.asyncio
 async def test_oidc_session_rejects_missing_client_id_after_decode(monkeypatch):
     import jwt


### PR DESCRIPTION
## Description

Fixes the Strix HIGH finding (CVSS 8.8, surfaced org-wide after the gpt-5.6-luna Strix migration): `_decode_cached_oidc_session_payload` in `backend/api/auth.py` accepted any same-issuer RS256 JWT whose `aud` contains `OIDC_CLIENT_ID` as an API bearer session, with no token-type/authorized-party validation — so access tokens, and tokens minted for other clients that share the issuer and audience, were replayable as API sessions.

The enterprise IdP mints naruon session claims (role/org/groups/workspace) directly into the **ID token**, so the ID token remains the intended bearer credential by design. This change pins the accepted material to exactly that shape instead of changing the architecture:

- **JOSE header `typ`**, when present, must be `JWT` (case-insensitive). RFC 9068 access tokens declare `at+jwt` and are rejected before decode.
- **`token_use`**, when present, must be `"id"` (Cognito/Azure-style access-token discriminator).
- **`scope`/`scp` claims** present → reject. ADFS and Azure access tokens keep header `typ: JWT` but always carry these; ID tokens do not.
- **`azp`**, when present, must equal `OIDC_CLIENT_ID` (OIDC Core §3.1.3.7), so a token minted for another authorized party cannot ride a shared `aud`.

All checks fail closed with the existing 401 path. The deliberate tuple-audience contract is preserved (multi-audience tokens without `azp` are still accepted — `test_oidc_session_accepts_tuple_audience` unchanged).

This finding is pre-existing on `develop` and currently fails the required Strix check on multiple open PR heads (#1074/#1068/#1066/#1059/#964 as of 09:1xZ); landing this unblocks them at the root cause.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Local evidence: `python -m pytest tests/test_auth_real.py -q` → 97 passed (7 new cases: `at+jwt` + non-string `typ` headers, `token_use=access`, `scope`, `scp`, `azp` mismatch, and a positive ID-token case with matching `azp`/`token_use` and no `typ` header); `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
