### PR TITLE
feat(email): preserve embedded metadata evidence for dedupe

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -30,6 +30,7 @@ from services.email_dedupe_service import (
     email_strong_fingerprint,
 )
 from services.email_import_service import (
+    DedupeMatchReason,
     EmailImportEmbeddingProvider,
     EmailImportQuotaExceeded,
     MAX_IMPORT_UPLOAD_BYTES,
@@ -250,6 +251,9 @@ class EmailFileImportItem(BaseModel):
     status: EmailImportItemStatus
     reason_code: str | None = None
     attachment_count: int = 0
+    dedupe_review_required: bool = False
+    dedupe_reason_codes: list[str] = Field(default_factory=list)
+    dedupe_match_reason: DedupeMatchReason | None = None
 
 
 class EmailFileImportResponse(BaseModel):
@@ -628,6 +632,9 @@ async def import_email_files(
                 status=item.status,
                 reason_code=item.reason_code,
                 attachment_count=item.attachment_count,
+                dedupe_review_required=item.dedupe_review_required,
+                dedupe_reason_codes=item.dedupe_reason_codes,
+                dedupe_match_reason=item.dedupe_match_reason,
             )
             for item in import_result.items
         ],

--- a/backend/services/email_dedupe_service.py
+++ b/backend/services/email_dedupe_service.py
@@ -1,8 +1,9 @@
 import datetime
+import hashlib
+import json
 from dataclasses import dataclass
 
 from db.models import Email
-from services.email_service import generate_email_fingerprint
 from services.threading_service import normalize_message_id
 
 
@@ -40,14 +41,12 @@ def strong_email_fingerprint(
         and body.strip()
     ):
         return None
-    return generate_email_fingerprint(
-        {
-            "sender": sender,
-            "subject": subject,
-            "date": _date_to_fingerprint_value(date),
-            "body": body,
-        }
+    fingerprint_source = json.dumps(
+        [sender, subject, _date_to_fingerprint_value(date), body],
+        ensure_ascii=True,
+        separators=(",", ":"),
     )
+    return hashlib.sha256(fingerprint_source.encode("utf-8")).hexdigest()
 
 
 def candidate_message_lookup_values(candidate: EmailDedupeCandidate) -> set[str]:

--- a/backend/services/email_dedupe_service.py
+++ b/backend/services/email_dedupe_service.py
@@ -30,12 +30,20 @@ def strong_email_fingerprint(
     date: datetime.datetime | None,
     body: str | None,
 ) -> str | None:
-    if not body:
+    if not (
+        sender
+        and sender.strip()
+        and subject
+        and subject.strip()
+        and date is not None
+        and body
+        and body.strip()
+    ):
         return None
     return generate_email_fingerprint(
         {
-            "sender": sender or "",
-            "subject": subject or "",
+            "sender": sender,
+            "subject": subject,
             "date": _date_to_fingerprint_value(date),
             "body": body,
         }
@@ -65,4 +73,3 @@ def email_strong_fingerprint(email_row: Email) -> str | None:
         date=email_row.date,
         body=email_row.body,
     )
-

--- a/backend/services/email_import_service.py
+++ b/backend/services/email_import_service.py
@@ -26,7 +26,11 @@ from db.models import (
 from services.archive import extract_backup_async
 from services.batch_embedding_service import try_batch_import_embeddings
 from services.content_graph import ParseResult, parse_content
-from services.email_dedupe_service import strong_email_fingerprint
+from services.email_dedupe_service import (
+    email_strong_fingerprint,
+    strong_email_fingerprint,
+)
+from services.email_service import generate_email_fingerprint
 from services.email_parser import EmailData, parse_eml_bytes
 from services.embedding import (
     STORAGE_EMBEDDING_DIMENSION,
@@ -230,6 +234,35 @@ def _email_fingerprint(parsed: EmailData) -> str | None:
     )
 
 
+def _legacy_email_fingerprint(parsed: EmailData) -> str | None:
+    source_date = parsed.get("source_date")
+    if (
+        parsed.get("date_evidence_status") != "parsed"
+        or not isinstance(source_date, datetime.datetime)
+    ):
+        return None
+    sender = parsed.get("sender")
+    subject = parsed.get("subject")
+    body = parsed.get("body")
+    if not (
+        sender
+        and sender.strip()
+        and subject
+        and subject.strip()
+        and body
+        and body.strip()
+    ):
+        return None
+    return generate_email_fingerprint(
+        {
+            "sender": sender,
+            "subject": subject,
+            "date": _utc_datetime(source_date).isoformat(),
+            "body": body,
+        }
+    )
+
+
 def _dedupe_review_reason_codes(
     parsed: EmailData, fingerprint: str | None
 ) -> list[str]:
@@ -259,24 +292,32 @@ async def _find_existing_email(
     message_id: str,
     identity_match_reason: DedupeMatchReason,
     fingerprint: str | None,
+    legacy_fingerprint: str | None,
 ) -> tuple[Email | None, DedupeMatchReason | None]:
     message_lookup_values = {message_id, f"<{message_id}>"}
     dedupe_conditions = [Email.message_id.in_(message_lookup_values)]
-    if fingerprint is not None:
-        dedupe_conditions.append(Email.fingerprint == fingerprint)
+    fingerprint_lookup_values = {
+        value for value in (fingerprint, legacy_fingerprint) if value is not None
+    }
+    if fingerprint_lookup_values:
+        dedupe_conditions.append(Email.fingerprint.in_(fingerprint_lookup_values))
     result = await session.execute(
         select(Email).where(
             *Email.owner_filters(user_id, organization_id),
             or_(*dedupe_conditions),
         )
     )
-    existing_email = result.scalar_one_or_none()
-    if existing_email is None:
-        return None, None
-    if normalize_message_id(existing_email.message_id) == message_id:
-        return existing_email, identity_match_reason
-    if fingerprint is not None and existing_email.fingerprint == fingerprint:
-        return existing_email, "complete_source_fingerprint"
+    existing_emails = result.scalars().all()
+    for existing_email in existing_emails:
+        if normalize_message_id(existing_email.message_id) == message_id:
+            return existing_email, identity_match_reason
+    if fingerprint is not None:
+        for existing_email in existing_emails:
+            if (
+                existing_email.fingerprint == fingerprint
+                or email_strong_fingerprint(existing_email) == fingerprint
+            ):
+                return existing_email, "complete_source_fingerprint"
     return None, None
 
 
@@ -873,6 +914,7 @@ async def _import_single_eml(
     parsed["message_id"] = message_id
     persisted_date = _utc_datetime(parsed.get("date"))
     fingerprint = _email_fingerprint(parsed)
+    legacy_fingerprint = _legacy_email_fingerprint(parsed)
 
     existing_email, dedupe_match_reason = await _find_existing_email(
         session,
@@ -881,6 +923,7 @@ async def _import_single_eml(
         message_id=message_id,
         identity_match_reason=identity_match_reason,
         fingerprint=fingerprint,
+        legacy_fingerprint=legacy_fingerprint,
     )
     if existing_email is not None:
         return EmailImportItemResult(

--- a/backend/services/email_import_service.py
+++ b/backend/services/email_import_service.py
@@ -44,7 +44,6 @@ from services.project_graph.extractor_registry import (
 )
 from services.threading_service import (
     assign_thread_id,
-    generate_email_fingerprint,
     normalize_message_id,
 )
 
@@ -61,6 +60,11 @@ SUPPORTED_EMAIL_IMPORT_SUFFIXES = frozenset({".eml", ".mbox", ".zip"})
 logger = logging.getLogger(__name__)
 
 EmailImportItemStatus = Literal["imported", "skipped_duplicate", "failed"]
+DedupeMatchReason = Literal[
+    "embedded_message_id",
+    "raw_content_sha256",
+    "complete_source_fingerprint",
+]
 
 
 class EmailImportQuotaExceeded(Exception):
@@ -100,6 +104,9 @@ class EmailImportItemResult:
     status: EmailImportItemStatus
     reason_code: str | None = None
     attachment_count: int = 0
+    dedupe_review_required: bool = False
+    dedupe_reason_codes: list[str] = field(default_factory=list)
+    dedupe_match_reason: DedupeMatchReason | None = None
 
 
 @dataclass
@@ -196,27 +203,52 @@ def _fallback_message_id(content: bytes) -> str:
     return f"import-{digest}@local.naruon"
 
 
-def _message_id_for(parsed: EmailData, content: bytes) -> str:
-    return normalize_message_id(parsed.get("message_id")) or _fallback_message_id(
-        content
-    )
+def _message_identity_for(
+    parsed: EmailData, content: bytes
+) -> tuple[str, DedupeMatchReason]:
+    embedded_message_id = normalize_message_id(parsed.get("message_id"))
+    if (
+        parsed.get("message_id_evidence_status") == "embedded"
+        and embedded_message_id
+    ):
+        return embedded_message_id, "embedded_message_id"
+    return _fallback_message_id(content), "raw_content_sha256"
 
 
-def _email_fingerprint(parsed: EmailData, persisted_date: datetime.datetime) -> str:
-    strong_fingerprint = strong_email_fingerprint(
+def _email_fingerprint(parsed: EmailData) -> str | None:
+    source_date = parsed.get("source_date")
+    if (
+        parsed.get("date_evidence_status") != "parsed"
+        or not isinstance(source_date, datetime.datetime)
+    ):
+        return None
+    return strong_email_fingerprint(
         sender=parsed.get("sender"),
         subject=parsed.get("subject"),
-        date=persisted_date,
+        date=_utc_datetime(source_date),
         body=parsed.get("body"),
     )
-    if strong_fingerprint:
-        return strong_fingerprint
-    return generate_email_fingerprint(
-        parsed.get("subject"),
-        persisted_date.isoformat(),
-        parsed.get("sender"),
-        parsed.get("recipients"),
-    )
+
+
+def _dedupe_review_reason_codes(
+    parsed: EmailData, fingerprint: str | None
+) -> list[str]:
+    reason_codes: list[str] = []
+    date_evidence_status = parsed.get("date_evidence_status")
+    if date_evidence_status == "missing":
+        reason_codes.append("date_evidence_missing")
+    elif date_evidence_status == "invalid":
+        reason_codes.append("date_evidence_invalid")
+    elif date_evidence_status != "parsed" or not isinstance(
+        parsed.get("source_date"), datetime.datetime
+    ):
+        reason_codes.append("date_evidence_unavailable")
+
+    if parsed.get("message_id_evidence_status") != "embedded":
+        reason_codes.append("message_id_evidence_missing")
+    if fingerprint is None:
+        reason_codes.append("complete_source_fingerprint_unavailable")
+    return reason_codes
 
 
 async def _find_existing_email(
@@ -225,19 +257,27 @@ async def _find_existing_email(
     user_id: str,
     organization_id: str,
     message_id: str,
-    fingerprint: str,
-) -> Email | None:
+    identity_match_reason: DedupeMatchReason,
+    fingerprint: str | None,
+) -> tuple[Email | None, DedupeMatchReason | None]:
     message_lookup_values = {message_id, f"<{message_id}>"}
+    dedupe_conditions = [Email.message_id.in_(message_lookup_values)]
+    if fingerprint is not None:
+        dedupe_conditions.append(Email.fingerprint == fingerprint)
     result = await session.execute(
         select(Email).where(
             *Email.owner_filters(user_id, organization_id),
-            or_(
-                Email.message_id.in_(message_lookup_values),
-                Email.fingerprint == fingerprint,
-            ),
+            or_(*dedupe_conditions),
         )
     )
-    return result.scalar_one_or_none()
+    existing_email = result.scalar_one_or_none()
+    if existing_email is None:
+        return None, None
+    if normalize_message_id(existing_email.message_id) == message_id:
+        return existing_email, identity_match_reason
+    if fingerprint is not None and existing_email.fingerprint == fingerprint:
+        return existing_email, "complete_source_fingerprint"
+    return None, None
 
 
 async def _owner_email_import_count(
@@ -323,7 +363,7 @@ def _build_email_object(
     organization_id: str,
     message_id: str,
     thread_id: str | None,
-    fingerprint: str,
+    fingerprint: str | None,
     persisted_date: datetime.datetime,
     attachment_payloads: list[dict],
     fitted_embeddings: list[list[float]],
@@ -829,16 +869,17 @@ async def _import_single_eml(
             reason_code="parse_failed",
         )
 
-    message_id = _message_id_for(parsed, content)
+    message_id, identity_match_reason = _message_identity_for(parsed, content)
     parsed["message_id"] = message_id
     persisted_date = _utc_datetime(parsed.get("date"))
-    fingerprint = _email_fingerprint(parsed, persisted_date)
+    fingerprint = _email_fingerprint(parsed)
 
-    existing_email = await _find_existing_email(
+    existing_email, dedupe_match_reason = await _find_existing_email(
         session,
         user_id=user_id,
         organization_id=organization_id,
         message_id=message_id,
+        identity_match_reason=identity_match_reason,
         fingerprint=fingerprint,
     )
     if existing_email is not None:
@@ -846,6 +887,7 @@ async def _import_single_eml(
             filename=display_filename,
             status="skipped_duplicate",
             reason_code="duplicate_email",
+            dedupe_match_reason=dedupe_match_reason,
         )
 
     thread_id = await assign_thread_id(
@@ -900,10 +942,13 @@ async def _import_single_eml(
         embedding_provider=embedding_provider,
     )
 
+    dedupe_reason_codes = _dedupe_review_reason_codes(parsed, fingerprint)
     return EmailImportItemResult(
         filename=display_filename,
         status="imported",
         attachment_count=attachment_count,
+        dedupe_review_required=bool(dedupe_reason_codes),
+        dedupe_reason_codes=dedupe_reason_codes,
     )
 
 

--- a/backend/services/email_parser.py
+++ b/backend/services/email_parser.py
@@ -4,10 +4,14 @@ from pathlib import Path
 import datetime
 from email.utils import formataddr, getaddresses
 from email.utils import parsedate_to_datetime
-from typing import NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 from .attachment_parser import parse_email_attachment
 from .exceptions import EmailParseError
 from .text_safety import strip_html_markup
+
+
+DateEvidenceStatus = Literal["parsed", "missing", "invalid"]
+MessageIdEvidenceStatus = Literal["embedded", "missing"]
 
 
 class EmailData(TypedDict):
@@ -22,6 +26,9 @@ class EmailData(TypedDict):
     in_reply_to: str | None
     references: str | None
     date: datetime.datetime
+    source_date: NotRequired[datetime.datetime | None]
+    date_evidence_status: NotRequired[DateEvidenceStatus]
+    message_id_evidence_status: NotRequired[MessageIdEvidenceStatus]
     body: str
     body_content_type: NotRequired[str]
     body_parse_content: NotRequired[str]
@@ -125,18 +132,21 @@ def _extract_body_and_attachments(msg: Message) -> tuple[str, str, list[dict]]:
     return html_body, "text/html" if html_body else "text/plain", attachments
 
 
-def _extract_date(msg: Message) -> datetime.datetime:
+def _extract_date(
+    msg: Message,
+) -> tuple[datetime.datetime, datetime.datetime | None, DateEvidenceStatus]:
     date_header = msg.get("Date")
-    parsed_date = None
-    if date_header:
-        try:
-            parsed_date = parsedate_to_datetime(date_header)
-        except (TypeError, ValueError):
-            parsed_date = None
+    fallback_date = datetime.datetime.now(datetime.timezone.utc)
+    if date_header is None:
+        return fallback_date, None, "missing"
 
-    if not parsed_date:
-        parsed_date = datetime.datetime.now(datetime.timezone.utc)
-    return parsed_date
+    try:
+        parsed_date = parsedate_to_datetime(str(date_header).strip())
+    except (TypeError, ValueError):
+        parsed_date = None
+    if parsed_date is None:
+        return fallback_date, None, "invalid"
+    return parsed_date, parsed_date, "parsed"
 
 
 def _extract_thread_id(msg: Message, message_id: str) -> str | None:
@@ -158,8 +168,11 @@ def _extract_thread_id(msg: Message, message_id: str) -> str | None:
 
 def _message_to_email_data(msg: Message) -> EmailData:
     body, body_content_type, attachments = _extract_body_and_attachments(msg)
-    parsed_date = _extract_date(msg)
-    message_id = _sanitize_nul(msg.get("Message-ID", ""))
+    persisted_date, source_date, date_evidence_status = _extract_date(msg)
+    message_id = _sanitize_nul(msg.get("Message-ID", "")).strip()
+    message_id_evidence_status: MessageIdEvidenceStatus = (
+        "embedded" if message_id else "missing"
+    )
     thread_id = _extract_thread_id(msg, message_id)
 
     return {
@@ -181,7 +194,10 @@ def _message_to_email_data(msg: Message) -> EmailData:
         "references": (
             _sanitize_nul(msg.get("References", "")) if msg.get("References") else None
         ),
-        "date": parsed_date,
+        "date": persisted_date,
+        "source_date": source_date,
+        "date_evidence_status": date_evidence_status,
+        "message_id_evidence_status": message_id_evidence_status,
         "body": _sanitize_display_text(body),
         "body_content_type": body_content_type,
         "body_parse_content": _sanitize_nul(body),

--- a/backend/tests/test_email_dedupe_service.py
+++ b/backend/tests/test_email_dedupe_service.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from services.email_dedupe_service import (
     EmailDedupeCandidate,
     candidate_message_lookup_values,
@@ -57,6 +59,20 @@ def test_strong_email_fingerprint_no_body():
         body=None
     )
     assert result is None
+
+
+@pytest.mark.parametrize("missing_field", ["sender", "subject", "date", "body"])
+def test_strong_email_fingerprint_requires_complete_source_metadata(missing_field):
+    values = {
+        "sender": "sender@example.com",
+        "subject": "Subject",
+        "date": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        "body": "Hello world",
+    }
+    values[missing_field] = None
+
+    assert strong_email_fingerprint(**values) is None
+
 
 def test_strong_email_fingerprint_valid():
     result = strong_email_fingerprint(

--- a/backend/tests/test_email_dedupe_service.py
+++ b/backend/tests/test_email_dedupe_service.py
@@ -85,6 +85,20 @@ def test_strong_email_fingerprint_valid():
     assert isinstance(result, str)
     assert len(result) > 0
 
+
+def test_strong_email_fingerprint_includes_body_beyond_legacy_snippet():
+    values = {
+        "sender": "sender@example.com",
+        "subject": "Subject",
+        "date": datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    }
+
+    first = strong_email_fingerprint(**values, body=f"{'A' * 500}first")
+    second = strong_email_fingerprint(**values, body=f"{'A' * 500}second")
+
+    assert first != second
+
+
 def test_candidate_strong_fingerprint():
     candidate = EmailDedupeCandidate(
         candidate_key="key",

--- a/backend/tests/test_email_parser.py
+++ b/backend/tests/test_email_parser.py
@@ -29,6 +29,11 @@ This is a test email.\x00"""
         assert parsed["subject"] == "HelloWorld"  # NUL removed
         assert "This is a test email." in parsed["body"]
         assert "\x00" not in parsed["body"]
+        assert parsed["source_date"] == datetime.datetime(
+            2026, 4, 27, 10, 0, tzinfo=datetime.timezone.utc
+        )
+        assert parsed["date_evidence_status"] == "parsed"
+        assert parsed["message_id_evidence_status"] == "embedded"
     finally:
         os.unlink(temp_path)
 
@@ -316,13 +321,36 @@ Test."""
         # Missing date
         parsed1 = parse_eml(temp_path1)
         assert isinstance(parsed1["date"], datetime.datetime)
+        assert parsed1["source_date"] is None
+        assert parsed1["date_evidence_status"] == "missing"
 
         # Malformed date
         parsed2 = parse_eml(temp_path2)
         assert isinstance(parsed2["date"], datetime.datetime)
+        assert parsed2["source_date"] is None
+        assert parsed2["date_evidence_status"] == "invalid"
     finally:
         os.unlink(temp_path1)
         os.unlink(temp_path2)
+
+
+def test_parse_eml_marks_missing_message_id_evidence():
+    eml_content = b"""From: test@test.com
+To: recipient@test.com
+Subject: No Message ID
+Date: Mon, 27 Apr 2026 10:00:00 +0000
+
+Test."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".eml") as f:
+        f.write(eml_content)
+        temp_path = f.name
+
+    try:
+        parsed = parse_eml(temp_path)
+        assert parsed["message_id"] == ""
+        assert parsed["message_id_evidence_status"] == "missing"
+    finally:
+        os.unlink(temp_path)
 
 
 def test_parse_eml_io_error():

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -1200,6 +1200,69 @@ async def test_import_email_files_reports_complete_source_fingerprint_match(
 
 
 @pytest.mark.asyncio
+async def test_import_email_files_rejects_legacy_body_prefix_false_positive(
+    client: AsyncClient,
+):
+    from db.session import get_db
+
+    shared_prefix = "A" * 500
+    existing_email = Email(
+        id=82,
+        user_id="testuser",
+        organization_id="org-acme",
+        message_id="existing-prefix@example.com",
+        thread_id="existing-prefix-thread",
+        sender="Partner <partner@example.com>",
+        recipients="User <user@example.com>",
+        subject="Long body",
+        date=datetime.datetime(2026, 6, 11, 10, 0, tzinfo=datetime.timezone.utc),
+        body=f"{shared_prefix}first",
+        fingerprint=generate_email_fingerprint(
+            {
+                "sender": "Partner <partner@example.com>",
+                "subject": "Long body",
+                "date": "2026-06-11T10:00:00+00:00",
+                "body": f"{shared_prefix}first",
+            }
+        ),
+        embedding=[0.0] * 1536,
+    )
+    session = ImportRecordingSession([existing_email])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "long-body.eml",
+                        _sample_eml_bytes(
+                            message_id="<new-prefix@example.com>",
+                            subject="Long body",
+                            body=f"{shared_prefix}second",
+                        ),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 1
+    assert data["skipped_count"] == 0
+    assert len(session.added) == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "member_name,expected_filename",
     [

--- a/backend/tests/test_emails_api.py
+++ b/backend/tests/test_emails_api.py
@@ -926,6 +926,9 @@ async def test_import_email_files_persists_signed_scoped_eml_upload(
             "status": "imported",
             "reason_code": None,
             "attachment_count": 0,
+            "dedupe_review_required": False,
+            "dedupe_reason_codes": [],
+            "dedupe_match_reason": None,
         }
     ]
     assert "imported@example.com" not in json.dumps(data)
@@ -1013,8 +1016,187 @@ async def test_import_email_files_skips_duplicate_message_id(client: AsyncClient
     assert data["failed_count"] == 0
     assert data["items"][0]["status"] == "skipped_duplicate"
     assert data["items"][0]["reason_code"] == "duplicate_email"
+    assert data["items"][0]["dedupe_review_required"] is False
+    assert data["items"][0]["dedupe_reason_codes"] == []
+    assert data["items"][0]["dedupe_match_reason"] == "embedded_message_id"
     assert session.added == []
     assert session.commit_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("date_header", "expected_date_reason"),
+    [
+        (b"", "date_evidence_missing"),
+        (b"Date: Invalid-Date-Format\r\n", "date_evidence_invalid"),
+    ],
+)
+async def test_import_email_files_does_not_treat_filename_date_as_source_metadata(
+    client: AsyncClient, date_header: bytes, expected_date_reason: str
+):
+    from db.session import get_db
+
+    session = ImportRecordingSession([])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "2026-04-28-message.eml",
+                        b"Message-ID: <filename-date@example.com>\r\n"
+                        b"From: partner@example.com\r\n"
+                        b"To: user@example.com\r\n"
+                        b"Subject: Filename date is not evidence\r\n"
+                        + date_header
+                        + b"\r\n"
+                        b"Body text\r\n",
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 1
+    assert data["provider_write_executed"] is False
+    assert data["items"] == [
+        {
+            "filename": "2026-04-28-message.eml",
+            "status": "imported",
+            "reason_code": None,
+            "attachment_count": 0,
+            "dedupe_review_required": True,
+            "dedupe_reason_codes": [
+                expected_date_reason,
+                "complete_source_fingerprint_unavailable",
+            ],
+            "dedupe_match_reason": None,
+        }
+    ]
+    assert session.added[0].fingerprint is None
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_uses_raw_sha_for_exact_no_id_duplicate(
+    client: AsyncClient,
+):
+    from db.session import get_db
+
+    content = (
+        b"Date: Thu, 11 Jun 2026 10:00:00 +0000\r\n"
+        b"From: partner@example.com\r\n"
+        b"To: user@example.com\r\n"
+        b"Subject: No embedded ID\r\n\r\n"
+        b"Body text\r\n"
+    )
+    session = ImportRecordingSession([])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                ("files", ("first.eml", content, "message/rfc822")),
+                ("files", ("second.eml", content, "message/rfc822")),
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["imported_count"] == 1
+    assert data["skipped_count"] == 1
+    assert data["provider_write_executed"] is False
+    assert data["items"][0]["dedupe_review_required"] is True
+    assert data["items"][0]["dedupe_reason_codes"] == [
+        "message_id_evidence_missing"
+    ]
+    assert data["items"][1]["status"] == "skipped_duplicate"
+    assert data["items"][1]["dedupe_review_required"] is False
+    assert data["items"][1]["dedupe_reason_codes"] == []
+    assert data["items"][1]["dedupe_match_reason"] == "raw_content_sha256"
+
+
+@pytest.mark.asyncio
+async def test_import_email_files_reports_complete_source_fingerprint_match(
+    client: AsyncClient,
+):
+    from db.session import get_db
+
+    existing_email = Email(
+        id=81,
+        user_id="testuser",
+        organization_id="org-acme",
+        message_id="existing-fingerprint@example.com",
+        thread_id="existing-fingerprint-thread",
+        sender="Partner <partner@example.com>",
+        recipients="User <user@example.com>",
+        subject="Fingerprint match",
+        date=datetime.datetime(2026, 6, 11, 10, 0, tzinfo=datetime.timezone.utc),
+        body="Same source body",
+        fingerprint=generate_email_fingerprint(
+            {
+                "sender": "Partner <partner@example.com>",
+                "subject": "Fingerprint match",
+                "date": "2026-06-11T10:00:00+00:00",
+                "body": "Same source body",
+            }
+        ),
+        embedding=[0.0] * 1536,
+    )
+    session = ImportRecordingSession([existing_email])
+    previous_db_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = lambda: session
+    try:
+        response = await client.post(
+            "/api/emails/import-files",
+            files=[
+                (
+                    "files",
+                    (
+                        "fingerprint-match.eml",
+                        _sample_eml_bytes(
+                            message_id="<new-id@example.com>",
+                            subject="Fingerprint match",
+                            body="Same source body",
+                        ),
+                        "message/rfc822",
+                    ),
+                )
+            ],
+            headers={"X-Organization-Id": "org-acme"},
+        )
+    finally:
+        if previous_db_override is None:
+            app.dependency_overrides.pop(get_db, None)
+        else:
+            app.dependency_overrides[get_db] = previous_db_override
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["skipped_count"] == 1
+    assert data["provider_write_executed"] is False
+    assert data["items"][0]["dedupe_match_reason"] == (
+        "complete_source_fingerprint"
+    )
+    assert data["items"][0]["dedupe_review_required"] is False
+    assert data["items"][0]["dedupe_reason_codes"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약

- 원본 Date와 저장용 fallback 시각을 분리하고 parsed, missing, invalid 근거를 보존합니다.
- Message-ID 근거를 embedded 또는 missing으로 기록합니다.
- 자동 중복 판정을 embedded Message-ID, raw EML SHA-256, 완전한 원본 fingerprint로 제한합니다.
- 불완전한 근거는 dedupe_review_required와 안정적인 reason code로 API에 노출합니다.
- 파일명 날짜는 원본 Date 근거로 사용하지 않으며 provider_write_executed는 false를 유지합니다.

## 적층 관계

PR #1085의 이메일 import 보안 수정을 base로 한 원자적 후속 PR입니다. #1085 병합 후 base를 develop으로 전환할 수 있습니다.

Refs #1086

## 검증

- 전체 backend: 1567 passed, 33 skipped
- 이메일 및 IMAP/스레딩 관련: 144 passed, 1 skipped
- Ruff: changed files passed
- 날짜형 파일명 + 누락/잘못된 내부 Date 회귀 테스트 포함
- Message-ID 없는 동일 raw EML SHA-256 중복 근거 테스트 포함

이 계약은 결정론적 provenance 처리이므로 noema, contextual-orchestrator, 외부 LLM, semantic-data-portal 연동을 추가하지 않았습니다.